### PR TITLE
feat: [#184306248] formation remembers last user visited page

### DIFF
--- a/api/src/api/userRouter.test.ts
+++ b/api/src/api/userRouter.test.ts
@@ -520,6 +520,7 @@ describe("userRouter", () => {
           formationResponse: undefined,
           getFilingResponse: undefined,
           completedFilingPayment: false,
+          lastVisitedPageIndex: 0,
         });
       });
     });

--- a/api/src/api/userRouter.ts
+++ b/api/src/api/userRouter.ts
@@ -197,6 +197,7 @@ export const userRouterFactory = (
               completedFilingPayment: false,
               formationFormData: createEmptyFormationFormData(),
               businessNameAvailability: undefined,
+              lastVisitedPageIndex: 0,
             },
           };
     }

--- a/api/src/db/migrations/migrations.ts
+++ b/api/src/db/migrations/migrations.ts
@@ -13,6 +13,7 @@ import { migrate_v108_to_v109 } from "./v109_add_business_name_search_timestamp"
 import { migrate_v9_to_v10 } from "./v10_add_mynjuserkey";
 import { migrate_v109_to_v110 } from "./v110_rename_form_progress_to_onboarding_form_progress";
 import { migrate_v110_to_v111 } from "./v111_add_date_created_and_initial_version";
+import { migrate_v111_to_v112 } from "./v112_add_last_visited_formation_page_to_formation_data";
 import { migrate_v10_to_v11 } from "./v11_change_license_statuses";
 import { migrate_v11_to_v12 } from "./v12_remove_scorp";
 import { migrate_v12_to_v13 } from "./v13_add_construction_renovation_plan";
@@ -226,4 +227,5 @@ export const Migrations: MigrationFunction[] = [
   migrate_v108_to_v109,
   migrate_v109_to_v110,
   migrate_v110_to_v111,
+  migrate_v111_to_v112,
 ];

--- a/api/src/db/migrations/v112_add_last_visited_formation_page_to_formation_data.ts
+++ b/api/src/db/migrations/v112_add_last_visited_formation_page_to_formation_data.ts
@@ -1,0 +1,403 @@
+import { v111UserData } from "./v111_add_date_created_and_initial_version";
+
+export interface v112UserData {
+  user: v112BusinessUser;
+  profileData: v112ProfileData;
+  onboardingFormProgress: v112OnboardingFormProgress;
+  taskProgress: Record<string, v112TaskProgress>;
+  taskItemChecklist: Record<string, boolean>;
+  licenseData: v112LicenseData | undefined;
+  preferences: v112Preferences;
+  taxFilingData: v112TaxFilingData;
+  formationData: v112FormationData;
+  lastUpdatedISO: string | undefined;
+  version: number;
+  dateCreatedISO: string | undefined;
+  versionWhenCreated: number;
+}
+
+export const migrate_v111_to_v112 = (v111Data: v111UserData): v112UserData => {
+  return {
+    ...v111Data,
+    formationData: {
+      ...v111Data.formationData,
+      lastVisitedPageIndex: 0,
+    },
+    version: 112,
+  };
+};
+
+// ---------------- v112 types ----------------
+type v112TaskProgress = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+type v112OnboardingFormProgress = "UNSTARTED" | "COMPLETED";
+type v112ABExperience = "ExperienceA" | "ExperienceB";
+
+type v112BusinessUser = {
+  name?: string;
+  email: string;
+  id: string;
+  receiveNewsletter: boolean;
+  userTesting: boolean;
+  externalStatus: v112ExternalStatus;
+  myNJUserKey?: string;
+  intercomHash?: string;
+  abExperience: v112ABExperience;
+};
+
+interface v112ProfileDocuments {
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+}
+
+type v112BusinessPersona = "STARTING" | "OWNING" | "FOREIGN" | undefined;
+type v112ForeignBusinessType = "REMOTE_WORKER" | "REMOTE_SELLER" | "NEXUS" | "NONE" | undefined;
+type v112OperatingPhase =
+  | "GUEST_MODE"
+  | "NEEDS_TO_FORM"
+  | "NEEDS_TO_REGISTER_FOR_TAXES"
+  | "FORMED_AND_REGISTERED"
+  | "UP_AND_RUNNING"
+  | "UP_AND_RUNNING_OWNING"
+  | undefined;
+
+type v112CarServiceType = "STANDARD" | "HIGH_CAPACITY" | "BOTH" | undefined;
+
+interface v112IndustrySpecificData {
+  liquorLicense: boolean;
+  requiresCpa: boolean;
+  homeBasedBusiness: boolean | undefined;
+  cannabisLicenseType: "CONDITIONAL" | "ANNUAL" | undefined;
+  cannabisMicrobusiness: boolean | undefined;
+  constructionRenovationPlan: boolean | undefined;
+  providesStaffingService: boolean;
+  certifiedInteriorDesigner: boolean;
+  realEstateAppraisalManagement: boolean;
+  carService: v112CarServiceType | undefined;
+  interstateTransport: boolean;
+  isInterstateLogisticsApplicable: boolean | undefined;
+  isInterstateMovingApplicable: boolean | undefined;
+  isChildcareForSixOrMore: boolean | undefined;
+  willSellPetCareItems: boolean | undefined;
+  petCareHousing: boolean | undefined;
+}
+
+interface v112ProfileData extends v112IndustrySpecificData {
+  businessPersona: v112BusinessPersona;
+  businessName: string;
+  industryId: string | undefined;
+  legalStructureId: string | undefined;
+  municipality: v112Municipality | undefined;
+  dateOfFormation: string | undefined;
+  entityId: string | undefined;
+  employerId: string | undefined;
+  taxId: string | undefined;
+  encryptedTaxId: string | undefined;
+  notes: string;
+  documents: v112ProfileDocuments;
+  ownershipTypeIds: string[];
+  existingEmployees: string | undefined;
+  taxPin: string | undefined;
+  sectorId: string | undefined;
+  naicsCode: string;
+  foreignBusinessType: v112ForeignBusinessType;
+  foreignBusinessTypeIds: string[];
+  nexusLocationInNewJersey: boolean | undefined;
+  nexusDbaName: string;
+  needsNexusDbaName: boolean;
+  operatingPhase: v112OperatingPhase;
+}
+
+type v112Municipality = {
+  name: string;
+  displayName: string;
+  county: string;
+  id: string;
+};
+
+type v112TaxFilingState = "SUCCESS" | "FAILED" | "UNREGISTERED" | "PENDING" | "API_ERROR";
+type v112TaxFilingErrorFields = "businessName" | "formFailure";
+
+type v112TaxFilingData = {
+  state?: v112TaxFilingState;
+  lastUpdatedISO?: string;
+  registeredISO?: string;
+  errorField?: v112TaxFilingErrorFields;
+  businessName?: string;
+  filings: v112TaxFiling[];
+};
+
+type v112TaxFiling = {
+  identifier: string;
+  dueDate: string;
+};
+
+type v112NameAndAddress = {
+  name: string;
+  addressLine1: string;
+  addressLine2: string;
+  zipCode: string;
+};
+
+type v112LicenseData = {
+  nameAndAddress: v112NameAndAddress;
+  completedSearch: boolean;
+  lastUpdatedISO: string;
+  status: v112LicenseStatus;
+  items: v112LicenseStatusItem[];
+};
+
+type v112Preferences = {
+  roadmapOpenSections: v112SectionType[];
+  roadmapOpenSteps: number[];
+  hiddenFundingIds: string[];
+  hiddenCertificationIds: string[];
+  visibleSidebarCards: string[];
+  isCalendarFullView: boolean;
+  returnToLink: string;
+  isHideableRoadmapOpen: boolean;
+};
+
+type v112LicenseStatusItem = {
+  title: string;
+  status: v112CheckoffStatus;
+};
+
+type v112CheckoffStatus = "ACTIVE" | "PENDING" | "UNKNOWN";
+
+type v112LicenseStatus =
+  | "ACTIVE"
+  | "PENDING"
+  | "UNKNOWN"
+  | "EXPIRED"
+  | "BARRED"
+  | "OUT_OF_BUSINESS"
+  | "REINSTATEMENT_PENDING"
+  | "CLOSED"
+  | "DELETED"
+  | "DENIED"
+  | "VOLUNTARY_SURRENDER"
+  | "WITHDRAWN";
+
+const v112SectionNames = ["PLAN", "START"] as const;
+type v112SectionType = (typeof v112SectionNames)[number];
+
+type v112ExternalStatus = {
+  newsletter?: v112NewsletterResponse;
+  userTesting?: v112UserTestingResponse;
+};
+
+interface v112NewsletterResponse {
+  success?: boolean;
+  status: v112NewsletterStatus;
+}
+
+interface v112UserTestingResponse {
+  success?: boolean;
+  status: v112UserTestingStatus;
+}
+
+type v112NewsletterStatus = (typeof newsletterStatusList)[number];
+
+const externalStatusList = ["SUCCESS", "IN_PROGRESS", "CONNECTION_ERROR"] as const;
+
+const userTestingStatusList = [...externalStatusList] as const;
+
+type v112UserTestingStatus = (typeof userTestingStatusList)[number];
+
+const newsletterStatusList = [
+  ...externalStatusList,
+  "EMAIL_ERROR",
+  "TOPIC_ERROR",
+  "RESPONSE_WARNING",
+  "RESPONSE_ERROR",
+  "RESPONSE_FAIL",
+  "QUESTION_WARNING",
+] as const;
+
+type v112NameAvailabilityStatus =
+  | "AVAILABLE"
+  | "DESIGNATOR_ERROR"
+  | "SPECIAL_CHARACTER_ERROR"
+  | "UNAVAILABLE"
+  | "RESTRICTED_ERROR"
+  | undefined;
+
+interface v112NameAvailabilityResponse {
+  status: v112NameAvailabilityStatus;
+  similarNames: string[];
+  invalidWord?: string;
+}
+
+interface v112NameAvailability extends v112NameAvailabilityResponse {
+  lastUpdatedTimeStamp: string;
+}
+
+interface v112FormationData {
+  formationFormData: v112FormationFormData;
+  businessNameAvailability: v112NameAvailability | undefined;
+  formationResponse: v112FormationSubmitResponse | undefined;
+  getFilingResponse: v112GetFilingResponse | undefined;
+  completedFilingPayment: boolean;
+  lastVisitedPageIndex: number;
+}
+
+interface v112FormationFormData extends v112FormationAddress {
+  readonly businessName: string;
+  readonly businessSuffix: v112BusinessSuffix | undefined;
+  readonly businessTotalStock: string;
+  readonly businessStartDate: string; // YYYY-MM-DD
+  readonly businessPurpose: string;
+  readonly withdrawals: string;
+  readonly combinedInvestment: string;
+  readonly dissolution: string;
+  readonly canCreateLimitedPartner: boolean | undefined;
+  readonly createLimitedPartnerTerms: string;
+  readonly canGetDistribution: boolean | undefined;
+  readonly getDistributionTerms: string;
+  readonly canMakeDistribution: boolean | undefined;
+  readonly makeDistributionTerms: string;
+  readonly provisions: string[] | undefined;
+  readonly agentNumberOrManual: "NUMBER" | "MANUAL_ENTRY";
+  readonly agentNumber: string;
+  readonly agentName: string;
+  readonly agentEmail: string;
+  readonly agentOfficeAddressLine1: string;
+  readonly agentOfficeAddressLine2: string;
+  readonly agentOfficeAddressMunicipality: v112Municipality | undefined;
+  readonly agentOfficeAddressCity: string | undefined;
+  readonly agentOfficeAddressZipCode: string;
+  readonly agentUseAccountInfo: boolean;
+  readonly agentUseBusinessAddress: boolean;
+  readonly members: v112FormationMember[] | undefined;
+  readonly incorporators: v112FormationIncorporator[] | undefined;
+  readonly signers: v112FormationSigner[] | undefined;
+  readonly paymentType: v112PaymentType;
+  readonly annualReportNotification: boolean;
+  readonly corpWatchNotification: boolean;
+  readonly officialFormationDocument: boolean;
+  readonly certificateOfStanding: boolean;
+  readonly certifiedCopyOfFormationDocument: boolean;
+  readonly contactFirstName: string;
+  readonly contactLastName: string;
+  readonly contactPhoneNumber: string;
+  readonly foreignStateOfFormation: v112StateObject | undefined;
+  readonly foreignDateOfFormation: string | undefined; // YYYY-MM-DD
+  readonly foreignGoodStandingFile: v112ForeignGoodStandingFileObject | undefined;
+}
+
+type v112ForeignGoodStandingFileObject = {
+  Extension: "PDF" | "PNG";
+  Content: string;
+};
+
+type v112StateObject = {
+  shortCode: string;
+  name: string;
+};
+
+interface v112FormationAddress {
+  readonly addressLine1: string;
+  readonly addressLine2: string;
+  readonly addressCity?: string;
+  readonly addressState?: v112StateObject;
+  readonly addressMunicipality?: v112Municipality;
+  readonly addressProvince?: string;
+  readonly addressZipCode: string;
+  readonly addressCountry: string;
+}
+
+type v112SignerTitle =
+  | "Authorized Representative"
+  | "Authorized Partner"
+  | "Incorporator"
+  | "General Partner"
+  | "President"
+  | "Vice-President"
+  | "Chairman of the Board"
+  | "CEO";
+
+interface v112FormationSigner {
+  readonly name: string;
+  readonly signature: boolean;
+  readonly title: v112SignerTitle;
+}
+
+interface v112FormationIncorporator extends v112FormationSigner, v112FormationAddress {}
+
+interface v112FormationMember extends v112FormationAddress {
+  readonly name: string;
+}
+
+type v112PaymentType = "CC" | "ACH" | undefined;
+
+const llcBusinessSuffix = [
+  "LLC",
+  "L.L.C.",
+  "LTD LIABILITY CO",
+  "LTD LIABILITY CO.",
+  "LTD LIABILITY COMPANY",
+  "LIMITED LIABILITY CO",
+  "LIMITED LIABILITY CO.",
+  "LIMITED LIABILITY COMPANY",
+] as const;
+
+const llpBusinessSuffix = [
+  "Limited Liability Partnership",
+  "LLP",
+  "L.L.P.",
+  "Registered Limited Liability Partnership",
+  "RLLP",
+  "R.L.L.P.",
+] as const;
+
+export const lpBusinessSuffix = ["LIMITED PARTNERSHIP", "LP", "L.P."] as const;
+
+const corpBusinessSuffix = [
+  "Corporation",
+  "Incorporated",
+  "Company",
+  "LTD",
+  "CO",
+  "CO.",
+  "CORP",
+  "CORP.",
+  "INC",
+  "INC.",
+] as const;
+
+const foreignCorpBusinessSuffix = [...corpBusinessSuffix, "P.C.", "P.A."] as const;
+
+const AllBusinessSuffixes = [
+  ...llcBusinessSuffix,
+  ...llpBusinessSuffix,
+  ...lpBusinessSuffix,
+  ...foreignCorpBusinessSuffix,
+] as const;
+
+type v112BusinessSuffix = (typeof AllBusinessSuffixes)[number];
+
+type v112FormationSubmitResponse = {
+  success: boolean;
+  token: string | undefined;
+  formationId: string | undefined;
+  redirect: string | undefined;
+  errors: v112FormationSubmitError[];
+  lastUpdatedISO: string | undefined;
+};
+
+type v112FormationSubmitError = {
+  field: string;
+  type: "FIELD" | "UNKNOWN" | "RESPONSE";
+  message: string;
+};
+
+type v112GetFilingResponse = {
+  success: boolean;
+  entityId: string;
+  transactionDate: string;
+  confirmationNumber: string;
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+};

--- a/api/test/factories.ts
+++ b/api/test/factories.ts
@@ -115,6 +115,7 @@ export const generateUserData = (overrides: Partial<UserData>): UserData => {
         formationResponse: undefined,
         getFilingResponse: undefined,
         completedFilingPayment: false,
+        lastVisitedPageIndex: 0,
       };
 
   return {
@@ -381,6 +382,7 @@ export const generateFormationData = (
     formationResponse: undefined,
     getFilingResponse: undefined,
     completedFilingPayment: false,
+    lastVisitedPageIndex: 0,
     ...overrides,
   };
 };

--- a/shared/src/formationData.ts
+++ b/shared/src/formationData.ts
@@ -71,6 +71,7 @@ export interface FormationData {
   readonly getFilingResponse: GetFilingResponse | undefined;
   readonly completedFilingPayment: boolean;
   readonly businessNameAvailability: NameAvailability | undefined;
+  readonly lastVisitedPageIndex: number;
 }
 
 export type FormationBusinessLocationType = "US" | "INTL" | "NJ";

--- a/shared/src/userData.ts
+++ b/shared/src/userData.ts
@@ -20,7 +20,7 @@ export interface UserData {
   versionWhenCreated: number;
 }
 
-export const CURRENT_VERSION = 111;
+export const CURRENT_VERSION = 112;
 
 export const createEmptyUserData = (user: BusinessUser): UserData => {
   return {
@@ -58,6 +58,7 @@ export const createEmptyUserData = (user: BusinessUser): UserData => {
       getFilingResponse: undefined,
       completedFilingPayment: false,
       businessNameAvailability: undefined,
+      lastVisitedPageIndex: 0,
     },
   };
 };

--- a/web/src/components/filings-calendar/FilingsCalendarTaxAccess.test.tsx
+++ b/web/src/components/filings-calendar/FilingsCalendarTaxAccess.test.tsx
@@ -91,6 +91,7 @@ describe("<FilingsCalendarTaxAccess />", () => {
       getFilingResponse: undefined,
       completedFilingPayment: false,
       businessNameAvailability: undefined,
+      lastVisitedPageIndex: 0,
     };
 
     if (params.publicFiling) {

--- a/web/src/components/tasks/business-formation/DbaFormationPaginator.tsx
+++ b/web/src/components/tasks/business-formation/DbaFormationPaginator.tsx
@@ -19,7 +19,7 @@ import { useMediaQuery } from "@mui/material";
 import { ReactElement, ReactNode, useContext, useEffect, useRef, useState } from "react";
 
 export const DbaFormationPaginator = (): ReactElement => {
-  const { userData } = useUserData();
+  const { userData, updateQueue } = useUserData();
   const { state, setStepIndex } = useContext(BusinessFormationContext);
   const { isAuthenticated, setRegistrationModalIsVisible } = useContext(AuthAlertContext);
   const { Config } = useConfig();
@@ -67,6 +67,7 @@ export const DbaFormationPaginator = (): ReactElement => {
     stepIndex: number,
     config: { moveType: "NEXT_BUTTON" | "STEPPER" }
   ): Promise<void> => {
+    if (!updateQueue) return;
     onStepChangeAnalytics(userData?.formationData.formationFormData, stepIndex, config.moveType);
     if (
       config.moveType === "NEXT_BUTTON" &&
@@ -81,6 +82,7 @@ export const DbaFormationPaginator = (): ReactElement => {
       stepperState[1].isComplete = stepIndex === 2;
       return stepperState;
     });
+    updateQueue.queueFormationData({ lastVisitedPageIndex: stepIndex }).update();
     moveToStep(stepIndex);
   };
 

--- a/web/src/components/tasks/business-formation/NexusFormation.test.tsx
+++ b/web/src/components/tasks/business-formation/NexusFormation.test.tsx
@@ -162,13 +162,24 @@ describe("<NexusFormationFlow />", () => {
     await page.clickSubmit();
 
     const base64String = Buffer.from("my cool file contents", "utf8").toString("base64");
+    const updatedForeignUserData = {
+      ...foreignUserData,
+      formationData: {
+        ...foreignUserData.formationData,
+        lastVisitedPageIndex: 4,
+      },
+    };
     await waitFor(() => {
-      expect(mockApi.postBusinessFormation).toHaveBeenCalledWith(foreignUserData, "http://localhost/", {
-        fileType: "PNG",
-        sizeInBytes: file.size,
-        base64Contents: base64String,
-        filename: "cool.png",
-      });
+      expect(mockApi.postBusinessFormation).toHaveBeenCalledWith(
+        updatedForeignUserData,
+        "http://localhost/",
+        {
+          fileType: "PNG",
+          sizeInBytes: file.size,
+          base64Contents: base64String,
+          filename: "cool.png",
+        }
+      );
     });
   });
 

--- a/web/src/components/tasks/business-formation/billing/BillingStep.test.tsx
+++ b/web/src/components/tasks/business-formation/billing/BillingStep.test.tsx
@@ -66,6 +66,7 @@ describe("Formation - BillingStep", () => {
       getFilingResponse: undefined,
       completedFilingPayment: false,
       businessNameAvailability: undefined,
+      lastVisitedPageIndex: 0,
     };
     const user = initialUser ? generateUser(initialUser) : generateUser({});
     // eslint-disable-next-line testing-library/render-result-naming-convention

--- a/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
@@ -74,6 +74,7 @@ describe("Formation - BusinessStep", () => {
       getFilingResponse: undefined,
       completedFilingPayment: false,
       businessNameAvailability: undefined,
+      lastVisitedPageIndex: 0,
     };
     const page = preparePage(
       generateUserData({ profileData, formationData }),

--- a/web/src/components/tasks/business-formation/business/MainBusinessAddressNj.test.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusinessAddressNj.test.tsx
@@ -51,6 +51,7 @@ const getPageHelper = async (
     completedFilingPayment: false,
     businessNameSearch: undefined,
     businessNameAvailability: undefined,
+    lastVisitedPageIndex: 0,
   };
 
   const userData = generateUserData({ profileData, formationData });

--- a/web/src/components/tasks/business-formation/contacts/testHelpers.tsx
+++ b/web/src/components/tasks/business-formation/contacts/testHelpers.tsx
@@ -35,6 +35,7 @@ export const getPageHelper = async (
     formationResponse: undefined,
     getFilingResponse: undefined,
     completedFilingPayment: false,
+    lastVisitedPageIndex: 0,
   };
   const user = initialUser ? generateUser(initialUser) : generateUser({});
   const page = preparePage(

--- a/web/src/components/tasks/business-formation/name/BusinessNameStep.test.tsx
+++ b/web/src/components/tasks/business-formation/name/BusinessNameStep.test.tsx
@@ -56,6 +56,7 @@ describe("Formation - BusinessNameStep", () => {
       getFilingResponse: undefined,
       completedFilingPayment: false,
       businessNameAvailability: businessNameAvailability ?? undefined,
+      lastVisitedPageIndex: 0,
     };
     return preparePage(generateUserData({ profileData, formationData }), {
       formationDbaContent: generateFormationDbaContent({}),
@@ -222,6 +223,7 @@ describe("Formation - BusinessNameStep", () => {
           getFilingResponse: undefined,
           completedFilingPayment: false,
           businessNameAvailability: undefined,
+          lastVisitedPageIndex: 0,
         };
 
         preparePage(generateUserData({ profileData, formationData }), {

--- a/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
@@ -66,6 +66,7 @@ describe("Formation - ReviewStep", () => {
       getFilingResponse: undefined,
       completedFilingPayment: false,
       businessNameAvailability: undefined,
+      lastVisitedPageIndex: 0,
     };
     const page = preparePage(
       {

--- a/web/src/lib/UpdateQueue.ts
+++ b/web/src/lib/UpdateQueue.ts
@@ -7,6 +7,7 @@ import {
   TaxFilingData,
   UserData,
 } from "@businessnjgovnavigator/shared";
+import { FormationData } from "@businessnjgovnavigator/shared/formationData";
 
 export class UpdateQueueFactory implements UpdateQueue {
   private internalQueue: UserData;
@@ -42,6 +43,17 @@ export class UpdateQueueFactory implements UpdateQueue {
       profileData: {
         ...this.internalQueue.profileData,
         ...profileData,
+      },
+    };
+    return this;
+  }
+
+  queueFormationData(formationData: Partial<FormationData>): UpdateQueue {
+    this.internalQueue = {
+      ...this.internalQueue,
+      formationData: {
+        ...this.internalQueue.formationData,
+        ...formationData,
       },
     };
     return this;

--- a/web/src/lib/types/types.ts
+++ b/web/src/lib/types/types.ts
@@ -6,6 +6,7 @@ import {
   emptyBusinessUser,
   emptyProfileData,
   FieldsForErrorHandling,
+  FormationData,
   FormationMember,
   FormationSigner,
   IndustrySpecificData,
@@ -462,6 +463,7 @@ export interface UpdateQueue {
   queueProfileData: (profileData: Partial<ProfileData>) => UpdateQueue;
   queuePreferences: (preferences: Partial<Preferences>) => UpdateQueue;
   queueTaxFilingData: (taxFilingData: Partial<TaxFilingData>) => UpdateQueue;
+  queueFormationData: (formationData: Partial<FormationData>) => UpdateQueue;
   update: () => Promise<void>;
   current: () => UserData;
 }

--- a/web/test/factories.ts
+++ b/web/test/factories.ts
@@ -412,6 +412,7 @@ export const generateFormationData = (
     formationResponse: undefined,
     getFilingResponse: undefined,
     completedFilingPayment: false,
+    lastVisitedPageIndex: 0,
     ...overrides,
   };
 };
@@ -423,6 +424,7 @@ export const generateEmptyFormationData = (): FormationData => {
     getFilingResponse: undefined,
     completedFilingPayment: false,
     businessNameAvailability: undefined,
+    lastVisitedPageIndex: 0,
   };
 };
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

We wanted to have the application remember the last formation page the user visited so that if they navigate away and come back they will still be on the same step. (This should be reset if the legal structure type is reset). 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/#184306248)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

Go to the formation page as a user, navigate to a step via the stepper or the save and continue button

navigate away from this page, 

navigate back

you should not be on the first step but the step you left off on,

got to the profile page and change your legal structure (business structure on the page) (NOTE not all business structure have a formation process)

go to formation and see that the formation step has reset 

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
