### PR TITLE
feat: [#184702190] task screen has new dropdown field license type

### DIFF
--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -1668,6 +1668,15 @@ collections:
           required: false,
           options: ["Department of Health", "County Clerk", "Municipal Clerk"],
         }
+      - label: "Type (Webflow)"
+        name: "webflowType"
+        widget: "select"
+        required: false
+        options:
+          - { label: "business license", value: "business-license" }
+          - { label: "individual license", value: "individual-license" }
+          - { label: "school/course", value: "school-course" }
+          - { label: "object or vehicle", value: "object-vehicle" }
 
   - name: "license-tasks"
     label: "License Tasks (Navigator with Webflow mappings)"
@@ -1744,6 +1753,15 @@ collections:
         }
       - { label: "Webflow Issuing Division", name: "issuingDivision", widget: "string", required: false }
       - { label: "Division Phone", name: "divisionPhone", widget: "string", required: false }
+      - label: "Type (Webflow)"
+        name: "webflowType"
+        widget: "select"
+        required: false
+        options:
+          - { label: "business license", value: "business-license" }
+          - { label: "individual license", value: "individual-license" }
+          - { label: "school/course", value: "school-course" }
+          - { label: "object or vehicle", value: "object-vehicle" }
 
   - name: "webflow-licenses"
     label: "Webflow Licenses"


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

It seems like the content team wanted a drop down label field so they could keep track of things better between themselves

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

Go into the CMS locally and see that under tasks - all and task - license tasks webflow on any / all entries their is now a license type drop down at the bottom with 4 fields 

<img width="252" alt="image" src="https://user-images.githubusercontent.com/22485301/230168182-14c85b30-df0d-42b8-85b8-580c4aa96e56.png">


<img width="769" alt="image" src="https://user-images.githubusercontent.com/22485301/230168054-5c02b21b-385a-4ad5-8466-c84882e42bab.png">

<img width="756" alt="image" src="https://user-images.githubusercontent.com/22485301/230168124-e72b752a-4d28-405c-9a7b-07a537a07da8.png">



### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
