### PR TITLE
chore(release): 3.4.1 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [3.4.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v3.4.0...v3.4.1) (2022-04-21)
+
+
+### Bug Fixes
+
+* hide bad material-ui styling on CMS checkboxes ([4e76b27](https://github.com/newjersey/navigator.business.nj.gov/commit/4e76b27fdaaa8ac90118dcf2fc4a0bb9cb4fe61a))
+* updating Industry Roadmaps e-commerce ([#2457](https://github.com/newjersey/navigator.business.nj.gov/issues/2457)) ([c302ad9](https://github.com/newjersey/navigator.business.nj.gov/commit/c302ad96d7d55738298bed7f7513f65fef1e411c))
+* updating Industry Roadmaps photography ([#2472](https://github.com/newjersey/navigator.business.nj.gov/issues/2472)) ([463cb42](https://github.com/newjersey/navigator.business.nj.gov/commit/463cb42255b2eeeb41ce3b9af7f7d2e0ba993824))
+* updating Poppy Onboarding Content business-name ([#2468](https://github.com/newjersey/navigator.business.nj.gov/issues/2468)) ([da16788](https://github.com/newjersey/navigator.business.nj.gov/commit/da167881764408208d21f09c18677fc4080427fc))
+* updating Tasks apply-for-shop-license ([#2476](https://github.com/newjersey/navigator.business.nj.gov/issues/2476)) ([e4ce8c1](https://github.com/newjersey/navigator.business.nj.gov/commit/e4ce8c1d335cdd721931ee579f236d070cd7679c))
+
 # [3.4.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v3.3.0...v3.4.0) (2022-04-20)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businessnjgovnavigator/root",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "This is the development repository for the work-in-progress business dashboard from the New Jersey Office of Innovation. For info on the existing [Business.NJ.gov](https://business.nj.gov) site, please see the [bottom of this document](https://github.com/newjersey/navigator.business.nj.gov#businessnjgov)",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
## [3.4.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v3.4.0...v3.4.1) (2022-04-21)

### Bug Fixes

* hide bad material-ui styling on CMS checkboxes ([4e76b27](https://github.com/newjersey/navigator.business.nj.gov/commit/4e76b27fdaaa8ac90118dcf2fc4a0bb9cb4fe61a))
* updating Industry Roadmaps e-commerce ([#2457](https://github.com/newjersey/navigator.business.nj.gov/issues/2457)) ([c302ad9](https://github.com/newjersey/navigator.business.nj.gov/commit/c302ad96d7d55738298bed7f7513f65fef1e411c))
* updating Industry Roadmaps photography ([#2472](https://github.com/newjersey/navigator.business.nj.gov/issues/2472)) ([463cb42](https://github.com/newjersey/navigator.business.nj.gov/commit/463cb42255b2eeeb41ce3b9af7f7d2e0ba993824))
* updating Poppy Onboarding Content business-name ([#2468](https://github.com/newjersey/navigator.business.nj.gov/issues/2468)) ([da16788](https://github.com/newjersey/navigator.business.nj.gov/commit/da167881764408208d21f09c18677fc4080427fc))
* updating Tasks apply-for-shop-license ([#2476](https://github.com/newjersey/navigator.business.nj.gov/issues/2476)) ([e4ce8c1](https://github.com/newjersey/navigator.business.nj.gov/commit/e4ce8c1d335cdd721931ee579f236d070cd7679c))
