### PR TITLE
[184478453] Fix page_name

### DIFF
--- a/web/src/lib/utils/analytics.ts
+++ b/web/src/lib/utils/analytics.ts
@@ -445,9 +445,10 @@ const dimensionRunner = new DimensionQueueFactory(analytics.userUpdate);
 export default {
   eventRunner,
   pageview: (path: string, name?: string, section_name?: string) => {
+    const page_name = document.title;
     analytics.sendEvent({
       event: "screen_view",
-      page_name: name,
+      page_name,
       page_path: path,
       hostname: window.location.hostname,
       section_name: section_name,


### PR DESCRIPTION
## Description

Update to Google Analytics work to get correct data for `page_name`.

### Ticket

[184478453](https://www.pivotaltracker.com/story/show/184478453)

### Approach

We're firing the pageview/screen_view event in the useEffect of `_app.tsx`.

```
  useEffect(() => {
    router.events.on("routeChangeComplete", analytics.pageview);
    return () => {
      router.events.off("routeChangeComplete", analytics.pageview);
    };
  }, [router.events]);
```

I don't think the params NextRouter is providing when the pageview callback fires are the ones initially expected. They don't seem to quite match up. I've changed page_name to grab from document.title and just provide the HTML title for now.

I'd like to talk to Mike about what his initial goal was with this implementation before too much changes.

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
