### PR TITLE
release 20220629

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.13.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v3.13.0...v3.13.1) (2022-06-29)
+
+
+### Bug Fixes
+
+* adjust the progressbar calculation to start at 0 ([35b7673](https://github.com/newjersey/navigator.business.nj.gov/commit/35b7673a33769a8753f07b6116d3839a9edfa479))
+
 # [3.13.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v3.12.3...v3.13.0) (2022-06-29)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businessnjgovnavigator/root",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "description": "This is the development repository for the work-in-progress business navigator from the New Jersey Office of Innovation. For info on the existing [Business.NJ.gov](https://business.nj.gov) site, please see the [bottom of this document](https://github.com/newjersey/navigator.business.nj.gov#businessnjgov)",
   "main": "index.js",
   "private": true,

--- a/web/src/components/roadmap/RoadmapSidebarCard.tsx
+++ b/web/src/components/roadmap/RoadmapSidebarCard.tsx
@@ -44,8 +44,7 @@ export const RoadmapSidebarCard = (props: Props) => {
   };
 
   const tasksCompleted = (): number => {
-    if (!userData) return 0;
-    if (!roadmap) return 1;
+    if (!userData || !roadmap) return 0;
     let totalTasksCompleted = 0;
     for (const step of roadmap.steps) {
       for (const task of step.tasks) {


### PR DESCRIPTION
- fix: adjust the progressbar calculation to start at 0
- chore(release): 3.13.1 [skip ci]
