### PR TITLE
Make separate component to parse  in config

### DIFF
--- a/web/src/components/ModifiedContent.tsx
+++ b/web/src/components/ModifiedContent.tsx
@@ -1,0 +1,12 @@
+import { useContentModifiedByUserData } from "@/lib/data-hooks/useContentModifiedByUserData";
+import { ReactElement } from "react";
+
+interface ContentProps {
+  children: string;
+}
+
+export const ModifiedContent = (props: ContentProps): ReactElement => {
+  const updatedContent = useContentModifiedByUserData(props.children ?? "");
+
+  return <>{updatedContent}</>;
+};

--- a/web/src/components/Step.tsx
+++ b/web/src/components/Step.tsx
@@ -1,11 +1,11 @@
 import { VerticalStepIndicator } from "@/components/njwds-extended/VerticalStepIndicator";
 import { Task } from "@/components/Task";
-import { useContentModifiedByUserData } from "@/lib/data-hooks/useContentModifiedByUserData";
 import { useRoadmap } from "@/lib/data-hooks/useRoadmap";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { isStepCompleted } from "@/lib/domain-logic/isStepCompleted";
 import * as types from "@/lib/types/types";
 import { ReactElement } from "react";
+import { ModifiedContent } from "./ModifiedContent";
 
 interface Props {
   step: types.Step;
@@ -15,7 +15,6 @@ interface Props {
 export const Step = (props: Props): ReactElement => {
   const { userData } = useUserData();
   const { roadmap } = useRoadmap();
-  const stepName = useContentModifiedByUserData(props.step.name ?? "");
   return (
     <div
       className={`margin-top-3 ${props.last ? "margin-bottom-1" : "padding-bottom-105"}`}
@@ -36,7 +35,7 @@ export const Step = (props: Props): ReactElement => {
               className="text-bold margin-right-1 tablet:margin-left-4"
               data-step={props.step.stepNumber}
             >
-              {stepName}
+              <ModifiedContent>{props.step.name}</ModifiedContent>
             </span>
             <span className="text-base">({props.step.timeEstimate})</span>
           </div>

--- a/web/src/components/dashboard/SidebarCardGeneric.tsx
+++ b/web/src/components/dashboard/SidebarCardGeneric.tsx
@@ -2,12 +2,12 @@ import { Content } from "@/components/Content";
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { Icon } from "@/components/njwds/Icon";
-import { useContentModifiedByUserData } from "@/lib/data-hooks/useContentModifiedByUserData";
 import { useSidebarCards } from "@/lib/data-hooks/useSidebarCards";
 import { MediaQueries } from "@/lib/PageSizes";
 import { SidebarCardContent } from "@/lib/types/types";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { ReactNode } from "react";
+import { ModifiedContent } from "../ModifiedContent";
 
 type Props = {
   card: SidebarCardContent;
@@ -20,7 +20,6 @@ type Props = {
 
 export const SidebarCardGeneric = (props: Props) => {
   const { hideCard } = useSidebarCards();
-  const headerText = useContentModifiedByUserData(props.headerText ?? "");
   const isMobile = useMediaQuery(MediaQueries.isMobile);
 
   const layout = props.layout ?? "column";
@@ -84,7 +83,7 @@ export const SidebarCardGeneric = (props: Props) => {
                   />
                 )}
                 <span className={props.card.imgPath ? "margin-top-2px padding-top-1px" : ""}>
-                  {headerText}
+                  <ModifiedContent>{props.headerText}</ModifiedContent>
                 </span>
               </h3>
               {props.card.hasCloseButton && (

--- a/web/src/components/roadmap/MiniRoadmapStep.tsx
+++ b/web/src/components/roadmap/MiniRoadmapStep.tsx
@@ -1,7 +1,7 @@
+import { ModifiedContent } from "@/components/ModifiedContent";
 import { VerticalStepIndicator } from "@/components/njwds-extended/VerticalStepIndicator";
 import { Icon } from "@/components/njwds/Icon";
 import { MiniRoadmapTask } from "@/components/roadmap/MiniRoadmapTask";
-import { useContentModifiedByUserData } from "@/lib/data-hooks/useContentModifiedByUserData";
 import { useRoadmap } from "@/lib/data-hooks/useRoadmap";
 import { Step } from "@/lib/types/types";
 import { ReactElement, useEffect, useMemo, useState } from "react";
@@ -20,7 +20,6 @@ export const MiniRoadmapStep = (props: Props): ReactElement => {
   const { roadmap } = useRoadmap();
   const [isOpen, setIsOpen] = useState<boolean>(props.isOpen ?? false);
   const stepNumber = props.step.stepNumber;
-  const stepName = useContentModifiedByUserData(props.step.name ?? "");
   const isActive = useMemo(() => {
     if (!props.activeTaskId || !roadmap?.tasks) {
       return undefined;
@@ -66,7 +65,7 @@ export const MiniRoadmapStep = (props: Props): ReactElement => {
               }`}
               data-step={stepNumber}
             >
-              {stepName}
+              <ModifiedContent>{props.step.name}</ModifiedContent>
             </div>
             <div className="mla fdc fac">
               <Icon className="usa-icon--size-3 text-base-darkest">

--- a/web/src/components/tasks/business-formation/BusinessFormationTextField.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationTextField.tsx
@@ -1,4 +1,5 @@
 import { GenericTextField, GenericTextFieldProps } from "@/components/GenericTextField";
+import { ModifiedContent } from "@/components/ModifiedContent";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useFormationErrors } from "@/lib/data-hooks/useFormationErrors";
@@ -28,7 +29,11 @@ export const BusinessFormationTextField = ({ className, ...props }: Props): Reac
   const hasError = doesFieldHaveError(props.fieldName);
   return (
     <WithErrorBar className={className ?? ""} hasError={hasError} type={props.errorBarType}>
-      {props.label && <b>{props.label}</b>}
+      {props.label && (
+        <b>
+          <ModifiedContent>{props.label}</ModifiedContent>
+        </b>
+      )}
       {props.secondaryLabel && <span className="margin-left-1">{props.secondaryLabel}</span>}
       <GenericTextField
         value={state.formationFormData[props.fieldName]}

--- a/web/src/components/tasks/business-formation/business/BusinessNameAndLegalStructure.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessNameAndLegalStructure.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@/components/Content";
 import { ModalTwoButton } from "@/components/ModalTwoButton";
+import { ModifiedContent } from "@/components/ModifiedContent";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { LookupStepIndexByName } from "@/components/tasks/business-formation/BusinessFormationStepsConfiguration";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
@@ -81,7 +82,9 @@ export const BusinessNameAndLegalStructure = ({ isReviewStep = false }: Props): 
       >
         <div className="padding-205 flex-half">
           <div>
-            <b>{Config.formation.fields.businessName.label}</b>
+            <b>
+              <ModifiedContent>{Config.formation.fields.businessName.label}</ModifiedContent>
+            </b>
           </div>
           <span className="text-accent-cool-darker">
             {state.formationFormData.businessName || Config.formation.general.notEntered} {""}

--- a/web/src/components/tasks/business-formation/business/MainBusinessAddressNj.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusinessAddressNj.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { ModifiedContent } from "@/components/ModifiedContent";
 import { Alert } from "@/components/njwds-extended/Alert";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { StateDropdown } from "@/components/StateDropdown";
@@ -96,7 +97,9 @@ export const MainBusinessAddressNj = (): ReactElement => {
               type="MOBILE-ONLY"
               className=" orm-input grid-col-5 tablet:grid-col-2"
             >
-              <b>{Config.formation.fields.addressState.label}</b>
+              <b>
+                <ModifiedContent>{Config.formation.fields.addressState.label}</ModifiedContent>
+              </b>
               <StateDropdown
                 fieldName="addressState"
                 value={"New Jersey"}

--- a/web/src/components/tasks/business-formation/business/Provisions.tsx
+++ b/web/src/components/tasks/business-formation/business/Provisions.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@/components/Content";
 import { GenericTextField } from "@/components/GenericTextField";
+import { ModifiedContent } from "@/components/ModifiedContent";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { Icon } from "@/components/njwds/Icon";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
@@ -73,7 +74,9 @@ export const Provisions = (): ReactElement => {
       {state.formationFormData.provisions?.map((provision: string, index: number) => {
         return (
           <div key={index}>
-            <b>{Config.formation.fields.provisions.secondaryLabel}</b>
+            <b>
+              <ModifiedContent>{Config.formation.fields.provisions.secondaryLabel}</ModifiedContent>
+            </b>
             <span className="margin-left-05">{Config.formation.general.optionalLabel}</span>
             <div className="grid-row">
               <div className="grid-col">

--- a/web/src/components/tasks/business-formation/contacts/AddressModal.tsx
+++ b/web/src/components/tasks/business-formation/contacts/AddressModal.tsx
@@ -2,6 +2,7 @@
 
 import { GenericTextField } from "@/components/GenericTextField";
 import { ModalTwoButton } from "@/components/ModalTwoButton";
+import { ModifiedContent } from "@/components/ModifiedContent";
 import { StateDropdown } from "@/components/StateDropdown";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -252,7 +253,9 @@ export const AddressModal = <T extends FormationMember | FormationIncorporator>(
             type="ALWAYS"
             className="margin-bottom-2"
           >
-            <b>{Config.formation.addressModal.name.label}</b>
+            <b>
+              <ModifiedContent>{Config.formation.addressModal.name.label}</ModifiedContent>
+            </b>
             <GenericTextField
               value={addressData.name}
               handleChange={(value: string) => {
@@ -273,7 +276,9 @@ export const AddressModal = <T extends FormationMember | FormationIncorporator>(
             type="ALWAYS"
             className="margin-bottom-2"
           >
-            <b>{Config.formation.addressModal.addressLine1.label}</b>
+            <b>
+              <ModifiedContent>{Config.formation.addressModal.addressLine1.label}</ModifiedContent>
+            </b>
             <GenericTextField
               fieldName="addressLine1"
               value={addressData.addressLine1}
@@ -295,7 +300,9 @@ export const AddressModal = <T extends FormationMember | FormationIncorporator>(
             type="ALWAYS"
             className="margin-bottom-2"
           >
-            <b>{Config.formation.addressModal.addressLine2.label}</b>
+            <b>
+              <ModifiedContent>{Config.formation.addressModal.addressLine2.label}</ModifiedContent>
+            </b>
             <span className="margin-left-1">{Config.formation.general.optionalLabel}</span>
             <GenericTextField
               fieldName="addressLine2"
@@ -323,7 +330,9 @@ export const AddressModal = <T extends FormationMember | FormationIncorporator>(
                 type="DESKTOP-ONLY"
               >
                 <WithErrorBar hasError={!!addressErrorMap["addressCity"].invalid} type="MOBILE-ONLY">
-                  <b>{Config.formation.addressModal.addressCity.label}</b>
+                  <b>
+                    <ModifiedContent>{Config.formation.addressModal.addressCity.label}</ModifiedContent>
+                  </b>
                   <GenericTextField
                     fieldName="addressCity"
                     autoComplete="address-level2"
@@ -350,7 +359,9 @@ export const AddressModal = <T extends FormationMember | FormationIncorporator>(
                 type="MOBILE-ONLY"
               >
                 <div className="margin-bottom-2">
-                  <b>{Config.formation.addressModal.addressState.label}</b>
+                  <b>
+                    <ModifiedContent>{Config.formation.addressModal.addressState.label}</ModifiedContent>
+                  </b>
                 </div>
                 <StateDropdown
                   fieldName="addressState"
@@ -370,7 +381,9 @@ export const AddressModal = <T extends FormationMember | FormationIncorporator>(
               </WithErrorBar>
             </div>
             <div className="grid-col-6 tablet:grid-col-3">
-              <b>{Config.formation.addressModal.addressZipCode.label}</b>
+              <b>
+                <ModifiedContent>{Config.formation.addressModal.addressZipCode.label}</ModifiedContent>
+              </b>
               <GenericTextField
                 numericProps={{
                   maxLength: 5,

--- a/web/src/components/tasks/business-formation/contacts/Signatures.tsx
+++ b/web/src/components/tasks/business-formation/contacts/Signatures.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Content } from "@/components/Content";
 import { GenericTextField } from "@/components/GenericTextField";
+import { ModifiedContent } from "@/components/ModifiedContent";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { Icon } from "@/components/njwds/Icon";
 import {
@@ -190,7 +191,9 @@ export const Signatures = (): ReactElement => {
       <>
         {!isTabletAndUp && (
           <div className="margin-bottom-1">
-            <b>{Config.formation.fields.signers.titleLabel}</b>
+            <b>
+              <ModifiedContent>{Config.formation.fields.signers.titleLabel}</ModifiedContent>
+            </b>
           </div>
         )}
 
@@ -249,7 +252,9 @@ export const Signatures = (): ReactElement => {
       <>
         {!isTabletAndUp && index !== 0 && (
           <div className="margin-bottom-1">
-            <b>{Config.formation.fields.signers.nameLabel}</b>
+            <b>
+              <ModifiedContent>{Config.formation.fields.signers.nameLabel}</ModifiedContent>
+            </b>
           </div>
         )}
         <GenericTextField
@@ -307,7 +312,9 @@ export const Signatures = (): ReactElement => {
                 <div className="grid-col">
                   <div className="grid-row margin-top-1">
                     <div className={`grid-col-12 ${needsSignerType ? "tablet:grid-col-6" : ""}`}>
-                      <b>{Config.formation.fields.signers.nameLabel}</b>
+                      <b>
+                        <ModifiedContent>{Config.formation.fields.signers.nameLabel}</ModifiedContent>
+                      </b>
                       {getSignatureField(0)}
                     </div>
                     {needsSignerType && (
@@ -319,7 +326,9 @@ export const Signatures = (): ReactElement => {
                   </div>
                 </div>
                 <div className="margin-top-1" style={{ marginBottom: "1em" }}>
-                  <b>{`${Config.formation.fields.signers.signColumnLabel}`}</b>
+                  <b>
+                    <ModifiedContent>{`${Config.formation.fields.signers.signColumnLabel}`}</ModifiedContent>
+                  </b>
                   {renderSignatureColumn({
                     index: 0,
                   })}

--- a/web/src/components/tasks/business-formation/review/ReviewPartnership.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewPartnership.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { ModifiedContent } from "@/components/ModifiedContent";
 import { ReviewSectionHeader } from "@/components/tasks/business-formation/review/ReviewSectionHeader";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -34,7 +35,9 @@ export const ReviewPartnership = () => {
         )}
         {params.radioData && (
           <div className="margin-left-4">
-            <i>{Config.formation.partnershipRights.reviewStepTermsLabel}</i>
+            <i>
+              <ModifiedContent>{Config.formation.partnershipRights.reviewStepTermsLabel}</ModifiedContent>
+            </i>
             <span className="margin-left-1">{params.termsData}</span>
           </div>
         )}


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Making a seperate component besides our main markdown content renderer to render our special strings like ${oos} and such

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

Created component, replaced uses of useContentModifiedByUserData and wrapped around some of the previously markdown content that was recently refactored into being strings, https://github.com/newjersey/navigator.business.nj.gov/commit/ae00697013f59640ac49cee09d044204e78ff49e

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#184697588](https://www.pivotaltracker.com/story/show/#184697588)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Check in the various relevent places that we still render the various <b> and <i> tags correctly
Also check that we still render ${oos} strings correctly around the code base in the relevant places

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
