### PR TITLE
Find and replace all instances of "==" with "==="

### DIFF
--- a/api/serverless.ts
+++ b/api/serverless.ts
@@ -7,7 +7,7 @@ import express from "./src/functions/express";
 import githubOauth2 from "./src/functions/githubOauth2";
 import updateExternalStatus from "./src/functions/updateExternalStatus";
 
-const isDocker = process.env.IS_DOCKER == "true" || false; // set in docker-compose
+const isDocker = process.env.IS_DOCKER === "true" || false; // set in docker-compose
 const stage = process.env.STAGE || "local";
 const dynamoOfflinePort = process.env.DYNAMO_PORT || 8000;
 const offlinePort = process.env.API_PORT || 5002;

--- a/api/src/api/externalEndpointRouter.ts
+++ b/api/src/api/externalEndpointRouter.ts
@@ -17,7 +17,7 @@ export const externalEndpointRouterFactory = (
     let userData = req.body as UserData;
     let isAnonymous;
     try {
-      isAnonymous = getSignedInUserId(req) != userData.user.id;
+      isAnonymous = getSignedInUserId(req) !== userData.user.id;
     } catch {
       isAnonymous = true;
     }
@@ -39,7 +39,7 @@ export const externalEndpointRouterFactory = (
     let userData = req.body as UserData;
     let isAnonymous;
     try {
-      isAnonymous = getSignedInUserId(req) != userData.user.id;
+      isAnonymous = getSignedInUserId(req) !== userData.user.id;
     } catch {
       isAnonymous = true;
     }

--- a/api/src/client/ApiFormationClient.test.ts
+++ b/api/src/client/ApiFormationClient.test.ts
@@ -311,11 +311,13 @@ describe("ApiFormationClient", () => {
                 Address2: formationFormData.addressLine2,
                 City: formationFormData.addressCity,
                 State:
-                  formationFormData.addressCountry == "US" ? formationFormData.addressState?.name : undefined,
+                  formationFormData.addressCountry === "US"
+                    ? formationFormData.addressState?.name
+                    : undefined,
                 Zipcode: formationFormData.addressZipCode,
                 Country: formationFormData.addressCountry,
                 Province:
-                  formationFormData.addressCountry == "US" ? undefined : formationFormData.addressProvince,
+                  formationFormData.addressCountry === "US" ? undefined : formationFormData.addressProvince,
               },
             },
             CompanyProfit: "Profit",
@@ -609,11 +611,13 @@ describe("ApiFormationClient", () => {
                 Address2: formationFormData.addressLine2,
                 City: formationFormData.addressCity,
                 State:
-                  formationFormData.addressCountry == "US" ? formationFormData.addressState?.name : undefined,
+                  formationFormData.addressCountry === "US"
+                    ? formationFormData.addressState?.name
+                    : undefined,
                 Zipcode: formationFormData.addressZipCode,
                 Country: formationFormData.addressCountry,
                 Province:
-                  formationFormData.addressCountry == "US" ? undefined : formationFormData.addressProvince,
+                  formationFormData.addressCountry === "US" ? undefined : formationFormData.addressProvince,
               },
             },
             CompanyProfit: "Profit",
@@ -864,11 +868,13 @@ describe("ApiFormationClient", () => {
                 Address2: formationFormData.addressLine2,
                 City: formationFormData.addressCity,
                 State:
-                  formationFormData.addressCountry == "US" ? formationFormData.addressState?.name : undefined,
+                  formationFormData.addressCountry === "US"
+                    ? formationFormData.addressState?.name
+                    : undefined,
                 Zipcode: formationFormData.addressZipCode,
                 Country: formationFormData.addressCountry,
                 Province:
-                  formationFormData.addressCountry == "US" ? undefined : formationFormData.addressProvince,
+                  formationFormData.addressCountry === "US" ? undefined : formationFormData.addressProvince,
               },
             },
             CompanyProfit: "Profit",

--- a/api/src/client/ApiFormationClient.ts
+++ b/api/src/client/ApiFormationClient.ts
@@ -162,54 +162,61 @@ export const ApiFormationClient = (config: ApiConfig, logger: LogWriterType): Fo
 
     const businessType = BusinessTypeMap[toFormationLegalStructure];
 
-    const isCorp = businessType.shortDescription == "DP";
-    const isForeignCorp = businessType.shortDescription == "FR";
+    const isCorp = businessType.shortDescription === "DP";
+    const isForeignCorp = businessType.shortDescription === "FR";
 
     const getAdditionalProvisions = (): Provisions => {
       const additionalProvisions =
         formationFormData.provisions?.map((it: string) => {
           return { Provision: it };
         }) ?? [];
-      if (toFormationLegalStructure == "limited-partnership") {
-        return {
-          AdditionalLimitedPartnership: {
-            AggregateAmount: formationFormData.combinedInvestment,
-            LimitedCanCreateLimited: formationFormData.canCreateLimitedPartner ? "Yes" : "No",
-            LimitedCanCreateLimitedTerms: formationFormData.createLimitedPartnerTerms,
-            LimitedCanGetDistribution: formationFormData.canGetDistribution ? "Yes" : "No",
-            LimitedCanGetDistributionTerms: formationFormData.getDistributionTerms,
-            LimitedCanMakeDistribution: formationFormData.canMakeDistribution ? "Yes" : "No",
-            LimitedCanMakeDistributionTerms: formationFormData.makeDistributionTerms,
-            GeneralPartnerWithdrawal: formationFormData.withdrawals,
-            DissolutionPlan: formationFormData.dissolution,
-            AdditionalProvisions: additionalProvisions,
-          },
-        };
-      } else if (toFormationLegalStructure == "foreign-limited-partnership") {
-        return {
-          AdditionalForeignLimitedPartnership: {
-            AggregateAmount: formationFormData.combinedInvestment,
-            AdditionalProvisions: additionalProvisions,
-          },
-        };
-      } else if (toFormationLegalStructure == "limited-liability-company") {
-        return {
-          AdditionalLimitedLiabilityCompany: {
-            OtherProvisions: additionalProvisions,
-          },
-        };
-      } else if (toFormationLegalStructure == "limited-liability-partnership") {
-        return {
-          AdditionalLimitedLiabilityPartnership: {
-            OtherProvisions: additionalProvisions,
-          },
-        };
-      } else if (["c-corporation", "s-corporation"].includes(toFormationLegalStructure)) {
-        return {
-          AdditionalCCorpOrProfessionalCorp: {
-            AdditionalProvisions: additionalProvisions,
-          },
-        };
+      switch (toFormationLegalStructure) {
+        case "limited-partnership": {
+          return {
+            AdditionalLimitedPartnership: {
+              AggregateAmount: formationFormData.combinedInvestment,
+              LimitedCanCreateLimited: formationFormData.canCreateLimitedPartner ? "Yes" : "No",
+              LimitedCanCreateLimitedTerms: formationFormData.createLimitedPartnerTerms,
+              LimitedCanGetDistribution: formationFormData.canGetDistribution ? "Yes" : "No",
+              LimitedCanGetDistributionTerms: formationFormData.getDistributionTerms,
+              LimitedCanMakeDistribution: formationFormData.canMakeDistribution ? "Yes" : "No",
+              LimitedCanMakeDistributionTerms: formationFormData.makeDistributionTerms,
+              GeneralPartnerWithdrawal: formationFormData.withdrawals,
+              DissolutionPlan: formationFormData.dissolution,
+              AdditionalProvisions: additionalProvisions,
+            },
+          };
+        }
+        case "foreign-limited-partnership": {
+          return {
+            AdditionalForeignLimitedPartnership: {
+              AggregateAmount: formationFormData.combinedInvestment,
+              AdditionalProvisions: additionalProvisions,
+            },
+          };
+        }
+        case "limited-liability-company": {
+          return {
+            AdditionalLimitedLiabilityCompany: {
+              OtherProvisions: additionalProvisions,
+            },
+          };
+        }
+        case "limited-liability-partnership": {
+          return {
+            AdditionalLimitedLiabilityPartnership: {
+              OtherProvisions: additionalProvisions,
+            },
+          };
+        }
+        default:
+          if (["c-corporation", "s-corporation"].includes(toFormationLegalStructure)) {
+            return {
+              AdditionalCCorpOrProfessionalCorp: {
+                AdditionalProvisions: additionalProvisions,
+              },
+            };
+          }
       }
       return {};
     };

--- a/api/src/client/ApiTaxFilingClient.test.ts
+++ b/api/src/client/ApiTaxFilingClient.test.ts
@@ -100,7 +100,7 @@ const generateErroredApiTaxFilingOnboardingResponse = (
   return {
     ApiKey: `some-ApiKey-${randomInt()}`,
     Errors:
-      statusCode == 400
+      statusCode === 400
         ? [
             {
               Error: `some-error-content-${randomInt()}`,

--- a/api/src/client/ApiTaxFilingClient.ts
+++ b/api/src/client/ApiTaxFilingClient.ts
@@ -134,7 +134,7 @@ export const ApiTaxFilingClient = (config: ApiConfig, logger: LogWriterType): Ta
 
       const apiResponse = response.data as ApiTaxFilingOnboardingResponse;
 
-      return apiResponse.StatusCode == 200 ? { state: "SUCCESS" } : { state: "API_ERROR" };
+      return apiResponse.StatusCode === 200 ? { state: "SUCCESS" } : { state: "API_ERROR" };
     } catch (error) {
       const axiosError = error as AxiosError;
       const apiResponse = axiosError.response?.data as ApiTaxFilingOnboardingResponse;

--- a/api/src/db/migrations/v100_add_updated_timestamp.ts
+++ b/api/src/db/migrations/v100_add_updated_timestamp.ts
@@ -480,7 +480,7 @@ export const v100generateFormationFormData = (
     agentUseAccountInfo: !!(randomInt() % 2),
     agentUseBusinessAddress: !!(randomInt() % 2),
     signers: [{ name: "some-name", signature: "some-signature", title: "some-title" }],
-    members: legalStructureId == "limited-liability-partnership" ? [] : [v100generateFormationMember({})],
+    members: legalStructureId === "limited-liability-partnership" ? [] : [v100generateFormationMember({})],
     paymentType: randomInt() % 2 ? "ACH" : "CC",
     annualReportNotification: !!(randomInt() % 2),
     corpWatchNotification: !!(randomInt() % 2),

--- a/api/src/db/migrations/v101_change_error_field.ts
+++ b/api/src/db/migrations/v101_change_error_field.ts
@@ -478,7 +478,7 @@ export const generateV101FormationFormData = (
     agentUseAccountInfo: !!(randomInt() % 2),
     agentUseBusinessAddress: !!(randomInt() % 2),
     signers: [{ name: "some-name", signature: "some-signature", title: "some-title" }],
-    members: legalStructureId == "limited-liability-partnership" ? [] : [generateV101FormationMember({})],
+    members: legalStructureId === "limited-liability-partnership" ? [] : [generateV101FormationMember({})],
     paymentType: randomInt() % 2 ? "ACH" : "CC",
     annualReportNotification: !!(randomInt() % 2),
     corpWatchNotification: !!(randomInt() % 2),

--- a/api/src/db/migrations/v102_rename_tax_registration_nudge.ts
+++ b/api/src/db/migrations/v102_rename_tax_registration_nudge.ts
@@ -476,7 +476,7 @@ export const generateV102FormationFormData = (
     agentUseAccountInfo: !!(randomInt() % 2),
     agentUseBusinessAddress: !!(randomInt() % 2),
     signers: [{ name: "some-name", signature: "some-signature", title: "some-title" }],
-    members: legalStructureId == "limited-liability-partnership" ? [] : [generateV102FormationMember({})],
+    members: legalStructureId === "limited-liability-partnership" ? [] : [generateV102FormationMember({})],
     paymentType: randomInt() % 2 ? "ACH" : "CC",
     annualReportNotification: !!(randomInt() % 2),
     corpWatchNotification: !!(randomInt() % 2),

--- a/api/src/db/migrations/v103_change_tax_calendar_view_default.ts
+++ b/api/src/db/migrations/v103_change_tax_calendar_view_default.ts
@@ -470,7 +470,7 @@ export const generateV103FormationFormData = (
     agentUseAccountInfo: !!(randomInt() % 2),
     agentUseBusinessAddress: !!(randomInt() % 2),
     signers: [{ name: "some-name", signature: "some-signature", title: "some-title" }],
-    members: legalStructureId == "limited-liability-partnership" ? [] : [generateV103FormationMember({})],
+    members: legalStructureId === "limited-liability-partnership" ? [] : [generateV103FormationMember({})],
     paymentType: randomInt() % 2 ? "ACH" : "CC",
     annualReportNotification: !!(randomInt() % 2),
     corpWatchNotification: !!(randomInt() % 2),

--- a/api/src/db/migrations/v104_add_needs_nexus_dba_name_field.ts
+++ b/api/src/db/migrations/v104_add_needs_nexus_dba_name_field.ts
@@ -21,7 +21,7 @@ export const migrate_v103_to_v104 = (v103Data: v103UserData): v104UserData => {
     profileData: {
       ...v103Data.profileData,
       nexusDbaName: v103Data.profileData.nexusDbaName ?? "",
-      needsNexusDbaName: v103Data.profileData.nexusDbaName == undefined ? false : true,
+      needsNexusDbaName: v103Data.profileData.nexusDbaName === undefined ? false : true,
     },
     version: 104,
   };
@@ -469,7 +469,7 @@ export const generateV104FormationFormData = (
     agentUseAccountInfo: !!(randomInt() % 2),
     agentUseBusinessAddress: !!(randomInt() % 2),
     signers: [{ name: "some-name", signature: "some-signature", title: "some-title" }],
-    members: legalStructureId == "limited-liability-partnership" ? [] : [generateV104FormationMember({})],
+    members: legalStructureId === "limited-liability-partnership" ? [] : [generateV104FormationMember({})],
     paymentType: randomInt() % 2 ? "ACH" : "CC",
     annualReportNotification: !!(randomInt() % 2),
     corpWatchNotification: !!(randomInt() % 2),

--- a/api/src/db/migrations/v105_add_pet_care_essential_question.ts
+++ b/api/src/db/migrations/v105_add_pet_care_essential_question.ts
@@ -20,7 +20,7 @@ export const migrate_v104_to_v105 = (v104Data: v104UserData): v105UserData => {
     ...v104Data,
     profileData: {
       ...v104Data.profileData,
-      willSellPetCareItems: v104Data.profileData.industryId == "petcare" ? true : undefined,
+      willSellPetCareItems: v104Data.profileData.industryId === "petcare" ? true : undefined,
     },
     version: 105,
   };
@@ -455,7 +455,7 @@ export const generateV105FormationFormData = (
     agentUseAccountInfo: !!(randomInt() % 2),
     agentUseBusinessAddress: !!(randomInt() % 2),
     signers: [{ name: "some-name", signature: "some-signature", title: "some-title" }],
-    members: legalStructureId == "limited-liability-partnership" ? [] : [generateV105FormationMember({})],
+    members: legalStructureId === "limited-liability-partnership" ? [] : [generateV105FormationMember({})],
     paymentType: randomInt() % 2 ? "ACH" : "CC",
     annualReportNotification: !!(randomInt() % 2),
     corpWatchNotification: !!(randomInt() % 2),

--- a/api/src/db/migrations/v106_add_pet_care_housing_essential_question.ts
+++ b/api/src/db/migrations/v106_add_pet_care_housing_essential_question.ts
@@ -20,7 +20,7 @@ export const migrate_v105_to_v106 = (v105Data: v105UserData): v106UserData => {
     ...v105Data,
     profileData: {
       ...v105Data.profileData,
-      petCareHousing: v105Data.profileData.industryId == "petcare" ? true : undefined,
+      petCareHousing: v105Data.profileData.industryId === "petcare" ? true : undefined,
     },
     version: 106,
   };
@@ -456,7 +456,7 @@ export const generateV106FormationFormData = (
     agentUseAccountInfo: !!(randomInt() % 2),
     agentUseBusinessAddress: !!(randomInt() % 2),
     signers: [{ name: "some-name", signature: "some-signature", title: "some-title" }],
-    members: legalStructureId == "limited-liability-partnership" ? [] : [generateV106FormationMember({})],
+    members: legalStructureId === "limited-liability-partnership" ? [] : [generateV106FormationMember({})],
     paymentType: randomInt() % 2 ? "ACH" : "CC",
     annualReportNotification: !!(randomInt() % 2),
     corpWatchNotification: !!(randomInt() % 2),

--- a/api/src/db/migrations/v96_added_date_field_to_tax_filing_data.ts
+++ b/api/src/db/migrations/v96_added_date_field_to_tax_filing_data.ts
@@ -414,7 +414,7 @@ export const v96generateFormationFormData = (
       v96generateFormationAddress({ signature: true }),
       v96generateFormationAddress({ signature: true }),
     ],
-    members: legalStructureId == "limited-liability-partnership" ? [] : [v96generateFormationAddress({})],
+    members: legalStructureId === "limited-liability-partnership" ? [] : [v96generateFormationAddress({})],
     paymentType: randomInt() % 2 ? "ACH" : "CC",
     annualReportNotification: !!(randomInt() % 2),
     corpWatchNotification: !!(randomInt() % 2),

--- a/api/src/db/migrations/v97_updating_formation_types.ts
+++ b/api/src/db/migrations/v97_updating_formation_types.ts
@@ -59,7 +59,7 @@ export const migrate_v96_to_v97 = (v96Data: v96UserData): v97UserData => {
             return {
               ...signer,
               addressState: arrayOfStateObjects.find((state) => {
-                return state.name == signer.addressState;
+                return state.name === signer.addressState;
               }),
               addressCountry: "US",
               title: v97businessSignerTypeMap[props.profileData.legalStructureId ?? ""][0],
@@ -74,7 +74,7 @@ export const migrate_v96_to_v97 = (v96Data: v96UserData): v97UserData => {
             return {
               ...member,
               addressState: arrayOfStateObjects.find((state) => {
-                return state.name == member.addressState;
+                return state.name === member.addressState;
               }),
               addressCountry: "US",
             };
@@ -662,7 +662,7 @@ export const v97generateFormationFormData = (
     agentUseAccountInfo: !!(randomInt() % 2),
     agentUseBusinessAddress: !!(randomInt() % 2),
     signers: [{ name: "some-name", signature: "some-signature", title: "some-title" }],
-    members: legalStructureId == "limited-liability-partnership" ? [] : [v97generateFormationMember({})],
+    members: legalStructureId === "limited-liability-partnership" ? [] : [v97generateFormationMember({})],
     paymentType: randomInt() % 2 ? "ACH" : "CC",
     annualReportNotification: !!(randomInt() % 2),
     corpWatchNotification: !!(randomInt() % 2),

--- a/api/src/db/migrations/v98_add_phase_newly_changed.ts
+++ b/api/src/db/migrations/v98_add_phase_newly_changed.ts
@@ -465,7 +465,7 @@ export const v98generateFormationFormData = (
     agentUseAccountInfo: !!(randomInt() % 2),
     agentUseBusinessAddress: !!(randomInt() % 2),
     signers: [{ name: "some-name", signature: "some-signature", title: "some-title" }],
-    members: legalStructureId == "limited-liability-partnership" ? [] : [v98generateFormationMember({})],
+    members: legalStructureId === "limited-liability-partnership" ? [] : [v98generateFormationMember({})],
     paymentType: randomInt() % 2 ? "ACH" : "CC",
     annualReportNotification: !!(randomInt() % 2),
     corpWatchNotification: !!(randomInt() % 2),

--- a/api/src/domain/s3Writer.ts
+++ b/api/src/domain/s3Writer.ts
@@ -44,7 +44,7 @@ export const getFileFromURL = async function (URI: string): Promise<AxiosRespons
 
 const escapeColons = (value: string) => {
   const segments = value.split(":");
-  if (segments.length == 1) {
+  if (segments.length === 1) {
     return value;
   }
   const initial = segments.shift();

--- a/api/src/domain/user/maskTaxId.ts
+++ b/api/src/domain/user/maskTaxId.ts
@@ -1,7 +1,7 @@
 import { maskingCharacter } from "@shared/profileData";
 
 export const maskTaxId = (taxId: string): string => {
-  return taxId.length == 12
+  return taxId.length === 12
     ? `${maskingCharacter.repeat(7)}${taxId.slice(7, taxId.length)}`
     : `${maskingCharacter.repeat(5)}${taxId.slice(5, taxId.length)}`;
 };

--- a/api/test/factories.ts
+++ b/api/test/factories.ts
@@ -136,7 +136,7 @@ export const generateTaxFilingData = (overrides: Partial<TaxFilingData>): TaxFil
     state: undefined,
     businessName: undefined,
     errorField:
-      overrides.state == "FAILED"
+      overrides.state === "FAILED"
         ? randomElementFromArray(["businessName", "formFailure", undefined])
         : undefined,
     lastUpdatedISO: overrides.state ? new Date(Date.now()).toISOString() : undefined,

--- a/shared/src/formationData.ts
+++ b/shared/src/formationData.ts
@@ -11,7 +11,7 @@ export const castPublicFilingLegalTypeToFormationType = (
   legalStructureId: PublicFilingLegalType,
   persona: BusinessPersona | undefined
 ): FormationLegalType => {
-  return `${persona == "FOREIGN" ? foreignLegalTypePrefix : ""}${legalStructureId}` as FormationLegalType;
+  return `${persona === "FOREIGN" ? foreignLegalTypePrefix : ""}${legalStructureId}` as FormationLegalType;
 };
 
 export type SignerTitle =

--- a/shared/src/test/formationFactories.ts
+++ b/shared/src/test/formationFactories.ts
@@ -30,7 +30,7 @@ export const generateFormationUSAddress = (overrides: Partial<FormationAddress>)
     addressCity: `some-address-city-${randomInt()}`,
     addressState: randomElementFromArray(
       states.filter((state) => {
-        return state.shortCode != "NJ";
+        return state.shortCode !== "NJ";
       })
     ),
     addressCountry: "US",
@@ -52,7 +52,7 @@ export const generateFormationForeignAddress = (overrides: Partial<FormationAddr
     businessLocationType: "INTL",
     addressCountry: randomElementFromArray(
       countries.filter((item) => {
-        return item.shortCode != "US";
+        return item.shortCode !== "US";
       })
     ).shortCode,
     addressProvince: `some-address-province-${randomInt()}`,

--- a/web/cypress/support/helpers.ts
+++ b/web/cypress/support/helpers.ts
@@ -912,7 +912,7 @@ export const generateFormationUSAddress = (overrides: Partial<FormationAddress>)
     addressCity: `some-address-city-${randomInt()}`,
     addressState: randomElementFromArray(
       states.filter((state) => {
-        return state.shortCode != "NJ";
+        return state.shortCode !== "NJ";
       })
     ),
     addressCountry: "US",
@@ -934,7 +934,7 @@ export const generateFormationForeignAddress = (overrides: Partial<FormationAddr
     addressMunicipality: undefined,
     addressCountry: randomElementFromArray(
       countries.filter((item) => {
-        return item.shortCode != "US";
+        return item.shortCode !== "US";
       })
     ).shortCode,
     addressProvince: `some-address-province-${randomInt()}`,

--- a/web/src/components/CountryDropdown.tsx
+++ b/web/src/components/CountryDropdown.tsx
@@ -59,13 +59,13 @@ export const CountryDropdown = (props: Props): ReactElement => {
   const filteredCountries = () =>
     props.excludeUS
       ? countries.filter((country) => {
-          return country.shortCode != "US";
+          return country.shortCode !== "US";
         })
       : countries;
 
   const getCountry = (value: string | undefined): CountriesObject | undefined => {
     return filteredCountries().find((country: CountriesObject) => {
-      return country.name == value || country.shortCode == value?.toUpperCase();
+      return country.name === value || country.shortCode === value?.toUpperCase();
     });
   };
 

--- a/web/src/components/StateDropdown.tsx
+++ b/web/src/components/StateDropdown.tsx
@@ -59,13 +59,13 @@ export const StateDropdown = (props: Props): ReactElement => {
   const filteredStates = () =>
     props.excludeNJ
       ? states.filter((stateObject) => {
-          return stateObject.shortCode != "NJ";
+          return stateObject.shortCode !== "NJ";
         })
       : states;
 
   const getState = (value: string | undefined): StateObject | undefined => {
     return filteredStates().find((state: StateObject) => {
-      return state.name == value || state.shortCode == value?.toUpperCase();
+      return state.name === value || state.shortCode === value?.toUpperCase();
     });
   };
 

--- a/web/src/components/Step.tsx
+++ b/web/src/components/Step.tsx
@@ -47,7 +47,7 @@ export const Step = (props: Props): ReactElement => {
           <ul className="usa-list usa-list--unstyled">
             {roadmap?.tasks
               .filter((task) => {
-                return task.stepNumber == props.step.stepNumber;
+                return task.stepNumber === props.step.stepNumber;
               })
               .map((task) => {
                 return <Task key={task.id} task={task} />;

--- a/web/src/components/TaxFilingLookupModal.tsx
+++ b/web/src/components/TaxFilingLookupModal.tsx
@@ -74,7 +74,7 @@ export const TaxFilingLookupModal = (props: Props): ReactElement => {
   };
 
   const errorAlert = (): ReactElement => {
-    if (userData?.taxFilingData.errorField == "businessName" && apiFailed == "FAILED") {
+    if (userData?.taxFilingData.errorField === "businessName" && apiFailed === "FAILED") {
       return (
         <>
           {Config.taxCalendar.failedErrorMessageHeader}
@@ -83,7 +83,7 @@ export const TaxFilingLookupModal = (props: Props): ReactElement => {
           </ul>
         </>
       );
-    } else if (apiFailed == "FAILED") {
+    } else if (apiFailed === "FAILED") {
       return (
         <>
           {Config.taxCalendar.failedErrorMessageHeader}
@@ -108,7 +108,7 @@ export const TaxFilingLookupModal = (props: Props): ReactElement => {
       let userDataToSet: UserData;
 
       const encryptedTaxId =
-        profileData.taxId == userData.profileData.taxId ? profileData.encryptedTaxId : undefined;
+        profileData.taxId === userData.profileData.taxId ? profileData.encryptedTaxId : undefined;
 
       try {
         let businessNameToSubmitToTaxApi = "";
@@ -143,26 +143,26 @@ export const TaxFilingLookupModal = (props: Props): ReactElement => {
 
       await update(userDataToSet);
 
-      if (userDataToSet.taxFilingData.state == "SUCCESS") {
+      if (userDataToSet.taxFilingData.state === "SUCCESS") {
         setIsLoading(false);
         analytics.event.tax_calendar_modal.submit.tax_deadlines_added_to_calendar();
         props.onSuccess();
       }
 
-      if (userDataToSet.taxFilingData.state == "PENDING") {
+      if (userDataToSet.taxFilingData.state === "PENDING") {
         setIsLoading(false);
         analytics.event.tax_calendar_modal.submit.business_exists_but_not_in_Gov2Go();
         props.close();
       }
 
-      if (userDataToSet.taxFilingData.state == "FAILED") {
-        if (userDataToSet.taxFilingData.errorField == "businessName" && displayBusinessName()) {
+      if (userDataToSet.taxFilingData.state === "FAILED") {
+        if (userDataToSet.taxFilingData.errorField === "businessName" && displayBusinessName()) {
           formContextState.reducer({
             type: FieldStateActionKind.VALIDATION,
             payload: { field: "businessName", invalid: true },
           });
         } else if (
-          userDataToSet.taxFilingData.errorField == "businessName" &&
+          userDataToSet.taxFilingData.errorField === "businessName" &&
           displayResponsibleOwnerName()
         ) {
           formContextState.reducer({
@@ -180,7 +180,7 @@ export const TaxFilingLookupModal = (props: Props): ReactElement => {
         setIsLoading(false);
       }
 
-      if (userDataToSet.taxFilingData.state == "API_ERROR") {
+      if (userDataToSet.taxFilingData.state === "API_ERROR") {
         setOnAPIfailed("UNKNOWN");
         setIsLoading(false);
       }

--- a/web/src/components/auth/SelfRegSnackbar.tsx
+++ b/web/src/components/auth/SelfRegSnackbar.tsx
@@ -15,7 +15,7 @@ export const SelfRegSnackbar = (): ReactElement => {
     useContext(AuthAlertContext);
 
   useEffect(() => {
-    if (registrationAlertStatus == "IN_PROGRESS" && isAuthenticated == IsAuthenticated.TRUE) {
+    if (registrationAlertStatus === "IN_PROGRESS" && isAuthenticated === IsAuthenticated.TRUE) {
       analytics.event.roadmap_dashboard.arrive.arrive_from_myNJ_registration();
       setRegistrationAlertStatus("SUCCESS");
     }
@@ -51,7 +51,7 @@ export const SelfRegSnackbar = (): ReactElement => {
       dataTestid="reg-snackbar"
     >
       <div className="fin fac padding-y-2 padding-right-3">
-        {alertMap[registrationAlertStatus] == "success" ? (
+        {alertMap[registrationAlertStatus] === "success" ? (
           <img
             src={`/img/congratulations-green.svg`}
             alt="congratulations"
@@ -62,7 +62,7 @@ export const SelfRegSnackbar = (): ReactElement => {
           <></>
         )}
         <div>
-          {alertMap[registrationAlertStatus] == "success" ? (
+          {alertMap[registrationAlertStatus] === "success" ? (
             <Content className="padding-right-2">{Config.navigationDefaults.guestSuccessTitle}</Content>
           ) : (
             <></>

--- a/web/src/components/auth/SignUpModal.tsx
+++ b/web/src/components/auth/SignUpModal.tsx
@@ -25,12 +25,12 @@ export const SignUpModal = (): ReactElement => {
   } = useContext(AuthAlertContext);
 
   useMountEffectWhenDefined(() => {
-    if (isAuthenticated == IsAuthenticated.TRUE) {
+    if (isAuthenticated === IsAuthenticated.TRUE) {
       setRegistrationModalIsVisible(false);
     }
   }, isAuthenticated);
 
-  if (isAuthenticated == IsAuthenticated.TRUE) {
+  if (isAuthenticated === IsAuthenticated.TRUE) {
     return <></>;
   }
 

--- a/web/src/components/auth/SignUpModalWrapper.tsx
+++ b/web/src/components/auth/SignUpModalWrapper.tsx
@@ -6,12 +6,12 @@ import { ReactElement, ReactNode, useContext } from "react";
 export const SignUpModalWrapper = (props: { children: ReactNode }): ReactElement => {
   const { isAuthenticated, setRegistrationModalIsVisible } = useContext(AuthAlertContext);
   useMountEffectWhenDefined(() => {
-    if (isAuthenticated != IsAuthenticated.TRUE) {
+    if (isAuthenticated !== IsAuthenticated.TRUE) {
       setRegistrationModalIsVisible(true);
     }
   }, isAuthenticated);
 
-  if (isAuthenticated != IsAuthenticated.TRUE) {
+  if (isAuthenticated !== IsAuthenticated.TRUE) {
     return (
       <div className="disabled-overlay">
         <div className="cursor-wrapper">{props.children}</div>

--- a/web/src/components/filings-calendar/FilingsCalendar.test.tsx
+++ b/web/src/components/filings-calendar/FilingsCalendar.test.tsx
@@ -526,7 +526,7 @@ describe("<FilingsCalendar />", () => {
           legalStructureId: randomLegalStructure({ requiresPublicFiling: true }).id,
           operatingPhase: randomElementFromArray(
             OperatingPhases.filter((obj) => {
-              return obj.displayTaxAccessButton === true && obj.displayCalendarType != "NONE";
+              return obj.displayTaxAccessButton === true && obj.displayCalendarType !== "NONE";
             })
           ).id,
         }),
@@ -555,7 +555,7 @@ describe("<FilingsCalendar />", () => {
           legalStructureId: randomLegalStructure({ requiresPublicFiling: false }).id,
           operatingPhase: randomElementFromArray(
             OperatingPhases.filter((obj) => {
-              return obj.displayTaxAccessButton === true && obj.displayCalendarType != "NONE";
+              return obj.displayTaxAccessButton === true && obj.displayCalendarType !== "NONE";
             })
           ).id,
         }),
@@ -587,7 +587,7 @@ describe("<FilingsCalendar />", () => {
           legalStructureId: randomLegalStructure({ requiresPublicFiling: true }).id,
           operatingPhase: randomElementFromArray(
             OperatingPhases.filter((obj) => {
-              return obj.displayTaxAccessButton !== true && obj.displayCalendarType != "NONE";
+              return obj.displayTaxAccessButton !== true && obj.displayCalendarType !== "NONE";
             })
           ).id,
         }),

--- a/web/src/components/filings-calendar/FilingsCalendarAsList.tsx
+++ b/web/src/components/filings-calendar/FilingsCalendarAsList.tsx
@@ -72,7 +72,7 @@ export const FilingsCalendarAsList = (props: Props): ReactElement => {
               {filings.map((filing, index) => (
                 <div
                   key={`${filing.identifier}-${filing.dueDate}`}
-                  className={`margin-bottom-05 ${index == 0 ? "margin-top-05" : ""}`}
+                  className={`margin-bottom-05 ${index === 0 ? "margin-top-05" : ""}`}
                 >
                   <Link href={`filings/${props.operateReferences[filing.identifier].urlSlug}`} passHref>
                     <a

--- a/web/src/components/filings-calendar/FilingsCalendarGrid.tsx
+++ b/web/src/components/filings-calendar/FilingsCalendarGrid.tsx
@@ -44,7 +44,7 @@ export const FilingsCalendarGrid = (props: Props): ReactElement => {
                       key={month}
                       className={
                         isCalendarMonthLessThanCurrentMonth(month) &&
-                        props.activeYear == getCurrentDate().year().toString()
+                        props.activeYear === getCurrentDate().year().toString()
                           ? "td-gray-border bg-base-extra-light"
                           : "td-gray-border"
                       }

--- a/web/src/components/filings-calendar/FilingsCalendarSingleGrid.tsx
+++ b/web/src/components/filings-calendar/FilingsCalendarSingleGrid.tsx
@@ -43,7 +43,7 @@ export const FilingsCalendarSingleGrid = (props: Props) => {
 
   const firstTwoFilings = thisMonthFilings.slice(0, NUM_OF_FILINGS_ALWAYS_VIEWABLE);
   const remainingFilings = thisMonthFilings.slice(NUM_OF_FILINGS_ALWAYS_VIEWABLE);
-  const isOnCurrentYear = getCurrentDate().year().toString() == props.activeYear;
+  const isOnCurrentYear = getCurrentDate().year().toString() === props.activeYear;
 
   const renderFilings = (filings: TaxFiling[]) => {
     return filings

--- a/web/src/components/filings-calendar/FilingsCalendarTaxAccess.tsx
+++ b/web/src/components/filings-calendar/FilingsCalendarTaxAccess.tsx
@@ -89,7 +89,7 @@ export const FilingsCalendarTaxAccess = (): ReactElement => {
 
   const getWidgetComponent = (): ReactElement => {
     if (userData?.taxFilingData.registeredISO) {
-      if (userData?.taxFilingData.state == "PENDING") {
+      if (userData?.taxFilingData.state === "PENDING") {
         return (
           <div className="tax-calendar-upper-widget-container" data-testid="pending-container">
             <div className="margin-bottom-2 tablet:margin-bottom-0 margin-right-2">

--- a/web/src/components/navbar/NavBarDesktop.tsx
+++ b/web/src/components/navbar/NavBarDesktop.tsx
@@ -77,7 +77,7 @@ export const NavBarDesktop = (): ReactElement => {
   }, [open]);
 
   const isAuthenticated = useMemo(() => {
-    return state.isAuthenticated == "TRUE";
+    return state.isAuthenticated === "TRUE";
   }, [state.isAuthenticated]);
   const textColor = isAuthenticated ? "primary" : "base";
   const accountIcon = isAuthenticated ? "account_circle" : "help";

--- a/web/src/components/navbar/NavBarMobile.tsx
+++ b/web/src/components/navbar/NavBarMobile.tsx
@@ -29,7 +29,7 @@ export const NavBarMobile = ({ scrolled, task, showSidebar, hideMiniRoadmap }: P
     return setSidebarIsOpen(false);
   };
   const isAuthenticated = useMemo(() => {
-    return state.isAuthenticated == "TRUE";
+    return state.isAuthenticated === "TRUE";
   }, [state.isAuthenticated]);
   const userName = getUserNameOrEmail(userData);
   const textColor = isAuthenticated ? "primary" : "base";

--- a/web/src/components/navbar/NavSidebarUserSettings.tsx
+++ b/web/src/components/navbar/NavSidebarUserSettings.tsx
@@ -19,7 +19,7 @@ export const NavSidebarUserSettings = (): ReactElement => {
   const router = useRouter();
 
   const isAuthenticated = useMemo(() => {
-    return state.isAuthenticated == "TRUE";
+    return state.isAuthenticated === "TRUE";
   }, [state.isAuthenticated]);
 
   const UnAuthenticatedMenu = () => {

--- a/web/src/components/njwds-extended/ThreeYearSelector.tsx
+++ b/web/src/components/njwds-extended/ThreeYearSelector.tsx
@@ -17,8 +17,8 @@ type Props = {
 };
 export const ThreeYearSelector = (props: Props): ReactElement => {
   const getColors = (year: string): string | undefined => {
-    if (year == props.activeYear) return colors["active"];
-    if (year == getCurrentDate().year().toString()) return colors["current"];
+    if (year === props.activeYear) return colors["active"];
+    if (year === getCurrentDate().year().toString()) return colors["current"];
     return colors["unselected"];
   };
 

--- a/web/src/components/onboarding/IndustryDropdown.tsx
+++ b/web/src/components/onboarding/IndustryDropdown.tsx
@@ -48,7 +48,7 @@ export const IndustryDropdown = (props: Props): ReactElement => {
     [isIndustryIdGeneric, "name"],
     ["desc", "asc"]
   ).filter((x) => {
-    return x.isEnabled || process.env.SHOW_DISABLED_INDUSTRIES == "true";
+    return x.isEnabled || process.env.SHOW_DISABLED_INDUSTRIES === "true";
   });
 
   const onIndustryIdChange = (industryId: string | undefined) => {

--- a/web/src/components/onboarding/OnboardingBusinessPersona.tsx
+++ b/web/src/components/onboarding/OnboardingBusinessPersona.tsx
@@ -20,7 +20,7 @@ export const OnboardingBusinessPersona = <T,>(props: FormContextFieldProps<T>): 
     props.errorTypes
   );
 
-  RegisterForOnSubmit(() => state.profileData.businessPersona != undefined);
+  RegisterForOnSubmit(() => state.profileData.businessPersona !== undefined);
   const handleSelection = (event: React.ChangeEvent<{ name?: string; value: unknown }>) => {
     Validate(false);
     setProfileData({

--- a/web/src/components/onboarding/OnboardingDateOfFormation.tsx
+++ b/web/src/components/onboarding/OnboardingDateOfFormation.tsx
@@ -53,7 +53,7 @@ export const OnboardingDateOfFormation = (props: Props): ReactElement => {
   }, state.profileData.dateOfFormation);
 
   const isValid = (): boolean =>
-    ((dateValue == null && !props.required) || (dateValue?.isValid() && !dateError)) ?? false;
+    ((dateValue === null && !props.required) || (dateValue?.isValid() && !dateError)) ?? false;
 
   RegisterForOnSubmit(isValid);
   const onValidation = (): void => Validate(!isValid());

--- a/web/src/components/onboarding/OnboardingLegalStructure.tsx
+++ b/web/src/components/onboarding/OnboardingLegalStructure.tsx
@@ -28,7 +28,7 @@ export const OnboardingLegalStructure = <T,>(props: FormContextFieldProps<T>): R
     props.errorTypes
   );
 
-  RegisterForOnSubmit(() => state.profileData.legalStructureId != undefined);
+  RegisterForOnSubmit(() => state.profileData.legalStructureId !== undefined);
 
   const LegalStructuresOrdered: LegalStructure[] = orderBy(
     LegalStructures,

--- a/web/src/components/onboarding/OnboardingLegalStructureDropDown.tsx
+++ b/web/src/components/onboarding/OnboardingLegalStructureDropDown.tsx
@@ -24,7 +24,7 @@ export const OnboardingLegalStructureDropdown = <T,>(props: Props<T>): ReactElem
     props.errorTypes
   );
 
-  const isValid = () => state.profileData.legalStructureId != undefined;
+  const isValid = () => state.profileData.legalStructureId !== undefined;
 
   RegisterForOnSubmit(isValid);
 

--- a/web/src/components/onboarding/OnboardingLocationInNewJersey.tsx
+++ b/web/src/components/onboarding/OnboardingLocationInNewJersey.tsx
@@ -25,7 +25,7 @@ export const OnboardingLocationInNewJersey = <T,>(props: FormContextFieldProps<T
       fieldName: "nexusLocationInNewJersey",
     });
 
-  RegisterForOnSubmit(() => state.profileData["nexusLocationInNewJersey"] != undefined);
+  RegisterForOnSubmit(() => state.profileData["nexusLocationInNewJersey"] !== undefined);
   const handleSelection = (event: React.ChangeEvent<{ name?: string; value: unknown }>) => {
     let hasLocationInNJ;
     event.target.value === "true" ? (hasLocationInNJ = true) : (hasLocationInNJ = false);

--- a/web/src/components/onboarding/OnboardingMunicipality.tsx
+++ b/web/src/components/onboarding/OnboardingMunicipality.tsx
@@ -40,7 +40,7 @@ export const OnboardingMunicipality = (props: Props): ReactElement => {
       legalStructureId: state.profileData.legalStructureId,
       operatingPhase: state.profileData.operatingPhase,
     }) || props.required
-      ? state.profileData[fieldName] != undefined
+      ? state.profileData[fieldName] !== undefined
       : true
   );
 

--- a/web/src/components/onboarding/OnboardingNameAndEmail.tsx
+++ b/web/src/components/onboarding/OnboardingNameAndEmail.tsx
@@ -55,10 +55,10 @@ export const OnboardingNameAndEmail = <T,>(props: FormContextFieldProps<T>): Rea
     return (value: string) => {
       if (confirm) {
         setConfirmEmail(value);
-        email == value && email.length > 0 ? updateEmailState(email) : updateEmailState("");
+        email === value && email.length > 0 ? updateEmailState(email) : updateEmailState("");
       } else {
         setEmail(value);
-        confirmEmail == value && value.length > 0 ? updateEmailState(value) : updateEmailState("");
+        confirmEmail === value && value.length > 0 ? updateEmailState(value) : updateEmailState("");
       }
     };
   };
@@ -91,7 +91,7 @@ export const OnboardingNameAndEmail = <T,>(props: FormContextFieldProps<T>): Rea
           validationText={Config.selfRegistration.errorTextEmailsNotMatching}
           required={true}
           additionalValidationIsValid={(value) => {
-            return confirmEmail ? value == confirmEmail : true && validateEmail(value);
+            return confirmEmail ? value === confirmEmail : true && validateEmail(value);
           }}
         />
       </div>
@@ -106,7 +106,7 @@ export const OnboardingNameAndEmail = <T,>(props: FormContextFieldProps<T>): Rea
           }}
           required={true}
           additionalValidationIsValid={(value) => {
-            return value == email && validateEmail(value);
+            return value === email && validateEmail(value);
           }}
           validationText={Config.selfRegistration.errorTextEmailsNotMatching}
           fieldName={"confirm-email"}

--- a/web/src/components/onboarding/OnboardingSectors.tsx
+++ b/web/src/components/onboarding/OnboardingSectors.tsx
@@ -48,7 +48,7 @@ export const OnboardingSectors = <T,>(props: FormContextFieldProps<T>): ReactEle
   };
 
   const isValid = () =>
-    !!state.profileData.sectorId && LookupSectorTypeById(state.profileData.sectorId)?.id != undefined;
+    !!state.profileData.sectorId && LookupSectorTypeById(state.profileData.sectorId)?.id !== undefined;
 
   const onValidation = (): void => Validate(!isValid());
 

--- a/web/src/components/onboarding/ProfileNexusBusinessNameField.tsx
+++ b/web/src/components/onboarding/ProfileNexusBusinessNameField.tsx
@@ -44,7 +44,7 @@ export const ProfileNexusBusinessNameField = (): ReactElement => {
 
   return (
     <>
-      {!state?.profileData.businessName || state?.profileData.businessName == ""
+      {!state?.profileData.businessName || state?.profileData.businessName === ""
         ? renderUserEmptyBusinessName()
         : renderUserBusinessName()}
     </>

--- a/web/src/components/onboarding/taxId/DisabledTaxId.tsx
+++ b/web/src/components/onboarding/taxId/DisabledTaxId.tsx
@@ -39,7 +39,7 @@ export const DisabledTaxId = (props: Props): ReactElement => {
   };
 
   const getTaxIdInitialStatus = (encryptionStatus: EncryptionStatus): TaxIdDisplayStatus => {
-    if (encryptionStatus == "encrypted") {
+    if (encryptionStatus === "encrypted") {
       return "password-view";
     } else {
       return "text-view";
@@ -84,13 +84,13 @@ export const DisabledTaxId = (props: Props): ReactElement => {
     if (!state.profileData.taxId) {
       return;
     } else if (
-      taxIdDisplayStatus == "password-view" &&
+      taxIdDisplayStatus === "password-view" &&
       getTaxIdEncryptionStatus(state.profileData) === "encrypted"
     ) {
       await getDecryptedTaxId().then((decryptedTaxId) => {
         updateSplitTaxId(decryptedTaxId);
       });
-    } else if (taxIdDisplayStatus == "text-view") {
+    } else if (taxIdDisplayStatus === "text-view") {
       updateSplitTaxId(state.profileData.taxId);
     }
     toggleTaxIdDisplay();
@@ -104,7 +104,7 @@ export const DisabledTaxId = (props: Props): ReactElement => {
 
   const getSpacedValue = (value: string) => (
     <>
-      <span className={taxIdDisplayStatus == "password-view" ? "text-ls-3" : ""}>{value.slice(0, 9)}</span>
+      <span className={taxIdDisplayStatus === "password-view" ? "text-ls-3" : ""}>{value.slice(0, 9)}</span>
       <span>{value.slice(9)}</span>
     </>
   );

--- a/web/src/components/onboarding/taxId/OnboardingTaxId.tsx
+++ b/web/src/components/onboarding/taxId/OnboardingTaxId.tsx
@@ -113,7 +113,7 @@ export const OnboardingTaxId = (props: Props): ReactElement => {
     if (!userData) return true;
     if (
       !(value.length === 0 || value.length === 12) &&
-      (userData.profileData.taxId != value || props.required)
+      (userData.profileData.taxId !== value || props.required)
     ) {
       return false;
     }

--- a/web/src/components/profile/ProfileTab.tsx
+++ b/web/src/components/profile/ProfileTab.tsx
@@ -34,7 +34,7 @@ export const ProfileTab = (props: Props): ReactElement => {
         return props.setProfileTab(props.tab);
       }}
     >
-      <div className={props.activeTab == props.tab ? "selected" : ""}>{lookupName(props.tab)}</div>
+      <div className={props.activeTab === props.tab ? "selected" : ""}>{lookupName(props.tab)}</div>
       <Icon className="usa-icon--size-3 margin-x-1">navigate_next</Icon>
     </button>
   );

--- a/web/src/components/profile/ProfileTabNav.tsx
+++ b/web/src/components/profile/ProfileTabNav.tsx
@@ -34,7 +34,7 @@ export const ProfileTabNav = (props: Props): ReactElement => {
     if (props.userData?.formationData.getFilingResponse?.success) {
       return true;
     }
-    if (props.businessPersona == "STARTING") {
+    if (props.businessPersona === "STARTING") {
       return LookupLegalStructureById(props.userData?.profileData.legalStructureId).elementsToDisplay.has(
         "formationDocuments"
       );

--- a/web/src/components/roadmap/MiniRoadmapStep.tsx
+++ b/web/src/components/roadmap/MiniRoadmapStep.tsx
@@ -26,7 +26,7 @@ export const MiniRoadmapStep = (props: Props): ReactElement => {
       return undefined;
     }
     return roadmap?.tasks.some((task) => {
-      return task.id === props.activeTaskId && task.stepNumber == stepNumber;
+      return task.id === props.activeTaskId && task.stepNumber === stepNumber;
     });
   }, [props.activeTaskId, roadmap?.tasks, stepNumber]);
   useEffect(() => {
@@ -80,7 +80,7 @@ export const MiniRoadmapStep = (props: Props): ReactElement => {
         {isOpen &&
           roadmap?.tasks
             .filter((task) => {
-              return task.stepNumber == props.step.stepNumber;
+              return task.stepNumber === props.step.stepNumber;
             })
             .map((task) => {
               return (

--- a/web/src/components/tasks/NaicsCodeInput.tsx
+++ b/web/src/components/tasks/NaicsCodeInput.tsx
@@ -41,7 +41,7 @@ export const NaicsCodeInput = (props: Props): ReactElement => {
 
   const getCode = (code: string) => {
     return (NaicsCodes as NaicsCodeObject[]).find((element) => {
-      return element?.SixDigitCode?.toString() == code;
+      return element?.SixDigitCode?.toString() === code;
     });
   };
 
@@ -167,7 +167,7 @@ export const NaicsCodeInput = (props: Props): ReactElement => {
                           href={templateEval(Config.determineNaicsCode.naicsDescriptionURL, { code: code })}
                         >
                           {descriptions.find((obj) => {
-                            return obj.SixDigitCode?.toString() == code;
+                            return obj.SixDigitCode?.toString() === code;
                           })?.SixDigitDescription ?? ""}
                         </ExternalLink>
                       </>
@@ -217,7 +217,7 @@ export const NaicsCodeInput = (props: Props): ReactElement => {
                   maxWidth: "350px",
                 },
               }}
-              error={isInvalid != undefined}
+              error={isInvalid !== undefined}
               handleChange={handleChange}
               validationText={errorMessages[isInvalid ?? "length"]}
             />
@@ -226,7 +226,7 @@ export const NaicsCodeInput = (props: Props): ReactElement => {
       ) : (
         <></>
       )}
-      {displayInput || naicsCode != "" ? (
+      {displayInput || naicsCode !== "" ? (
         <>
           <hr className="margin-y-2" />
           <div className="flex flex-row margin-left-auto">

--- a/web/src/components/tasks/TaxInput.tsx
+++ b/web/src/components/tasks/TaxInput.tsx
@@ -38,7 +38,7 @@ export const TaxInput = (props: Props): ReactElement => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const isTabletAndUp = useMediaQuery(MediaQueries.tabletAndUp);
   const shouldLockTaxId =
-    userData?.taxFilingData.state === "SUCCESS" || userData?.taxFilingData.state == "PENDING";
+    userData?.taxFilingData.state === "SUCCESS" || userData?.taxFilingData.state === "PENDING";
 
   const saveButtonText =
     isAuthenticated === IsAuthenticated.FALSE

--- a/web/src/components/tasks/UnlockingAlert.tsx
+++ b/web/src/components/tasks/UnlockingAlert.tsx
@@ -32,7 +32,7 @@ export const UnlockingAlert = (props: Props): ReactElement => {
                   <a className="usa-link" href={taskLink.urlSlug}>
                     {taskLink.name}
                   </a>
-                  {index == props.taskLinks.length - 1 ? "" : ", "}
+                  {index === props.taskLinks.length - 1 ? "" : ", "}
                 </span>
               );
             })}

--- a/web/src/components/tasks/business-formation/BusinessFormation.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormation.tsx
@@ -180,7 +180,7 @@ export const BusinessFormation = (props: Props): ReactElement => {
     });
   };
 
-  if (!isValidLegalStructure && userData?.profileData.businessPersona != "FOREIGN") {
+  if (!isValidLegalStructure && userData?.profileData.businessPersona !== "FOREIGN") {
     return (
       <div className="flex flex-column space-between minh-38">
         <div>

--- a/web/src/components/tasks/business-formation/DbaFormationPaginator.tsx
+++ b/web/src/components/tasks/business-formation/DbaFormationPaginator.tsx
@@ -34,7 +34,7 @@ export const DbaFormationPaginator = (): ReactElement => {
       return {
         name: value.name,
         hasError: false,
-        isComplete: index == 0,
+        isComplete: index === 0,
       };
     })
   );
@@ -55,7 +55,7 @@ export const DbaFormationPaginator = (): ReactElement => {
 
   const onPreviousButtonClick = (): void => {
     setStepperState((stepperState) => {
-      stepperState[1].isComplete = state.stepIndex != 2;
+      stepperState[1].isComplete = state.stepIndex !== 2;
       return stepperState;
     });
     moveToStep(state.stepIndex - 1);
@@ -69,8 +69,8 @@ export const DbaFormationPaginator = (): ReactElement => {
   ): Promise<void> => {
     onStepChangeAnalytics(userData?.formationData.formationFormData, stepIndex, config.moveType);
     if (
-      config.moveType == "NEXT_BUTTON" &&
-      stepIndex == 1 &&
+      config.moveType === "NEXT_BUTTON" &&
+      stepIndex === 1 &&
       isNotDba &&
       isAuthenticated === IsAuthenticated.FALSE
     ) {
@@ -78,7 +78,7 @@ export const DbaFormationPaginator = (): ReactElement => {
       return;
     }
     setStepperState((stepperState) => {
-      stepperState[1].isComplete = stepIndex == 2;
+      stepperState[1].isComplete = stepIndex === 2;
       return stepperState;
     });
     moveToStep(stepIndex);
@@ -93,19 +93,19 @@ export const DbaFormationPaginator = (): ReactElement => {
       return;
     }
 
-    if (moveType === "STEPPER" && nextStepIndex == 0) {
+    if (moveType === "STEPPER" && nextStepIndex === 0) {
       analytics.event.business_formation_name_tab.click.arrive_on_business_formation_name_step();
     }
-    if (moveType === "STEPPER" && nextStepIndex == 1) {
+    if (moveType === "STEPPER" && nextStepIndex === 1) {
       analytics.event.business_formation_dba_resolution_tab.click.arrive_on_business_formation_dba_resolution_step();
     }
-    if (moveType === "STEPPER" && nextStepIndex == 2) {
+    if (moveType === "STEPPER" && nextStepIndex === 2) {
       analytics.event.business_formation_dba_authorization_tab.click.arrive_on_business_formation_dba_authorization_step();
     }
-    if (moveType === "NEXT_BUTTON" && nextStepIndex == 1) {
+    if (moveType === "NEXT_BUTTON" && nextStepIndex === 1) {
       analytics.event.business_formation_dba_resolution_step_continue_button.click.arrive_on_business_formation_dba_resolution_step();
     }
-    if (moveType === "NEXT_BUTTON" && nextStepIndex == 2) {
+    if (moveType === "NEXT_BUTTON" && nextStepIndex === 2) {
       analytics.event.business_formation_dba_authorization_step_continue_button.click.arrive_on_business_formation_dba_authorization_step();
     }
   };
@@ -150,20 +150,20 @@ export const DbaFormationPaginator = (): ReactElement => {
   };
 
   const displayButtons = () => {
-    if (state.stepIndex == 0 && state.businessNameAvailability?.status == "AVAILABLE") {
+    if (state.stepIndex === 0 && state.businessNameAvailability?.status === "AVAILABLE") {
       return (
         <ButtonWrapper>
           <ForwardButton />
         </ButtonWrapper>
       );
-    } else if (state.stepIndex == 1) {
+    } else if (state.stepIndex === 1) {
       return (
         <ButtonWrapper>
           <BackButton />
           <ForwardButton />
         </ButtonWrapper>
       );
-    } else if (state.stepIndex == 2) {
+    } else if (state.stepIndex === 2) {
       return (
         <TaskCTA
           link={state.dbaContent.Authorize.callToActionLink}

--- a/web/src/components/tasks/business-formation/NexusFormationFlow.tsx
+++ b/web/src/components/tasks/business-formation/NexusFormationFlow.tsx
@@ -45,7 +45,7 @@ export const NexusFormationFlow = (): ReactElement => {
       return;
     }
 
-    if (moveType === "STEPPER" && nextStepIndex == 0) {
+    if (moveType === "STEPPER" && nextStepIndex === 0) {
       analytics.event.business_formation_name_tab.click.arrive_on_business_formation_name_step();
     }
   };
@@ -71,7 +71,7 @@ export const NexusFormationFlow = (): ReactElement => {
                   return {
                     name: value.name,
                     hasError: false,
-                    isComplete: index == 0,
+                    isComplete: index === 0,
                   };
                 })}
                 currentStep={state.stepIndex}

--- a/web/src/components/tasks/business-formation/business/BusinessNameAndLegalStructure.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessNameAndLegalStructure.tsx
@@ -37,7 +37,7 @@ export const BusinessNameAndLegalStructure = ({ isReviewStep = false }: Props): 
   const legalStructureName = (): string => {
     if (!userData || !userData.profileData.legalStructureId) return "";
     const preface =
-      userData?.profileData.businessPersona == "FOREIGN"
+      userData?.profileData.businessPersona === "FOREIGN"
         ? `${Config.formation.legalStructure.foreignPrefaceText} `
         : "";
 

--- a/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
@@ -62,7 +62,7 @@ describe("Formation - BusinessStep", () => {
     municipalities?: Municipality[]
   ): Promise<FormationPageHelpers> => {
     const profileData = generateFormationProfileData(initialProfileData);
-    const isForeign = initialProfileData.businessPersona == "FOREIGN";
+    const isForeign = initialProfileData.businessPersona === "FOREIGN";
     const formationData = {
       formationFormData: generateFormationFormData(formationFormData, {
         legalStructureId: castPublicFilingLegalTypeToFormationType(
@@ -279,7 +279,7 @@ describe("Formation - BusinessStep", () => {
       await getPageHelper(
         {
           businessPersona: "FOREIGN",
-          legalStructureId: randomPublicFilingLegalType((value) => value != "limited-partnership"),
+          legalStructureId: randomPublicFilingLegalType((value) => value !== "limited-partnership"),
         },
         { provisions: [] }
       );
@@ -290,7 +290,7 @@ describe("Formation - BusinessStep", () => {
       await getPageHelper(
         {
           businessPersona: "FOREIGN",
-          legalStructureId: randomPublicFilingLegalType((value) => value == "limited-partnership"),
+          legalStructureId: randomPublicFilingLegalType((value) => value === "limited-partnership"),
         },
         { provisions: [] }
       );

--- a/web/src/components/tasks/business-formation/business/BusinessStep.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessStep.tsx
@@ -13,7 +13,7 @@ export const BusinessStep = (): ReactElement => {
   return (
     <div data-testid="business-step">
       <MainBusiness />
-      {state.formationFormData.legalType == "limited-partnership" ? (
+      {state.formationFormData.legalType === "limited-partnership" ? (
         <>
           <hr className="margin-bottom-2 margin-top-0" aria-hidden={true} />
           <BusinessFormationTextBox
@@ -55,8 +55,8 @@ export const BusinessStep = (): ReactElement => {
         title={Config.formation.fields.businessPurpose.label}
         contentMd={Config.formation.fields.businessPurpose.body}
       />
-      {state.formationFormData.businessLocationType != "NJ" &&
-      state.formationFormData.legalType != "foreign-limited-partnership" ? (
+      {state.formationFormData.businessLocationType !== "NJ" &&
+      state.formationFormData.legalType !== "foreign-limited-partnership" ? (
         <></>
       ) : (
         <>

--- a/web/src/components/tasks/business-formation/business/FormationDate.tsx
+++ b/web/src/components/tasks/business-formation/business/FormationDate.tsx
@@ -81,13 +81,13 @@ export const FormationDate = (props: Props): ReactElement => {
       <div className="tablet:display-flex tablet:flex-row tablet:flex-justify">
         <LocalizationProvider dateAdapter={AdapterDayjs}>
           <Picker
-            minDate={props.fieldName == "businessStartDate" ? getCurrentDate() : undefined}
+            minDate={props.fieldName === "businessStartDate" ? getCurrentDate() : undefined}
             disabled={
-              props.fieldName == "businessStartDate" &&
-              getBusinessStartDateRule(state.formationFormData.legalType) == "Today"
+              props.fieldName === "businessStartDate" &&
+              getBusinessStartDateRule(state.formationFormData.legalType) === "Today"
             }
             maxDate={
-              props.fieldName == "businessStartDate"
+              props.fieldName === "businessStartDate"
                 ? getBusinessStartDateMaxDate(state.formationFormData.legalType)
                 : getCurrentDate().add(100, "years")
             }

--- a/web/src/components/tasks/business-formation/business/MainBusiness.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusiness.tsx
@@ -17,7 +17,7 @@ export const MainBusiness = (): ReactElement => {
   const { state } = useContext(BusinessFormationContext);
   const { doSomeFieldsHaveError, doesFieldHaveError } = useFormationErrors();
   const isForeign = useMemo(
-    () => state.formationFormData.businessLocationType != "NJ",
+    () => state.formationFormData.businessLocationType !== "NJ",
     [state.formationFormData.businessLocationType]
   );
 

--- a/web/src/components/tasks/business-formation/business/MainBusinessForeignAddressFlow.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusinessForeignAddressFlow.tsx
@@ -15,7 +15,7 @@ export const MainBusinessForeignAddressFlow = (): ReactElement => {
   type FlowBusinessLocationType = Exclude<FormationBusinessLocationType, "NJ">;
 
   useMountEffect(() => {
-    if (state.formationFormData.businessLocationType == "US") {
+    if (state.formationFormData.businessLocationType === "US") {
       setFormationFormData((previousState) => {
         return {
           ...previousState,
@@ -31,7 +31,7 @@ export const MainBusinessForeignAddressFlow = (): ReactElement => {
       setToUninteracted: true,
     });
 
-    if (value == "US") {
+    if (value === "US") {
       resetAddress = { ...resetAddress, addressCountry: "US" };
     }
 
@@ -74,7 +74,7 @@ export const MainBusinessForeignAddressFlow = (): ReactElement => {
           </>
         </RadioGroup>
       </FormControl>
-      {state.formationFormData.businessLocationType == "US" ? <MainBusinessUs /> : <MainBusinessIntl />}
+      {state.formationFormData.businessLocationType === "US" ? <MainBusinessUs /> : <MainBusinessIntl />}
     </>
   );
 };

--- a/web/src/components/tasks/business-formation/contacts/Addresses.test.tsx
+++ b/web/src/components/tasks/business-formation/contacts/Addresses.test.tsx
@@ -118,7 +118,7 @@ describe("Formation - Addresses", () => {
           expect(newIncorporators?.length).toEqual(2);
           expect(
             newIncorporators?.findIndex((signer) => {
-              return signer.name == newName;
+              return signer.name === newName;
             })
           ).toEqual(1);
         });

--- a/web/src/components/tasks/business-formation/contacts/Addresses.tsx
+++ b/web/src/components/tasks/business-formation/contacts/Addresses.tsx
@@ -107,7 +107,7 @@ export const Addresses = <T extends FormationMember | FormationIncorporator>(
           {Config.formation.fields.signers.tableHeader
             .split(",")
             .filter((_, index) => {
-              return props.needSignature ? true : index != 2;
+              return props.needSignature ? true : index !== 2;
             })
             .map((value: string) => {
               return (

--- a/web/src/components/tasks/business-formation/contacts/ContactsStep.tsx
+++ b/web/src/components/tasks/business-formation/contacts/ContactsStep.tsx
@@ -24,7 +24,7 @@ export const ContactsStep = (): ReactElement => {
   const shouldShowMembers = (): boolean => {
     return (
       [...corpLegalStructures, "limited-liability-company"].includes(state.formationFormData.legalType) &&
-      state.formationFormData.businessLocationType == "NJ"
+      state.formationFormData.businessLocationType === "NJ"
     );
   };
 

--- a/web/src/components/tasks/business-formation/contacts/Members.test.tsx
+++ b/web/src/components/tasks/business-formation/contacts/Members.test.tsx
@@ -50,7 +50,7 @@ describe("Formation - Members Field", () => {
 
   describe(`shared behaviors`, () => {
     legalStructureIds.map((legalStructureId) => {
-      const configField = legalStructureId == "limited-liability-company" ? "members" : "directors";
+      const configField = legalStructureId === "limited-liability-company" ? "members" : "directors";
       const nextButtonText = Config.formation.fields[configField].addButtonText;
       const successBodyText = Config.formation.fields[configField].successSnackbarBody;
 
@@ -104,7 +104,7 @@ describe("Formation - Members Field", () => {
           expect(newMembers?.length).toEqual(2);
           expect(
             newMembers?.findIndex((member) => {
-              return member.name == newName;
+              return member.name === newName;
             })
           ).toEqual(1);
         });
@@ -124,7 +124,7 @@ describe("Formation - Members Field", () => {
           expect(newMembers?.length).toEqual(1);
           expect(
             newMembers?.find((member) => {
-              return member == members[1];
+              return member === members[1];
             })
           ).toBeFalsy();
         });

--- a/web/src/components/tasks/business-formation/contacts/RegisteredAgent.tsx
+++ b/web/src/components/tasks/business-formation/contacts/RegisteredAgent.tsx
@@ -218,7 +218,7 @@ export const RegisteredAgent = (): ReactElement => {
                   />
                 </div>
               </WithErrorBar>
-              {state.formationFormData.businessLocationType == "NJ" && (
+              {state.formationFormData.businessLocationType === "NJ" && (
                 <div className="margin-bottom-1">
                   <FormControlLabel
                     label={Config.formation.registeredAgent.sameAddressCheckbox}

--- a/web/src/components/tasks/business-formation/contacts/Signatures.tsx
+++ b/web/src/components/tasks/business-formation/contacts/Signatures.tsx
@@ -133,7 +133,7 @@ export const Signatures = (): ReactElement => {
     return (
       <div
         className={`grid-col-auto width-6 display-flex flex-column flex-align-center ${
-          index == 0 ? "flex-justify-center" : "tablet:flex-justify-start margin-top-4 tablet:margin-top-0"
+          index === 0 ? "flex-justify-center" : "tablet:flex-justify-start margin-top-4 tablet:margin-top-0"
         }`}
       >
         <label
@@ -144,7 +144,7 @@ export const Signatures = (): ReactElement => {
           {Config.formation.fields.signers.signColumnLabel}*
         </label>
         <div
-          style={{ height: `${index == 0 ? "44px" : "60px"}` }}
+          style={{ height: `${index === 0 ? "44px" : "60px"}` }}
           className="display-flex flex-column flex-justify-center"
         >
           <ValidatedCheckbox
@@ -222,7 +222,7 @@ export const Signatures = (): ReactElement => {
             );
           })}
         </Select>
-        {hasError && state.formationFormData!.signers[index].title == undefined && (
+        {hasError && state.formationFormData!.signers[index].title === undefined && (
           <FormHelperText className={"text-error-dark"}>
             {Config.formation.fields.signers.errorInlineSignerTitle}
           </FormHelperText>

--- a/web/src/components/tasks/business-formation/contacts/testHelpers.tsx
+++ b/web/src/components/tasks/business-formation/contacts/testHelpers.tsx
@@ -23,7 +23,7 @@ export const getPageHelper = async (
   initialUser?: Partial<BusinessUser>
 ): Promise<FormationPageHelpers> => {
   const profileData = generateFormationProfileData(initialProfileData);
-  const isForeign = profileData.businessPersona == "FOREIGN";
+  const isForeign = profileData.businessPersona === "FOREIGN";
   const formationData = {
     formationFormData: generateFormationFormData(formationFormData, {
       legalStructureId: castPublicFilingLegalTypeToFormationType(

--- a/web/src/components/tasks/business-formation/getErrorStateForField.test.ts
+++ b/web/src/components/tasks/business-formation/getErrorStateForField.test.ts
@@ -467,7 +467,7 @@ describe("getErrorStateForField", () => {
 
   describe(`incorporator and signer fields`, () => {
     (["signers", "incorporators"] as ("signers" | "incorporators")[]).map((field) => {
-      const generator = field == "signers" ? generateFormationSigner : generateFormationIncorporator;
+      const generator = field === "signers" ? generateFormationSigner : generateFormationIncorporator;
       return describe(`${field}`, () => {
         it(`has NAME-labelled error when some ${field} do not have a name`, () => {
           const formData = generateFormationFormData({
@@ -566,7 +566,7 @@ describe("getErrorStateForField", () => {
           expect(getErrorStateForField(field, formData, undefined).hasError).toEqual(false);
         });
 
-        if (field == "incorporators") {
+        if (field === "incorporators") {
           it(`has error if some incorporators missing city and municipality`, () => {
             const formData = generateFormationFormData({
               incorporators: [

--- a/web/src/components/tasks/business-formation/getErrorStateForField.ts
+++ b/web/src/components/tasks/business-formation/getErrorStateForField.ts
@@ -106,7 +106,7 @@ export const getErrorStateForField = (
     "foreignStateOfFormation",
   ];
 
-  if (field == "foreignStateOfFormation") {
+  if (field === "foreignStateOfFormation") {
     return {
       ...errorState,
       hasError: formationFormData.foreignStateOfFormation === undefined,

--- a/web/src/components/tasks/business-formation/name/BusinessNameStep.tsx
+++ b/web/src/components/tasks/business-formation/name/BusinessNameStep.tsx
@@ -127,7 +127,7 @@ export const BusinessNameStep = (): ReactElement => {
           </div>
         </WithErrorBar>
       </form>
-      {error != null && (
+      {error && (
         <Alert variant="error" dataTestid={`error-alert-${error}`}>
           {SearchBusinessNameErrorLookup[error]}
         </Alert>

--- a/web/src/components/tasks/business-formation/review/ReviewBusinessSuffixAndStartDate.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewBusinessSuffixAndStartDate.tsx
@@ -31,7 +31,7 @@ export const ReviewBusinessSuffixAndStartDate = (): ReactElement => {
           defaultDisplayDateFormat
         )}
       />
-      {state.formationFormData.businessLocationType != "NJ" && (
+      {state.formationFormData.businessLocationType !== "NJ" && (
         <>
           <ReviewLineItem
             dataTestId="foreign-state-of-formation"

--- a/web/src/components/tasks/business-formation/review/ReviewMainBusinessLocation.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewMainBusinessLocation.tsx
@@ -17,19 +17,19 @@ export const ReviewMainBusinessLocation = (): ReactElement => {
     return getStringifiedAddress({
       addressLine1: state.formationFormData.addressLine1 || italicNotEnteredText,
       city:
-        (businessLocationType == "NJ"
+        (businessLocationType === "NJ"
           ? state.formationFormData.addressMunicipality?.displayName
           : state.formationFormData.addressCity) || italicNotEnteredText,
       state:
-        (businessLocationType == "INTL"
+        (businessLocationType === "INTL"
           ? state.formationFormData.addressProvince
           : state.formationFormData.addressState?.name) || italicNotEnteredText,
       zipcode: state.formationFormData.addressZipCode || italicNotEnteredText,
       addressLine2: state.formationFormData.addressLine2,
       country:
-        businessLocationType == "INTL"
+        businessLocationType === "INTL"
           ? arrayOfCountriesObjects.find(
-              (country) => country.shortCode == state.formationFormData.addressCountry
+              (country) => country.shortCode === state.formationFormData.addressCountry
             )?.name ?? italicNotEnteredText
           : undefined,
     });

--- a/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
@@ -54,7 +54,7 @@ describe("Formation - ReviewStep", () => {
     formationFormData: Partial<FormationFormData>
   ) => {
     const profileData = generateFormationProfileData(initialProfileData);
-    const isForeign = profileData.businessPersona == "FOREIGN";
+    const isForeign = profileData.businessPersona === "FOREIGN";
     const formationData = {
       formationFormData: generateFormationFormData(formationFormData, {
         legalStructureId: castPublicFilingLegalTypeToFormationType(
@@ -189,7 +189,7 @@ describe("Formation - ReviewStep", () => {
     await renderStep({ businessPersona: "FOREIGN" }, { addressCountry: "US", businessLocationType: "US" });
     expect(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      screen.queryByText(arrayOfCountriesObjects.find((cu) => cu.shortCode == "US")!.name, { exact: false })
+      screen.queryByText(arrayOfCountriesObjects.find((cu) => cu.shortCode === "US")!.name, { exact: false })
     ).not.toBeInTheDocument();
   });
 
@@ -197,7 +197,7 @@ describe("Formation - ReviewStep", () => {
     await renderStep({ businessPersona: "FOREIGN" }, { addressCountry: "US", businessLocationType: "INTL" });
     expect(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      screen.getByText(arrayOfCountriesObjects.find((cu) => cu.shortCode == "US")!.name, { exact: false })
+      screen.getByText(arrayOfCountriesObjects.find((cu) => cu.shortCode === "US")!.name, { exact: false })
     ).toBeInTheDocument();
   });
 

--- a/web/src/components/tasks/business-formation/review/ReviewStep.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.tsx
@@ -20,7 +20,7 @@ export const ReviewStep = (): ReactElement => {
   const { state } = useContext(BusinessFormationContext);
   const { Config } = useConfig();
 
-  const isLP = state.formationFormData.legalType == "limited-partnership";
+  const isLP = state.formationFormData.legalType === "limited-partnership";
   const hasProvisions = (state.formationFormData.provisions?.length ?? 0) > 0;
   const hasPurpose = !!state.formationFormData.businessPurpose;
   const hasMembers = (state.formationFormData.members?.length ?? 0) > 0;

--- a/web/src/lib/data-hooks/useFormContextFieldHelpers.ts
+++ b/web/src/lib/data-hooks/useFormContextFieldHelpers.ts
@@ -45,7 +45,7 @@ export const useFormContextFieldHelpers = <T, FieldError = FieldErrorType>(
       debug && console.log(runValidations);
       debug && console.log(isValidFunc());
       runValidations &&
-        fieldStates[fieldName].updated != undefined &&
+        fieldStates[fieldName].updated !== undefined &&
         reducer({
           type: FieldStateActionKind.VALIDATION,
           payload: { field: fieldName, invalid: !isValidFunc(), errorTypes },

--- a/web/src/lib/data-hooks/useFormContextHelper.ts
+++ b/web/src/lib/data-hooks/useFormContextHelper.ts
@@ -111,7 +111,7 @@ export const useFormContextHelper = <
 
       if (onChangeFunc) {
         debug && console.log("change func");
-        onChangeFunc && onChangeFunc(valid, getErrors(), submitted || stagingTab != undefined);
+        onChangeFunc && onChangeFunc(valid, getErrors(), submitted || stagingTab !== undefined);
       }
 
       if (!stillNeedsUpdates) {
@@ -169,7 +169,7 @@ export const useFormContextHelper = <
     getErrors,
     state: {
       fieldStates,
-      runValidations: submitted || stagingTab != undefined,
+      runValidations: submitted || stagingTab !== undefined,
       reducer: fieldStateDispatch,
     },
   };

--- a/web/src/lib/data-hooks/useUserData.ts
+++ b/web/src/lib/data-hooks/useUserData.ts
@@ -21,7 +21,7 @@ export const useUserData = (): UseUserDataResponse => {
   const { setRoadmap } = useContext(RoadmapContext);
   const { data, error, mutate } = useSWR<UserData | undefined>(state.user?.id || null, api.getUserData, {
     isPaused: () => {
-      return state.isAuthenticated != IsAuthenticated.TRUE;
+      return state.isAuthenticated !== IsAuthenticated.TRUE;
     },
   });
   const dataExists = !!data;
@@ -39,7 +39,7 @@ export const useUserData = (): UseUserDataResponse => {
   }, []);
 
   useEffect(() => {
-    if (!data || !state.user || state.isAuthenticated != IsAuthenticated.TRUE) {
+    if (!data || !state.user || state.isAuthenticated !== IsAuthenticated.TRUE) {
       return;
     }
     dispatch({
@@ -55,7 +55,7 @@ export const useUserData = (): UseUserDataResponse => {
   }, [dataExists]);
 
   useEffect(() => {
-    if (error && dataExists && state.isAuthenticated == IsAuthenticated.TRUE) {
+    if (error && dataExists && state.isAuthenticated === IsAuthenticated.TRUE) {
       setUserDataError("CACHED_ONLY");
     } else if (error && !dataExists) {
       setUserDataError("NO_DATA");
@@ -78,7 +78,7 @@ export const useUserData = (): UseUserDataResponse => {
     if (newUserData) {
       mutate(newUserData, false);
       setUpdateQueue(new UpdateQueueFactory(newUserData, update));
-      if (config?.local || state.isAuthenticated != IsAuthenticated.TRUE) {
+      if (config?.local || state.isAuthenticated !== IsAuthenticated.TRUE) {
         if (profileDataHasChanged(data, newUserData)) {
           onProfileDataChange(newUserData);
         }

--- a/web/src/lib/domain-logic/allowFormation.ts
+++ b/web/src/lib/domain-logic/allowFormation.ts
@@ -11,15 +11,15 @@ export const allowFormation = (
   persona: BusinessPersona | undefined
 ): boolean => {
   const featureFlagMap: Partial<Record<FormationLegalType, boolean>> = {
-    "foreign-limited-liability-company": process.env.FEATURE_BUSINESS_FLC == "true",
-    "foreign-limited-liability-partnership": process.env.FEATURE_BUSINESS_FLLP == "true",
-    "foreign-limited-partnership": process.env.FEATURE_BUSINESS_FLP == "true",
-    "foreign-s-corporation": process.env.FEATURE_BUSINESS_FCORP == "true",
-    "foreign-c-corporation": process.env.FEATURE_BUSINESS_FCORP == "true",
+    "foreign-limited-liability-company": process.env.FEATURE_BUSINESS_FLC === "true",
+    "foreign-limited-liability-partnership": process.env.FEATURE_BUSINESS_FLLP === "true",
+    "foreign-limited-partnership": process.env.FEATURE_BUSINESS_FLP === "true",
+    "foreign-s-corporation": process.env.FEATURE_BUSINESS_FCORP === "true",
+    "foreign-c-corporation": process.env.FEATURE_BUSINESS_FCORP === "true",
   };
 
   if (publicFilingLegalTypes.includes(legalStructureId as PublicFilingLegalType)) {
-    if (persona == "FOREIGN") {
+    if (persona === "FOREIGN") {
       return (
         featureFlagMap[
           castPublicFilingLegalTypeToFormationType(legalStructureId as PublicFilingLegalType, persona)

--- a/web/src/lib/domain-logic/lookupNaicsCode.ts
+++ b/web/src/lib/domain-logic/lookupNaicsCode.ts
@@ -3,6 +3,6 @@ import { NaicsCodeObject } from "@/lib/types/types";
 
 export const lookupNaicsCode = (code: string): NaicsCodeObject | undefined => {
   return (NaicsCodes as NaicsCodeObject[]).find((element) => {
-    return element?.SixDigitCode?.toString() == code;
+    return element?.SixDigitCode?.toString() === code;
   });
 };

--- a/web/src/lib/roadmap/buildUserRoadmap.ts
+++ b/web/src/lib/roadmap/buildUserRoadmap.ts
@@ -39,7 +39,7 @@ export const buildUserRoadmap = async (profileData: ProfileData): Promise<Roadma
 
   if (
     getIsApplicableToFunctionByFieldName("carService")(profileData.industryId) &&
-    profileData.carService == "BOTH"
+    profileData.carService === "BOTH"
   ) {
     roadmap = removeTask(roadmap, "taxi-insurance");
   }
@@ -170,7 +170,7 @@ const getLegalStructureAddOns = (profileData: ProfileData): string[] => {
     return [];
   }
   const addOns = [];
-  if (profileData.businessPersona == "FOREIGN") {
+  if (profileData.businessPersona === "FOREIGN") {
     if (LookupLegalStructureById(profileData.legalStructureId).requiresPublicFiling) {
       addOns.push("public-record-filing-foreign");
     } else if (LookupLegalStructureById(profileData.legalStructureId).hasTradeName) {

--- a/web/src/lib/roadmap/roadmapBuilder.ts
+++ b/web/src/lib/roadmap/roadmapBuilder.ts
@@ -94,7 +94,7 @@ const importAddOn = async (relativePath: string): Promise<IndustryRoadmap> => {
 };
 
 const orderByWeight = (taskA: TaskBuilder, taskB: TaskBuilder): number => {
-  if (taskA.stepNumber == taskB.stepNumber) {
+  if (taskA.stepNumber === taskB.stepNumber) {
     return taskA.weight > taskB.weight ? 1 : -1;
   } else if (taskA.stepNumber > taskB.stepNumber) {
     return 1;

--- a/web/src/lib/utils/cases-helpers.ts
+++ b/web/src/lib/utils/cases-helpers.ts
@@ -15,7 +15,7 @@ export const kebabSnakeSentenceToCamelCase = (text: string): string => {
     .toLowerCase()
     .split(/[\s_-]/gm)
     .map((cased, index) => {
-      return index == 0 ? cased : capitalizeFirstLetter(cased);
+      return index === 0 ? cased : capitalizeFirstLetter(cased);
     })
     .join("");
 };

--- a/web/src/pages/dashboard.tsx
+++ b/web/src/pages/dashboard.tsx
@@ -166,9 +166,8 @@ const DashboardPage = (props: Props): ReactElement => {
                 <Roadmap />
               </>
             )}
-            {LookupOperatingPhaseById(userData?.profileData.operatingPhase).displayCalendarType != "NONE" && (
-              <FilingsCalendar operateReferences={props.operateReferences} />
-            )}
+            {LookupOperatingPhaseById(userData?.profileData.operatingPhase).displayCalendarType !==
+              "NONE" && <FilingsCalendar operateReferences={props.operateReferences} />}
             {LookupOperatingPhaseById(userData?.profileData.operatingPhase).displayHideableRoadmapTasks && (
               <HideableTasks />
             )}

--- a/web/src/pages/filings/[filingUrlSlug].tsx
+++ b/web/src/pages/filings/[filingUrlSlug].tsx
@@ -73,7 +73,7 @@ export const FilingElement = (props: {
         {(props.filing.taxRates ||
           props.filing.filingMethod ||
           props.filing.frequency ||
-          props.filing.agency == "New Jersey Division of Taxation") && (
+          props.filing.agency === "New Jersey Division of Taxation") && (
           <GreenBox>
             {props.filing.taxRates && (
               <>
@@ -114,7 +114,7 @@ export const FilingElement = (props: {
                 </span>
               </>
             )}
-            {props.filing.agency == "New Jersey Division of Taxation" && (
+            {props.filing.agency === "New Jersey Division of Taxation" && (
               <span className="flex margin-top-05" data-testid="late-filing">
                 <Icon className="usa-icon--size-3 minw-3 margin-1 text-green margin-right-2">cancel</Icon>
                 <Content className="margin-top-1">{`**${Config.filingDefaults.lateFilingsTitle}** &nbsp;&nbsp;${Config.filingDefaults.lateFilingsMarkdown}`}</Content>

--- a/web/src/pages/index.tsx
+++ b/web/src/pages/index.tsx
@@ -73,7 +73,7 @@ const Home = (): ReactElement => {
         router.replace(ROUTES.dashboard);
       } else if (userData?.formProgress === "UNSTARTED") {
         router.replace(ROUTES.onboarding);
-      } else if (userData === undefined && error != undefined) {
+      } else if (userData === undefined && error !== undefined) {
         router.replace(`${ROUTES.dashboard}?error=true`);
       }
     } else if (state.isAuthenticated === IsAuthenticated.FALSE && alternateLandingPageEnabled) {

--- a/web/src/pages/mgmt/deadlinks.tsx
+++ b/web/src/pages/mgmt/deadlinks.tsx
@@ -53,7 +53,7 @@ const DeadLinksPage = (props: Props): ReactElement => {
 
 export const getServerSideProps = async (): Promise<GetServerSidePropsResult<Props>> => {
   const buildCheckDeadPages =
-    (process.env.CHECK_DEAD_LINKS && process.env.CHECK_DEAD_LINKS == "true") || false;
+    (process.env.CHECK_DEAD_LINKS && process.env.CHECK_DEAD_LINKS === "true") || false;
   return buildCheckDeadPages
     ? {
         props: {

--- a/web/src/pages/mgmt/deadurls.tsx
+++ b/web/src/pages/mgmt/deadurls.tsx
@@ -56,7 +56,7 @@ const DeadUrlsPage = (props: Props): ReactElement => {
 
 export const getServerSideProps = async (): Promise<GetServerSidePropsResult<Props>> => {
   const buildCheckDeadPages =
-    (process.env.CHECK_DEAD_LINKS && process.env.CHECK_DEAD_LINKS == "true") || false;
+    (process.env.CHECK_DEAD_LINKS && process.env.CHECK_DEAD_LINKS === "true") || false;
   return buildCheckDeadPages
     ? {
         props: {

--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -167,7 +167,7 @@ const OnboardingPage = (props: Props): ReactElement => {
         setProfileData(currentUserData.profileData);
         setUser(currentUserData.user);
         setCurrentFlow(getFlow(currentUserData));
-      } else if (state.isAuthenticated == IsAuthenticated.FALSE) {
+      } else if (state.isAuthenticated === IsAuthenticated.FALSE) {
         currentUserData = createEmptyUserData(state.user);
         setRegistrationDimension("Began Onboarding");
         await update(currentUserData);
@@ -342,7 +342,7 @@ const OnboardingPage = (props: Props): ReactElement => {
         if (errors.includes("ALERT_BAR")) {
           setAlert("ERROR");
         }
-        const banner = errors.filter((error) => error != "ALERT_BAR") as ProfileError[];
+        const banner = errors.filter((error) => error !== "ALERT_BAR") as ProfileError[];
         if (banner.length > 0) {
           setError(banner[0]);
         }

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -190,7 +190,7 @@ const ProfilePage = (props: Props): ReactElement => {
         updateQueue.queueTaskProgress({ [einTaskId]: "COMPLETED" });
       }
 
-      if (updateQueue.current().profileData.taxId != profileData.taxId) {
+      if (updateQueue.current().profileData.taxId !== profileData.taxId) {
         updateQueue.queueTaxFilingData({ state: undefined, registeredISO: undefined, filings: [] });
       }
 
@@ -277,7 +277,7 @@ const ProfilePage = (props: Props): ReactElement => {
 
   const shouldLockFormationFields = userData?.formationData.getFilingResponse?.success;
   const shouldLockTaxId =
-    userData?.taxFilingData.state === "SUCCESS" || userData?.taxFilingData.state == "PENDING";
+    userData?.taxFilingData.state === "SUCCESS" || userData?.taxFilingData.state === "PENDING";
 
   const nexusBusinessElements: Record<ProfileTabs, ReactNode> = {
     info: (

--- a/web/src/scripts/airtableCsvNaicsDump.js
+++ b/web/src/scripts/airtableCsvNaicsDump.js
@@ -29,7 +29,7 @@ const DigitRangeToArray = (value) => {
   const values = value.split("-").map((value) => {
     return Number.parseInt(value);
   });
-  if (values.length != 2) {
+  if (values.length !== 2) {
     return;
   }
   return Array.from({ length: values[1] + 1 - values[0] }, (v, k) => {

--- a/web/src/scripts/airtableTaxTypeDump.js
+++ b/web/src/scripts/airtableTaxTypeDump.js
@@ -50,7 +50,7 @@ const airtableToOpportunity = (airtableOpp) => {
     callToActionText: "File and Pay",
     description: airtableOpp["Description"] ?? "",
     frequency: airtableOpp["Frequncy of Filing"] ?? "",
-    extension: airtableOpp["Extension Y/N"] == "Extension",
+    extension: airtableOpp["Extension Y/N"] === "Extension",
     taxRates: airtableOpp["Tax Rates"] ?? "",
     additionalInfo: airtableOpp["Additional Info"]?.trim() ?? "",
     filingMethod: convertFilingMethod(airtableOpp["Can Be filed Online (Filing Method)"] ?? ""),

--- a/web/test/factories.ts
+++ b/web/test/factories.ts
@@ -679,7 +679,7 @@ export const randomFilteredIndustry = (
   { isEnabled = true }
 ): Industry => {
   const filteredIndustries = Industries.filter((x: Industry) => {
-    return func(x) && x.isEnabled == isEnabled;
+    return func(x) && x.isEnabled === isEnabled;
   });
   const randomIndex = Math.floor(Math.random() * filteredIndustries.length);
   return filteredIndustries[randomIndex];

--- a/web/test/pages/profile.test.tsx
+++ b/web/test/pages/profile.test.tsx
@@ -1820,7 +1820,7 @@ describe("profile", () => {
                 taxId: "*******89123",
                 encryptedTaxId: "some-encrypted-value",
                 businessPersona,
-                foreignBusinessTypeIds: businessPersona == "FOREIGN" ? ["NONE"] : undefined,
+                foreignBusinessTypeIds: businessPersona === "FOREIGN" ? ["NONE"] : undefined,
               }),
               taxFilingData: generateTaxFilingData({ state: randomInt() % 2 ? "SUCCESS" : "PENDING" }),
             });
@@ -1837,7 +1837,7 @@ describe("profile", () => {
       describe("disclaimer", () => {
         businessPersonas.map((businessPersona) => {
           const foreignBusinessTypes: ForeignBusinessType[] = [undefined];
-          if (businessPersona == "FOREIGN") foreignBusinessTypes.push("NEXUS");
+          if (businessPersona === "FOREIGN") foreignBusinessTypes.push("NEXUS");
           foreignBusinessTypes.map((foreignBusinessType) => {
             it(`shows disclaimer for trade name legal structure for ${businessPersona} ${
               foreignBusinessType ?? ""


### PR DESCRIPTION
## Description

We've talked enough about == that I figured it would be worth checking how many instances were in the code. Did a global search for " == " and " != "  and found `195 occurrences across 108 files`. Did a global replace of " == " and " != "with " === " and " !== ". In theory there could be some == and != that are jammed up against a variable and wouldn't match, but I'm not a regex wizard and I didn't feel like looking.

If tests pass, then this should be good to go. Hopefully no behaviors are changed.

## Code author checklist

- [x] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
