### PR TITLE
feat: [#183443674] update c-corp formation

### DIFF
--- a/api/src/api/formationRouter.test.ts
+++ b/api/src/api/formationRouter.test.ts
@@ -7,6 +7,7 @@ import {
   generateFormationData,
   generateFormationSubmitResponse,
   generateGetFilingResponse,
+  generateInputFile,
   generateProfileData,
   generateUserData,
 } from "../../test/factories";
@@ -76,10 +77,14 @@ describe("formationRouter", () => {
       stubFormationClient.form.mockResolvedValue(formationResponse);
 
       const userData = generateUserData({});
+      const foreignGoodStandingFile = generateInputFile({});
       const response = await request(app).post(`/formation`).send({
         userData: userData,
         returnUrl: "some-url",
+        foreignGoodStandingFile,
       });
+
+      expect(stubFormationClient.form).toHaveBeenCalledWith(userData, "some-url", foreignGoodStandingFile);
 
       expect(response.status).toEqual(200);
       expect(response.body).toEqual({

--- a/api/src/api/formationRouter.ts
+++ b/api/src/api/formationRouter.ts
@@ -14,10 +14,10 @@ export const formationRouterFactory = (
   const router = Router();
 
   router.post("/formation", async (req, res) => {
-    const { userData, returnUrl } = req.body;
+    const { userData, returnUrl, foreignGoodStandingFile } = req.body;
 
     formationClient
-      .form(userData, returnUrl)
+      .form(userData, returnUrl, foreignGoodStandingFile)
       .then(async (formationResponse: FormationSubmitResponse) => {
         const userDataWithResponse = {
           ...userData,

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -1,7 +1,7 @@
 import { NameAvailability, NameAvailabilityResponse } from "@shared/businessNameSearch";
 import { BusinessUser, NewsletterResponse, UserTestingResponse } from "@shared/businessUser";
 import { UserFeedbackRequest, UserIssueRequest } from "@shared/feedbackRequest";
-import { FormationSubmitResponse, GetFilingResponse } from "@shared/formationData";
+import { FormationSubmitResponse, GetFilingResponse, InputFile } from "@shared/formationData";
 import { LicenseEntity, LicenseStatusResult, NameAndAddress } from "@shared/license";
 import { ProfileData } from "@shared/profileData";
 import { TaxFiling, TaxFilingLookupState, TaxFilingOnboardingState } from "@shared/taxFiling";
@@ -26,7 +26,11 @@ export interface NewsletterClient {
 }
 
 export interface FormationClient {
-  form: (userData: UserData, returnUrl: string) => Promise<FormationSubmitResponse>;
+  form: (
+    userData: UserData,
+    returnUrl: string,
+    foreignGoodStandingFile?: InputFile
+  ) => Promise<FormationSubmitResponse>;
   getCompletedFiling: (formationId: string) => Promise<GetFilingResponse>;
 }
 

--- a/api/test/factories.ts
+++ b/api/test/factories.ts
@@ -21,6 +21,7 @@ import {
   FormationLegalType,
   FormationSubmitResponse,
   GetFilingResponse,
+  InputFile,
   PublicFilingLegalType,
   publicFilingLegalTypes,
 } from "@shared/formationData";
@@ -153,6 +154,16 @@ export const generateTaxFiling = (overrides: Partial<TaxFiling>): TaxFiling => {
   return {
     identifier: `some-identifier-${randomInt()}`,
     dueDate: getCurrentDateFormatted(defaultDateFormat),
+    ...overrides,
+  };
+};
+
+export const generateInputFile = (overrides: Partial<InputFile>): InputFile => {
+  return {
+    base64Contents: `some-base-64-contents-${randomInt()}`,
+    fileType: randomElementFromArray(["PNG", "PDF"]),
+    sizeInBytes: randomInt(),
+    filename: `some-filename-${randomInt()}`,
     ...overrides,
   };
 };

--- a/content/src/fieldConfig/business-formation.json
+++ b/content/src/fieldConfig/business-formation.json
@@ -205,6 +205,13 @@
         "label": "Original State of Formation",
         "error": "Select a State"
       },
+      "foreignGoodStandingFile": {
+        "label": "Foreign Certificate of Good Standing",
+        "helperText": "Select a PNG or PDF file. Max file size: 3MB.",
+        "errorMessageFileSize": "${fileName} exceeds maximum size of ${maxFileSize} MB.",
+        "errorMessageFileType": "${fileName} file format is not supported.",
+        "errorMessageRequired": "A Certificate of Good Standing is required."
+      },
       "createLimitedPartnerTerms": {
         "label": "Partnership Rights - Assign rights terms"
       },
@@ -293,6 +300,12 @@
             "description": "`Authorized representative(s)|authorized-representative` or `general partner(s)|general-partner` should sign below by adding their full name. You can have up to 10 signers listed."
           }
         }
+      },
+      "willPracticeLaw": {
+        "label": "Will you practice law?",
+        "radioNoText": "No",
+        "radioYesText": "Yes",
+        "error": "Select 'Yes' or 'No'."
       },
       "withdrawals": {
         "label": "Withdrawals",

--- a/shared/src/formationData.ts
+++ b/shared/src/formationData.ts
@@ -98,11 +98,6 @@ export interface FormationMember extends FormationAddress {
   readonly name: string;
 }
 
-export type ForeignGoodStandingFileObject = {
-  Extension: "PDF" | "PNG";
-  Content: string; // Binary contents converted to base64 string 4,000,000 string limit (3mb)
-};
-
 export interface FormationFormData extends FormationAddress {
   readonly legalType: FormationLegalType;
   readonly businessName: string;
@@ -145,10 +140,11 @@ export interface FormationFormData extends FormationAddress {
   readonly contactPhoneNumber: string;
   readonly foreignStateOfFormation: StateNames | undefined;
   readonly foreignDateOfFormation: string | undefined; // YYYY-MM-DD
-  readonly foreignGoodStandingFile: ForeignGoodStandingFileObject | undefined;
+  readonly willPracticeLaw: boolean | undefined;
 }
 
 export type FormationFields = keyof FormationFormData;
+export type FieldsForErrorHandling = keyof FormationFormData | "foreignGoodStandingFile";
 
 export type FormationTextField = Exclude<
   keyof FormationFormData,
@@ -180,6 +176,7 @@ export type FormationTextField = Exclude<
   | "foreignDateOfFormation"
   | "foreignStateOfFormation"
   | "foreignGoodStandingFile"
+  | "willPracticeLaw"
 >;
 
 export const createEmptyFormationAddress = (): FormationAddress => {
@@ -264,7 +261,7 @@ export const createEmptyFormationFormData = (): FormationFormData => {
     contactPhoneNumber: "",
     foreignDateOfFormation: undefined,
     foreignStateOfFormation: undefined,
-    foreignGoodStandingFile: undefined,
+    willPracticeLaw: undefined,
   };
 };
 
@@ -352,6 +349,15 @@ export const incorporationLegalStructures: FormationLegalType[] = [
   ...corpLegalStructures,
   "limited-partnership",
 ];
+
+export type AcceptedFileType = "PDF" | "PNG";
+
+export type InputFile = {
+  base64Contents: string;
+  fileType: AcceptedFileType;
+  sizeInBytes: number;
+  filename: string;
+};
 
 export type FormationSubmitResponse = {
   success: boolean;

--- a/shared/src/test/formationFactories.ts
+++ b/shared/src/test/formationFactories.ts
@@ -224,7 +224,7 @@ export const generateFormationFormData = (
     makeDistributionTerms: `some-makeDistributionTerms-text-${randomInt()}`,
     foreignStateOfFormation: isForeign ? randomElementFromArray(states).name : undefined,
     foreignDateOfFormation: isForeign ? getCurrentDate().add(1, "days").format(defaultDateFormat) : undefined,
-    foreignGoodStandingFile: undefined,
+    willPracticeLaw: undefined,
     ...overrides,
   };
 };

--- a/web/.dependency-cruiser.js
+++ b/web/.dependency-cruiser.js
@@ -92,6 +92,10 @@ module.exports = {
     },
     {
       from: {},
+      to: { path: "@uswds/uswds" },
+    },
+    {
+      from: {},
       to: { path: "axios" },
     },
     {

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -483,6 +483,17 @@ collections:
                     fields:
                       - { label: "Label", name: "label", widget: "string" }
                       - { label: "Inline error", name: "error", widget: "string" }
+                  - label: Foreign Certificate of Good Standing
+                    name: foreignGoodStandingFile
+                    collapsed: true
+                    widget: object
+                    fields:
+                      - { label: "Label", name: "label", widget: "string" }
+                      - { label: "Inline error", name: "error", widget: "string" }
+                      - { label: "Helper Text", name: "helperText", widget: "string" }
+                      - { label: "Error Message - File Size", name: "errorMessageFileSize", widget: "string" }
+                      - { label: "Error Message - File Type", name: "errorMessageFileType", widget: "string" }
+                      - { label: "Error Message - Required", name: "errorMessageRequired", widget: "string" }
                   - label: Incorporators
                     name: incorporators
                     collapsed: true

--- a/web/src/components/njwds-extended/FileInput.test.tsx
+++ b/web/src/components/njwds-extended/FileInput.test.tsx
@@ -1,0 +1,88 @@
+import { getMergedConfig } from "@/contexts/configContext";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { FileInput } from "./FileInput";
+
+describe("<FileInput />", () => {
+  let file: File;
+  const Config = getMergedConfig();
+
+  beforeEach(() => {
+    file = new File(["my cool file contents"], "cool.png", { type: "image/png" });
+  });
+
+  it("passes file to onchange handler", async () => {
+    const mockOnChange = jest.fn();
+    render(
+      <FileInput
+        errorMessageRequired="error-message-required"
+        helperText="input-label"
+        onChange={mockOnChange}
+        value={undefined}
+      />
+    );
+
+    const uploader = screen.getByTestId("file-input");
+
+    fireEvent.change(uploader, { target: { files: [file] } });
+
+    const base64Contents = Buffer.from("my cool file contents", "utf8").toString("base64");
+
+    await waitFor(() => {
+      expect(mockOnChange).toHaveBeenCalledWith({
+        fileType: "PNG",
+        sizeInBytes: file.size,
+        base64Contents,
+        filename: "cool.png",
+      });
+    });
+  });
+
+  it("refuses files larger than the provided max file size", async () => {
+    const mockOnChange = jest.fn();
+    const errorMessageFileSize = Config.formation.fields.foreignGoodStandingFile.errorMessageFileSize;
+
+    file = new File(["x".repeat(1048576 / 2)], "cool.png", { type: "image/png" }); // .5 MB file
+    render(
+      <FileInput
+        maxFileSize={{
+          errorMessage: errorMessageFileSize,
+          maxSizeInMegabytes: 0.4,
+        }}
+        errorMessageRequired="error-message-required"
+        helperText="input-label"
+        onChange={mockOnChange}
+        value={undefined}
+      />
+    );
+
+    const uploader = screen.getByTestId("file-input");
+
+    fireEvent.change(uploader, { target: { files: [file] } });
+
+    expect(mockOnChange).not.toHaveBeenCalled();
+    expect(screen.getByText("cool.png exceeds maximum size of 0.4 MB.")).toBeInTheDocument();
+  });
+
+  it("refuses files of the wrong type", async () => {
+    const mockOnChange = jest.fn();
+    render(
+      <FileInput
+        acceptedFileTypes={{
+          fileTypes: ["PDF"],
+          errorMessage: Config.formation.fields.foreignGoodStandingFile.errorMessageFileType,
+        }}
+        errorMessageRequired="error-message-required"
+        helperText="input-label"
+        onChange={mockOnChange}
+        value={undefined}
+      />
+    );
+
+    const uploader = screen.getByTestId("file-input");
+
+    fireEvent.change(uploader, { target: { files: [file] } });
+
+    expect(mockOnChange).not.toHaveBeenCalled();
+    expect(screen.getByText("cool.png file format is not supported.")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/njwds-extended/FileInput.tsx
+++ b/web/src/components/njwds-extended/FileInput.tsx
@@ -1,0 +1,170 @@
+import { flipObject, templateEval } from "@/lib/utils/helpers";
+import { AcceptedFileType, InputFile } from "@businessnjgovnavigator/shared";
+import { ReactElement, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+interface Props {
+  acceptedFileTypes?: {
+    errorMessage: string;
+    fileTypes: AcceptedFileType[];
+  };
+  maxFileSize?: {
+    errorMessage: string;
+    maxSizeInMegabytes: number;
+  };
+  errorMessageRequired: string;
+  hasError?: boolean;
+  helperText: string;
+  value: InputFile | undefined;
+  onChange: (file: InputFile) => void;
+}
+
+const FileTypeToInputString: Record<AcceptedFileType, string> = {
+  PDF: "application/pdf",
+  PNG: "image/png",
+};
+
+const InputStringToFileType = flipObject(FileTypeToInputString) as Record<string, AcceptedFileType>;
+
+const BYTES_IN_A_MB = 1048576;
+
+export const FileInput = ({
+  acceptedFileTypes,
+  errorMessageRequired,
+  hasError,
+  helperText,
+  maxFileSize,
+  value,
+  onChange,
+}: Props): ReactElement => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const fileInput = require("../../../../node_modules/@uswds/uswds/packages/usa-file-input/src");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const size = maxFileSize?.maxSizeInMegabytes ? maxFileSize.maxSizeInMegabytes * BYTES_IN_A_MB : undefined;
+
+  const [hasFileBeenRead, setHasFileBeenRead] = useState<boolean>(false);
+  const [fileUploadError, setFileUploadError] = useState({ hasError: false, errorMessage: "" });
+
+  const createAcceptedFileString = (): string | undefined => {
+    if (!acceptedFileTypes) return undefined;
+    return acceptedFileTypes.fileTypes.map((it) => FileTypeToInputString[it]).join(",");
+  };
+
+  const getErrorMessage = (): string => {
+    if (fileUploadError.hasError) {
+      return fileUploadError.errorMessage;
+    } else if (hasError) {
+      return errorMessageRequired;
+    }
+    return "";
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    if (e.target.files && e.target.files.length > 0) {
+      const uploadedFile = e.target.files[0];
+      const reader = new FileReader();
+
+      // eslint-disable-next-line unicorn/prefer-add-event-listener
+      reader.onload = function (event: ProgressEvent<FileReader>): void {
+        if (!event.target?.result) {
+          return;
+        }
+
+        setHasFileBeenRead(true);
+        onChange({
+          base64Contents: (event.target.result as string).split(",")[1],
+          sizeInBytes: uploadedFile.size,
+          fileType: InputStringToFileType[uploadedFile.type],
+          filename: uploadedFile.name,
+        });
+        setFileUploadError({ hasError: false, errorMessage: "" });
+      };
+      reader.readAsDataURL(uploadedFile);
+    }
+  };
+
+  useLayoutEffect(() => {
+    const fileInputElement = fileInputRef.current;
+
+    // Prevent the user from selecting a file that is too large or of the wrong file type
+    const preventInvalidFileSelection = (e: Event): void => {
+      const eventTarget = e.target as HTMLInputElement;
+      if (eventTarget.files && eventTarget.files.length > 0) {
+        const selectedFile = eventTarget.files[0];
+        if (
+          acceptedFileTypes &&
+          !acceptedFileTypes.fileTypes.includes(InputStringToFileType[selectedFile.type])
+        ) {
+          e.stopImmediatePropagation();
+          setFileUploadError({
+            hasError: true,
+            errorMessage: templateEval(acceptedFileTypes.errorMessage, { fileName: selectedFile.name }),
+          });
+        } else if (maxFileSize && size && selectedFile.size > size) {
+          e.stopImmediatePropagation();
+          setFileUploadError({
+            hasError: true,
+            errorMessage: templateEval(maxFileSize.errorMessage, {
+              fileName: selectedFile.name,
+              maxFileSize: `${maxFileSize.maxSizeInMegabytes}`,
+            }),
+          });
+        }
+      }
+    };
+
+    // Event listener is added to the file input element ahead of USWDS listeners - React onChange will be added after
+    fileInputElement?.addEventListener("change", (e: Event) => {
+      preventInvalidFileSelection(e);
+    });
+    if (typeof fileInput.on === "function" && typeof fileInput.off === "function") {
+      fileInput.on(fileInputElement); // initialize USWDS fileInput component
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const addPreviouslyUploadedFile = (): void => {
+    const fileInputElement = fileInputRef.current;
+    if (value && fileInputElement?.files?.length === 0) {
+      const file = new File([Buffer.from(value.base64Contents, "base64").toString("utf8")], value.filename, {
+        type: FileTypeToInputString[value.fileType],
+      });
+
+      const dT = new DataTransfer();
+      if (fileInputElement) {
+        dT.items.add(file);
+        fileInputElement.files = dT.files;
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        fileInputElement.dispatchEvent(new Event("change", { target: { files: [file] } }));
+      }
+    }
+  };
+
+  useEffect(() => {
+    addPreviouslyUploadedFile();
+  }, [value]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <>
+      <div className="usa-form-group">
+        <label className="usa-label" htmlFor="file-input-single">
+          {helperText}
+        </label>
+        <span className="usa-error-message" id="file-input-error-alert">
+          {getErrorMessage()}
+        </span>
+        <input
+          data-testid="file-input"
+          accept={createAcceptedFileString()}
+          className="usa-file-input"
+          id="file-input-single"
+          name="file-input-single"
+          onChange={handleChange}
+          size={size}
+          ref={fileInputRef}
+          type="file"
+        />
+      </div>
+      <div aria-hidden="true" data-testid={hasFileBeenRead ? "file-is-read" : ""} />
+    </>
+  );
+};

--- a/web/src/components/tasks/business-formation/BusinessFormation.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormation.tsx
@@ -26,11 +26,12 @@ import {
   createEmptyFormationFormData,
   defaultDateFormat,
   defaultFormationLegalType,
+  FieldsForErrorHandling,
   foreignLegalTypePrefix,
-  FormationFields,
   FormationFormData,
   FormationLegalType,
   getCurrentDateFormatted,
+  InputFile,
   NameAvailability,
   PublicFilingLegalType,
   UserData,
@@ -53,7 +54,7 @@ export const BusinessFormation = (props: Props): ReactElement => {
     createEmptyFormationFormData()
   );
   const [stepIndex, setStepIndex] = useState(0);
-  const [interactedFields, setInteractedFields] = useState<FormationFields[]>([]);
+  const [interactedFields, setInteractedFields] = useState<FieldsForErrorHandling[]>([]);
   const [showResponseAlert, setShowResponseAlert] = useState<boolean>(false);
   const [isLoadingGetFiling, setIsLoadingGetFiling] = useState<boolean>(false);
   const [hasBeenSubmitted, setHasBeenSubmitted] = useState<boolean>(false);
@@ -62,6 +63,7 @@ export const BusinessFormation = (props: Props): ReactElement => {
   const [businessNameAvailability, setBusinessNameAvailability] = useState<NameAvailability | undefined>(
     undefined
   );
+  const [foreignGoodStandingFile, setForeignGoodStandingFile] = useState<InputFile | undefined>(undefined);
 
   const legalStructureId: FormationLegalType = useMemo(() => {
     return castPublicFilingLegalTypeToFormationType(
@@ -166,7 +168,10 @@ export const BusinessFormation = (props: Props): ReactElement => {
     })();
   }, [router.isReady, update, router, props.task.urlSlug, userData]);
 
-  const setFieldsInteracted = (fields: FormationFields[], config?: { setToUninteracted: boolean }): void => {
+  const setFieldsInteracted = (
+    fields: FieldsForErrorHandling[],
+    config?: { setToUninteracted: boolean }
+  ): void => {
     setInteractedFields((prevState) => {
       const prevStateFieldRemoved = prevState.filter((it) => {
         return !fields.includes(it);
@@ -241,6 +246,7 @@ export const BusinessFormation = (props: Props): ReactElement => {
           interactedFields,
           hasBeenSubmitted,
           hasSetStateFirstTime,
+          foreignGoodStandingFile,
         },
         setFormationFormData,
         setBusinessNameAvailability,
@@ -248,6 +254,7 @@ export const BusinessFormation = (props: Props): ReactElement => {
         setShowResponseAlert,
         setFieldsInteracted,
         setHasBeenSubmitted,
+        setForeignGoodStandingFile,
       }}
     >
       <div className="flex flex-column minh-38" data-testid="formation-form">

--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.tsx
@@ -281,7 +281,11 @@ export const BusinessFormationPaginator = (): ReactElement => {
 
     setIsLoading(true);
 
-    const newUserData = await api.postBusinessFormation(filteredUserData, window.location.href);
+    const newUserData = await api.postBusinessFormation(
+      filteredUserData,
+      window.location.href,
+      state.foreignGoodStandingFile
+    );
     update(newUserData);
     submitToApiAnalytics(newUserData);
     resetInteractedFields(newUserData);

--- a/web/src/components/tasks/business-formation/business/ForeignCertificate.tsx
+++ b/web/src/components/tasks/business-formation/business/ForeignCertificate.tsx
@@ -1,0 +1,41 @@
+import { FileInput } from "@/components/njwds-extended/FileInput";
+import { BusinessFormationContext } from "@/contexts/businessFormationContext";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { FormControl } from "@mui/material";
+import { ReactElement, useContext } from "react";
+
+interface Props {
+  hasError: boolean;
+}
+
+export const ForeignCertificate = (props: Props): ReactElement => {
+  const { hasError } = props;
+  const { Config } = useConfig();
+  const { state, setForeignGoodStandingFile } = useContext(BusinessFormationContext);
+
+  return (
+    <>
+      <hr className="margin-bottom-2 margin-top-0" aria-hidden={true} />
+      <FormControl variant="outlined" fullWidth className="padding-bottom-2">
+        <h3 className="margin-bottom-2" data-testid="MainBusinesAddressContainer-Header">
+          {Config.formation.fields.foreignGoodStandingFile.label}
+        </h3>
+        <FileInput
+          acceptedFileTypes={{
+            errorMessage: Config.formation.fields.foreignGoodStandingFile.errorMessageFileType,
+            fileTypes: ["PNG", "PDF"],
+          }}
+          onChange={setForeignGoodStandingFile}
+          hasError={hasError}
+          helperText={Config.formation.fields.foreignGoodStandingFile.helperText}
+          errorMessageRequired={Config.formation.fields.foreignGoodStandingFile.errorMessageRequired}
+          maxFileSize={{
+            errorMessage: Config.formation.fields.foreignGoodStandingFile.errorMessageFileSize,
+            maxSizeInMegabytes: 3,
+          }}
+          value={state.foreignGoodStandingFile}
+        />
+      </FormControl>
+    </>
+  );
+};

--- a/web/src/components/tasks/business-formation/business/MainBusiness.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusiness.tsx
@@ -11,6 +11,8 @@ import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormationErrors } from "@/lib/data-hooks/useFormationErrors";
 import { corpLegalStructures } from "@businessnjgovnavigator/shared/";
 import { ReactElement, useContext, useMemo } from "react";
+import { ForeignCertificate } from "./ForeignCertificate";
+import { PracticesLaw } from "./PracticesLaw";
 
 export const MainBusiness = (): ReactElement => {
   const { Config } = useConfig();
@@ -45,26 +47,38 @@ export const MainBusiness = (): ReactElement => {
         </WithErrorBar>
       </WithErrorBar>
       {isForeign && (
-        <WithErrorBar
-          hasError={doSomeFieldsHaveError(["foreignStateOfFormation", "foreignDateOfFormation"])}
-          type="DESKTOP-ONLY"
-          className="grid-row tablet:grid-gap-1"
-        >
+        <>
           <WithErrorBar
-            hasError={doesFieldHaveError("foreignStateOfFormation")}
-            type="MOBILE-ONLY"
-            className="tablet:grid-col-6"
+            hasError={doSomeFieldsHaveError(["foreignStateOfFormation", "foreignDateOfFormation"])}
+            type="DESKTOP-ONLY"
+            className="grid-row tablet:grid-gap-1"
           >
-            <ForeignStateOfFormation />
+            <WithErrorBar
+              hasError={doesFieldHaveError("foreignStateOfFormation")}
+              type="MOBILE-ONLY"
+              className="tablet:grid-col-6"
+            >
+              <ForeignStateOfFormation />
+            </WithErrorBar>
+            <WithErrorBar
+              hasError={doesFieldHaveError("foreignDateOfFormation")}
+              type="MOBILE-ONLY"
+              className="tablet:grid-col-6"
+            >
+              <FormationDate fieldName="foreignDateOfFormation" />
+            </WithErrorBar>
           </WithErrorBar>
-          <WithErrorBar
-            hasError={doesFieldHaveError("foreignDateOfFormation")}
-            type="MOBILE-ONLY"
-            className="tablet:grid-col-6"
-          >
-            <FormationDate fieldName="foreignDateOfFormation" />
-          </WithErrorBar>
-        </WithErrorBar>
+          {state.formationFormData.legalType === "foreign-c-corporation" && (
+            <>
+              <WithErrorBar hasError={doesFieldHaveError("willPracticeLaw")} type="ALWAYS">
+                <PracticesLaw hasError={doesFieldHaveError("willPracticeLaw")} />
+              </WithErrorBar>
+              <WithErrorBar hasError={doesFieldHaveError("foreignGoodStandingFile")} type="ALWAYS">
+                <ForeignCertificate hasError={doesFieldHaveError("foreignGoodStandingFile")} />
+              </WithErrorBar>
+            </>
+          )}
+        </>
       )}
       {corpLegalStructures.includes(state.formationFormData.legalType) && (
         <div className="grid-row">

--- a/web/src/components/tasks/business-formation/business/PracticesLaw.tsx
+++ b/web/src/components/tasks/business-formation/business/PracticesLaw.tsx
@@ -1,0 +1,67 @@
+import { BusinessFormationContext } from "@/contexts/businessFormationContext";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { camelCaseToSentence } from "@/lib/utils/cases-helpers";
+import { FormControl, FormControlLabel, FormHelperText, Radio, RadioGroup } from "@mui/material";
+import { ReactElement, useContext } from "react";
+
+interface Props {
+  hasError: boolean;
+}
+
+export const PracticesLaw = (props: Props): ReactElement => {
+  const { hasError } = props;
+  const { Config } = useConfig();
+  const { state, setFormationFormData } = useContext(BusinessFormationContext);
+
+  const onChange = (value: "true" | "false"): void => {
+    const willPracticeLaw = JSON.parse(value);
+    setFormationFormData((previousState) => {
+      return {
+        ...previousState,
+        willPracticeLaw,
+      };
+    });
+  };
+
+  return (
+    <FormControl variant="outlined" fullWidth className="padding-bottom-2">
+      <RadioGroup
+        aria-label={camelCaseToSentence(Config.formation.fields.willPracticeLaw.label)}
+        className="fac"
+        key={`${state.formationFormData.willPracticeLaw}-key`}
+        value={state.formationFormData.willPracticeLaw}
+        onChange={(e): void => onChange(e.target.value as "true" | "false")}
+        row
+      >
+        <label className="margin-right-3">{Config.formation.fields.willPracticeLaw.label}</label>
+        <FormControlLabel
+          labelPlacement="end"
+          data-testid={"practice-law-yes"}
+          value={"true"}
+          control={<Radio color="primary" />}
+          label={
+            <div className="padding-y-1 margin-right-3">
+              {Config.formation.fields.willPracticeLaw.radioYesText}
+            </div>
+          }
+        />
+        <FormControlLabel
+          labelPlacement="end"
+          data-testid={"practice-law-no"}
+          value={"false"}
+          control={<Radio color="primary" />}
+          label={
+            <div className="padding-y-1 margin-right-3">
+              {Config.formation.fields.willPracticeLaw.radioNoText}
+            </div>
+          }
+        />
+      </RadioGroup>
+      {hasError && (
+        <FormHelperText className={"text-error-dark"}>
+          {Config.formation.fields.willPracticeLaw.error}
+        </FormHelperText>
+      )}
+    </FormControl>
+  );
+};

--- a/web/src/components/tasks/business-formation/contacts/ContactsStep.tsx
+++ b/web/src/components/tasks/business-formation/contacts/ContactsStep.tsx
@@ -48,7 +48,7 @@ export const ContactsStep = (): ReactElement => {
             {doesFieldHaveError("members") && (
               <Alert variant="error">
                 {
-                  getErrorStateForField("members", state.formationFormData, state.businessNameAvailability)
+                  getErrorStateForField({ field: "members", formationFormData: state.formationFormData })
                     .label
                 }
               </Alert>
@@ -59,13 +59,13 @@ export const ContactsStep = (): ReactElement => {
         <hr className="margin-top-0 margin-bottom-3" />
         {doesFieldHaveError("signers") && (
           <Alert variant="error">
-            {getErrorStateForField("signers", state.formationFormData, state.businessNameAvailability).label}
+            {getErrorStateForField({ field: "signers", formationFormData: state.formationFormData }).label}
           </Alert>
         )}
         {doesFieldHaveError("incorporators") && (
           <Alert variant="error">
             {
-              getErrorStateForField("incorporators", state.formationFormData, state.businessNameAvailability)
+              getErrorStateForField({ field: "incorporators", formationFormData: state.formationFormData })
                 .label
             }
           </Alert>

--- a/web/src/components/tasks/business-formation/getErrorStateForField.test.ts
+++ b/web/src/components/tasks/business-formation/getErrorStateForField.test.ts
@@ -3,6 +3,7 @@
 import { getErrorStateForField } from "@/components/tasks/business-formation/getErrorStateForField";
 import { getMergedConfig } from "@/contexts/configContext";
 import { templateEval } from "@/lib/utils/helpers";
+import { generateInputFile } from "@/test/factories";
 import {
   defaultDateFormat,
   FormationFields,
@@ -22,165 +23,217 @@ const Config = getMergedConfig();
 describe("getErrorStateForField", () => {
   describe("businessName", () => {
     it("has error if empty", () => {
-      const formData = generateFormationFormData({ businessName: "" });
-      expect(getErrorStateForField("businessName", formData, undefined).hasError).toEqual(true);
+      const formationFormData = generateFormationFormData({ businessName: "" });
+      expect(
+        getErrorStateForField({
+          field: "businessName",
+          formationFormData,
+        }).hasError
+      ).toEqual(true);
     });
 
     it("has error if no name availability data", () => {
-      const formData = generateFormationFormData({ businessName: "some name" });
-      expect(getErrorStateForField("businessName", formData, undefined).hasError).toEqual(true);
+      const formationFormData = generateFormationFormData({ businessName: "some name" });
+      expect(
+        getErrorStateForField({
+          field: "businessName",
+          formationFormData,
+        }).hasError
+      ).toEqual(true);
     });
 
     it("has error if unavailable", () => {
-      const formData = generateFormationFormData({
-        businessName: "some name",
-      });
-      const businessNameAvailability = generateBusinessNameAvailability({
-        status: "UNAVAILABLE",
-      });
-      expect(getErrorStateForField("businessName", formData, businessNameAvailability).hasError).toEqual(
-        true
-      );
+      const formationFormData = generateFormationFormData({ businessName: "some name" });
+      const businessNameAvailability = generateBusinessNameAvailability({ status: "UNAVAILABLE" });
+      expect(
+        getErrorStateForField({ field: "businessName", formationFormData, businessNameAvailability }).hasError
+      ).toEqual(true);
     });
 
     it("has error if availability error", () => {
-      const formData = generateFormationFormData({
-        businessName: "some name",
-      });
-      const businessNameAvailability = generateBusinessNameAvailability({
-        status: "DESIGNATOR_ERROR",
-      });
-      expect(getErrorStateForField("businessName", formData, businessNameAvailability).hasError).toEqual(
-        true
-      );
+      const formationFormData = generateFormationFormData({ businessName: "some name" });
+      const businessNameAvailability = generateBusinessNameAvailability({ status: "DESIGNATOR_ERROR" });
+      expect(
+        getErrorStateForField({ field: "businessName", formationFormData, businessNameAvailability }).hasError
+      ).toEqual(true);
     });
 
     it("has no error if available", () => {
-      const formData = generateFormationFormData({
-        businessName: "some name",
-      });
-      const businessNameAvailability = generateBusinessNameAvailability({
-        status: "AVAILABLE",
-      });
-      expect(getErrorStateForField("businessName", formData, businessNameAvailability).hasError).toEqual(
-        false
-      );
+      const formationFormData = generateFormationFormData({ businessName: "some name" });
+      const businessNameAvailability = generateBusinessNameAvailability({ status: "AVAILABLE" });
+      expect(
+        getErrorStateForField({ field: "businessName", formationFormData, businessNameAvailability }).hasError
+      ).toEqual(false);
     });
 
     it("uses errorInlineEmpty as label if name is missing", () => {
-      const formData = generateFormationFormData({ businessName: "" });
-      expect(getErrorStateForField("businessName", formData, undefined).label).toEqual(
-        Config.formation.fields.businessName.errorInlineEmpty
-      );
+      const formationFormData = generateFormationFormData({ businessName: "" });
+      expect(
+        getErrorStateForField({
+          field: "businessName",
+          formationFormData,
+        }).label
+      ).toEqual(Config.formation.fields.businessName.errorInlineEmpty);
     });
 
     it("uses errorInlineNeedsToSearch as label if name exists but availability is undefined", () => {
-      const formData = generateFormationFormData({ businessName: "some name" });
-      expect(getErrorStateForField("businessName", formData, undefined).label).toEqual(
-        Config.formation.fields.businessName.errorInlineNeedsToSearch
-      );
+      const formationFormData = generateFormationFormData({ businessName: "some name" });
+      expect(
+        getErrorStateForField({
+          field: "businessName",
+          formationFormData,
+        }).label
+      ).toEqual(Config.formation.fields.businessName.errorInlineNeedsToSearch);
     });
 
     it("uses errorInlineUnavailable as label if name availability is UNAVAILABLE", () => {
-      const formData = generateFormationFormData({
-        businessName: "some name",
-      });
-      const businessNameAvailability = generateBusinessNameAvailability({
-        status: "UNAVAILABLE",
-      });
-      expect(getErrorStateForField("businessName", formData, businessNameAvailability).label).toEqual(
-        Config.formation.fields.businessName.errorInlineUnavailable
-      );
+      const formationFormData = generateFormationFormData({ businessName: "some name" });
+      const businessNameAvailability = generateBusinessNameAvailability({ status: "UNAVAILABLE" });
+      expect(
+        getErrorStateForField({
+          field: "businessName",
+          formationFormData,
+          businessNameAvailability,
+        }).label
+      ).toEqual(Config.formation.fields.businessName.errorInlineUnavailable);
     });
 
     it("uses errorInlineUnavailable as label if name availability is error", () => {
-      const formData = generateFormationFormData({
-        businessName: "some name",
-      });
-      const businessNameAvailability = generateBusinessNameAvailability({
-        status: "DESIGNATOR_ERROR",
-      });
-      expect(getErrorStateForField("businessName", formData, businessNameAvailability).label).toEqual(
-        Config.formation.fields.businessName.errorInlineUnavailable
-      );
+      const formationFormData = generateFormationFormData({ businessName: "some name" });
+      const businessNameAvailability = generateBusinessNameAvailability({ status: "DESIGNATOR_ERROR" });
+      expect(
+        getErrorStateForField({
+          field: "businessName",
+          formationFormData,
+          businessNameAvailability,
+        }).label
+      ).toEqual(Config.formation.fields.businessName.errorInlineUnavailable);
     });
 
     it("uses field name as label if name availability is AVAILABLE", () => {
-      const formData = generateFormationFormData({
-        businessName: "some name",
-      });
-      const businessNameAvailability = generateBusinessNameAvailability({
-        status: "AVAILABLE",
-      });
-      expect(getErrorStateForField("businessName", formData, businessNameAvailability).label).toEqual(
-        Config.formation.fields.businessName.label
-      );
+      const formationFormData = generateFormationFormData({ businessName: "some name" });
+      const businessNameAvailability = generateBusinessNameAvailability({ status: "AVAILABLE" });
+      expect(
+        getErrorStateForField({
+          field: "businessName",
+          formationFormData,
+          businessNameAvailability,
+        }).label
+      ).toEqual(Config.formation.fields.businessName.label);
     });
   });
 
   describe("foreignDateOfFormation", () => {
     it("has error if empty", () => {
-      const formData = generateFormationFormData({ foreignDateOfFormation: undefined });
-      expect(getErrorStateForField("foreignDateOfFormation", formData, undefined).hasError).toEqual(true);
+      const formationFormData = generateFormationFormData({ foreignDateOfFormation: undefined });
+      expect(
+        getErrorStateForField({
+          field: "foreignDateOfFormation",
+          formationFormData,
+        }).hasError
+      ).toEqual(true);
     });
 
     it("has error if invalid date", () => {
-      const formData = generateFormationFormData({ foreignDateOfFormation: "1234567" });
-      expect(getErrorStateForField("foreignDateOfFormation", formData, undefined).hasError).toEqual(true);
+      const formationFormData = generateFormationFormData({ foreignDateOfFormation: "1234567" });
+      expect(
+        getErrorStateForField({
+          field: "foreignDateOfFormation",
+          formationFormData,
+        }).hasError
+      ).toEqual(true);
     });
 
     it("has no error in the past", () => {
-      const formData = generateFormationFormData({
+      const formationFormData = generateFormationFormData({
         foreignDateOfFormation: getCurrentDate().subtract(1, "day").format(defaultDateFormat),
       });
-      expect(getErrorStateForField("foreignDateOfFormation", formData, undefined).hasError).toEqual(false);
+      expect(
+        getErrorStateForField({
+          field: "foreignDateOfFormation",
+          formationFormData,
+        }).hasError
+      ).toEqual(false);
     });
 
     it("has no error if today", () => {
-      const formData = generateFormationFormData({
+      const formationFormData = generateFormationFormData({
         foreignDateOfFormation: getCurrentDateFormatted(defaultDateFormat),
       });
-      expect(getErrorStateForField("foreignDateOfFormation", formData, undefined).hasError).toEqual(false);
+      expect(
+        getErrorStateForField({
+          field: "foreignDateOfFormation",
+          formationFormData,
+        }).hasError
+      ).toEqual(false);
     });
 
     it("has no error if in the future", () => {
-      const formData = generateFormationFormData({
+      const formationFormData = generateFormationFormData({
         foreignDateOfFormation: getCurrentDate().add(1, "day").format(defaultDateFormat),
       });
-      expect(getErrorStateForField("foreignDateOfFormation", formData, undefined).hasError).toEqual(false);
+      expect(
+        getErrorStateForField({
+          field: "foreignDateOfFormation",
+          formationFormData,
+        }).hasError
+      ).toEqual(false);
     });
 
     it("inserts label from config", () => {
-      const formData = generateFormationFormData({ foreignDateOfFormation: "1234567" });
-      expect(getErrorStateForField("foreignDateOfFormation", formData, undefined).label).toEqual(
-        Config.formation.fields.foreignDateOfFormation.error
-      );
+      const formationFormData = generateFormationFormData({ foreignDateOfFormation: "1234567" });
+      expect(
+        getErrorStateForField({
+          field: "foreignDateOfFormation",
+          formationFormData,
+        }).label
+      ).toEqual(Config.formation.fields.foreignDateOfFormation.error);
     });
   });
 
   describe("businessStartDate", () => {
     it("has error if empty", () => {
-      const formData = generateFormationFormData({ businessStartDate: "" });
-      expect(getErrorStateForField("businessStartDate", formData, undefined).hasError).toEqual(true);
+      const formationFormData = generateFormationFormData({ businessStartDate: "" });
+      expect(
+        getErrorStateForField({
+          field: "businessStartDate",
+          formationFormData,
+        }).hasError
+      ).toEqual(true);
     });
 
     it("has error if invalid date", () => {
-      const formData = generateFormationFormData({ businessStartDate: "1234567" });
-      expect(getErrorStateForField("businessStartDate", formData, undefined).hasError).toEqual(true);
+      const formationFormData = generateFormationFormData({ businessStartDate: "1234567" });
+      expect(
+        getErrorStateForField({
+          field: "businessStartDate",
+          formationFormData,
+        }).hasError
+      ).toEqual(true);
     });
 
     it("has error in the past", () => {
-      const formData = generateFormationFormData({
+      const formationFormData = generateFormationFormData({
         businessStartDate: getCurrentDate().subtract(1, "day").format(defaultDateFormat),
       });
-      expect(getErrorStateForField("businessStartDate", formData, undefined).hasError).toEqual(true);
+      expect(
+        getErrorStateForField({
+          field: "businessStartDate",
+          formationFormData,
+        }).hasError
+      ).toEqual(true);
     });
 
     it("has no error if today", () => {
-      const formData = generateFormationFormData({
+      const formationFormData = generateFormationFormData({
         businessStartDate: getCurrentDateFormatted(defaultDateFormat),
       });
-      expect(getErrorStateForField("businessStartDate", formData, undefined).hasError).toEqual(false);
+      expect(
+        getErrorStateForField({
+          field: "businessStartDate",
+          formationFormData,
+        }).hasError
+      ).toEqual(false);
     });
 
     describe("future date validation", () => {
@@ -192,13 +245,18 @@ describe("getErrorStateForField", () => {
         legalStructureIds.map((legalStructureId) =>
           describe(`for ${legalStructureId}`, () => {
             it(`has${error ? " " : " no "}error if in the future`, () => {
-              const formData = generateFormationFormData(
+              const formationFormData = generateFormationFormData(
                 {
                   businessStartDate: getCurrentDate().add(additionalDays, "day").format(defaultDateFormat),
                 },
                 { legalStructureId }
               );
-              expect(getErrorStateForField("businessStartDate", formData, undefined).hasError).toEqual(error);
+              expect(
+                getErrorStateForField({
+                  field: "businessStartDate",
+                  formationFormData,
+                }).hasError
+              ).toEqual(error);
             });
           })
         );
@@ -235,10 +293,10 @@ describe("getErrorStateForField", () => {
     });
 
     it("inserts label from config", () => {
-      const formData = generateFormationFormData({
+      const formationFormData = generateFormationFormData({
         businessStartDate: getCurrentDate().add(1, "day").format(defaultDateFormat),
       });
-      expect(getErrorStateForField("businessStartDate", formData, undefined).label).toEqual(
+      expect(getErrorStateForField({ field: "businessStartDate", formationFormData }).label).toEqual(
         Config.formation.fields.businessStartDate.label
       );
     });
@@ -249,83 +307,100 @@ describe("getErrorStateForField", () => {
       const legalStructureId = "foreign-limited-liability-company";
 
       it("has error if empty", () => {
-        const formData = generateFormationFormData({ addressZipCode: "" }, { legalStructureId });
-        expect(getErrorStateForField("addressZipCode", formData, undefined).hasError).toEqual(true);
+        const formationFormData = generateFormationFormData({ addressZipCode: "" }, { legalStructureId });
+        expect(getErrorStateForField({ field: "addressZipCode", formationFormData }).hasError).toEqual(true);
       });
 
       it("inserts label from config", () => {
-        const formData = generateFormationFormData({ addressZipCode: "08100" }, { legalStructureId });
-        expect(getErrorStateForField("addressZipCode", formData, undefined).label).toEqual(
+        const formationFormData = generateFormationFormData(
+          { addressZipCode: "08100" },
+          { legalStructureId }
+        );
+        expect(getErrorStateForField({ field: "addressZipCode", formationFormData }).label).toEqual(
           Config.formation.fields.addressZipCode.error
         );
       });
 
       describe("US", () => {
         it("has no error if outside of NJ range", () => {
-          const formData = generateFormationFormData(
+          const formationFormData = generateFormationFormData(
             { addressZipCode: "12345", businessLocationType: "US" },
             { legalStructureId }
           );
-          expect(getErrorStateForField("addressZipCode", formData, undefined).hasError).toEqual(false);
+          expect(getErrorStateForField({ field: "addressZipCode", formationFormData }).hasError).toEqual(
+            false
+          );
         });
 
         it("has error if less than 5 digits long", () => {
-          const formData = generateFormationFormData(
+          const formationFormData = generateFormationFormData(
             { addressZipCode: "0810", businessLocationType: "US" },
             { legalStructureId }
           );
-          expect(getErrorStateForField("addressZipCode", formData, undefined).hasError).toEqual(true);
+          expect(getErrorStateForField({ field: "addressZipCode", formationFormData }).hasError).toEqual(
+            true
+          );
         });
 
         it("has error if more than 5 digits long", () => {
-          const formData = generateFormationFormData(
+          const formationFormData = generateFormationFormData(
             { addressZipCode: "1231245", businessLocationType: "US" },
             { legalStructureId }
           );
-          expect(getErrorStateForField("addressZipCode", formData, undefined).hasError).toEqual(true);
+          expect(getErrorStateForField({ field: "addressZipCode", formationFormData }).hasError).toEqual(
+            true
+          );
         });
       });
 
       describe("INTL", () => {
         it("has no error if more than 5", () => {
-          const formData = generateFormationFormData(
+          const formationFormData = generateFormationFormData(
             {
               addressZipCode: "1231245",
               businessLocationType: "INTL",
             },
             { legalStructureId }
           );
-          expect(getErrorStateForField("addressZipCode", formData, undefined).hasError).toEqual(false);
+          expect(getErrorStateForField({ field: "addressZipCode", formationFormData }).hasError).toEqual(
+            false
+          );
         });
 
         it("has no error if equal to or less than 11 digits in length", () => {
-          const formData = generateFormationFormData(
+          const formationFormData = generateFormationFormData(
             {
               addressZipCode: "12345678912",
               businessLocationType: "INTL",
             },
             { legalStructureId }
           );
-          expect(getErrorStateForField("addressZipCode", formData, undefined).hasError).toEqual(false);
+          expect(getErrorStateForField({ field: "addressZipCode", formationFormData }).hasError).toEqual(
+            false
+          );
         });
 
         it("has error if greater than 11 digits in length", () => {
-          const formData = generateFormationFormData(
+          const formationFormData = generateFormationFormData(
             {
               addressZipCode: "123456789124",
               businessLocationType: "INTL",
             },
             { legalStructureId }
           );
-          expect(getErrorStateForField("addressZipCode", formData, undefined).hasError).toEqual(true);
+          expect(getErrorStateForField({ field: "addressZipCode", formationFormData }).hasError).toEqual(
+            true
+          );
         });
 
         it("has error if zip code has no characters", () => {
-          const formData = generateFormationFormData(
+          const formationFormData = generateFormationFormData(
             { addressZipCode: "", businessLocationType: "INTL" },
             { legalStructureId }
           );
-          expect(getErrorStateForField("addressZipCode", formData, undefined).hasError).toEqual(true);
+          expect(getErrorStateForField({ field: "addressZipCode", formationFormData }).hasError).toEqual(
+            true
+          );
         });
       });
     });
@@ -334,23 +409,23 @@ describe("getErrorStateForField", () => {
       const legalStructureId = "limited-liability-company";
 
       it("has error if not in range", () => {
-        const formData = generateFormationFormData(
+        const formationFormData = generateFormationFormData(
           { addressZipCode: "12345", businessLocationType: "NJ" },
           { legalStructureId }
         );
-        expect(getErrorStateForField("addressZipCode", formData, undefined).hasError).toEqual(true);
+        expect(getErrorStateForField({ field: "addressZipCode", formationFormData }).hasError).toEqual(true);
       });
 
       it("has no error if in range", () => {
-        const formData = generateFormationFormData(
+        const formationFormData = generateFormationFormData(
           { addressZipCode: "08100", businessLocationType: "NJ" },
           { legalStructureId }
         );
-        expect(getErrorStateForField("addressZipCode", formData, undefined).hasError).toEqual(false);
+        expect(getErrorStateForField({ field: "addressZipCode", formationFormData }).hasError).toEqual(false);
       });
 
       it("has partial address error when it is missing and addressLine1 exists", () => {
-        const formData = generateFormationFormData(
+        const formationFormData = generateFormationFormData(
           {
             addressLine1: "some-stuff",
             addressZipCode: "",
@@ -358,13 +433,13 @@ describe("getErrorStateForField", () => {
           { legalStructureId }
         );
 
-        const errorState = getErrorStateForField("addressZipCode", formData, undefined);
+        const errorState = getErrorStateForField({ field: "addressZipCode", formationFormData });
         expect(errorState.hasError).toEqual(true);
         expect(errorState.label).toEqual(Config.formation.general.partialAddressErrorText);
       });
 
       it("has partial address error when it is missing and addressMunicipality exist", () => {
-        const formData = generateFormationFormData(
+        const formationFormData = generateFormationFormData(
           {
             addressZipCode: "",
             addressMunicipality: generateMunicipality({}),
@@ -372,13 +447,13 @@ describe("getErrorStateForField", () => {
           { legalStructureId }
         );
 
-        const errorState = getErrorStateForField("addressZipCode", formData, undefined);
+        const errorState = getErrorStateForField({ field: "addressZipCode", formationFormData });
         expect(errorState.hasError).toEqual(true);
         expect(errorState.label).toEqual(Config.formation.general.partialAddressErrorText);
       });
 
       it("has partial address error when it is missing and addressMunicipality and addressLine1 both exist", () => {
-        const formData = generateFormationFormData(
+        const formationFormData = generateFormationFormData(
           {
             addressLine1: "some-stuff",
             addressMunicipality: generateMunicipality({}),
@@ -387,13 +462,13 @@ describe("getErrorStateForField", () => {
           { legalStructureId }
         );
 
-        const errorState = getErrorStateForField("addressZipCode", formData, undefined);
+        const errorState = getErrorStateForField({ field: "addressZipCode", formationFormData });
         expect(errorState.hasError).toEqual(true);
         expect(errorState.label).toEqual(Config.formation.general.partialAddressErrorText);
       });
 
       it("has no error when it is missing and addressMunicipality and addressLine1 are also missing", () => {
-        const formData = generateFormationFormData(
+        const formationFormData = generateFormationFormData(
           {
             addressLine1: "",
             addressMunicipality: undefined,
@@ -402,7 +477,7 @@ describe("getErrorStateForField", () => {
           { legalStructureId }
         );
 
-        const errorState = getErrorStateForField("addressZipCode", formData, undefined);
+        const errorState = getErrorStateForField({ field: "addressZipCode", formationFormData });
         expect(errorState.hasError).toEqual(false);
       });
     });
@@ -410,23 +485,29 @@ describe("getErrorStateForField", () => {
 
   describe("agentOfficeAddressZipCode", () => {
     it("has error if empty", () => {
-      const formData = generateFormationFormData({ agentOfficeAddressZipCode: "" });
-      expect(getErrorStateForField("agentOfficeAddressZipCode", formData, undefined).hasError).toEqual(true);
+      const formationFormData = generateFormationFormData({ agentOfficeAddressZipCode: "" });
+      expect(
+        getErrorStateForField({ field: "agentOfficeAddressZipCode", formationFormData }).hasError
+      ).toEqual(true);
     });
 
     it("has error if not in range", () => {
-      const formData = generateFormationFormData({ agentOfficeAddressZipCode: "12345" });
-      expect(getErrorStateForField("agentOfficeAddressZipCode", formData, undefined).hasError).toEqual(true);
+      const formationFormData = generateFormationFormData({ agentOfficeAddressZipCode: "12345" });
+      expect(
+        getErrorStateForField({ field: "agentOfficeAddressZipCode", formationFormData }).hasError
+      ).toEqual(true);
     });
 
     it("has no error if in range", () => {
-      const formData = generateFormationFormData({ agentOfficeAddressZipCode: "08100" });
-      expect(getErrorStateForField("agentOfficeAddressZipCode", formData, undefined).hasError).toEqual(false);
+      const formationFormData = generateFormationFormData({ agentOfficeAddressZipCode: "08100" });
+      expect(
+        getErrorStateForField({ field: "agentOfficeAddressZipCode", formationFormData }).hasError
+      ).toEqual(false);
     });
 
     it("inserts label from config", () => {
-      const formData = generateFormationFormData({ agentOfficeAddressZipCode: "08100" });
-      expect(getErrorStateForField("agentOfficeAddressZipCode", formData, undefined).label).toEqual(
+      const formationFormData = generateFormationFormData({ agentOfficeAddressZipCode: "08100" });
+      expect(getErrorStateForField({ field: "agentOfficeAddressZipCode", formationFormData }).label).toEqual(
         Config.formation.fields.agentOfficeAddressZipCode.label
       );
     });
@@ -434,33 +515,33 @@ describe("getErrorStateForField", () => {
 
   describe("agentEmail", () => {
     it("has error if empty", () => {
-      const formData = generateFormationFormData({ agentEmail: "" });
-      const errorState = getErrorStateForField("agentEmail", formData, undefined);
+      const formationFormData = generateFormationFormData({ agentEmail: "" });
+      const errorState = getErrorStateForField({ field: "agentEmail", formationFormData });
       expect(errorState.hasError).toEqual(true);
       expect(errorState.label).toEqual(Config.formation.fields.agentEmail.error);
     });
 
     it("has error if not valid email format", () => {
       const formData1 = generateFormationFormData({ agentEmail: "whatever@" });
-      const errorState1 = getErrorStateForField("agentEmail", formData1, undefined);
+      const errorState1 = getErrorStateForField({ field: "agentEmail", formationFormData: formData1 });
       expect(errorState1.hasError).toEqual(true);
       expect(errorState1.label).toEqual(Config.formation.fields.agentEmail.error);
 
       const formData2 = generateFormationFormData({ agentEmail: "whatever@thing" });
-      const errorState2 = getErrorStateForField("agentEmail", formData2, undefined);
+      const errorState2 = getErrorStateForField({ field: "agentEmail", formationFormData: formData2 });
       expect(errorState2.hasError).toEqual(true);
       expect(errorState2.label).toEqual(Config.formation.fields.agentEmail.error);
 
       const formData3 = generateFormationFormData({ agentEmail: "stuff" });
-      const errorState3 = getErrorStateForField("agentEmail", formData3, undefined);
+      const errorState3 = getErrorStateForField({ field: "agentEmail", formationFormData: formData3 });
       expect(errorState3.hasError).toEqual(true);
       expect(errorState3.label).toEqual(Config.formation.fields.agentEmail.error);
     });
 
     it("has error if valid-format length is greater than 50 chars", () => {
       const longFormEntry = `${Array(43).fill("A").join("")}@aol.com`;
-      const formData = generateFormationFormData({ agentEmail: longFormEntry });
-      const errorState = getErrorStateForField("agentEmail", formData, undefined);
+      const formationFormData = generateFormationFormData({ agentEmail: longFormEntry });
+      const errorState = getErrorStateForField({ field: "agentEmail", formationFormData });
       expect(errorState.hasError).toEqual(true);
       expect(errorState.label).toEqual(
         templateEval(Config.formation.general.maximumLengthErrorText, {
@@ -472,27 +553,27 @@ describe("getErrorStateForField", () => {
 
     it("has no error if valid-format length is less than or equal to 50 chars", () => {
       const longFormEntry = `${Array(42).fill("A").join("")}@aol.com`;
-      const formData = generateFormationFormData({ agentEmail: longFormEntry });
-      const errorState = getErrorStateForField("agentEmail", formData, undefined);
+      const formationFormData = generateFormationFormData({ agentEmail: longFormEntry });
+      const errorState = getErrorStateForField({ field: "agentEmail", formationFormData });
       expect(errorState.hasError).toEqual(false);
     });
   });
 
   describe("agentOfficeAddressMunicipality", () => {
     it("has error if undefined", () => {
-      const formData = generateFormationFormData({ agentOfficeAddressMunicipality: undefined });
-      expect(getErrorStateForField("agentOfficeAddressMunicipality", formData, undefined).hasError).toEqual(
-        true
-      );
+      const formationFormData = generateFormationFormData({ agentOfficeAddressMunicipality: undefined });
+      expect(
+        getErrorStateForField({ field: "agentOfficeAddressMunicipality", formationFormData }).hasError
+      ).toEqual(true);
     });
 
     it("inserts label from config", () => {
-      const formData = generateFormationFormData({
+      const formationFormData = generateFormationFormData({
         agentOfficeAddressMunicipality: generateMunicipality({}),
       });
-      expect(getErrorStateForField("agentOfficeAddressMunicipality", formData, undefined).label).toEqual(
-        Config.formation.fields.agentOfficeAddressMunicipality.label
-      );
+      expect(
+        getErrorStateForField({ field: "agentOfficeAddressMunicipality", formationFormData }).label
+      ).toEqual(Config.formation.fields.agentOfficeAddressMunicipality.label);
     });
   });
 
@@ -501,64 +582,64 @@ describe("getErrorStateForField", () => {
       const generator = field === "signers" ? generateFormationSigner : generateFormationIncorporator;
       return describe(`${field}`, () => {
         it(`has NAME-labelled error when some ${field} do not have a name`, () => {
-          const formData = generateFormationFormData({
+          const formationFormData = generateFormationFormData({
             [field]: [
               generator({ name: "", signature: true }),
               generator({ name: "some-name", signature: true }),
             ],
           });
-          expect(getErrorStateForField(field, formData, undefined).hasError).toEqual(true);
-          expect(getErrorStateForField(field, formData, undefined).label).toEqual(
+          expect(getErrorStateForField({ field, formationFormData }).hasError).toEqual(true);
+          expect(getErrorStateForField({ field, formationFormData }).label).toEqual(
             Config.formation.fields.signers.errorBannerSignerName
           );
         });
 
         it(`has NAME-labelled error when some ${field} name is just whitespace`, () => {
-          const formData = generateFormationFormData({
+          const formationFormData = generateFormationFormData({
             [field]: [generator({ name: " ", signature: true })],
           });
-          expect(getErrorStateForField(field, formData, undefined).hasError).toEqual(true);
-          expect(getErrorStateForField(field, formData, undefined).label).toEqual(
+          expect(getErrorStateForField({ field, formationFormData }).hasError).toEqual(true);
+          expect(getErrorStateForField({ field, formationFormData }).label).toEqual(
             Config.formation.fields.signers.errorBannerSignerName
           );
         });
 
         it(`has CHECKBOX-labelled error when some ${field} are not checked`, () => {
-          const formData = generateFormationFormData({
+          const formationFormData = generateFormationFormData({
             [field]: [
               generator({ name: "some-name", signature: false }),
               generator({ name: "some-name", signature: true }),
             ],
           });
-          expect(getErrorStateForField(field, formData, undefined).hasError).toEqual(true);
-          expect(getErrorStateForField(field, formData, undefined).label).toEqual(
+          expect(getErrorStateForField({ field, formationFormData }).hasError).toEqual(true);
+          expect(getErrorStateForField({ field, formationFormData }).label).toEqual(
             Config.formation.fields.signers.errorBannerCheckbox
           );
         });
 
         it(`has TYPE-labelled error when some ${field} are not set`, () => {
-          const formData = generateFormationFormData({
+          const formationFormData = generateFormationFormData({
             [field]: [
               generator({ name: "some-name", signature: true }),
               generator({ name: "some-name", signature: true, title: "" }),
             ],
           });
-          expect(getErrorStateForField(field, formData, undefined).hasError).toEqual(true);
-          expect(getErrorStateForField(field, formData, undefined).label).toEqual(
+          expect(getErrorStateForField({ field, formationFormData }).hasError).toEqual(true);
+          expect(getErrorStateForField({ field, formationFormData }).label).toEqual(
             Config.formation.fields.signers.errorBannerSignerTitle
           );
         });
 
         it(`has MAX-LENGTH-labelled error when some ${field} names are too long`, () => {
           const tooLongName = Array(51).fill("A").join("");
-          const formData = generateFormationFormData({
+          const formationFormData = generateFormationFormData({
             [field]: [
               generator({ name: "some-name", signature: true }),
               generator({ name: tooLongName, signature: true }),
             ],
           });
-          expect(getErrorStateForField(field, formData, undefined).hasError).toEqual(true);
-          expect(getErrorStateForField(field, formData, undefined).label).toEqual(
+          expect(getErrorStateForField({ field, formationFormData }).hasError).toEqual(true);
+          expect(getErrorStateForField({ field, formationFormData }).label).toEqual(
             templateEval(Config.formation.general.maximumLengthErrorText, {
               field: Config.formation.fields.signers.label,
               maxLen: "50",
@@ -567,65 +648,73 @@ describe("getErrorStateForField", () => {
         });
 
         it(`has MINIMUM-labelled error when length of ${field} is 0`, () => {
-          const formData = generateFormationFormData({ [field]: [] });
-          expect(getErrorStateForField(field, formData, undefined).hasError).toEqual(true);
-          expect(getErrorStateForField(field, formData, undefined).label).toEqual(
+          const formationFormData = generateFormationFormData({ [field]: [] });
+          expect(getErrorStateForField({ field, formationFormData }).hasError).toEqual(true);
+          expect(getErrorStateForField({ field, formationFormData }).label).toEqual(
             Config.formation.fields.signers.errorBannerMinimum
           );
         });
 
         it(`shows NAME error before CHECKBOX error if ${field} is missing both`, () => {
-          const formData = generateFormationFormData({
+          const formationFormData = generateFormationFormData({
             [field]: [
               generator({ name: "", signature: true }),
               generator({ name: "some-name", signature: false }),
             ],
           });
-          expect(getErrorStateForField(field, formData, undefined).hasError).toEqual(true);
-          expect(getErrorStateForField(field, formData, undefined).label).toEqual(
+          expect(getErrorStateForField({ field, formationFormData }).hasError).toEqual(true);
+          expect(getErrorStateForField({ field, formationFormData }).label).toEqual(
             Config.formation.fields.signers.errorBannerSignerName
           );
         });
 
         it(`has no error when all ${field} have name and checkbox`, () => {
-          const formData = generateFormationFormData({
+          const formationFormData = generateFormationFormData({
             [field]: [
               generator({ name: "some-name", signature: true }),
               generator({ name: "some-name", signature: true }),
             ],
           });
-          expect(getErrorStateForField(field, formData, undefined).hasError).toEqual(false);
+          expect(getErrorStateForField({ field, formationFormData }).hasError).toEqual(false);
         });
 
         if (field === "incorporators") {
           it(`has error if some incorporators missing city and municipality`, () => {
-            const formData = generateFormationFormData({
+            const formationFormData = generateFormationFormData({
               incorporators: [
                 generateFormationIncorporator({ addressCity: "", addressMunicipality: undefined }),
               ],
             });
-            expect(getErrorStateForField("incorporators", formData, undefined).hasError).toEqual(true);
+            expect(getErrorStateForField({ field: "incorporators", formationFormData }).hasError).toEqual(
+              true
+            );
           });
 
           it(`has error if some incorporators missing addressLine1`, () => {
-            const formData = generateFormationFormData({
+            const formationFormData = generateFormationFormData({
               incorporators: [generateFormationIncorporator({ addressLine1: "" })],
             });
-            expect(getErrorStateForField("incorporators", formData, undefined).hasError).toEqual(true);
+            expect(getErrorStateForField({ field: "incorporators", formationFormData }).hasError).toEqual(
+              true
+            );
           });
 
           it(`has error if some incorporators missing state`, () => {
-            const formData = generateFormationFormData({
+            const formationFormData = generateFormationFormData({
               incorporators: [generateFormationIncorporator({ addressState: undefined })],
             });
-            expect(getErrorStateForField("incorporators", formData, undefined).hasError).toEqual(true);
+            expect(getErrorStateForField({ field: "incorporators", formationFormData }).hasError).toEqual(
+              true
+            );
           });
 
           it(`has error if some incorporators missing zip code`, () => {
-            const formData = generateFormationFormData({
+            const formationFormData = generateFormationFormData({
               incorporators: [generateFormationIncorporator({ addressZipCode: "" })],
             });
-            expect(getErrorStateForField("incorporators", formData, undefined).hasError).toEqual(true);
+            expect(getErrorStateForField({ field: "incorporators", formationFormData }).hasError).toEqual(
+              true
+            );
           });
         }
       });
@@ -634,49 +723,51 @@ describe("getErrorStateForField", () => {
 
   describe("members", () => {
     it("has MINIMUM-labelled error when members length is 0", () => {
-      const formData = generateFormationFormData({ members: [] });
-      expect(getErrorStateForField("members", formData, undefined).hasError).toEqual(true);
-      expect(getErrorStateForField("members", formData, undefined).label).toEqual(
+      const formationFormData = generateFormationFormData({ members: [] });
+      expect(getErrorStateForField({ field: "members", formationFormData }).hasError).toEqual(true);
+      expect(getErrorStateForField({ field: "members", formationFormData }).label).toEqual(
         Config.formation.fields.directors.error
       );
     });
 
     it("has no error when members exist", () => {
-      const formData = generateFormationFormData({ members: [generateFormationMember({})] });
-      expect(getErrorStateForField("members", formData, undefined).hasError).toEqual(false);
+      const formationFormData = generateFormationFormData({ members: [generateFormationMember({})] });
+      expect(getErrorStateForField({ field: "members", formationFormData }).hasError).toEqual(false);
     });
 
     it("has error if some members missing name", () => {
-      const formData = generateFormationFormData({ members: [generateFormationMember({ name: "" })] });
-      expect(getErrorStateForField("members", formData, undefined).hasError).toEqual(true);
+      const formationFormData = generateFormationFormData({
+        members: [generateFormationMember({ name: "" })],
+      });
+      expect(getErrorStateForField({ field: "members", formationFormData }).hasError).toEqual(true);
     });
 
     it("has error if some members missing city and municipality", () => {
-      const formData = generateFormationFormData({
+      const formationFormData = generateFormationFormData({
         members: [generateFormationMember({ addressCity: "", addressMunicipality: undefined })],
       });
-      expect(getErrorStateForField("members", formData, undefined).hasError).toEqual(true);
+      expect(getErrorStateForField({ field: "members", formationFormData }).hasError).toEqual(true);
     });
 
     it("has error if some members missing addressLine1", () => {
-      const formData = generateFormationFormData({
+      const formationFormData = generateFormationFormData({
         members: [generateFormationMember({ addressLine1: "" })],
       });
-      expect(getErrorStateForField("members", formData, undefined).hasError).toEqual(true);
+      expect(getErrorStateForField({ field: "members", formationFormData }).hasError).toEqual(true);
     });
 
     it("has error if some members missing state", () => {
-      const formData = generateFormationFormData({
+      const formationFormData = generateFormationFormData({
         members: [generateFormationMember({ addressState: undefined })],
       });
-      expect(getErrorStateForField("members", formData, undefined).hasError).toEqual(true);
+      expect(getErrorStateForField({ field: "members", formationFormData }).hasError).toEqual(true);
     });
 
     it("has error if some members missing zip code", () => {
-      const formData = generateFormationFormData({
+      const formationFormData = generateFormationFormData({
         members: [generateFormationMember({ addressZipCode: "" })],
       });
-      expect(getErrorStateForField("members", formData, undefined).hasError).toEqual(true);
+      expect(getErrorStateForField({ field: "members", formationFormData }).hasError).toEqual(true);
     });
   });
 
@@ -685,16 +776,19 @@ describe("getErrorStateForField", () => {
       const legalStructureId = "foreign-limited-liability-company";
 
       it("has error and label if empty", () => {
-        const formData = generateFormationFormData({ addressLine1: "" }, { legalStructureId });
-        const errorState = getErrorStateForField("addressLine1", formData, undefined);
+        const formationFormData = generateFormationFormData({ addressLine1: "" }, { legalStructureId });
+        const errorState = getErrorStateForField({ field: "addressLine1", formationFormData });
         expect(errorState.hasError).toEqual(true);
         expect(errorState.label).toEqual(Config.formation.fields.addressLine1.error);
       });
 
       it("has error if length is greater than 35 chars", () => {
         const longFormEntry = Array(36).fill("A").join("");
-        const formData = generateFormationFormData({ addressLine1: longFormEntry }, { legalStructureId });
-        const errorState = getErrorStateForField("addressLine1", formData, undefined);
+        const formationFormData = generateFormationFormData(
+          { addressLine1: longFormEntry },
+          { legalStructureId }
+        );
+        const errorState = getErrorStateForField({ field: "addressLine1", formationFormData });
         expect(errorState.hasError).toEqual(true);
         const expectedLabel = templateEval(Config.formation.general.maximumLengthErrorText, {
           field: Config.formation.fields.addressLine1.label,
@@ -705,8 +799,11 @@ describe("getErrorStateForField", () => {
 
       it("has no error if length is less than or equal to 35 chars", () => {
         const longFormEntry = Array(35).fill("A").join("");
-        const formData = generateFormationFormData({ addressLine1: longFormEntry }, { legalStructureId });
-        const errorState = getErrorStateForField("addressLine1", formData, undefined);
+        const formationFormData = generateFormationFormData(
+          { addressLine1: longFormEntry },
+          { legalStructureId }
+        );
+        const errorState = getErrorStateForField({ field: "addressLine1", formationFormData });
         expect(errorState.hasError).toEqual(false);
       });
     });
@@ -716,26 +813,32 @@ describe("getErrorStateForField", () => {
 
       it("has max length error when more than 35 characters", () => {
         const tooLongData = Array(36).fill("A").join("");
-        const formData = generateFormationFormData({ addressLine1: tooLongData }, { legalStructureId });
+        const formationFormData = generateFormationFormData(
+          { addressLine1: tooLongData },
+          { legalStructureId }
+        );
         const expectedLabel = templateEval(Config.formation.general.maximumLengthErrorText, {
           field: Config.formation.fields.addressLine1.label,
           maxLen: "35",
         });
 
-        const errorState = getErrorStateForField("addressLine1", formData, undefined);
+        const errorState = getErrorStateForField({ field: "addressLine1", formationFormData });
         expect(errorState.hasError).toEqual(true);
         expect(errorState.label).toEqual(expectedLabel);
       });
 
       it(`has no error if length is less than or equal to 35 chars`, () => {
         const longFormEntry = Array(35).fill("A").join("");
-        const formData = generateFormationFormData({ addressLine1: longFormEntry }, { legalStructureId });
-        const errorState = getErrorStateForField("addressLine1", formData, undefined);
+        const formationFormData = generateFormationFormData(
+          { addressLine1: longFormEntry },
+          { legalStructureId }
+        );
+        const errorState = getErrorStateForField({ field: "addressLine1", formationFormData });
         expect(errorState.hasError).toEqual(false);
       });
 
       it("has partial address error when it is missing and addressZipCode exists", () => {
-        const formData = generateFormationFormData(
+        const formationFormData = generateFormationFormData(
           {
             addressLine1: "",
             addressZipCode: "08100",
@@ -743,13 +846,13 @@ describe("getErrorStateForField", () => {
           { legalStructureId }
         );
 
-        const errorState = getErrorStateForField("addressLine1", formData, undefined);
+        const errorState = getErrorStateForField({ field: "addressLine1", formationFormData });
         expect(errorState.hasError).toEqual(true);
         expect(errorState.label).toEqual(Config.formation.general.partialAddressErrorText);
       });
 
       it("has partial address error when it is missing and addressMunicipality exist", () => {
-        const formData = generateFormationFormData(
+        const formationFormData = generateFormationFormData(
           {
             addressLine1: "",
             addressMunicipality: generateMunicipality({}),
@@ -757,13 +860,13 @@ describe("getErrorStateForField", () => {
           { legalStructureId }
         );
 
-        const errorState = getErrorStateForField("addressLine1", formData, undefined);
+        const errorState = getErrorStateForField({ field: "addressLine1", formationFormData });
         expect(errorState.hasError).toEqual(true);
         expect(errorState.label).toEqual(Config.formation.general.partialAddressErrorText);
       });
 
       it("has partial address error when it is missing and addressMunicipality and addressZipCode both exist", () => {
-        const formData = generateFormationFormData(
+        const formationFormData = generateFormationFormData(
           {
             addressLine1: "",
             addressMunicipality: generateMunicipality({}),
@@ -772,13 +875,13 @@ describe("getErrorStateForField", () => {
           { legalStructureId }
         );
 
-        const errorState = getErrorStateForField("addressLine1", formData, undefined);
+        const errorState = getErrorStateForField({ field: "addressLine1", formationFormData });
         expect(errorState.hasError).toEqual(true);
         expect(errorState.label).toEqual(Config.formation.general.partialAddressErrorText);
       });
 
       it("has no error when it is missing and addressMunicipality and addressZipCode are also missing", () => {
-        const formData = generateFormationFormData(
+        const formationFormData = generateFormationFormData(
           {
             addressLine1: "",
             addressMunicipality: undefined,
@@ -787,7 +890,7 @@ describe("getErrorStateForField", () => {
           { legalStructureId }
         );
 
-        const errorState = getErrorStateForField("addressLine1", formData, undefined);
+        const errorState = getErrorStateForField({ field: "addressLine1", formationFormData });
         expect(errorState.hasError).toEqual(false);
       });
     });
@@ -798,7 +901,7 @@ describe("getErrorStateForField", () => {
       const legalStructureId = "limited-liability-company";
 
       it("has partial address error when it is missing and addressZipCode exists", () => {
-        const formData = generateFormationFormData(
+        const formationFormData = generateFormationFormData(
           {
             addressMunicipality: undefined,
             addressZipCode: "08100",
@@ -806,13 +909,13 @@ describe("getErrorStateForField", () => {
           { legalStructureId }
         );
 
-        const errorState = getErrorStateForField("addressMunicipality", formData, undefined);
+        const errorState = getErrorStateForField({ field: "addressMunicipality", formationFormData });
         expect(errorState.hasError).toEqual(true);
         expect(errorState.label).toEqual(Config.formation.general.partialAddressErrorText);
       });
 
       it("has partial address error when it is missing and addressLine1 exist", () => {
-        const formData = generateFormationFormData(
+        const formationFormData = generateFormationFormData(
           {
             addressLine1: "some-stuff",
             addressMunicipality: undefined,
@@ -820,13 +923,13 @@ describe("getErrorStateForField", () => {
           { legalStructureId }
         );
 
-        const errorState = getErrorStateForField("addressMunicipality", formData, undefined);
+        const errorState = getErrorStateForField({ field: "addressMunicipality", formationFormData });
         expect(errorState.hasError).toEqual(true);
         expect(errorState.label).toEqual(Config.formation.general.partialAddressErrorText);
       });
 
       it("has partial address error when it is missing and addressLine1 and addressZipCode both exist", () => {
-        const formData = generateFormationFormData(
+        const formationFormData = generateFormationFormData(
           {
             addressLine1: "some-stuff",
             addressMunicipality: undefined,
@@ -835,13 +938,13 @@ describe("getErrorStateForField", () => {
           { legalStructureId }
         );
 
-        const errorState = getErrorStateForField("addressMunicipality", formData, undefined);
+        const errorState = getErrorStateForField({ field: "addressMunicipality", formationFormData });
         expect(errorState.hasError).toEqual(true);
         expect(errorState.label).toEqual(Config.formation.general.partialAddressErrorText);
       });
 
       it("has no error when it is missing and addressMunicipality and addressZipCode are also missing", () => {
-        const formData = generateFormationFormData(
+        const formationFormData = generateFormationFormData(
           {
             addressLine1: "",
             addressMunicipality: undefined,
@@ -850,7 +953,7 @@ describe("getErrorStateForField", () => {
           { legalStructureId }
         );
 
-        const errorState = getErrorStateForField("addressMunicipality", formData, undefined);
+        const errorState = getErrorStateForField({ field: "addressMunicipality", formationFormData });
         expect(errorState.hasError).toEqual(false);
       });
     });
@@ -913,15 +1016,15 @@ describe("getErrorStateForField", () => {
     for (const data of fieldData) {
       describe(`${data.field}`, () => {
         it("has error and label if empty", () => {
-          const formData = generateFormationFormData({ [data.field]: "" });
-          const errorState = getErrorStateForField(data.field, formData, undefined);
+          const formationFormData = generateFormationFormData({ [data.field]: "" });
+          const errorState = getErrorStateForField({ field: data.field, formationFormData });
           expect(errorState.hasError).toEqual(true);
           expect(errorState.label).toEqual(data.labelWhenMissing);
         });
 
         it("has error and label if undefined", () => {
-          const formData = generateFormationFormData({ [data.field]: undefined });
-          const errorState = getErrorStateForField(data.field, formData, undefined);
+          const formationFormData = generateFormationFormData({ [data.field]: undefined });
+          const errorState = getErrorStateForField({ field: data.field, formationFormData });
           expect(errorState.hasError).toEqual(true);
           expect(errorState.label).toEqual(data.labelWhenMissing);
         });
@@ -930,16 +1033,16 @@ describe("getErrorStateForField", () => {
           const longFormEntry = Array(data.maxLen + 1)
             .fill("A")
             .join("");
-          const formData = generateFormationFormData({ [data.field]: longFormEntry });
-          const errorState = getErrorStateForField(data.field, formData, undefined);
+          const formationFormData = generateFormationFormData({ [data.field]: longFormEntry });
+          const errorState = getErrorStateForField({ field: data.field, formationFormData });
           expect(errorState.hasError).toEqual(true);
           expect(errorState.label).toEqual(data.labelWhenTooLong);
         });
 
         it(`has no error if length is less than or equal to ${data.maxLen} chars`, () => {
           const longFormEntry = Array(data.maxLen).fill("A").join("");
-          const formData = generateFormationFormData({ [data.field]: longFormEntry });
-          const errorState = getErrorStateForField(data.field, formData, undefined);
+          const formationFormData = generateFormationFormData({ [data.field]: longFormEntry });
+          const errorState = getErrorStateForField({ field: data.field, formationFormData });
           expect(errorState.hasError).toEqual(false);
         });
       });
@@ -973,8 +1076,8 @@ describe("getErrorStateForField", () => {
     for (const data of fieldData) {
       describe(`${data.field}`, () => {
         it("has no error if empty", () => {
-          const formData = generateFormationFormData({ [data.field]: "" });
-          const errorState = getErrorStateForField(data.field, formData, undefined);
+          const formationFormData = generateFormationFormData({ [data.field]: "" });
+          const errorState = getErrorStateForField({ field: data.field, formationFormData });
           expect(errorState.hasError).toEqual(false);
         });
 
@@ -982,16 +1085,16 @@ describe("getErrorStateForField", () => {
           const longFormEntry = Array(data.maxLen + 1)
             .fill("A")
             .join("");
-          const formData = generateFormationFormData({ [data.field]: longFormEntry });
-          const errorState = getErrorStateForField(data.field, formData, undefined);
+          const formationFormData = generateFormationFormData({ [data.field]: longFormEntry });
+          const errorState = getErrorStateForField({ field: data.field, formationFormData });
           expect(errorState.hasError).toEqual(true);
           expect(errorState.label).toEqual(data.labelWhenTooLong);
         });
 
         it(`has no error if length is less than or equal to ${data.maxLen} chars`, () => {
           const longFormEntry = Array(data.maxLen).fill("A").join("");
-          const formData = generateFormationFormData({ [data.field]: longFormEntry });
-          const errorState = getErrorStateForField(data.field, formData, undefined);
+          const formationFormData = generateFormationFormData({ [data.field]: longFormEntry });
+          const errorState = getErrorStateForField({ field: data.field, formationFormData });
           expect(errorState.hasError).toEqual(false);
         });
       });
@@ -1005,33 +1108,34 @@ describe("getErrorStateForField", () => {
       "canMakeDistribution",
       "addressCountry",
       "addressState",
+      "willPracticeLaw",
     ];
 
     const runTests = (hasErrorIfUndefined: FormationFields[], expectedLabel?: string): void => {
       for (const field of hasErrorIfUndefined) {
         describe(`${field}`, () => {
           it("has error if undefined", () => {
-            const formData = generateFormationFormData({ [field]: undefined });
-            expect(getErrorStateForField(field, formData, undefined).hasError).toEqual(true);
+            const formationFormData = generateFormationFormData({ [field]: undefined });
+            expect(getErrorStateForField({ field, formationFormData }).hasError).toEqual(true);
           });
 
           it("has no error if false", () => {
-            const formData = generateFormationFormData({ [field]: false });
-            expect(getErrorStateForField(field, formData, undefined).hasError).toEqual(false);
+            const formationFormData = generateFormationFormData({ [field]: false });
+            expect(getErrorStateForField({ field, formationFormData }).hasError).toEqual(false);
           });
 
           it("has no error if value", () => {
-            const formData = generateFormationFormData({ [field]: "some-value" });
-            expect(getErrorStateForField(field, formData, undefined).hasError).toEqual(false);
+            const formationFormData = generateFormationFormData({ [field]: "some-value" });
+            expect(getErrorStateForField({ field, formationFormData }).hasError).toEqual(false);
           });
 
           it("inserts label from config", () => {
-            const formData = generateFormationFormData({ [field]: undefined });
+            const formationFormData = generateFormationFormData({ [field]: undefined });
             const label = expectedLabel ?? (Config.formation.fields as any)[field].label;
             if (!label) {
               throw `label missing in config for ${field}`;
             }
-            expect(getErrorStateForField(field, formData, undefined).label).toEqual(label);
+            expect(getErrorStateForField({ field, formationFormData }).label).toEqual(label);
           });
         });
       }
@@ -1041,6 +1145,38 @@ describe("getErrorStateForField", () => {
 
     runTests(["foreignStateOfFormation"], Config.formation.fields.foreignStateOfFormation.error);
     runTests(["foreignStateOfFormation"], Config.formation.fields.foreignStateOfFormation.error);
+  });
+
+  describe("foreignGoodStandingFile", () => {
+    const field = "foreignGoodStandingFile";
+
+    it("has error if undefined", () => {
+      const formationFormData = generateFormationFormData({});
+      expect(
+        getErrorStateForField({
+          field,
+          formationFormData,
+          foreignGoodStandingFile: undefined,
+        }).hasError
+      ).toEqual(true);
+    });
+
+    it("has no error if value", () => {
+      const formationFormData = generateFormationFormData({});
+      const foreignGoodStandingFile = generateInputFile({});
+      expect(getErrorStateForField({ field, formationFormData, foreignGoodStandingFile }).hasError).toEqual(
+        false
+      );
+    });
+
+    it("inserts label from config", () => {
+      const formationFormData = generateFormationFormData({});
+      const label = (Config.formation.fields as any)[field].errorMessageRequired;
+      if (!label) {
+        throw `label missing in config for ${field}`;
+      }
+      expect(getErrorStateForField({ field, formationFormData }).label).toEqual(label);
+    });
   });
 
   describe("fields that have error when empty or false", () => {
@@ -1064,27 +1200,27 @@ describe("getErrorStateForField", () => {
       for (const field of hasErrorIfEmpty) {
         describe(`${field}`, () => {
           it("has error if empty", () => {
-            const formData = generateFormationFormData({ [field]: "" });
-            expect(getErrorStateForField(field, formData, undefined).hasError).toEqual(true);
+            const formationFormData = generateFormationFormData({ [field]: "" });
+            expect(getErrorStateForField({ field, formationFormData }).hasError).toEqual(true);
           });
 
           it("has error if undefined", () => {
-            const formData = generateFormationFormData({ [field]: undefined });
-            expect(getErrorStateForField(field, formData, undefined).hasError).toEqual(true);
+            const formationFormData = generateFormationFormData({ [field]: undefined });
+            expect(getErrorStateForField({ field, formationFormData }).hasError).toEqual(true);
           });
 
           it("has no error if value", () => {
-            const formData = generateFormationFormData({ [field]: "some-value" });
-            expect(getErrorStateForField(field, formData, undefined).hasError).toEqual(false);
+            const formationFormData = generateFormationFormData({ [field]: "some-value" });
+            expect(getErrorStateForField({ field, formationFormData }).hasError).toEqual(false);
           });
 
           it("inserts label from config", () => {
-            const formData = generateFormationFormData({ [field]: "some-value" });
+            const formationFormData = generateFormationFormData({ [field]: "some-value" });
             const expectedLabel = (Config.formation.fields as any)[field].label;
             if (!expectedLabel) {
               throw `label missing in config for ${field}`;
             }
-            expect(getErrorStateForField(field, formData, undefined).label).toEqual(expectedLabel);
+            expect(getErrorStateForField({ field, formationFormData }).label).toEqual(expectedLabel);
           });
         });
       }

--- a/web/src/components/tasks/business-formation/getErrorStateForField.ts
+++ b/web/src/components/tasks/business-formation/getErrorStateForField.ts
@@ -10,19 +10,36 @@ import { isZipCodeNj } from "@/lib/domain-logic/isZipCodeNj";
 import { isZipCodeUs } from "@/lib/domain-logic/isZipCodeUs";
 import { FormationFieldErrorState } from "@/lib/types/types";
 import { templateEval, validateEmail } from "@/lib/utils/helpers";
-import { FormationFields, FormationFormData, NameAvailability } from "@businessnjgovnavigator/shared";
+import {
+  FieldsForErrorHandling,
+  FormationFields,
+  FormationFormData,
+  InputFile,
+  NameAvailability,
+} from "@businessnjgovnavigator/shared";
 
-export const getErrorStateForField = (
-  field: FormationFields,
-  formationFormData: FormationFormData,
-  businessNameAvailability: NameAvailability | undefined
-): FormationFieldErrorState => {
+export const getErrorStateForField = (inputParams: {
+  field: FieldsForErrorHandling;
+  formationFormData: FormationFormData;
+  businessNameAvailability?: NameAvailability | undefined;
+  foreignGoodStandingFile?: InputFile | undefined;
+}): FormationFieldErrorState => {
   const Config = getMergedConfig();
+  const { field, formationFormData, businessNameAvailability, foreignGoodStandingFile } = inputParams;
 
   const errorState = {
     field: field,
     label: (Config.formation.fields as any)[field].label,
   };
+
+  // foreignGoodStandingFile must be first in order to prevent type errors
+  if (field === "foreignGoodStandingFile") {
+    return {
+      ...errorState,
+      label: Config.formation.fields.foreignGoodStandingFile.errorMessageRequired,
+      hasError: !foreignGoodStandingFile,
+    };
+  }
 
   const fieldWithMaxLength = (params: { required: boolean; maxLen: number }): FormationFieldErrorState => {
     const exists = !!formationFormData[field];
@@ -101,6 +118,7 @@ export const getErrorStateForField = (
     "addressState",
     "addressCountry",
     "foreignStateOfFormation",
+    "willPracticeLaw",
   ];
 
   if (field === "foreignStateOfFormation") {

--- a/web/src/components/tasks/business-formation/getFieldForApiField.ts
+++ b/web/src/components/tasks/business-formation/getFieldForApiField.ts
@@ -1,4 +1,4 @@
-import { FormationFields } from "@businessnjgovnavigator/shared/formationData";
+import { FieldsForErrorHandling } from "@businessnjgovnavigator/shared/formationData";
 import { invert } from "lodash";
 
 export const UNKNOWN_API_ERROR_FIELD = "UNKNOWN_API_ERROR_FIELD";
@@ -37,11 +37,13 @@ const fieldToApiFieldMapping: Record<string, string> = {
   withdrawals: "Limited Partnership - General Partner Withdrawal",
   dissolution: "Limited Partnership - Dissolution Plan",
   businessName: "Business Information - Business Name",
+  willPracticeLaw: "Business Information - Will Practice Law",
+  foreignGoodStandingFile: "Business Information - Foreign Certificate of Good Standing",
 };
 
 const apiFieldToFieldMapping = invert(fieldToApiFieldMapping);
 
-export const getApiField = (field: FormationFields): string => {
+export const getApiField = (field: FieldsForErrorHandling): string => {
   return fieldToApiFieldMapping[field] || UNKNOWN_API_ERROR_FIELD;
 };
 

--- a/web/src/components/tasks/business-formation/getStepForField.ts
+++ b/web/src/components/tasks/business-formation/getStepForField.ts
@@ -1,7 +1,7 @@
 import { FormationStepNames } from "@/lib/types/types";
-import { FormationFields } from "@businessnjgovnavigator/shared";
+import { FieldsForErrorHandling } from "@businessnjgovnavigator/shared";
 
-export const getStepForField = (field: FormationFields): FormationStepNames => {
+export const getStepForField = (field: FieldsForErrorHandling): FormationStepNames => {
   switch (field) {
     case "businessName":
       return "Name";
@@ -28,6 +28,8 @@ export const getStepForField = (field: FormationFields): FormationStepNames => {
     case "createLimitedPartnerTerms":
     case "getDistributionTerms":
     case "makeDistributionTerms":
+    case "foreignGoodStandingFile":
+    case "willPracticeLaw":
       return "Business";
 
     case "agentNumber":

--- a/web/src/components/tasks/business-formation/name/BusinessNameStep.tsx
+++ b/web/src/components/tasks/business-formation/name/BusinessNameStep.tsx
@@ -75,11 +75,11 @@ export const BusinessNameStep = (): ReactElement => {
                   error={hasError}
                   helperText={
                     hasError
-                      ? getErrorStateForField(
-                          "businessName",
-                          state.formationFormData,
-                          state.businessNameAvailability
-                        ).label
+                      ? getErrorStateForField({
+                          field: "businessName",
+                          formationFormData: state.formationFormData,
+                          businessNameAvailability: state.businessNameAvailability,
+                        }).label
                       : undefined
                   }
                   onBlur={(event: FocusEvent<HTMLInputElement>): void => {

--- a/web/src/components/tasks/business-formation/review/ReviewForeignCertificate.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewForeignCertificate.tsx
@@ -1,0 +1,35 @@
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { InputFile } from "@businessnjgovnavigator/shared/formationData";
+import { ReactElement } from "rehype-react/lib";
+import { ReviewSection } from "./section/ReviewSection";
+
+interface Props {
+  foreignGoodStandingFile: InputFile | undefined;
+}
+
+const filePreviewImage = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"; // taken from USWDS
+
+export const ReviewForeignCertificate = (props: Props): ReactElement => {
+  const { Config } = useConfig();
+  return (
+    <ReviewSection
+      buttonText={Config.formation.general.editButtonText}
+      header={Config.formation.fields.foreignGoodStandingFile.label}
+      stepName="Business"
+      testId="edit-foreign-certificate-step"
+    >
+      {props.foreignGoodStandingFile?.filename ? (
+        <div className="fac">
+          <img
+            src={filePreviewImage}
+            alt="file preview"
+            className="usa-file-input__preview-image usa-file-input__preview-image--generic"
+          />
+          {props.foreignGoodStandingFile?.filename}
+        </div>
+      ) : (
+        <i>{Config.formation.general.notEntered}</i>
+      )}
+    </ReviewSection>
+  );
+};

--- a/web/src/components/tasks/business-formation/review/ReviewStep.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.tsx
@@ -16,12 +16,15 @@ import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import analytics from "@/lib/utils/analytics";
 import { ReactElement, useContext } from "react";
+import { ReviewForeignCertificate } from "./ReviewForeignCertificate";
+import { ReviewWillPracticeLaw } from "./ReviewWillPracticeLaw";
 
 export const ReviewStep = (): ReactElement => {
   const { state } = useContext(BusinessFormationContext);
   const { Config } = useConfig();
 
   const isLP = state.formationFormData.legalType === "limited-partnership";
+  const isForeignCCorp = state.formationFormData.legalType === "foreign-c-corporation";
   const hasProvisions = (state.formationFormData.provisions?.length ?? 0) > 0;
   const hasPurpose = !!state.formationFormData.businessPurpose;
   const hasMembers = (state.formationFormData.members?.length ?? 0) > 0;
@@ -31,6 +34,12 @@ export const ReviewStep = (): ReactElement => {
       <div data-testid="review-step">
         <BusinessNameAndLegalStructure isReviewStep />
         <ReviewBusinessSuffixAndStartDate />
+        {isForeignCCorp && (
+          <>
+            <ReviewWillPracticeLaw willPracticeLaw={state.formationFormData.willPracticeLaw} />
+            <ReviewForeignCertificate foreignGoodStandingFile={state.foreignGoodStandingFile} />
+          </>
+        )}
         <ReviewMainBusinessLocation />
         {isLP && (
           <ReviewSection

--- a/web/src/components/tasks/business-formation/review/ReviewWillPracticeLaw.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewWillPracticeLaw.tsx
@@ -1,0 +1,29 @@
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { ReactElement } from "rehype-react/lib";
+import { ReviewSection } from "./section/ReviewSection";
+
+interface Props {
+  willPracticeLaw: boolean | undefined;
+}
+
+export const ReviewWillPracticeLaw = (props: Props): ReactElement => {
+  const { Config } = useConfig();
+
+  const displayResponse = (): ReactElement => {
+    if (props.willPracticeLaw === undefined) {
+      return <i>{Config.formation.general.notEntered}</i>;
+    } else {
+      return <>{props.willPracticeLaw ? "Yes" : "No"}</>;
+    }
+  };
+  return (
+    <ReviewSection
+      buttonText={Config.formation.general.editButtonText}
+      header={Config.formation.fields.willPracticeLaw.label}
+      stepName="Business"
+      testId="edit-will-practice-law-step"
+    >
+      {displayResponse()}
+    </ReviewSection>
+  );
+};

--- a/web/src/components/tasks/business-formation/validatedFieldsForUser.test.ts
+++ b/web/src/components/tasks/business-formation/validatedFieldsForUser.test.ts
@@ -206,4 +206,12 @@ describe("validatedFieldsForUser", () => {
       });
     });
   });
+
+  describe("foreign c-corp", () => {
+    it("requires 'practice law' and 'certificate of good standing' fields", () => {
+      const formationFormData = generateFormationFormData({}, { legalStructureId: "foreign-c-corporation" });
+      expect(validatedFieldsForUser(formationFormData)).toContain("willPracticeLaw");
+      expect(validatedFieldsForUser(formationFormData)).toContain("foreignGoodStandingFile");
+    });
+  });
 });

--- a/web/src/components/tasks/business-formation/validatedFieldsForUser.ts
+++ b/web/src/components/tasks/business-formation/validatedFieldsForUser.ts
@@ -1,12 +1,13 @@
 import {
   corpLegalStructures,
+  FieldsForErrorHandling,
   FormationFields,
   FormationFormData,
   incorporationLegalStructures,
 } from "@businessnjgovnavigator/shared/formationData";
 
-export const validatedFieldsForUser = (formationFormData: FormationFormData): FormationFields[] => {
-  let validatedFields: FormationFields[] = [
+export const validatedFieldsForUser = (formationFormData: FormationFormData): FieldsForErrorHandling[] => {
+  let validatedFields: FieldsForErrorHandling[] = [
     "businessName",
     "businessSuffix",
     "businessStartDate",
@@ -62,6 +63,10 @@ export const validatedFieldsForUser = (formationFormData: FormationFormData): Fo
     validatedFields = [...validatedFields, "businessTotalStock", "members"];
   }
 
+  if (formationFormData.legalType === "foreign-c-corporation") {
+    validatedFields = [...validatedFields, "willPracticeLaw", "foreignGoodStandingFile"];
+  }
+
   if (formationFormData.legalType === "limited-partnership") {
     validatedFields = [
       ...validatedFields,
@@ -83,6 +88,5 @@ export const validatedFieldsForUser = (formationFormData: FormationFormData): Fo
       validatedFields.push("makeDistributionTerms");
     }
   }
-
   return validatedFields;
 };

--- a/web/src/contexts/businessFormationContext.ts
+++ b/web/src/contexts/businessFormationContext.ts
@@ -1,10 +1,11 @@
 import { createEmptyDbaDisplayContent, FormationDbaContent } from "@/lib/types/types";
 import {
   createEmptyFormationFormData,
-  FormationFields,
+  FieldsForErrorHandling,
   FormationFormData,
+  InputFile,
+  NameAvailability,
 } from "@businessnjgovnavigator/shared";
-import { NameAvailability } from "@businessnjgovnavigator/shared/";
 import { createContext } from "react";
 
 interface BusinessFormationState {
@@ -14,8 +15,9 @@ interface BusinessFormationState {
   showResponseAlert: boolean;
   hasBeenSubmitted: boolean;
   dbaContent: FormationDbaContent;
-  interactedFields: FormationFields[];
+  interactedFields: FieldsForErrorHandling[];
   hasSetStateFirstTime: boolean;
+  foreignGoodStandingFile: InputFile | undefined;
 }
 
 interface BusinessFormationContextType {
@@ -23,9 +25,10 @@ interface BusinessFormationContextType {
   setFormationFormData: React.Dispatch<React.SetStateAction<FormationFormData>>;
   setStepIndex: React.Dispatch<React.SetStateAction<number>>;
   setShowResponseAlert: React.Dispatch<React.SetStateAction<boolean>>;
-  setFieldsInteracted: (fields: FormationFields[], config?: { setToUninteracted: boolean }) => void;
+  setFieldsInteracted: (fields: FieldsForErrorHandling[], config?: { setToUninteracted: boolean }) => void;
   setHasBeenSubmitted: (hasBeenSubmitted: boolean) => void;
   setBusinessNameAvailability: React.Dispatch<React.SetStateAction<NameAvailability | undefined>>;
+  setForeignGoodStandingFile: (file: InputFile | undefined) => void;
 }
 
 export const BusinessFormationContext = createContext<BusinessFormationContextType>({
@@ -36,6 +39,7 @@ export const BusinessFormationContext = createContext<BusinessFormationContextTy
     showResponseAlert: false,
     hasBeenSubmitted: false,
     interactedFields: [],
+    foreignGoodStandingFile: undefined,
     hasSetStateFirstTime: false,
     businessNameAvailability: undefined,
   },
@@ -45,4 +49,5 @@ export const BusinessFormationContext = createContext<BusinessFormationContextTy
   setFieldsInteracted: () => {},
   setHasBeenSubmitted: () => {},
   setBusinessNameAvailability: () => {},
+  setForeignGoodStandingFile: () => {},
 });

--- a/web/src/lib/api-client/apiClient.test.ts
+++ b/web/src/lib/api-client/apiClient.test.ts
@@ -1,4 +1,5 @@
 import {
+  generateInputFile,
   generateNameAndAddress,
   generateTaxIdAndBusinessName,
   generateUser,
@@ -9,6 +10,7 @@ import {
   checkLicenseStatus,
   get,
   getUserData,
+  postBusinessFormation,
   postFeedback,
   postIssue,
   postNewsletter,
@@ -118,5 +120,20 @@ describe("apiClient", () => {
     mockAxios.post.mockResolvedValue({ data: true });
     expect(await postIssue(issueRequest, userData)).toEqual(true);
     expect(mockAxios.post).toHaveBeenCalledWith("/api/external/issue", { issueRequest, userData }, {});
+  });
+
+  it("posts business formation request", async () => {
+    const inputUserData = generateUserData({});
+    const responseUserData = generateUserData({});
+    const returnUrl = "/i-came-from-here.com";
+    const inputFile = generateInputFile({});
+
+    mockAxios.post.mockResolvedValue({ data: responseUserData });
+    expect(await postBusinessFormation(inputUserData, returnUrl, inputFile)).toEqual(responseUserData);
+    expect(mockAxios.post).toHaveBeenCalledWith(
+      "/api/formation",
+      { userData: inputUserData, returnUrl, foreignGoodStandingFile: inputFile },
+      { headers: { Authorization: "Bearer some-token" } }
+    );
   });
 });

--- a/web/src/lib/api-client/apiClient.ts
+++ b/web/src/lib/api-client/apiClient.ts
@@ -2,6 +2,7 @@ import { getCurrentToken } from "@/lib/auth/sessionHelper";
 import { SelfRegResponse } from "@/lib/types/types";
 import { phaseChangeAnalytics, setPhaseDimension } from "@/lib/utils/analytics-helpers";
 import {
+  InputFile,
   NameAndAddress,
   NameAvailability,
   UserData,
@@ -30,8 +31,12 @@ export const checkLicenseStatus = (nameAndAddress: NameAndAddress): Promise<User
   return post(`/license-status`, nameAndAddress);
 };
 
-export const postBusinessFormation = (userData: UserData, returnUrl: string): Promise<UserData> => {
-  return post(`/formation`, { userData, returnUrl });
+export const postBusinessFormation = (
+  userData: UserData,
+  returnUrl: string,
+  foreignGoodStandingFile: InputFile | undefined
+): Promise<UserData> => {
+  return post(`/formation`, { userData, returnUrl, foreignGoodStandingFile });
 };
 
 export const getCompletedFiling = (): Promise<UserData> => {

--- a/web/src/lib/types/types.ts
+++ b/web/src/lib/types/types.ts
@@ -1,7 +1,7 @@
 import { getMergedConfig } from "@/contexts/configContext";
 import {
   BusinessUser,
-  FormationFields,
+  FieldsForErrorHandling,
   FormationMember,
   FormationSigner,
   IndustrySpecificData,
@@ -70,7 +70,7 @@ export type FormationStepNames = "Name" | "Business" | "Contacts" | "Billing" | 
 export type DbaStepNames = "Business Name" | "DBA Resolution" | "Authorize Business";
 
 export type FormationFieldErrorState = {
-  field: FormationFields;
+  field: FieldsForErrorHandling;
   hasError: boolean;
   label: string;
 };

--- a/web/src/lib/utils/helpers.ts
+++ b/web/src/lib/utils/helpers.ts
@@ -149,6 +149,13 @@ export const validateEmail = (email: string): boolean => {
   );
 };
 
+export const flipObject = <T extends string | number | symbol>(obj: Record<string, T>): Record<T, string> => {
+  return Object.keys(obj).reduce((acc, key) => {
+    acc[obj[key]] = key;
+    return acc;
+  }, {} as Record<T, string>);
+};
+
 export const getPhoneNumberFormat = (phoneNumber: string): string => {
   const length = phoneNumber.length;
   if (length === 0) {

--- a/web/src/styles/base/global.scss
+++ b/web/src/styles/base/global.scss
@@ -209,6 +209,10 @@ ol {
   }
 }
 
+.usa-file-input {
+  max-width: unset;
+}
+
 .usa-link:visited,
 .usa-prose > a:visited {
   color: $primary !important;

--- a/web/test/factories.ts
+++ b/web/test/factories.ts
@@ -46,6 +46,7 @@ import {
   Industries,
   Industry,
   IndustrySpecificData,
+  InputFile,
   LegalStructure,
   LegalStructures,
   LicenseData,
@@ -455,6 +456,16 @@ export const generateGetFilingResponse = (overrides: Partial<GetFilingResponse>)
     formationDoc: `some-formation-doc-${randomInt()}`,
     standingDoc: `some-standing-doc-${randomInt()}`,
     certifiedDoc: `some-certified-doc-${randomInt()}`,
+    ...overrides,
+  };
+};
+
+export const generateInputFile = (overrides: Partial<InputFile>): InputFile => {
+  return {
+    base64Contents: `some-base-64-contents-${randomInt()}`,
+    fileType: randomElementFromArray(["PNG", "PDF"]),
+    sizeInBytes: randomInt(),
+    filename: `some-filename-${randomInt()}`,
     ...overrides,
   };
 };

--- a/web/test/helpers/helpers-formation.tsx
+++ b/web/test/helpers/helpers-formation.tsx
@@ -180,6 +180,8 @@ export type FormationPageHelpers = {
   fillAndSubmitAddressModal: (overrides: Partial<FormationSignedAddress>, fieldName: string) => Promise<void>;
   clickSubmit: () => Promise<void>;
   selectDate: (value: DateObject, fieldType: "Business start date" | "Foreign date of formation") => void;
+  uploadFile: (file: File) => void;
+  completeWillPracticeLaw: (response?: boolean) => void;
 };
 
 export const createFormationPageHelpers = (): FormationPageHelpers => {
@@ -447,6 +449,22 @@ export const createFormationPageHelpers = (): FormationPageHelpers => {
     fillText("Contact phone number", "1234567890");
   };
 
+  const uploadFile = async (file: File): Promise<void> => {
+    const uploader = screen.getByTestId("file-input");
+    fireEvent.change(uploader, { target: { files: [file] } });
+    await waitFor(() => {
+      expect(screen.getByTestId("file-is-read")).toBeInTheDocument();
+    });
+  };
+
+  const completeWillPracticeLaw = (response = false): void => {
+    if (response) {
+      fireEvent.click(screen.getByTestId("practice-law-yes"));
+    } else {
+      fireEvent.click(screen.getByTestId("practice-law-no"));
+    }
+  };
+
   return {
     fillText,
     fillAndSubmitBusinessNameStep,
@@ -486,5 +504,7 @@ export const createFormationPageHelpers = (): FormationPageHelpers => {
     stepperClickToReviewStep,
     getStepStateInStepper,
     completeRequiredBillingFields,
+    uploadFile,
+    completeWillPracticeLaw,
   };
 };


### PR DESCRIPTION
NOTE: Waiting on feedback from the PrepareFiling API team. Currently, cannot successfully submit. Getting the following error:

```
[{"Valid":false,"ErrorMessage":"Required","Name":"Formation.ForeignGoodStandingFile"}]
```

---

## Description

Updates the flow for foreign c-corp formation.

### Ticket

[183443674](https://www.pivotaltracker.com/story/show/183443674)

### Approach

- Create new components associated with new formation questions
  - `PracticesLaw`
  - `ForeignCertificate`
- Create a new `FileInput` component using the USWDS component and functionality as a launchpad
- Established new types and updated config files as necessary
- Updated existing tests to be more flexible and to accommodate for the new `foreignGoodStandingFile` that will be passed around alongside formation data

We are not storing the `foreignGoodStandingFile` but it needs to be maintained in state while the user is filling out the form prior to submission. To accomplish this, we created a new state object. Passing this around required updating a number of functions to accept a props object (easier to handle optional props) and modifying some types.

### Steps to Test

You can experiment with this work by creating a foreign c-corp. The UI changes should be on the formation Business step and Review step. Clicking submit should hit the NICUSA API. Check for errors and successful submission to NICUSA.

### Notes

n/a

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [ ] I have not used any relative imports
  - This does in fact use a relative import to get the USWDS library to play nicely. 
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
