### PR TITLE
chore: [#184320737] seperate tax filing onboarding and lookup states

### DIFF
--- a/api/src/domain/tax-filings/taxFilingsInterfaceFactory.ts
+++ b/api/src/domain/tax-filings/taxFilingsInterfaceFactory.ts
@@ -60,39 +60,11 @@ export const taxFilingsInterfaceFactory = (apiTaxFilingClient: TaxFilingClient):
     });
 
     switch (response.state) {
-      case "PENDING": {
-        return {
-          ...request.userData,
-          taxFilingData: {
-            ...request.userData.taxFilingData,
-            lastUpdatedISO: new Date(Date.now()).toISOString(),
-            registeredISO: new Date(Date.now()).toISOString(),
-            errorField: response.errorField,
-            state: response.state,
-            businessName: request.businessName,
-          },
-        };
-      }
-
       case "SUCCESS": {
         return await lookup(request);
       }
-
       case "API_ERROR":
       case "FAILED": {
-        return {
-          ...request.userData,
-          taxFilingData: {
-            ...request.userData.taxFilingData,
-            registeredISO: undefined,
-            state: response.state,
-            errorField: response.errorField,
-            businessName: request.businessName,
-          },
-        };
-      }
-
-      default: {
         return {
           ...request.userData,
           taxFilingData: {

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -4,7 +4,7 @@ import { UserFeedbackRequest, UserIssueRequest } from "@shared/feedbackRequest";
 import { FormationSubmitResponse, GetFilingResponse } from "@shared/formationData";
 import { LicenseEntity, LicenseStatusResult, NameAndAddress } from "@shared/license";
 import { ProfileData } from "@shared/profileData";
-import { TaxFiling, TaxFilingState } from "@shared/taxFiling";
+import { TaxFiling, TaxFilingLookupState, TaxFilingOnboardingState } from "@shared/taxFiling";
 import { UserData } from "@shared/userData";
 import * as https from "node:https";
 
@@ -77,11 +77,11 @@ export type TaxFilingResult = { Content: string; Id: string; Values: string[] };
 export type TaxIdentifierToIdsRecord = Record<string, string[]>;
 
 export type TaxFilingOnboardingResponse = {
-  state: TaxFilingState;
+  state: TaxFilingOnboardingState;
   errorField?: "businessName" | "formFailure";
 };
 export interface TaxFilingLookupResponse {
-  state: TaxFilingState;
+  state: TaxFilingLookupState;
   filings: TaxFiling[];
 }
 export type SelfRegResponse = {

--- a/shared/src/taxFiling.ts
+++ b/shared/src/taxFiling.ts
@@ -1,4 +1,6 @@
-export type TaxFilingState = "SUCCESS" | "FAILED" | "UNREGISTERED" | "PENDING" | "API_ERROR";
+export type TaxFilingLookupState = "SUCCESS" | "FAILED" | "API_ERROR" | "PENDING" | "UNREGISTERED";
+export type TaxFilingOnboardingState = "SUCCESS" | "FAILED" | "API_ERROR";
+export type TaxFilingState = TaxFilingLookupState | TaxFilingOnboardingState;
 export type TaxFilingErrorFields = "businessName" | "formFailure";
 export type TaxFilingData = {
   readonly state?: TaxFilingState;


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Separated the `TaxFilingState` into two: `TaxFilingLookupState` and `TaxFilingOnboardingState` to better reflect data the types of `TaxFilingOnboardingResponse` and `TaxFilingLookupResponse` are representing.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[184320737](https://www.pivotaltracker.com/story/show/184320737)

### Notes
There was an error among the cases of the state within the onboarding function, based on what's being returned in `ApiTaxFilingClient.ts` the onboarding doesn't ever return `PENDING` state, only `SUCCESS`, `FAILED`, and `API_ERROR`, so I removed that case from onboarding.

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
