### PR TITLE
chore: [#184822735] add date of formation input to profile page for n…

### DIFF
--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -319,6 +319,15 @@ const ProfilePage = (props: Props): ReactElement => {
         </ProfileField>
 
         <ProfileField
+          fieldName="dateOfFormation"
+          isVisible={!!userData?.profileData.dateOfFormation}
+          locked={shouldLockFormationFields}
+          lockedValueFormatter={formatDate}
+        >
+          <ProfileDateOfFormation futureAllowed={true} />
+        </ProfileField>
+
+        <ProfileField
           fieldName="legalStructureId"
           locked={shouldLockFormationFields}
           lockedValueFormatter={(value: string): string => LookupLegalStructureById(value).name}


### PR DESCRIPTION
…exus users

## Description

I added the data formation input to the profile page for nexus users

### Ticket

[#184822735](https://www.pivotaltracker.com/story/show/184822735)

### Approach

Leverage the existing logic that is used to render this component for Poppy users on the profile page.

### Notes

I notice an irregularity on how the information date is displayed when the field is locked, requested input from the product team to determine if a bug ticket is necessary.

One of the tests that I did not create, is when a user removes the date of formation data from the input, and proceeds to save the page, when the save occurs, a model renders, requesting the user to confirm if they are actually deleting the data and the impact of the deletion. Seems like no additional functionality was needed for this behavior to occur. Let me know if I  need to create a test to cover this.


## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
