### PR TITLE
feat: [#184595589] update annual filings logic to return next 3 years

### DIFF
--- a/api/src/api/guestRouter.test.ts
+++ b/api/src/api/guestRouter.test.ts
@@ -7,7 +7,7 @@ import {
   generateUser,
   generateUserData,
 } from "../../test/factories";
-import { determineAnnualFilingDate } from "../../test/helpers";
+import { generateAnnualFilings } from "../../test/helpers";
 import { BusinessNameClient } from "../domain/types";
 import { setupExpress } from "../libs/express";
 import { guestRouterFactory } from "./guestRouter";
@@ -49,7 +49,7 @@ describe("guestRouter", () => {
         ...postedUserData,
         taxFilingData: {
           ...postedUserData.taxFilingData,
-          filings: [{ identifier: "ANNUAL_FILING", dueDate: determineAnnualFilingDate("2021-03-01") }],
+          filings: generateAnnualFilings("2021-03-01"),
         },
       });
     });

--- a/api/src/api/guestRouter.test.ts
+++ b/api/src/api/guestRouter.test.ts
@@ -49,7 +49,7 @@ describe("guestRouter", () => {
         ...postedUserData,
         taxFilingData: {
           ...postedUserData.taxFilingData,
-          filings: generateAnnualFilings("2021-03-01"),
+          filings: generateAnnualFilings(["2023-03-31", "2024-03-31", "2025-03-31"]),
         },
       });
     });

--- a/api/src/api/guestRouter.test.ts
+++ b/api/src/api/guestRouter.test.ts
@@ -30,7 +30,7 @@ describe("guestRouter", () => {
   });
 
   describe("POST annualFilings", () => {
-    it("calculates new annual filing date and updates it for dateOfFormation", async () => {
+    it("calculates 3 new annual filing dates and updates them for dateOfFormation", async () => {
       const postedUserData = generateUserData({
         user: generateUser({ id: "123" }),
         profileData: generateProfileData({

--- a/api/src/api/userRouter.test.ts
+++ b/api/src/api/userRouter.test.ts
@@ -14,7 +14,7 @@ import {
   generateUser,
   generateUserData,
 } from "../../test/factories";
-import { determineAnnualFilingDate, getLastCalledWith } from "../../test/helpers";
+import { generateAnnualFilings, getLastCalledWith } from "../../test/helpers";
 import { EncryptionDecryptionClient, UserDataClient } from "../domain/types";
 import { setupExpress } from "../libs/express";
 import { userRouterFactory } from "./userRouter";
@@ -257,9 +257,7 @@ describe("userRouter", () => {
       await request(app).post(`/users`).send(postedUserData).set("Authorization", "Bearer user-123-token");
 
       const taxFilingsPut = getLastCalledWith(stubUserDataClient.put)[0].taxFilingData.filings;
-      expect(taxFilingsPut).toEqual([
-        { identifier: "ANNUAL_FILING", dueDate: determineAnnualFilingDate("2021-03-01") },
-      ]);
+      expect(taxFilingsPut).toEqual(generateAnnualFilings("2021-03-01"));
     });
 
     it("clears taskChecklistItems if industry has changed", async () => {

--- a/api/src/api/userRouter.test.ts
+++ b/api/src/api/userRouter.test.ts
@@ -257,7 +257,7 @@ describe("userRouter", () => {
       await request(app).post(`/users`).send(postedUserData).set("Authorization", "Bearer user-123-token");
 
       const taxFilingsPut = getLastCalledWith(stubUserDataClient.put)[0].taxFilingData.filings;
-      expect(taxFilingsPut).toEqual(generateAnnualFilings("2021-03-01"));
+      expect(taxFilingsPut).toEqual(generateAnnualFilings(["2023-03-31", "2024-03-31", "2025-03-31"]));
     });
 
     it("clears taskChecklistItems if industry has changed", async () => {

--- a/api/src/api/userRouter.test.ts
+++ b/api/src/api/userRouter.test.ts
@@ -237,7 +237,7 @@ describe("userRouter", () => {
       ).toEqual(true);
     });
 
-    it("calculates new annual filing date and updates it for dateOfFormation", async () => {
+    it("calculates 3 new annual filing dates and updates them for dateOfFormation", async () => {
       mockJwt.decode.mockReturnValue(cognitoPayload({ id: "123" }));
       const postedUserData = generateUserData({
         user: generateUser({ id: "123" }),

--- a/api/src/domain/annual-filings/calculateNextAnnualFilingDates.test.ts
+++ b/api/src/domain/annual-filings/calculateNextAnnualFilingDates.test.ts
@@ -19,7 +19,7 @@ describe("calculateNextAnnualFilingDates", () => {
       currentDateMock.mockReturnValue(dayjs("2021-10-05", defaultDateFormat));
     });
 
-    it("finds the next-year date for an earlier-this year date", () => {
+    it("finds the next 3 filing dates for an earlier-this year date", () => {
       expect(calculateNextAnnualFilingDates("2021-03-01")).toEqual([
         "2022-03-31",
         "2023-03-31",
@@ -27,7 +27,7 @@ describe("calculateNextAnnualFilingDates", () => {
       ]);
     });
 
-    it("finds the next-year date for a date from last year", () => {
+    it("finds the next 3 filing dates for a date from last year", () => {
       expect(calculateNextAnnualFilingDates("2020-06-01")).toEqual([
         "2022-06-30",
         "2023-06-30",
@@ -35,7 +35,7 @@ describe("calculateNextAnnualFilingDates", () => {
       ]);
     });
 
-    it("finds the next-year date for a much older formation date", () => {
+    it("finds the next 3 filing dates for a much older formation date", () => {
       expect(calculateNextAnnualFilingDates("2001-04-01")).toEqual([
         "2022-04-30",
         "2023-04-30",
@@ -43,7 +43,7 @@ describe("calculateNextAnnualFilingDates", () => {
       ]);
     });
 
-    it("finds the this-year date for a date later this year", () => {
+    it("finds the this 3 filing dates for a date later this year", () => {
       expect(calculateNextAnnualFilingDates("2020-11-01")).toEqual([
         "2021-11-30",
         "2022-11-30",
@@ -51,7 +51,7 @@ describe("calculateNextAnnualFilingDates", () => {
       ]);
     });
 
-    it("finds the next-year date for a date from this month this year", () => {
+    it("finds the next 3 filing dates for a date from this month this year", () => {
       expect(calculateNextAnnualFilingDates("2021-10-01")).toEqual([
         "2022-10-31",
         "2023-10-31",
@@ -59,7 +59,7 @@ describe("calculateNextAnnualFilingDates", () => {
       ]);
     });
 
-    it("finds the this-year date for a date from this month last year", () => {
+    it("finds the next 3 filing dates for a date from this month last year", () => {
       expect(calculateNextAnnualFilingDates("2020-10-01")).toEqual([
         "2021-10-31",
         "2022-10-31",
@@ -67,7 +67,7 @@ describe("calculateNextAnnualFilingDates", () => {
       ]);
     });
 
-    it("finds the this-year date for a much older formation date of this month", () => {
+    it("finds the next 3 filing dates for a much older formation date of this month", () => {
       expect(calculateNextAnnualFilingDates("2001-10-01")).toEqual([
         "2021-10-31",
         "2022-10-31",
@@ -75,7 +75,7 @@ describe("calculateNextAnnualFilingDates", () => {
       ]);
     });
 
-    it("finds the future-year date for a formation date in the future", () => {
+    it("finds the future 3 filing dates for a formation date in the future", () => {
       expect(calculateNextAnnualFilingDates("2030-08-29")).toEqual([
         "2031-08-31",
         "2032-08-31",
@@ -83,7 +83,7 @@ describe("calculateNextAnnualFilingDates", () => {
       ]);
     });
 
-    it("finds the next-year date for a formation date in a later month of the same year", () => {
+    it("finds the next 3 filing dates for a formation date in a later month of the same year", () => {
       expect(calculateNextAnnualFilingDates("2021-11-01")).toEqual([
         "2022-11-30",
         "2023-11-30",
@@ -97,7 +97,7 @@ describe("calculateNextAnnualFilingDates", () => {
       currentDateMock.mockReturnValue(dayjs("2021-10-31", defaultDateFormat));
     });
 
-    it("finds the next-year date for a date from this month this year", () => {
+    it("finds the next 3 filing dates for a date from this month this year", () => {
       expect(calculateNextAnnualFilingDates("2021-10-01")).toEqual([
         "2022-10-31",
         "2023-10-31",
@@ -105,7 +105,7 @@ describe("calculateNextAnnualFilingDates", () => {
       ]);
     });
 
-    it("finds the this-year date for a date from this month last year", () => {
+    it("finds the next 3 filing dates for a date from this month last year", () => {
       expect(calculateNextAnnualFilingDates("2020-10-01")).toEqual([
         "2021-10-31",
         "2022-10-31",
@@ -119,7 +119,7 @@ describe("calculateNextAnnualFilingDates", () => {
       currentDateMock.mockReturnValue(dayjs("2021-11-01", defaultDateFormat));
     });
 
-    it("finds the next-year date for a date from this month this year", () => {
+    it("finds the next 3 filing dates for a date from this month this year", () => {
       expect(calculateNextAnnualFilingDates("2021-11-01")).toEqual([
         "2022-11-30",
         "2023-11-30",
@@ -127,7 +127,7 @@ describe("calculateNextAnnualFilingDates", () => {
       ]);
     });
 
-    it("finds the this-year date for a date from last month last year", () => {
+    it("finds the next 3 filing dates for a date from last month last year", () => {
       expect(calculateNextAnnualFilingDates("2020-10-01")).toEqual([
         "2022-10-31",
         "2023-10-31",

--- a/api/src/domain/annual-filings/calculateNextAnnualFilingDates.test.ts
+++ b/api/src/domain/annual-filings/calculateNextAnnualFilingDates.test.ts
@@ -1,7 +1,7 @@
 import * as getCurrentDateModule from "@shared/dateHelpers";
 import { defaultDateFormat } from "@shared/defaultConstants";
 import dayjs from "dayjs";
-import { calculateNextAnnualFilingDate } from "./calculateNextAnnualFilingDate";
+import { calculateNextAnnualFilingDates } from "./calculateNextAnnualFilingDates";
 
 jest.mock("@shared/dateHelpers", () => {
   return {
@@ -13,46 +13,82 @@ jest.mock("@shared/dateHelpers", () => {
 });
 const currentDateMock = (getCurrentDateModule as jest.Mocked<typeof getCurrentDateModule>).getCurrentDate;
 
-describe("calculateNextAnnualFilingDate", () => {
+describe("calculateNextAnnualFilingDates", () => {
   describe("when today is October 5, 2021", () => {
     beforeEach(() => {
       currentDateMock.mockReturnValue(dayjs("2021-10-05", defaultDateFormat));
     });
 
     it("finds the next-year date for an earlier-this year date", () => {
-      expect(calculateNextAnnualFilingDate("2021-03-01")).toEqual("2022-03-31");
+      expect(calculateNextAnnualFilingDates("2021-03-01")).toEqual([
+        "2022-03-31",
+        "2023-03-31",
+        "2024-03-31",
+      ]);
     });
 
     it("finds the next-year date for a date from last year", () => {
-      expect(calculateNextAnnualFilingDate("2020-06-01")).toEqual("2022-06-30");
+      expect(calculateNextAnnualFilingDates("2020-06-01")).toEqual([
+        "2022-06-30",
+        "2023-06-30",
+        "2024-06-30",
+      ]);
     });
 
     it("finds the next-year date for a much older formation date", () => {
-      expect(calculateNextAnnualFilingDate("2001-04-01")).toEqual("2022-04-30");
+      expect(calculateNextAnnualFilingDates("2001-04-01")).toEqual([
+        "2022-04-30",
+        "2023-04-30",
+        "2024-04-30",
+      ]);
     });
 
     it("finds the this-year date for a date later this year", () => {
-      expect(calculateNextAnnualFilingDate("2020-11-01")).toEqual("2021-11-30");
+      expect(calculateNextAnnualFilingDates("2020-11-01")).toEqual([
+        "2021-11-30",
+        "2022-11-30",
+        "2023-11-30",
+      ]);
     });
 
     it("finds the next-year date for a date from this month this year", () => {
-      expect(calculateNextAnnualFilingDate("2021-10-01")).toEqual("2022-10-31");
+      expect(calculateNextAnnualFilingDates("2021-10-01")).toEqual([
+        "2022-10-31",
+        "2023-10-31",
+        "2024-10-31",
+      ]);
     });
 
     it("finds the this-year date for a date from this month last year", () => {
-      expect(calculateNextAnnualFilingDate("2020-10-01")).toEqual("2021-10-31");
+      expect(calculateNextAnnualFilingDates("2020-10-01")).toEqual([
+        "2021-10-31",
+        "2022-10-31",
+        "2023-10-31",
+      ]);
     });
 
     it("finds the this-year date for a much older formation date of this month", () => {
-      expect(calculateNextAnnualFilingDate("2001-10-01")).toEqual("2021-10-31");
+      expect(calculateNextAnnualFilingDates("2001-10-01")).toEqual([
+        "2021-10-31",
+        "2022-10-31",
+        "2023-10-31",
+      ]);
     });
 
     it("finds the future-year date for a formation date in the future", () => {
-      expect(calculateNextAnnualFilingDate("2030-08-29")).toEqual("2031-08-31");
+      expect(calculateNextAnnualFilingDates("2030-08-29")).toEqual([
+        "2031-08-31",
+        "2032-08-31",
+        "2033-08-31",
+      ]);
     });
 
     it("finds the next-year date for a formation date in a later month of the same year", () => {
-      expect(calculateNextAnnualFilingDate("2021-11-01")).toEqual("2022-11-30");
+      expect(calculateNextAnnualFilingDates("2021-11-01")).toEqual([
+        "2022-11-30",
+        "2023-11-30",
+        "2024-11-30",
+      ]);
     });
   });
 
@@ -62,11 +98,19 @@ describe("calculateNextAnnualFilingDate", () => {
     });
 
     it("finds the next-year date for a date from this month this year", () => {
-      expect(calculateNextAnnualFilingDate("2021-10-01")).toEqual("2022-10-31");
+      expect(calculateNextAnnualFilingDates("2021-10-01")).toEqual([
+        "2022-10-31",
+        "2023-10-31",
+        "2024-10-31",
+      ]);
     });
 
     it("finds the this-year date for a date from this month last year", () => {
-      expect(calculateNextAnnualFilingDate("2020-10-01")).toEqual("2021-10-31");
+      expect(calculateNextAnnualFilingDates("2020-10-01")).toEqual([
+        "2021-10-31",
+        "2022-10-31",
+        "2023-10-31",
+      ]);
     });
   });
 
@@ -76,11 +120,19 @@ describe("calculateNextAnnualFilingDate", () => {
     });
 
     it("finds the next-year date for a date from this month this year", () => {
-      expect(calculateNextAnnualFilingDate("2021-11-01")).toEqual("2022-11-30");
+      expect(calculateNextAnnualFilingDates("2021-11-01")).toEqual([
+        "2022-11-30",
+        "2023-11-30",
+        "2024-11-30",
+      ]);
     });
 
     it("finds the this-year date for a date from last month last year", () => {
-      expect(calculateNextAnnualFilingDate("2020-10-01")).toEqual("2022-10-31");
+      expect(calculateNextAnnualFilingDates("2020-10-01")).toEqual([
+        "2022-10-31",
+        "2023-10-31",
+        "2024-10-31",
+      ]);
     });
   });
 });

--- a/api/src/domain/annual-filings/calculateNextAnnualFilingDates.ts
+++ b/api/src/domain/annual-filings/calculateNextAnnualFilingDates.ts
@@ -1,7 +1,7 @@
 import { getCurrentDate, parseDateWithFormat } from "@shared/dateHelpers";
 import { defaultDateFormat } from "@shared/defaultConstants";
 
-export const calculateNextAnnualFilingDate = (dateOfFormation: string): string => {
+export const calculateNextAnnualFilingDates = (dateOfFormation: string): string[] => {
   const today = getCurrentDate();
   const currentYear = today.year();
   const currentMonth = today.month();
@@ -22,5 +22,11 @@ export const calculateNextAnnualFilingDate = (dateOfFormation: string): string =
     dueDateYear = nextYear;
   }
 
-  return formationDate.year(dueDateYear).endOf("month").format(defaultDateFormat);
+  const baseFilingDate = formationDate.year(dueDateYear).endOf("month");
+
+  return [
+    baseFilingDate.format(defaultDateFormat),
+    baseFilingDate.add(1, "year").format(defaultDateFormat),
+    baseFilingDate.add(2, "year").format(defaultDateFormat),
+  ];
 };

--- a/api/src/domain/annual-filings/getAnnualFilings.test.ts
+++ b/api/src/domain/annual-filings/getAnnualFilings.test.ts
@@ -4,7 +4,7 @@ import {
   generateUser,
   generateUserData,
 } from "../../../test/factories";
-import { determineAnnualFilingDate } from "../../../test/helpers";
+import { generateAnnualFilings } from "../../../test/helpers";
 import { getAnnualFilings } from "./getAnnualFilings";
 
 describe("getAnnualFilings", () => {
@@ -27,7 +27,7 @@ describe("getAnnualFilings", () => {
       ...postedUserData,
       taxFilingData: {
         ...postedUserData.taxFilingData,
-        filings: [{ identifier: "ANNUAL_FILING", dueDate: determineAnnualFilingDate("2021-03-01") }],
+        filings: generateAnnualFilings("2021-03-01"),
       },
     });
   });
@@ -51,7 +51,7 @@ describe("getAnnualFilings", () => {
       ...postedUserData,
       taxFilingData: {
         ...postedUserData.taxFilingData,
-        filings: [{ identifier: "ANNUAL_FILING", dueDate: determineAnnualFilingDate("2021-03-01") }],
+        filings: generateAnnualFilings("2021-03-01"),
       },
     });
   });
@@ -75,7 +75,7 @@ describe("getAnnualFilings", () => {
       ...postedUserData,
       taxFilingData: {
         ...postedUserData.taxFilingData,
-        filings: [{ identifier: "ANNUAL_FILING", dueDate: determineAnnualFilingDate("2021-03-31") }],
+        filings: generateAnnualFilings("2021-03-31"),
       },
     });
   });

--- a/api/src/domain/annual-filings/getAnnualFilings.test.ts
+++ b/api/src/domain/annual-filings/getAnnualFilings.test.ts
@@ -27,7 +27,7 @@ describe("getAnnualFilings", () => {
       ...postedUserData,
       taxFilingData: {
         ...postedUserData.taxFilingData,
-        filings: generateAnnualFilings("2021-03-01"),
+        filings: generateAnnualFilings(["2023-03-31", "2024-03-31", "2025-03-31"]),
       },
     });
   });
@@ -51,7 +51,7 @@ describe("getAnnualFilings", () => {
       ...postedUserData,
       taxFilingData: {
         ...postedUserData.taxFilingData,
-        filings: generateAnnualFilings("2021-03-01"),
+        filings: generateAnnualFilings(["2023-03-31", "2024-03-31", "2025-03-31"]),
       },
     });
   });
@@ -75,7 +75,7 @@ describe("getAnnualFilings", () => {
       ...postedUserData,
       taxFilingData: {
         ...postedUserData.taxFilingData,
-        filings: generateAnnualFilings("2021-03-31"),
+        filings: generateAnnualFilings(["2023-03-31", "2024-03-31", "2025-03-31"]),
       },
     });
   });

--- a/api/src/domain/annual-filings/getAnnualFilings.test.ts
+++ b/api/src/domain/annual-filings/getAnnualFilings.test.ts
@@ -8,7 +8,7 @@ import { generateAnnualFilings } from "../../../test/helpers";
 import { getAnnualFilings } from "./getAnnualFilings";
 
 describe("getAnnualFilings", () => {
-  it("calculates new annual filing date and updates it for dateOfFormation", async () => {
+  it("calculates 3 new annual filing datea and updates them for dateOfFormation", async () => {
     const postedUserData = generateUserData({
       user: generateUser({ id: "123" }),
       profileData: generateProfileData({
@@ -32,7 +32,7 @@ describe("getAnnualFilings", () => {
     });
   });
 
-  it("calculates new annual filing date and overrides it if needed", async () => {
+  it("calculates 3 new annual filing dates and overrides existing dates if needed", async () => {
     const postedUserData = generateUserData({
       user: generateUser({ id: "123" }),
       profileData: generateProfileData({
@@ -56,7 +56,7 @@ describe("getAnnualFilings", () => {
     });
   });
 
-  it("calculates new annual filing date and updates it for dateOfFormation when there is no legalStructureId", async () => {
+  it("calculates 3 new annual filing dates and updates them for dateOfFormation when there is no legalStructureId", async () => {
     const postedUserData = generateUserData({
       user: generateUser({ id: "123" }),
       profileData: generateProfileData({

--- a/api/src/domain/annual-filings/getAnnualFilings.ts
+++ b/api/src/domain/annual-filings/getAnnualFilings.ts
@@ -1,6 +1,6 @@
 import { LookupLegalStructureById } from "@shared/legalStructure";
 import { UserData } from "@shared/userData";
-import { calculateNextAnnualFilingDate } from "./calculateNextAnnualFilingDate";
+import { calculateNextAnnualFilingDates } from "./calculateNextAnnualFilingDates";
 
 export const getAnnualFilings = (userData: UserData) => {
   const filings = userData.taxFilingData.filings.filter((it) => {
@@ -16,10 +16,12 @@ export const getAnnualFilings = (userData: UserData) => {
   }
 
   if (userData.profileData.dateOfFormation && requiresPublicFiling) {
-    filings.push({
-      identifier: "ANNUAL_FILING",
-      dueDate: calculateNextAnnualFilingDate(userData.profileData.dateOfFormation),
-    });
+    filings.push(
+      ...calculateNextAnnualFilingDates(userData.profileData.dateOfFormation).map((dueDate: string) => ({
+        identifier: "ANNUAL_FILING",
+        dueDate,
+      }))
+    );
   }
 
   return {

--- a/api/test/helpers.ts
+++ b/api/test/helpers.ts
@@ -1,9 +1,8 @@
 import { TaxFiling } from "@shared/taxFiling";
 import { createHmac } from "node:crypto";
-import { calculateNextAnnualFilingDates } from "../src/domain/annual-filings/calculateNextAnnualFilingDates";
 
-export const generateAnnualFilings = (dateOfFormation: string): TaxFiling[] => {
-  return calculateNextAnnualFilingDates(dateOfFormation).map((dueDate: string) => ({
+export const generateAnnualFilings = (dueDates: string[]): TaxFiling[] => {
+  return dueDates.map((dueDate: string) => ({
     identifier: "ANNUAL_FILING",
     dueDate,
   }));

--- a/api/test/helpers.ts
+++ b/api/test/helpers.ts
@@ -1,16 +1,12 @@
-import { getCurrentDate, parseDate } from "@shared/dateHelpers";
-import { defaultDateFormat } from "@shared/defaultConstants";
+import { TaxFiling } from "@shared/taxFiling";
 import { createHmac } from "node:crypto";
+import { calculateNextAnnualFilingDates } from "../src/domain/annual-filings/calculateNextAnnualFilingDates";
 
-export const determineAnnualFilingDate = (dateOfFormation: string) => {
-  const currentDate = getCurrentDate();
-  const dateOfFormationDate = parseDate(dateOfFormation);
-  let year = currentDate.year();
-  if (dateOfFormationDate.month() < currentDate.month()) {
-    year = year + 1;
-  }
-  const nextMonth = dateOfFormationDate.month() + 2;
-  return parseDate(`${year}-${nextMonth}-01`).add(-1, "day").format(defaultDateFormat);
+export const generateAnnualFilings = (dateOfFormation: string): TaxFiling[] => {
+  return calculateNextAnnualFilingDates(dateOfFormation).map((dueDate: string) => ({
+    identifier: "ANNUAL_FILING",
+    dueDate,
+  }));
 };
 
 export const generateHashedKey = (key: string) => {


### PR DESCRIPTION
## Purpose

Calculate the next 3 annual tax filing events to be displayed on a user's calendar.

## Ticket

[#184595589](https://www.pivotaltracker.com/story/show/184595589)

## Approach
- Updated the `calculateNextAnnualFIlingDate` function to return the next 3 years as an array.
- Modified test helper functions to reference this new logic to reduce redundancy.
 