### PR TITLE
chore: [#185009333] refactor auto name check to not fire for users wh…

### DIFF
--- a/api/src/api/userRouter.ts
+++ b/api/src/api/userRouter.ts
@@ -66,7 +66,8 @@ const shouldUpdateBusinessNameSearch = (userData: UserData): boolean => {
   return (
     userData.profileData.businessName !== undefined &&
     userData.formationData.businessNameAvailability !== undefined &&
-    hasBeenMoreThanOneHour(userData.formationData.businessNameAvailability.lastUpdatedTimeStamp)
+    hasBeenMoreThanOneHour(userData.formationData.businessNameAvailability.lastUpdatedTimeStamp) &&
+    userData.formationData.completedFilingPayment !== true
   );
 };
 


### PR DESCRIPTION
…o have formed successfully

<!-- Please complete the following sections as necessary. -->

## Description

Refactored the auto-namecheck to not fire if the user has formed successfully by checking `formationData.completedFilingPayment` and `formationData.formationResponse.success`. The auto-checkname only runs when both of the values are not true.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#185009333](https://www.pivotaltracker.com/story/show/185009333)

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
