### PR TITLE
chore: [#184890192] fix display name for industry dropdown in tasks

### DIFF
--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -1416,7 +1416,7 @@ collections:
             collection: "tasks"
             search_fields: ["{{filename}}", "name", "urlSlug"]
             value_field: "{{filename}}"
-            display_fields: ["{{name}}"]
+            display_fields: ["{{filename}}"]
             options_length: 500
           - label: "Required"
             name: "required"
@@ -1730,7 +1730,7 @@ collections:
         collection: "roadmaps"
         search_fields: ["{{id}}"]
         value_field: "{{id}}"
-        display_fields: ["{{id}}"]
+        display_fields: ["{{name}}"]
         options_length: 500
       - {
           label: "Call To Action Text (Webflow & Navigator)",


### PR DESCRIPTION
## Description

Fix for displaying industry name in tasks.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[184890192](https://www.pivotaltracker.com/story/show/184890192)

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
