### PR TITLE
[#185008380] Update S-Corp Formation

### DIFF
--- a/api/src/client/ApiFormationClient.test.ts
+++ b/api/src/client/ApiFormationClient.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { getCurrentDate, getCurrentDateISOString, parseDate, parseDateWithFormat } from "@shared/dateHelpers";
-import { formationApiDateFormat } from "@shared/formationData";
+import { formationApiDateFormat, FormationLegalType } from "@shared/formationData";
 import {
   generateFormationFormData,
   generateFormationIncorporator,
@@ -681,81 +681,79 @@ describe("ApiFormationClient", () => {
           mockAxios.post.mockResolvedValue({ data: stubResponse });
         });
 
-        it("is undefined if not provided", async () => {
-          const legalStructureId = "c-corporation";
-          const formationFormData = generateFormationFormData(
-            {},
-            { legalStructureId: `foreign-${legalStructureId}` }
-          );
+        for (const legalStructureId of ["c-corporation", "s-corporation"]) {
+          it("is undefined if not provided", async () => {
+            const formationFormData = generateFormationFormData(
+              {},
+              { legalStructureId: `foreign-${legalStructureId}` as FormationLegalType }
+            );
 
-          const userData = generateFormationUserData(
-            { legalStructureId, businessPersona: "FOREIGN" },
-            {},
-            formationFormData
-          );
+            const userData = generateFormationUserData(
+              { legalStructureId, businessPersona: "FOREIGN" },
+              {},
+              formationFormData
+            );
 
-          await client.form(userData, "hostname.com/form-business");
+            await client.form(userData, "hostname.com/form-business");
 
-          const payload = mockAxios.post.mock.calls[0][1] as ApiSubmission;
-          expect(payload.Formation.BusinessInformation.PracticesLaw).toBe(undefined);
-        });
+            const payload = mockAxios.post.mock.calls[0][1] as ApiSubmission;
+            expect(payload.Formation.BusinessInformation.PracticesLaw).toBe(undefined);
+          });
 
-        it("is 'Yes' if willPracticeLaw is true", async () => {
-          const legalStructureId = "c-corporation";
-          const formationFormData = generateFormationFormData(
-            { willPracticeLaw: true },
-            { legalStructureId: `foreign-${legalStructureId}` }
-          );
+          it("is 'Yes' if willPracticeLaw is true", async () => {
+            const formationFormData = generateFormationFormData(
+              { willPracticeLaw: true },
+              { legalStructureId: `foreign-${legalStructureId}` as FormationLegalType }
+            );
 
-          const userData = generateFormationUserData(
-            { legalStructureId, businessPersona: "FOREIGN" },
-            {},
-            formationFormData
-          );
+            const userData = generateFormationUserData(
+              { legalStructureId, businessPersona: "FOREIGN" },
+              {},
+              formationFormData
+            );
 
-          await client.form(userData, "hostname.com/form-business");
+            await client.form(userData, "hostname.com/form-business");
 
-          const payload = mockAxios.post.mock.calls[0][1] as ApiSubmission;
-          expect(payload.Formation.BusinessInformation.PracticesLaw).toBe("Yes");
-        });
+            const payload = mockAxios.post.mock.calls[0][1] as ApiSubmission;
+            expect(payload.Formation.BusinessInformation.PracticesLaw).toBe("Yes");
+          });
 
-        it("is 'No' if willPracticeLaw is false", async () => {
-          const legalStructureId = "c-corporation";
-          const formationFormData = generateFormationFormData(
-            { willPracticeLaw: false },
-            { legalStructureId: `foreign-${legalStructureId}` }
-          );
+          it("is 'No' if willPracticeLaw is false", async () => {
+            const formationFormData = generateFormationFormData(
+              { willPracticeLaw: false },
+              { legalStructureId: `foreign-${legalStructureId}` as FormationLegalType }
+            );
 
-          const userData = generateFormationUserData(
-            { legalStructureId, businessPersona: "FOREIGN" },
-            {},
-            formationFormData
-          );
+            const userData = generateFormationUserData(
+              { legalStructureId, businessPersona: "FOREIGN" },
+              {},
+              formationFormData
+            );
 
-          await client.form(userData, "hostname.com/form-business");
+            await client.form(userData, "hostname.com/form-business");
 
-          const payload = mockAxios.post.mock.calls[0][1] as ApiSubmission;
-          expect(payload.Formation.BusinessInformation.PracticesLaw).toBe("No");
-        });
+            const payload = mockAxios.post.mock.calls[0][1] as ApiSubmission;
+            expect(payload.Formation.BusinessInformation.PracticesLaw).toBe("No");
+          });
 
-        it("is undefined if not foreign c-corp", async () => {
-          const legalStructureId = "s-corporation";
-          const formationFormData = generateFormationFormData(
-            { willPracticeLaw: true },
-            { legalStructureId: `${legalStructureId}` }
-          );
+          it("is undefined if not foreign corp", async () => {
+            const formationFormData = generateFormationFormData(
+              { willPracticeLaw: true },
+              { legalStructureId: `${legalStructureId}` as FormationLegalType }
+            );
 
-          const userData = generateFormationUserData(
-            { legalStructureId, businessPersona: "OWNING" },
-            {},
-            formationFormData
-          );
+            const userData = generateFormationUserData(
+              { legalStructureId, businessPersona: "OWNING" },
+              {},
+              formationFormData
+            );
 
-          await client.form(userData, "hostname.com/form-business");
+            await client.form(userData, "hostname.com/form-business");
 
-          const payload = mockAxios.post.mock.calls[0][1] as ApiSubmission;
-          expect(payload.Formation.BusinessInformation.PracticesLaw).toBe(undefined);
-        });
+            const payload = mockAxios.post.mock.calls[0][1] as ApiSubmission;
+            expect(payload.Formation.BusinessInformation.PracticesLaw).toBe(undefined);
+          });
+        }
       });
     });
 

--- a/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
@@ -23,6 +23,7 @@ import {
   PublicFilingLegalType,
   randomPublicFilingLegalType,
 } from "@businessnjgovnavigator/shared";
+import { publicFilingLegalTypes } from "@businessnjgovnavigator/shared/formationData";
 import * as materialUi from "@mui/material";
 import { fireEvent, screen, within } from "@testing-library/react";
 
@@ -393,6 +394,60 @@ describe("Formation - BusinessStep", () => {
       page.fillText("Foreign state of formation", "test");
       expect(screen.getByText(Config.formation.fields.foreignStateOfFormation.error)).toBeInTheDocument();
     });
+  });
+
+  describe("Foreign Certificate of Good Standing", () => {
+    for (const legalStructureId of ["c-corporation", "s-corporation"]) {
+      it(`should render for foreign${legalStructureId}`, async () => {
+        await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, {});
+        expect(screen.getByTestId("foreign-certificate-of-good-standing-header")).toBeInTheDocument();
+      });
+    }
+
+    for (const legalStructureId of [
+      "limited-liability-partnership",
+      "limited-liability-company",
+      "limited-partnership",
+    ]) {
+      it(`should not render for foreign${legalStructureId}`, async () => {
+        await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, {});
+        expect(screen.queryByTestId("foreign-certificate-of-good-standing-header")).not.toBeInTheDocument();
+      });
+    }
+
+    for (const legalStructureId of publicFilingLegalTypes) {
+      it(`should not render for ${legalStructureId}`, async () => {
+        await getPageHelper({ businessPersona: "OWNING", legalStructureId }, {});
+        expect(screen.queryByTestId("foreign-certificate-of-good-standing-header")).not.toBeInTheDocument();
+      });
+    }
+  });
+
+  describe("Will Practice Law", () => {
+    for (const legalStructureId of ["c-corporation", "s-corporation"]) {
+      it(`should render for foreign${legalStructureId}`, async () => {
+        await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, {});
+        expect(screen.getByTestId("will-practice-law-label")).toBeInTheDocument();
+      });
+    }
+
+    for (const legalStructureId of [
+      "limited-liability-partnership",
+      "limited-liability-company",
+      "limited-partnership",
+    ]) {
+      it(`should not render for foreign${legalStructureId}`, async () => {
+        await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, {});
+        expect(screen.queryByTestId("will-practice-law-label")).not.toBeInTheDocument();
+      });
+    }
+
+    for (const legalStructureId of publicFilingLegalTypes) {
+      it(`should not render for ${legalStructureId}`, async () => {
+        await getPageHelper({ businessPersona: "OWNING", legalStructureId }, {});
+        expect(screen.queryByTestId("will-practice-law-label")).not.toBeInTheDocument();
+      });
+    }
   });
 
   describe("Business location type radio buttons", () => {

--- a/web/src/components/tasks/business-formation/business/ForeignCertificate.tsx
+++ b/web/src/components/tasks/business-formation/business/ForeignCertificate.tsx
@@ -18,7 +18,7 @@ export const ForeignCertificate = (props: Props): ReactElement => {
     <>
       <hr className="margin-bottom-2 margin-top-0" aria-hidden={true} />
       <FormControl variant="outlined" fullWidth className="padding-bottom-2">
-        <h3 className="margin-bottom-2" data-testid="main-business-address-container-header">
+        <h3 className="margin-bottom-2" data-testid="foreign-certificate-of-good-standing-header">
           <Content className="h3-styling">
             {Config.formation.fields.foreignGoodStandingFile.contextualLabel}
           </Content>

--- a/web/src/components/tasks/business-formation/business/MainBusiness.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusiness.tsx
@@ -9,6 +9,7 @@ import { WithErrorBar } from "@/components/WithErrorBar";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormationErrors } from "@/lib/data-hooks/useFormationErrors";
+import { isForeignCorporation } from "@/lib/utils/helpers";
 import { corpLegalStructures } from "@businessnjgovnavigator/shared/";
 import { ReactElement, useContext, useMemo } from "react";
 import { ForeignCertificate } from "./ForeignCertificate";
@@ -68,7 +69,7 @@ export const MainBusiness = (): ReactElement => {
               <FormationDate fieldName="foreignDateOfFormation" />
             </WithErrorBar>
           </WithErrorBar>
-          {state.formationFormData.legalType === "foreign-c-corporation" && (
+          {isForeignCorporation(state.formationFormData.legalType) && (
             <>
               <WithErrorBar hasError={doesFieldHaveError("willPracticeLaw")} type="ALWAYS">
                 <PracticesLaw hasError={doesFieldHaveError("willPracticeLaw")} />

--- a/web/src/components/tasks/business-formation/business/PracticesLaw.tsx
+++ b/web/src/components/tasks/business-formation/business/PracticesLaw.tsx
@@ -30,7 +30,9 @@ export const PracticesLaw = (props: Props): ReactElement => {
         }
         row
       >
-        <label className="margin-right-3">{Config.formation.fields.willPracticeLaw.label}</label>
+        <label className="margin-right-3" data-testid="will-practice-law-label">
+          {Config.formation.fields.willPracticeLaw.label}
+        </label>
         <FormControlLabel
           labelPlacement="end"
           data-testid={"practice-law-yes"}

--- a/web/src/components/tasks/business-formation/review/ReviewStep.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.tsx
@@ -18,6 +18,7 @@ import { ReviewText } from "@/components/tasks/business-formation/review/section
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import analytics from "@/lib/utils/analytics";
+import { isForeignCorporation } from "@/lib/utils/helpers";
 import { ReactElement, useContext } from "react";
 
 export const ReviewStep = (): ReactElement => {
@@ -25,7 +26,6 @@ export const ReviewStep = (): ReactElement => {
   const { Config } = useConfig();
 
   const isLP = state.formationFormData.legalType === "limited-partnership";
-  const isForeignCCorp = state.formationFormData.legalType === "foreign-c-corporation";
   const hasProvisions = (state.formationFormData.provisions?.length ?? 0) > 0;
   const hasPurpose = !!state.formationFormData.businessPurpose;
   const hasMembers = (state.formationFormData.members?.length ?? 0) > 0;
@@ -36,7 +36,7 @@ export const ReviewStep = (): ReactElement => {
         <ReviewSection stepName={"Business"} testId="edit-business-name-step">
           <BusinessNameAndLegalStructure isReviewStep />
           <ReviewBusinessSuffixAndStartDate />
-          {isForeignCCorp && (
+          {isForeignCorporation(state.formationFormData.legalType) && (
             <>
               <ReviewWillPracticeLaw willPracticeLaw={state.formationFormData.willPracticeLaw} />
               <ReviewForeignCertificate foreignGoodStandingFile={state.foreignGoodStandingFile} />

--- a/web/src/components/tasks/business-formation/validatedFieldsForUser.ts
+++ b/web/src/components/tasks/business-formation/validatedFieldsForUser.ts
@@ -1,3 +1,4 @@
+import { isForeignCorporation } from "@/lib/utils/helpers";
 import {
   corpLegalStructures,
   FieldsForErrorHandling,
@@ -63,7 +64,7 @@ export const validatedFieldsForUser = (formationFormData: FormationFormData): Fi
     validatedFields = [...validatedFields, "businessTotalStock", "members"];
   }
 
-  if (formationFormData.legalType === "foreign-c-corporation") {
+  if (isForeignCorporation(formationFormData.legalType)) {
     validatedFields = [...validatedFields, "willPracticeLaw", "foreignGoodStandingFile"];
   }
 

--- a/web/src/lib/utils/helpers.ts
+++ b/web/src/lib/utils/helpers.ts
@@ -2,6 +2,7 @@ import { ConfigType, getMergedConfig } from "@/contexts/configContext";
 import { FlowType, OnboardingStatus } from "@/lib/types/types";
 import {
   BusinessPersona,
+  FormationLegalType,
   Municipality,
   MunicipalityDetail,
   ProfileData,
@@ -209,4 +210,8 @@ export const mapMunicipalityDetailToMunicipality = (municipalityDetail: Municipa
     name: municipalityDetail.townName,
     county: municipalityDetail.countyName,
   };
+};
+
+export const isForeignCorporation = (legalStructure: FormationLegalType): boolean => {
+  return ["foreign-c-corporation", "foreign-s-corporation"].includes(legalStructure);
 };


### PR DESCRIPTION
## Description

Applies changes made to foreign-c-corp flow in #5603 to the foreign-s-corp flow.

### Ticket

[185008380](https://www.pivotaltracker.com/story/show/185008380)

### Approach

- Update all checks for business formation type to account for both foreign-c-corp and foreign-s-corp.
- Update tests to more accurately represent the desired workflow.

### Steps to Test

See previous PR and associated ticket.

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
