### PR TITLE
feat: [#184597648] expand mapping of known api formation errors

### DIFF
--- a/web/src/components/tasks/business-formation/BusinessFormation.test.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormation.test.tsx
@@ -328,7 +328,7 @@ describe("<BusinessFormation />", () => {
     page.fillText("Contact first name", "John");
     page.fillText("Contact last name", "Smith");
     page.fillText("Contact phone number", "123A45a678 90");
-    fireEvent.click(screen.getByLabelText("Credit card"));
+    fireEvent.click(screen.getByLabelText(Config.formation.fields.paymentType.creditCardLabel));
     page.selectCheckbox(Config.formation.fields.corpWatchNotification.checkboxText);
     page.selectCheckboxByTestId("certificateOfStanding");
     page.selectCheckboxByTestId("certifiedCopyOfFormationDocument");
@@ -442,7 +442,7 @@ describe("<BusinessFormation />", () => {
     page.fillText("Contact first name", "John");
     page.fillText("Contact last name", "Smith");
     page.fillText("Contact phone number", "123A45a678 90");
-    fireEvent.click(screen.getByLabelText("Credit card"));
+    fireEvent.click(screen.getByLabelText(Config.formation.fields.paymentType.creditCardLabel));
     page.selectCheckbox(Config.formation.fields.corpWatchNotification.checkboxText);
     page.selectCheckboxByTestId("certificateOfStanding");
     page.selectCheckboxByTestId("certifiedCopyOfFormationDocument");
@@ -539,7 +539,7 @@ describe("<BusinessFormation />", () => {
     page.fillText("Contact first name", "John");
     page.fillText("Contact last name", "Smith");
     page.fillText("Contact phone number", "123A45a678 90");
-    fireEvent.click(screen.getByLabelText("Credit card"));
+    fireEvent.click(screen.getByLabelText(Config.formation.fields.paymentType.creditCardLabel));
     page.selectCheckbox(Config.formation.fields.corpWatchNotification.checkboxText);
 
     page.selectCheckboxByTestId("certificateOfStanding");
@@ -651,7 +651,7 @@ describe("<BusinessFormation />", () => {
     page.fillText("Contact first name", "John");
     page.fillText("Contact last name", "Smith");
     page.fillText("Contact phone number", "123A45a678 90");
-    fireEvent.click(screen.getByLabelText("Credit card"));
+    fireEvent.click(screen.getByLabelText(Config.formation.fields.paymentType.creditCardLabel));
     page.selectCheckbox(Config.formation.fields.corpWatchNotification.checkboxText);
 
     page.selectCheckboxByTestId("certificateOfStanding");
@@ -772,7 +772,7 @@ describe("<BusinessFormation />", () => {
     page.fillText("Contact first name", "John");
     page.fillText("Contact last name", "Smith");
     page.fillText("Contact phone number", "123A45a678 90");
-    fireEvent.click(screen.getByLabelText("Credit card"));
+    fireEvent.click(screen.getByLabelText(Config.formation.fields.paymentType.creditCardLabel));
     page.selectCheckbox(Config.formation.fields.corpWatchNotification.checkboxText);
 
     page.selectCheckboxByTestId("certificateOfStanding");
@@ -886,7 +886,7 @@ describe("<BusinessFormation />", () => {
     page.fillText("Contact first name", "John");
     page.fillText("Contact last name", "Smith");
     page.fillText("Contact phone number", "123A45a678 90");
-    fireEvent.click(screen.getByLabelText("Credit card"));
+    fireEvent.click(screen.getByLabelText(Config.formation.fields.paymentType.creditCardLabel));
     page.selectCheckbox(Config.formation.fields.corpWatchNotification.checkboxText);
 
     page.selectCheckboxByTestId("certificateOfStanding");

--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
@@ -3,7 +3,7 @@ import { LookupStepIndexByName } from "@/components/tasks/business-formation/Bus
 import { getMergedConfig } from "@/contexts/configContext";
 import { MunicipalitiesContext } from "@/contexts/municipalitiesContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
-import { TasksDisplayContent } from "@/lib/types/types";
+import { FormationStepNames, TasksDisplayContent } from "@/lib/types/types";
 import analytics from "@/lib/utils/analytics";
 import {
   generateEmptyFormationData,
@@ -27,6 +27,8 @@ import {
   userDataUpdatedNTimes,
   WithStatefulUserData,
 } from "@/test/mock/withStatefulUserData";
+import { FormationSubmitResponse } from "@businessnjgovnavigator/shared";
+import { FormationFormData } from "@businessnjgovnavigator/shared/";
 import { generateFormationFormData, generateMunicipality } from "@businessnjgovnavigator/shared/test";
 import { UserData } from "@businessnjgovnavigator/shared/userData";
 import * as materialUi from "@mui/material";
@@ -507,63 +509,376 @@ describe("<BusinessFormationPaginator />", () => {
         });
       });
 
-      describe("on known API error (registered agent)", () => {
-        beforeEach(() => {
-          filledInUserData = {
-            ...initialUserData,
-            formationData: {
-              ...initialUserData.formationData,
-              formationFormData: generateFormationFormData(
-                { agentNumberOrManual: "NUMBER", agentNumber: "1111111" },
-                { legalStructureId: "limited-liability-company" }
-              ),
-              formationResponse: generateFormationSubmitResponse({
-                success: false,
-                errors: [
-                  generateFormationSubmitError({
-                    field: "Registered Agent - Id",
-                    message: "very bad input",
-                    type: "RESPONSE",
-                  }),
-                ],
+      describe("on known API error", () => {
+        const agentNumber = [
+          "agentNumber",
+          generateFormationFormData(
+            { agentNumberOrManual: "NUMBER", agentNumber: "1111111" },
+            { legalStructureId: "limited-liability-company" }
+          ),
+          generateFormationSubmitResponse({
+            success: false,
+            errors: [
+              generateFormationSubmitError({
+                field: "Registered Agent - Id",
+                message: "very bad input",
+                type: "RESPONSE",
               }),
+            ],
+          }),
+          "Contacts",
+          "Agent number",
+          "1234567",
+        ];
+        const agentName = [
+          "agentName",
+          generateFormationFormData(
+            { agentNumberOrManual: "MANUAL_ENTRY", agentName: "1111111" },
+            { legalStructureId: "limited-liability-company" }
+          ),
+          generateFormationSubmitResponse({
+            success: false,
+            errors: [
+              generateFormationSubmitError({
+                field: "Registered Agent - Name",
+                message: "very bad input",
+                type: "RESPONSE",
+              }),
+            ],
+          }),
+          "Contacts",
+          "Agent name",
+          "new name",
+        ];
+        const agentEmail = [
+          "agentEmail",
+          generateFormationFormData(
+            { agentNumberOrManual: "MANUAL_ENTRY", agentEmail: "1111111" },
+            { legalStructureId: "limited-liability-company" }
+          ),
+          generateFormationSubmitResponse({
+            success: false,
+            errors: [
+              generateFormationSubmitError({
+                field: "Registered Agent - Email",
+                message: "very bad input",
+                type: "RESPONSE",
+              }),
+            ],
+          }),
+          "Contacts",
+          "Agent email",
+          "test@test.com",
+        ];
+        const agentOfficeAddressLine1 = [
+          "agentOfficeAddressLine1",
+          generateFormationFormData(
+            { agentNumberOrManual: "MANUAL_ENTRY", agentOfficeAddressLine1: "1111111" },
+            { legalStructureId: "limited-liability-company" }
+          ),
+          generateFormationSubmitResponse({
+            success: false,
+            errors: [
+              generateFormationSubmitError({
+                field: "Registered Agent - Street Address - Address1",
+                message: "very bad input",
+                type: "RESPONSE",
+              }),
+            ],
+          }),
+          "Contacts",
+          "Agent office address line1",
+          "22222222",
+        ];
+        const agentOfficeAddressLine2 = [
+          "agentOfficeAddressLine2",
+          generateFormationFormData(
+            { agentNumberOrManual: "MANUAL_ENTRY", agentOfficeAddressLine2: "1111111" },
+            { legalStructureId: "limited-liability-company" }
+          ),
+          generateFormationSubmitResponse({
+            success: false,
+            errors: [
+              generateFormationSubmitError({
+                field: "Registered Agent - Street Address - Address2",
+                message: "very bad input",
+                type: "RESPONSE",
+              }),
+            ],
+          }),
+          "Contacts",
+          "Agent office address line2",
+          "22222222",
+        ];
+        const agentOfficeAddressMunicipality = [
+          "agentOfficeAddressMunicipality",
+          generateFormationFormData(
+            {
+              agentNumberOrManual: "MANUAL_ENTRY",
+              agentOfficeAddressMunicipality: generateMunicipality({ displayName: "Newark" }),
             },
-          };
-        });
+            { legalStructureId: "limited-liability-company" }
+          ),
+          generateFormationSubmitResponse({
+            success: false,
+            errors: [
+              generateFormationSubmitError({
+                field: "Registered Agent - Street Address - City",
+                message: "very bad input",
+                type: "RESPONSE",
+              }),
+            ],
+          }),
+          "Contacts",
+          "Agent office address municipality",
+          "22222222", // dropdown
+        ];
+        const agentOfficeAddressZipCode = [
+          "agentOfficeAddressZipCode",
+          generateFormationFormData(
+            { agentNumberOrManual: "MANUAL_ENTRY", agentOfficeAddressZipCode: "07004" },
+            { legalStructureId: "limited-liability-company" }
+          ),
+          generateFormationSubmitResponse({
+            success: false,
+            errors: [
+              generateFormationSubmitError({
+                field: "Registered Agent - Street Address - Zipcode",
+                message: "very bad input",
+                type: "RESPONSE",
+              }),
+            ],
+          }),
+          "Contacts",
+          "Agent office address zip code",
+          "07005",
+        ];
 
-        it("shows error alert and error state on step associated with API error", async () => {
-          const page = preparePage(filledInUserData, displayContent);
-          await page.fillAndSubmitBusinessNameStep();
-          await page.stepperClickToReviewStep();
-          await page.clickSubmit();
-          expect(page.getStepStateInStepper(LookupStepIndexByName("Contacts"))).toEqual("ERROR");
-          expect(screen.getByText(Config.formation.errorBanner.incompleteStepsError)).toBeInTheDocument();
-        });
+        const contactFirstName = [
+          "contactFirstName",
+          generateFormationFormData(
+            { contactFirstName: "1111111" },
+            { legalStructureId: "limited-liability-company" }
+          ),
+          generateFormationSubmitResponse({
+            success: false,
+            errors: [
+              generateFormationSubmitError({
+                field: "Contact First Name",
+                message: "very bad input",
+                type: "RESPONSE",
+              }),
+            ],
+          }),
+          "Billing",
+          "Contact first name",
+          "22222222",
+        ];
+        const contactLastName = [
+          "contactLastName",
+          generateFormationFormData(
+            { contactLastName: "1111111" },
+            { legalStructureId: "limited-liability-company" }
+          ),
+          generateFormationSubmitResponse({
+            success: false,
+            errors: [
+              generateFormationSubmitError({
+                field: "Contact Last Name",
+                message: "very bad input",
+                type: "RESPONSE",
+              }),
+            ],
+          }),
+          "Billing",
+          "Contact last name",
+          "22222222",
+        ];
+        const contactPhoneNumber = [
+          "contactPhoneNumber",
+          generateFormationFormData(
+            { contactPhoneNumber: "4325435432" },
+            { legalStructureId: "limited-liability-company" }
+          ),
+          generateFormationSubmitResponse({
+            success: false,
+            errors: [
+              generateFormationSubmitError({
+                field: "Contact Phone Number",
+                message: "very bad input",
+                type: "RESPONSE",
+              }),
+            ],
+          }),
+          "Billing",
+          "Contact phone number",
+          "1232343452",
+        ];
+        const paymentType = [
+          "paymentType",
+          generateFormationFormData(
+            { paymentType: undefined },
+            { legalStructureId: "limited-liability-company" }
+          ),
+          generateFormationSubmitResponse({
+            success: false,
+            errors: [
+              generateFormationSubmitError({
+                field: "Select Payment Type",
+                message: "very bad input",
+                type: "RESPONSE",
+              }),
+            ],
+          }),
+          "Billing",
+          "CC",
+        ];
 
-        it("shows API error message on step for error", async () => {
-          const page = preparePage(filledInUserData, displayContent);
-          await page.fillAndSubmitBusinessNameStep();
-          await page.stepperClickToReviewStep();
-          await page.clickSubmit();
-          await page.stepperClickToContactsStep();
-          expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.errorBanner.errorOnStep);
-          expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.fields.agentNumber.label);
-          expect(screen.getByRole("alert")).toHaveTextContent("very bad input");
-        });
+        it.each([
+          agentNumber,
+          agentName,
+          agentEmail,
+          agentOfficeAddressLine1,
+          agentOfficeAddressLine2,
+          agentOfficeAddressMunicipality,
+          agentOfficeAddressZipCode,
+          contactFirstName,
+          contactLastName,
+          contactPhoneNumber,
+          paymentType,
+        ])(
+          "shows error alert and error state on step associated with %o API error",
+          async (fieldName, formationFormData, formationResponse, formationStepName) => {
+            filledInUserData = {
+              ...initialUserData,
+              formationData: {
+                ...initialUserData.formationData,
+                formationFormData: formationFormData as FormationFormData,
+                formationResponse: formationResponse as FormationSubmitResponse,
+              },
+            };
+            const page = preparePage(filledInUserData, displayContent);
+            await page.fillAndSubmitBusinessNameStep();
 
-        it("removes API error on blur when user changes field", async () => {
-          const page = preparePage(filledInUserData, displayContent);
-          await page.fillAndSubmitBusinessNameStep();
-          await page.stepperClickToReviewStep();
-          await page.clickSubmit();
-          await page.stepperClickToContactsStep();
-          page.fillText("Agent number", "1234567");
+            await page.stepperClickToReviewStep();
+            await page.clickSubmit();
+            expect(
+              page.getStepStateInStepper(LookupStepIndexByName(formationStepName as FormationStepNames))
+            ).toEqual("ERROR");
+            expect(screen.getByText(Config.formation.errorBanner.incompleteStepsError)).toBeInTheDocument();
+          }
+        );
 
-          expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-          expect(screen.queryByText(Config.formation.errorBanner.errorOnStep)).not.toBeInTheDocument();
+        it.each([
+          agentNumber,
+          agentName,
+          agentEmail,
+          agentOfficeAddressLine1,
+          agentOfficeAddressLine2,
+          agentOfficeAddressMunicipality,
+          agentOfficeAddressZipCode,
+          contactFirstName,
+          contactLastName,
+          contactPhoneNumber,
+          paymentType,
+        ])(
+          "shows API error message on step for %o API error",
+          async (fieldName, formationFormData, formationResponse, formationStepName) => {
+            filledInUserData = {
+              ...initialUserData,
+              formationData: {
+                ...initialUserData.formationData,
+                formationFormData: formationFormData as FormationFormData,
+                formationResponse: formationResponse as FormationSubmitResponse,
+              },
+            };
+            const page = preparePage(filledInUserData, displayContent);
+            await page.fillAndSubmitBusinessNameStep();
+            await page.stepperClickToReviewStep();
+            await page.clickSubmit();
+            if (formationStepName === "Contacts") await page.stepperClickToContactsStep();
+            else if (formationStepName === "Billing") await page.stepperClickToBillingStep();
+            expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.errorBanner.errorOnStep);
+            expect(screen.getByRole("alert")).toHaveTextContent(
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              (Config.formation.fields as any)[fieldName as string].label
+            );
+            expect(screen.getByRole("alert")).toHaveTextContent("very bad input");
+          }
+        );
 
-          expect(page.getStepStateInStepper(LookupStepIndexByName("Contacts"))).toEqual("COMPLETE-ACTIVE");
-        });
+        it.each([
+          agentNumber,
+          agentName,
+          agentEmail,
+          agentOfficeAddressLine1,
+          agentOfficeAddressLine2,
+          agentOfficeAddressMunicipality,
+          agentOfficeAddressZipCode,
+          contactFirstName,
+          contactLastName,
+          contactPhoneNumber,
+        ])(
+          "removes %o API error on blur when user changes text field",
+          async (
+            fieldName,
+            formationFormData,
+            formationResponse,
+            formationStepName,
+            fieldLabel,
+            newInput
+          ) => {
+            filledInUserData = {
+              ...initialUserData,
+              formationData: {
+                ...initialUserData.formationData,
+                formationFormData: formationFormData as FormationFormData,
+                formationResponse: formationResponse as FormationSubmitResponse,
+              },
+            };
+            const page = preparePage(filledInUserData, displayContent);
+            await page.fillAndSubmitBusinessNameStep();
+            await page.stepperClickToReviewStep();
+            await page.clickSubmit();
+            if (formationStepName === "Contacts") await page.stepperClickToContactsStep();
+            else if (formationStepName === "Billing") await page.stepperClickToBillingStep();
+            expect(screen.getByRole("alert")).toBeInTheDocument();
+            page.fillText(fieldLabel as string, newInput as string);
+            expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+            expect(screen.queryByText(Config.formation.errorBanner.errorOnStep)).not.toBeInTheDocument();
+
+            expect(
+              page.getStepStateInStepper(LookupStepIndexByName(formationStepName as FormationStepNames))
+            ).toEqual("COMPLETE-ACTIVE");
+          }
+        );
+
+        it.each([paymentType])(
+          "removes %o API error when user selects radio button",
+          async (fieldName, formationFormData, formationResponse, formationStepName) => {
+            filledInUserData = {
+              ...initialUserData,
+              formationData: {
+                ...initialUserData.formationData,
+                formationFormData: formationFormData as FormationFormData,
+                formationResponse: formationResponse as FormationSubmitResponse,
+              },
+            };
+            const page = preparePage(filledInUserData, displayContent);
+            await page.fillAndSubmitBusinessNameStep();
+            await page.stepperClickToReviewStep();
+            await page.clickSubmit();
+            if (formationStepName === "Contacts") await page.stepperClickToContactsStep();
+            else if (formationStepName === "Billing") await page.stepperClickToBillingStep();
+            expect(screen.getByRole("alert")).toBeInTheDocument();
+            fireEvent.click(screen.getByText("Pay with E-Check"));
+            expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+            expect(screen.queryByText(Config.formation.errorBanner.errorOnStep)).not.toBeInTheDocument();
+            expect(
+              page.getStepStateInStepper(LookupStepIndexByName(formationStepName as FormationStepNames))
+            ).toEqual("COMPLETE-ACTIVE");
+          }
+        );
       });
 
       describe("on unknown API error (generic)", () => {

--- a/web/src/components/tasks/business-formation/billing/BillingStep.test.tsx
+++ b/web/src/components/tasks/business-formation/billing/BillingStep.test.tsx
@@ -119,8 +119,10 @@ describe("Formation - BillingStep", () => {
         .checked
     ).toBe(true);
 
-    expect(page.getInputElementByLabel("Credit card").checked).toBe(true);
-    expect(page.getInputElementByLabel("E check").checked).toBe(false);
+    expect(page.getInputElementByLabel(Config.formation.fields.paymentType.creditCardLabel).checked).toBe(
+      true
+    );
+    expect(page.getInputElementByLabel(Config.formation.fields.paymentType.achLabel).checked).toBe(false);
   });
 
   describe("certificateOfStanding", () => {
@@ -210,11 +212,11 @@ describe("Formation - BillingStep", () => {
     expect(screen.getByLabelText(subtotalLabel)).toHaveTextContent(finalTotal.toString());
     expect(screen.getByLabelText(totalLabel)).toHaveTextContent(finalTotal.toString());
 
-    fireEvent.click(screen.getByLabelText("Credit card"));
+    fireEvent.click(screen.getByLabelText(Config.formation.fields.paymentType.creditCardLabel));
     expect(screen.getByLabelText(totalLabel)).toHaveTextContent(
       (finalTotal + ccInitialCost + ccExtraCost).toString()
     );
-    fireEvent.click(screen.getByLabelText("E check"));
+    fireEvent.click(screen.getByLabelText(Config.formation.fields.paymentType.achLabel));
     const numberOfDocuments = 2;
     expect(screen.getByLabelText(totalLabel)).toHaveTextContent(
       (finalTotal + achCost * numberOfDocuments).toString()

--- a/web/src/components/tasks/business-formation/billing/PaymentTypeTable.tsx
+++ b/web/src/components/tasks/business-formation/billing/PaymentTypeTable.tsx
@@ -12,7 +12,7 @@ import React, { ReactElement, useContext, useEffect, useState } from "react";
 export const PaymentTypeTable = (): ReactElement => {
   const FIELD = "paymentType";
   const { Config } = useConfig();
-  const { state, setFormationFormData } = useContext(BusinessFormationContext);
+  const { state, setFormationFormData, setFieldsInteracted } = useContext(BusinessFormationContext);
 
   const achPaymentCost = Number.parseFloat(Config.formation.fields.paymentType.paymentCosts.ach);
   const ccPaymentCostExtra = Number.parseFloat(
@@ -64,6 +64,7 @@ export const PaymentTypeTable = (): ReactElement => {
         paymentType: event.target.value as PaymentType,
       };
     });
+    setFieldsInteracted([FIELD]);
   };
 
   const hasError = doesFieldHaveError(FIELD);
@@ -98,9 +99,6 @@ export const PaymentTypeTable = (): ReactElement => {
                   color={hasError ? "error" : "primary"}
                   checked={state.formationFormData.paymentType === "CC"}
                   onChange={handleChange}
-                  inputProps={{
-                    "aria-label": "Credit card",
-                  }}
                   value="CC"
                   name="radio-buttons"
                 />
@@ -108,7 +106,7 @@ export const PaymentTypeTable = (): ReactElement => {
             </td>
             <td>
               <label
-                htmlFor="creditCardRadio"
+                htmlFor="paymentTypeCreditCardRadio"
                 className={
                   hasError
                     ? "text-error-dark"
@@ -133,9 +131,6 @@ export const PaymentTypeTable = (): ReactElement => {
                   checked={state.formationFormData.paymentType === "ACH"}
                   onChange={handleChange}
                   value="ACH"
-                  inputProps={{
-                    "aria-label": "E check",
-                  }}
                   name="radio-buttons"
                 />
               </div>

--- a/web/src/components/tasks/business-formation/getFieldForApiField.ts
+++ b/web/src/components/tasks/business-formation/getFieldForApiField.ts
@@ -5,6 +5,16 @@ export const UNKNOWN_API_ERROR_FIELD = "UNKNOWN_API_ERROR_FIELD";
 
 const fieldToApiFieldMapping: Record<string, string> = {
   agentNumber: "Registered Agent - Id",
+  agentName: "Registered Agent - Name",
+  agentEmail: "Registered Agent - Email",
+  contactFirstName: "Contact First Name",
+  contactLastName: "Contact Last Name",
+  contactPhoneNumber: "Contact Phone Number",
+  agentOfficeAddressLine1: "Registered Agent - Street Address - Address1",
+  agentOfficeAddressLine2: "Registered Agent - Street Address - Address2",
+  agentOfficeAddressMunicipality: "Registered Agent - Street Address - City",
+  agentOfficeAddressZipCode: "Registered Agent - Street Address - Zipcode",
+  paymentType: "Select Payment Type",
 };
 
 const apiFieldToFieldMapping = invert(fieldToApiFieldMapping);

--- a/web/test/helpers/helpers-formation.tsx
+++ b/web/test/helpers/helpers-formation.tsx
@@ -419,7 +419,7 @@ export const createFormationPageHelpers = (): FormationPageHelpers => {
   };
 
   const completeRequiredBillingFields = () => {
-    fireEvent.click(screen.getByLabelText("Credit card"));
+    fireEvent.click(screen.getByLabelText(Config.formation.fields.paymentType.creditCardLabel));
     fillText("Contact first name", "John");
     fillText("Contact last name", "Smith");
     fillText("Contact phone number", "1234567890");


### PR DESCRIPTION
I've completed the mapping for the registered agent, and the contacts tab

note: within registered agent fields the following fields were not done, let me know if you disagree.
-  State -- logic is hard coded
-  Country -- logic is hard coded

note: within the contacts tab the following fields were not done, let me know if you disagree.
- Gov2GoAnnualReports -- data is a boolean value, unable to get error
- Gov2GoCorpWatch -- data is a boolean value, unable to get error
- ShortGoodStanding -- data is a boolean value, unable to get error
- Certified -- data is a boolean value, unable to get error

Below are the fields that are sent in the post request, can you review and let me know if anything should be mapped? 

    ForeignGoodStandingFile: {
      Extension - unable to get error
      Content- unable to get error
    },
    Payer: {
      CompanyName - unable to get error
      Address1 - unable to get error
      Address2 - unable to get error
      City - unable to get error
      StateAbbreviation - unable to get error
      ZipCode - unable to get error
      Email - unable to get error
    },
    Business - user selects via onboarding
    CompanyProfit - hard coded
    MemberAttestation - hard coded
    CompanyOrigin - hard coded
    PayerEmail - users email
    Naic - pulled from profile data
    PracticesLaw - hard coded