### PR TITLE
chore(release): 3.2.1 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.2.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v3.2.0...v3.2.1) (2022-04-12)
+
+
+### Bug Fixes
+
+* **deps:** update aws-sdk to v3.67.0 ([41ac37d](https://github.com/newjersey/navigator.business.nj.gov/commit/41ac37d36b4f2342984050c387ff6c0529b05a01))
+
 # [3.2.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v3.1.1...v3.2.0) (2022-04-11)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businessnjgovnavigator/root",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "This is the development repository for the work-in-progress business dashboard from the New Jersey Office of Innovation. For info on the existing [Business.NJ.gov](https://business.nj.gov) site, please see the [bottom of this document](https://github.com/newjersey/navigator.business.nj.gov#businessnjgov)",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
## [3.2.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v3.2.0...v3.2.1) (2022-04-12)

### Bug Fixes

* **deps:** update aws-sdk to v3.67.0 ([41ac37d](https://github.com/newjersey/navigator.business.nj.gov/commit/41ac37d36b4f2342984050c387ff6c0529b05a01))
