### PR TITLE
fix: [#184675379] add logistics JSON inadvertently missed, fixes broken Cypress test

### DIFF
--- a/content/src/roadmaps/add-ons/interstate-logistics.json
+++ b/content/src/roadmaps/add-ons/interstate-logistics.json
@@ -1,0 +1,22 @@
+{
+    "roadmapSteps": [
+      {
+        "step": 4,
+        "weight": 19,
+        "task": "trucking-boc3",
+        "required": true
+      },
+      {
+        "step": 4,
+        "weight": 21,
+        "task": "trucking-usdot",
+        "required": true
+      },
+      {
+        "step": 4,
+        "weight": 23,
+        "task": "trucking-irp",
+        "required": true
+      }
+    ]
+  }


### PR DESCRIPTION
I inadvertently missed adding `interstate-logistics.json`, which "broke" a Cypress test, so this PR is the fix.

### Ticket
https://www.pivotaltracker.com/n/projects/2573455/stories/184675379

### Approach

N/A

### Steps to Test

N/A

### Notes

N/A

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
