### PR TITLE
fix: [#184306179] confirm availability in-line error on blur

### DIFF
--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
@@ -221,7 +221,7 @@ describe("<BusinessFormationPaginator />", () => {
       expect(page.getStepStateInStepper(LookupStepIndexByName("Name"))).toEqual("ERROR");
     });
 
-    it("maintains business name search error, even after switching steps and returning", async () => {
+    it("maintains the unavailable business name search error, even after switching steps and returning", async () => {
       const page = preparePage(initialUserData, displayContent);
       page.fillText("Search business name", "Pizza Joint");
       await page.searchBusinessName({ status: "UNAVAILABLE" });
@@ -231,6 +231,19 @@ describe("<BusinessFormationPaginator />", () => {
       await page.stepperClickToBusinessNameStep();
       expect(screen.getByTestId("unavailable-text")).toBeInTheDocument();
       expect(page.getStepStateInStepper(LookupStepIndexByName("Name"))).toEqual("ERROR-ACTIVE");
+    });
+
+    it("maintains the confirm business name error, even after switching steps and returning", async () => {
+      const page = preparePage(initialUserData, displayContent);
+      await page.fillAndBlurBusinessName("Pizza Joint");
+      expect(
+        screen.getByText(Config.formation.fields.businessName.errorInlineNeedsToSearch)
+      ).toBeInTheDocument();
+      await page.stepperClickToBusinessStep();
+      await page.stepperClickToBusinessNameStep();
+      expect(
+        screen.getByText(Config.formation.fields.businessName.errorInlineNeedsToSearch)
+      ).toBeInTheDocument();
     });
 
     const switchingStepTests = (switchStepFunction: () => void) => {

--- a/web/src/components/tasks/business-formation/getErrorStateForField.ts
+++ b/web/src/components/tasks/business-formation/getErrorStateForField.ts
@@ -129,7 +129,7 @@ export const getErrorStateForField = (
     let label = errorState.label;
     if (!exists) {
       label = Config.formation.fields.businessName.errorInlineEmpty;
-    } else if (businessNameAvailability === undefined) {
+    } else if (businessNameAvailability?.status === undefined) {
       label = Config.formation.fields.businessName.errorInlineNeedsToSearch;
     } else if (businessNameAvailability?.status !== "AVAILABLE") {
       label = Config.formation.fields.businessName.errorInlineUnavailable;

--- a/web/src/components/tasks/business-formation/name/BusinessNameStep.test.tsx
+++ b/web/src/components/tasks/business-formation/name/BusinessNameStep.test.tsx
@@ -85,6 +85,27 @@ describe("Formation - BusinessNameStep", () => {
     );
   });
 
+  it("displays the confirm availability inline error when user blurs without searching", () => {
+    const page = getPageHelper();
+    page.fillText("Search business name", "First Name");
+    page.fillAndBlurBusinessName();
+    expect(
+      screen.getByText(Config.formation.fields.businessName.errorInlineNeedsToSearch)
+    ).toBeInTheDocument();
+  });
+
+  it("displays the confirm availability inline error when user types in a new name after finding an available one", async () => {
+    const page = getPageHelper();
+
+    page.fillText("Search business name", "First Name");
+    await page.searchBusinessName({ status: "AVAILABLE" });
+    expect(screen.getByTestId("available-text")).toBeInTheDocument();
+    await page.fillAndBlurBusinessName("New Name");
+    expect(
+      screen.getByText(Config.formation.fields.businessName.errorInlineNeedsToSearch)
+    ).toBeInTheDocument();
+  });
+
   it("does not display available alert if user types in new name after finding an available one", async () => {
     const page = getPageHelper();
 

--- a/web/src/lib/data-hooks/useBusinessNameSearch.ts
+++ b/web/src/lib/data-hooks/useBusinessNameSearch.ts
@@ -34,15 +34,20 @@ export const useBusinessNameSearch = ({
   const [error, setError] = useState<SearchBusinessNameError | undefined>(undefined);
   const [updateButtonClicked, setUpdateButtonClicked] = useState<boolean>(false);
 
+  const businessNameHasBeenSearched = (): boolean => {
+    return userData?.formationData.businessNameAvailability !== undefined;
+  };
+
+  const businessNameIsNotAvailable = (): boolean => {
+    return userData?.formationData.businessNameAvailability?.status !== "AVAILABLE";
+  };
+
   useMountEffectWhenDefined(() => {
     if (!userData) {
       return;
     }
     setCurrentName(isDba ? userData.profileData.nexusDbaName || "" : userData.profileData.businessName);
-    if (
-      userData.formationData.businessNameAvailability?.status !== "AVAILABLE" &&
-      userData.formationData.businessNameAvailability?.status !== undefined
-    ) {
+    if (businessNameIsNotAvailable() && businessNameHasBeenSearched()) {
       setFieldsInteracted(["businessName"]);
     }
   }, userData);

--- a/web/test/helpers/helpers-formation.tsx
+++ b/web/test/helpers/helpers-formation.tsx
@@ -161,6 +161,7 @@ export type FormationPageHelpers = {
   stepperClickToReviewStep: () => Promise<void>;
   getStepStateInStepper: (index: number | undefined) => string;
   searchBusinessName: (nameAvailability: Partial<NameAvailability>) => Promise<void>;
+  fillAndBlurBusinessName: (businessName?: string) => Promise<void>;
   searchBusinessNameAndGetError: (errorCode?: number) => Promise<void>;
   chooseRadio: (value: string) => void;
   getInputElementByLabel: (label: string) => HTMLInputElement;
@@ -199,6 +200,11 @@ export const createFormationPageHelpers = (): FormationPageHelpers => {
     await waitFor(() => {
       expect(screen.queryByTestId("business-step")).toBeInTheDocument();
     });
+  };
+
+  const fillAndBlurBusinessName = async (businessName = "Default Test Name"): Promise<void> => {
+    fillText("Search business name", businessName);
+    fireEvent.blur(screen.getByLabelText("Search business name"));
   };
 
   const submitNexusBusinessNameStep = async (): Promise<void> => {
@@ -438,6 +444,7 @@ export const createFormationPageHelpers = (): FormationPageHelpers => {
   return {
     fillText,
     fillAndSubmitBusinessNameStep,
+    fillAndBlurBusinessName,
     submitBusinessNameStep,
     submitBusinessStep,
     submitContactsStep,


### PR DESCRIPTION
## Description
Fix to address the faulty behavior with the wrong in-line error being fired on blur in business name search.

### Ticket
[184306179](https://www.pivotaltracker.com/story/show/184306179)

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
