### PR TITLE
release 20220316

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.4.2](https://github.com/newjersey/navigator.business.nj.gov/compare/v2.4.1...v2.4.2) (2022-03-16)
+
+
+### Bug Fixes
+
+* correct a typo on the landing page ([be90310](https://github.com/newjersey/navigator.business.nj.gov/commit/be9031061034c5c7aa68b90ffa8c1e18a8f74ca2))
+
 ## [2.4.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v2.4.0...v2.4.1) (2022-03-16)
 
 

--- a/content/src/fieldConfig/config.json
+++ b/content/src/fieldConfig/config.json
@@ -221,7 +221,7 @@
     "section2Icon3Text": "Location",
     "column1SupportingText": "Visit our website with more resources to start, operate, and grow your business.",
     "heroCalloutFirstLineText": "Your Business,",
-    "column2SupportingText": "Already a registered business and want to know the lastest grants and regulations likely to affect your business? Join our weekly newsletter.",
+    "column2SupportingText": "Already a registered business and want to know the latest grants and regulations likely to affect your business? Join our weekly newsletter.",
     "column3SupportingText": "Local experts are available 9 a.m–5 p.m Eastern Time, Monday through Friday, to help you with any business challenge.",
     "column3Image": "../img/Not-Starting-3-chat.svg",
     "column2Image": "../img/Not-Starting-2-newsletter.svg"


### PR DESCRIPTION
- fix: correct a typo on the landing page
- chore(release): 2.4.2 [skip ci]
