### PR TITLE
feat: [#184998185] marketing-calendar-welcome-landing-page

### DIFF
--- a/web/src/components/LandingPageActionTile.tsx
+++ b/web/src/components/LandingPageActionTile.tsx
@@ -1,17 +1,12 @@
 import { MediaQueries } from "@/lib/PageSizes";
+import { ActionTile } from "@/lib/types/types";
 import { useMediaQuery } from "@mui/material";
 import { MutableRefObject, ReactElement, ReactNode } from "react";
 
-interface Props {
+interface Props extends ActionTile {
   className: string;
-  imgPath: string;
-  tileText: string;
-  tileText2?: string;
-  isPrimary?: boolean;
   isActive?: boolean;
-  dataTestId: string;
   reference?: MutableRefObject<null | HTMLDivElement>;
-  onClick: () => void;
 }
 
 const setTileText = (props: Props, isMobile: boolean): ReactNode => {

--- a/web/src/components/LandingPageSlider.tsx
+++ b/web/src/components/LandingPageSlider.tsx
@@ -1,10 +1,7 @@
 import { LandingPageActionTile } from "@/components/LandingPageActionTile";
 import { Icon } from "@/components/njwds/Icon";
-import { useConfig } from "@/lib/data-hooks/useConfig";
-import { QUERIES, ROUTES, routeWithQuery } from "@/lib/domain-logic/routes";
-import analytics from "@/lib/utils/analytics";
+import { ActionTile } from "@/lib/types/types";
 import { useMountEffect } from "@/lib/utils/helpers";
-import { useRouter } from "next/router";
 import { ReactElement, useRef, useState } from "react";
 import Slider, { CustomArrowProps } from "react-slick";
 
@@ -23,9 +20,11 @@ function PrevArrow(props: CustomArrowProps): ReactElement {
   );
 }
 
-export const LandingPageSlider = (): ReactElement => {
-  const router = useRouter();
-  const { Config } = useConfig();
+interface Props {
+  actionTiles: ActionTile[];
+}
+
+export const LandingPageSlider = (props: Props): ReactElement => {
   const [activeTile, setActiveTile] = useState(0);
   const [slideBreakPoint, setSlideBreakPoint] = useState(7);
   const cardRef = useRef<null | HTMLDivElement>(null);
@@ -53,18 +52,6 @@ export const LandingPageSlider = (): ReactElement => {
       window.removeEventListener("resize", handleResize);
     };
   });
-
-  const routeToOnboarding = (): void => {
-    router.push(ROUTES.onboarding);
-    analytics.event.landing_page_hero_get_started.click.go_to_onboarding();
-  };
-
-  const setFlowAndRouteUser = (flow: "starting" | "out-of-state" | "up-and-running"): void => {
-    routeWithQuery(router, {
-      path: ROUTES.onboarding,
-      queries: { [QUERIES.flow]: flow },
-    });
-  };
 
   const settings = {
     className: "slider variable-width",
@@ -99,65 +86,16 @@ export const LandingPageSlider = (): ReactElement => {
   return (
     <div className="slider" ref={sliderRef} style={{ marginLeft: "25px", marginRight: "25px" }}>
       <Slider {...settings}>
-        <LandingPageActionTile
-          className={"landing-page-slide"}
-          imgPath={"/img/getStarted-icon.svg"}
-          tileText={Config.landingPage.landingPageTile1Line1Text}
-          tileText2={Config.landingPage.landingPageTile1Line2Text}
-          dataTestId={"get-started-tile"}
-          reference={cardRef}
-          onClick={routeToOnboarding}
-          isActive={activeTile === 0}
-          isPrimary
-        />
-        <LandingPageActionTile
-          className={"landing-page-slide"}
-          imgPath={"/img/briefcase-icon.svg"}
-          dataTestId={"register-biz-tile"}
-          tileText={Config.landingPage.landingPageTile2Text}
-          onClick={(): void => setFlowAndRouteUser("starting")}
-          isActive={activeTile === 1}
-        />
-        <LandingPageActionTile
-          className={"landing-page-slide"}
-          imgPath={"/img/payTaxes-icon.svg"}
-          dataTestId={"pay-taxes-tile"}
-          tileText={Config.landingPage.landingPageTile3Text}
-          onClick={(): void => setFlowAndRouteUser("up-and-running")}
-          isActive={activeTile === 2}
-        />
-        <LandingPageActionTile
-          className={"landing-page-slide"}
-          imgPath={"/img/outOfState-icon.svg"}
-          dataTestId={"out-of-state-tile"}
-          tileText={Config.landingPage.landingPageTile4Text}
-          onClick={(): void => setFlowAndRouteUser("out-of-state")}
-          isActive={activeTile === 3}
-        />
-        <LandingPageActionTile
-          className={"landing-page-slide"}
-          imgPath={"/img/eligibleFunding-icon.svg"}
-          dataTestId={"eligible-funding-tile"}
-          tileText={Config.landingPage.landingPageTile5Text}
-          onClick={(): void => setFlowAndRouteUser("up-and-running")}
-          isActive={activeTile === 4}
-        />
-        <LandingPageActionTile
-          className={"landing-page-slide"}
-          imgPath={"/img/startBusiness-icon.svg"}
-          tileText={Config.landingPage.landingPageTile6Text}
-          dataTestId={"start-biz-tile"}
-          onClick={(): void => setFlowAndRouteUser("starting")}
-          isActive={activeTile === 5}
-        />
-        <LandingPageActionTile
-          className={"landing-page-slide"}
-          imgPath={"/img/runBusiness-icon.svg"}
-          tileText={Config.landingPage.landingPageTile7Text}
-          dataTestId={"run-biz-tile"}
-          onClick={(): void => setFlowAndRouteUser("up-and-running")}
-          isActive={activeTile === 6}
-        />
+        {props.actionTiles.map((actionTile, index) => {
+          const actionTileObj = {
+            ...actionTile,
+            key: `landing-page-slider-key-${index}`,
+            className: "landing-page-slide",
+            isActive: activeTile === index,
+            reference: index === 0 ? cardRef : undefined,
+          };
+          return <LandingPageActionTile {...actionTileObj} key={actionTileObj.key} />;
+        })}
       </Slider>
     </div>
   );

--- a/web/src/components/LandingPageTiles.test.tsx
+++ b/web/src/components/LandingPageTiles.test.tsx
@@ -14,7 +14,7 @@ describe("<LandingPageTiles />", () => {
   });
 
   it("routes user to industry selection when the starting a business button is clicked", async () => {
-    render(<LandingPageTiles />);
+    render(<LandingPageTiles isWelcomePage={false} />);
 
     fireEvent.click(screen.getByText(Config.landingPage.landingPageTile2Text));
 
@@ -22,7 +22,7 @@ describe("<LandingPageTiles />", () => {
   });
 
   it("routes user to out-of-state business section when the out-of-state business button is clicked", async () => {
-    render(<LandingPageTiles />);
+    render(<LandingPageTiles isWelcomePage={false} />);
 
     fireEvent.click(screen.getByText(Config.landingPage.landingPageTile4Text));
 
@@ -30,10 +30,22 @@ describe("<LandingPageTiles />", () => {
   });
 
   it("routes user to business status section when the running a business button is clicked", async () => {
-    render(<LandingPageTiles />);
+    render(<LandingPageTiles isWelcomePage={false} />);
 
     fireEvent.click(screen.getByText(Config.landingPage.landingPageTile3Text));
 
     expect(mockPush).toHaveBeenCalledWith({ pathname: "/onboarding", query: { flow: "up-and-running" } });
+  });
+
+  it("shows only 'Get Started' and 'Pay Taxes' tiles when visiting welcome page URL", () => {
+    render(<LandingPageTiles isWelcomePage={true} />);
+
+    expect(screen.queryByTestId("start-biz-tile")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("run-biz-tile")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("out-of-state-tile")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("register-biz-tile")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("eligible-funding-tile")).not.toBeInTheDocument();
+    expect(screen.getByTestId("get-started-tile")).toBeInTheDocument();
+    expect(screen.getByTestId("pay-taxes-tile")).toBeInTheDocument();
   });
 });

--- a/web/src/components/LandingPageTiles.tsx
+++ b/web/src/components/LandingPageTiles.tsx
@@ -3,12 +3,17 @@ import { LandingPageSlider } from "@/components/LandingPageSlider";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { QUERIES, ROUTES, routeWithQuery } from "@/lib/domain-logic/routes";
 import { MediaQueries } from "@/lib/PageSizes";
+import { ActionTile } from "@/lib/types/types";
 import analytics from "@/lib/utils/analytics";
 import { useMediaQuery } from "@mui/material";
 import { useRouter } from "next/router";
 import { ReactElement } from "react";
 
-export const LandingPageTiles = (): ReactElement => {
+interface Props {
+  isWelcomePage?: boolean;
+}
+
+export const LandingPageTiles = (props: Props): ReactElement => {
   const router = useRouter();
   const istabletAndUp = useMediaQuery(MediaQueries.tabletAndUp);
   const { Config } = useConfig();
@@ -25,67 +30,80 @@ export const LandingPageTiles = (): ReactElement => {
     });
   };
 
+  const actionTiles: ActionTile[] = [
+    {
+      imgPath: "/img/getStarted-icon.svg",
+      tileText: Config.landingPage.landingPageTile1Line1Text,
+      tileText2: Config.landingPage.landingPageTile1Line2Text,
+      dataTestId: "get-started-tile",
+      onClick: routeToOnboarding,
+      isPrimary: true,
+    },
+    {
+      imgPath: "/img/briefcase-icon.svg",
+      tileText: Config.landingPage.landingPageTile2Text,
+      dataTestId: "register-biz-tile",
+      onClick: (): void => setFlowAndRouteUser("starting"),
+    },
+    {
+      imgPath: "/img/payTaxes-icon.svg",
+      tileText: Config.landingPage.landingPageTile3Text,
+      dataTestId: "pay-taxes-tile",
+      onClick: (): void => setFlowAndRouteUser("up-and-running"),
+    },
+    {
+      imgPath: "/img/outOfState-icon.svg",
+      dataTestId: "out-of-state-tile",
+      tileText: Config.landingPage.landingPageTile4Text,
+      onClick: (): void => setFlowAndRouteUser("out-of-state"),
+    },
+    {
+      imgPath: "/img/eligibleFunding-icon.svg",
+      dataTestId: "eligible-funding-tile",
+      tileText: Config.landingPage.landingPageTile5Text,
+      onClick: (): void => setFlowAndRouteUser("up-and-running"),
+    },
+    {
+      imgPath: "/img/startBusiness-icon.svg",
+      dataTestId: "start-biz-tile",
+      tileText: Config.landingPage.landingPageTile6Text,
+      onClick: (): void => setFlowAndRouteUser("starting"),
+    },
+    {
+      imgPath: "/img/runBusiness-icon.svg",
+      dataTestId: "run-biz-tile",
+      tileText: Config.landingPage.landingPageTile7Text,
+      onClick: (): void => setFlowAndRouteUser("up-and-running"),
+    },
+  ];
+
+  const filterActionTiles = (actionTiles: ActionTile[]): ActionTile[] =>
+    actionTiles.filter((actionTile): boolean => {
+      if (props.isWelcomePage) {
+        const welcomePageTiles = ["get-started-tile", "pay-taxes-tile"];
+        return welcomePageTiles.includes(actionTile.dataTestId);
+      }
+      return true;
+    });
+
   return (
     <>
-      {istabletAndUp ? (
+      {istabletAndUp && !props.isWelcomePage ? (
         <div className="desktop:grid-container-widescreen desktop:width-100">
           <div>
-            <LandingPageSlider />
+            <LandingPageSlider actionTiles={actionTiles} />
           </div>
         </div>
       ) : (
-        <div className={"fdc fjc fac"}>
-          <LandingPageActionTile
-            className={"landing-page-slide"}
-            imgPath={"/img/getStarted-icon.svg"}
-            tileText={Config.landingPage.landingPageTile1Line1Text}
-            tileText2={Config.landingPage.landingPageTile1Line2Text}
-            dataTestId={"get-started-tile"}
-            onClick={routeToOnboarding}
-            isPrimary
-          />
-          <LandingPageActionTile
-            className={"landing-page-slide"}
-            imgPath={"/img/startBusiness-icon.svg"}
-            tileText={Config.landingPage.landingPageTile2Text}
-            dataTestId={"start-biz-tile"}
-            onClick={(): void => setFlowAndRouteUser("starting")}
-          />
-          <LandingPageActionTile
-            className={"landing-page-slide"}
-            imgPath={"/img/runBusiness-icon.svg"}
-            tileText={Config.landingPage.landingPageTile3Text}
-            dataTestId={"run-biz-tile"}
-            onClick={(): void => setFlowAndRouteUser("up-and-running")}
-          />
-          <LandingPageActionTile
-            className={"landing-page-slide"}
-            imgPath={"/img/outOfState-icon.svg"}
-            dataTestId={"out-of-state-tile"}
-            tileText={Config.landingPage.landingPageTile4Text}
-            onClick={(): void => setFlowAndRouteUser("out-of-state")}
-          />
-          <LandingPageActionTile
-            className={"landing-page-slide"}
-            imgPath={"/img/briefcase-icon.svg"}
-            dataTestId={"register-biz-tile"}
-            tileText={Config.landingPage.landingPageTile5Text}
-            onClick={(): void => setFlowAndRouteUser("starting")}
-          />
-          <LandingPageActionTile
-            className={"landing-page-slide"}
-            imgPath={"/img/payTaxes-icon.svg"}
-            dataTestId={"pay-taxes-tile"}
-            tileText={Config.landingPage.landingPageTile6Text}
-            onClick={(): void => setFlowAndRouteUser("up-and-running")}
-          />
-          <LandingPageActionTile
-            className={"landing-page-slide"}
-            imgPath={"/img/eligibleFunding-icon.svg"}
-            dataTestId={"eligible-funding-tile"}
-            tileText={Config.landingPage.landingPageTile7Text}
-            onClick={(): void => setFlowAndRouteUser("up-and-running")}
-          />
+        <div className={`fjc fac ${istabletAndUp ? "fdr" : "fdc"}`}>
+          {filterActionTiles(actionTiles).map((actionTile, index) => {
+            const actionTileObj = {
+              ...actionTile,
+              key: `landing-page-tiles-key-${index}`,
+              className: "landing-page-tiles",
+            };
+            return <LandingPageActionTile {...actionTileObj} key={actionTileObj.key} />;
+          })}
         </div>
       )}
     </>

--- a/web/src/components/njwds/Hero.tsx
+++ b/web/src/components/njwds/Hero.tsx
@@ -9,7 +9,11 @@ import { useMediaQuery } from "@mui/material";
 import { useRouter } from "next/router";
 import { ReactElement } from "react";
 
-export const Hero = (): ReactElement => {
+interface Props {
+  isWelcomePage?: boolean;
+}
+
+export const Hero = (props: Props): ReactElement => {
   const isDesktopAndUp = useMediaQuery(MediaQueries.desktopAndUp);
   const isTabletAndUp = useMediaQuery(MediaQueries.tabletAndUp);
   const router = useRouter();
@@ -58,7 +62,7 @@ export const Hero = (): ReactElement => {
             </div>
           </div>
         </div>
-        <LandingPageTiles />
+        <LandingPageTiles isWelcomePage={props.isWelcomePage} />
       </div>
       <div className={`${isDesktopAndUp ? "hero-gradient-bg-bottom" : "bg-primary-extra-light"}`}>
         <div className="desktop:grid-container-widescreen desktop:padding-x-7 width-100">

--- a/web/src/lib/auth/signinHelper.test.ts
+++ b/web/src/lib/auth/signinHelper.test.ts
@@ -180,6 +180,17 @@ describe("SigninHelper", () => {
       await onGuestSignIn(mockPush, ROUTES.onboarding, mockDispatch);
       expect(mockPush).not.toHaveBeenCalledWith(ROUTES.landing);
     });
+
+    it("does not redirect user when at /welcome", async () => {
+      mockGetCurrentUserData.mockImplementation(() => {
+        return undefined;
+      });
+      mockSession.getCurrentUser.mockImplementation(() => {
+        throw new Error("New");
+      });
+      await onGuestSignIn(mockPush, ROUTES.welcome, mockDispatch);
+      expect(mockPush).not.toHaveBeenCalledWith(ROUTES.landing);
+    });
   });
 
   describe("onSignOut", () => {

--- a/web/src/lib/auth/signinHelper.ts
+++ b/web/src/lib/auth/signinHelper.ts
@@ -99,14 +99,28 @@ export const onGuestSignIn = async (
       setRegistrationDimension("Onboarded Guest");
     }
   } else {
-    if (pathname === ROUTES.onboarding) {
-      setRegistrationDimension("Began Onboarding");
-    } else if (pathname === ROUTES.loading) {
-      setRegistrationDimension("Began Onboarding");
-      push(ROUTES.onboarding);
-    } else {
-      setRegistrationDimension("Not Started");
-      push(ROUTES.landing);
+    switch (pathname) {
+      case ROUTES.welcome: {
+        setRegistrationDimension("Not Started");
+        push(ROUTES.welcome);
+
+        break;
+      }
+      case ROUTES.onboarding: {
+        setRegistrationDimension("Began Onboarding");
+
+        break;
+      }
+      case ROUTES.loading: {
+        setRegistrationDimension("Began Onboarding");
+        push(ROUTES.onboarding);
+
+        break;
+      }
+      default: {
+        setRegistrationDimension("Not Started");
+        push(ROUTES.landing);
+      }
     }
   }
 };

--- a/web/src/lib/domain-logic/routes.ts
+++ b/web/src/lib/domain-logic/routes.ts
@@ -7,6 +7,7 @@ export const ROUTES = {
   dashboard: "/dashboard",
   onboarding: "/onboarding",
   unsupported: "/unsupported",
+  welcome: "/welcome",
 };
 
 export interface QUERY_PARAMS_VALUES {

--- a/web/src/lib/types/types.ts
+++ b/web/src/lib/types/types.ts
@@ -490,3 +490,12 @@ export type StepperStep = { name: string; hasError: boolean; isComplete: boolean
 export interface ContextualInfoFile extends ContextualInfo {
   filename: string;
 }
+
+export interface ActionTile {
+  imgPath: string;
+  tileText: string;
+  tileText2?: string;
+  dataTestId: string;
+  onClick: () => void;
+  isPrimary?: boolean;
+}

--- a/web/src/pages/index.tsx
+++ b/web/src/pages/index.tsx
@@ -18,7 +18,11 @@ import { useMediaQuery } from "@mui/material";
 import { useRouter } from "next/router";
 import { ReactElement, useContext, useEffect, useRef, useState } from "react";
 
-const Home = (): ReactElement => {
+interface Props {
+  isWelcomePage?: boolean;
+}
+
+const Home = (props: Props): ReactElement => {
   const { userData, error } = useUserData();
   const { state } = useContext(AuthContext);
   const router = useRouter();
@@ -145,7 +149,7 @@ const Home = (): ReactElement => {
     <PageSkeleton landingPage={true}>
       <NavBar landingPage={true} />
       <main data-testid="main">
-        <Hero />
+        <Hero isWelcomePage={props.isWelcomePage} />
         <section ref={sectionHowItWorks} aria-label="How it works">
           <div className="minh-mobile margin-top-2 desktop:margin-top-neg-205  padding-bottom-6 text-center bg-base-extra-light">
             <h2 className="text-accent-cool-darker h1-styling margin-bottom-6 padding-top-6">

--- a/web/src/pages/welcome.tsx
+++ b/web/src/pages/welcome.tsx
@@ -1,0 +1,8 @@
+import Home from "@/pages/index";
+import { ReactElement } from "react";
+
+const WelcomePage = (): ReactElement => {
+  return <Home isWelcomePage={true} />;
+};
+
+export default WelcomePage;


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

As a user visiting navigator.business.nj.gov/welcome, when viewing the welcome page, only the ‘Get Started’ and ‘File for Taxes’ tiles appear. 

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#184998185](https://www.pivotaltracker.com/story/show/184998185)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
N/A

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

Upon visiting navigator.business.nj.gov/welcome, when viewing the welcome page, only the ‘Get Started’ and ‘File for Taxes’ tiles appear. 

### Notes

<!-- Additional information, key learnings, and future development considerations. -->
Refactored `LandingPageTiles.tsx` and `LandingPageSlider.tsx` to ensure DRY code and use of props to create one source of truth for the tiles.

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
