### PR TITLE
feat: [#184858230] add business structure task for all industries

### DIFF
--- a/content/src/fieldConfig/business-structure-task.json
+++ b/content/src/fieldConfig/business-structure-task.json
@@ -1,0 +1,10 @@
+{
+  "businessStructureTask": {
+    "uncompletedTooltip": "Select and then save to complete this task.",
+    "completedTooltip": "This task is complete. You can edit your business structure selection below.",
+    "saveButton": "Save Business Structure",
+    "radioQuestionHeader": "Select a business structure",
+    "completedHeader": "Your business structure:",
+    "successMessage": "${legalStructure} was saved."
+  }
+}

--- a/content/src/roadmaps/industries/acupuncture.json
+++ b/content/src/roadmaps/industries/acupuncture.json
@@ -19,6 +19,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/architecture.json
+++ b/content/src/roadmaps/industries/architecture.json
@@ -18,6 +18,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/auto-body-repair.json
+++ b/content/src/roadmaps/industries/auto-body-repair.json
@@ -19,6 +19,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/cannabis.json
+++ b/content/src/roadmaps/industries/cannabis.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/car-rental.json
+++ b/content/src/roadmaps/industries/car-rental.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/car-service.json
+++ b/content/src/roadmaps/industries/car-service.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/certified-public-accountant.json
+++ b/content/src/roadmaps/industries/certified-public-accountant.json
@@ -20,6 +20,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 30,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/cleaning-janitorial-services.json
+++ b/content/src/roadmaps/industries/cleaning-janitorial-services.json
@@ -20,6 +20,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/cosmetology.json
+++ b/content/src/roadmaps/industries/cosmetology.json
@@ -19,6 +19,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/courier.json
+++ b/content/src/roadmaps/industries/courier.json
@@ -20,6 +20,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/daycare.json
+++ b/content/src/roadmaps/industries/daycare.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/detective.json
+++ b/content/src/roadmaps/industries/detective.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/e-commerce.json
+++ b/content/src/roadmaps/industries/e-commerce.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/electrical-contractor.json
+++ b/content/src/roadmaps/industries/electrical-contractor.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/employment-agency.json
+++ b/content/src/roadmaps/industries/employment-agency.json
@@ -20,6 +20,12 @@
     },
     {
       "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
+      "step": 1,
       "weight": 5,
       "task": "determine-naics-code",
       "required": true

--- a/content/src/roadmaps/industries/engineering.json
+++ b/content/src/roadmaps/industries/engineering.json
@@ -18,6 +18,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/event-planning.json
+++ b/content/src/roadmaps/industries/event-planning.json
@@ -20,6 +20,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/food-truck.json
+++ b/content/src/roadmaps/industries/food-truck.json
@@ -24,6 +24,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/freight-forwarding.json
+++ b/content/src/roadmaps/industries/freight-forwarding.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/generic.json
+++ b/content/src/roadmaps/industries/generic.json
@@ -19,6 +19,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/graphic-design.json
+++ b/content/src/roadmaps/industries/graphic-design.json
@@ -20,6 +20,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/healthcare.json
+++ b/content/src/roadmaps/industries/healthcare.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/home-baker.json
+++ b/content/src/roadmaps/industries/home-baker.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/home-contractor.json
+++ b/content/src/roadmaps/industries/home-contractor.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/homemaker-home-health-aide.json
+++ b/content/src/roadmaps/industries/homemaker-home-health-aide.json
@@ -20,6 +20,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/hvac-contractor.json
+++ b/content/src/roadmaps/industries/hvac-contractor.json
@@ -20,6 +20,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/independent-artist.json
+++ b/content/src/roadmaps/industries/independent-artist.json
@@ -14,6 +14,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/interior-designer.json
+++ b/content/src/roadmaps/industries/interior-designer.json
@@ -19,6 +19,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/it-consultant.json
+++ b/content/src/roadmaps/industries/it-consultant.json
@@ -20,6 +20,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/law-firm.json
+++ b/content/src/roadmaps/industries/law-firm.json
@@ -18,6 +18,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/lawn-care.json
+++ b/content/src/roadmaps/industries/lawn-care.json
@@ -20,6 +20,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/logistics.json
+++ b/content/src/roadmaps/industries/logistics.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/management-consulting.json
+++ b/content/src/roadmaps/industries/management-consulting.json
@@ -20,6 +20,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/marketing-pr-consulting.json
+++ b/content/src/roadmaps/industries/marketing-pr-consulting.json
@@ -20,6 +20,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/massage-therapy.json
+++ b/content/src/roadmaps/industries/massage-therapy.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 31,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/moving-company.json
+++ b/content/src/roadmaps/industries/moving-company.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/non-medical-transport.json
+++ b/content/src/roadmaps/industries/non-medical-transport.json
@@ -24,6 +24,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/notary-public.json
+++ b/content/src/roadmaps/industries/notary-public.json
@@ -18,6 +18,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/petcare.json
+++ b/content/src/roadmaps/industries/petcare.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/pharmacy.json
+++ b/content/src/roadmaps/industries/pharmacy.json
@@ -23,6 +23,12 @@
       "task": "pharmacy-prepare"
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/photography.json
+++ b/content/src/roadmaps/industries/photography.json
@@ -20,6 +20,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/printing-business.json
+++ b/content/src/roadmaps/industries/printing-business.json
@@ -20,6 +20,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/real-estate-appraisals.json
+++ b/content/src/roadmaps/industries/real-estate-appraisals.json
@@ -18,6 +18,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/real-estate-broker.json
+++ b/content/src/roadmaps/industries/real-estate-broker.json
@@ -23,6 +23,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/real-estate-investor.json
+++ b/content/src/roadmaps/industries/real-estate-investor.json
@@ -19,6 +19,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/restaurant.json
+++ b/content/src/roadmaps/industries/restaurant.json
@@ -20,6 +20,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/retail.json
+++ b/content/src/roadmaps/industries/retail.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/school-bus.json
+++ b/content/src/roadmaps/industries/school-bus.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/transportation.json
+++ b/content/src/roadmaps/industries/transportation.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/travel-agent.json
+++ b/content/src/roadmaps/industries/travel-agent.json
@@ -20,6 +20,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/trucking.json
+++ b/content/src/roadmaps/industries/trucking.json
@@ -15,6 +15,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/industries/vending-machine.json
+++ b/content/src/roadmaps/industries/vending-machine.json
@@ -18,6 +18,12 @@
       "required": true
     },
     {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
       "step": 2,
       "weight": 20,
       "task": "register-for-ein",

--- a/content/src/roadmaps/tasks/business-structure.md
+++ b/content/src/roadmaps/tasks/business-structure.md
@@ -1,0 +1,15 @@
+---
+urlSlug: business-structure
+name: Select Your Business Structure
+id: business-structure
+callToActionLink: ""
+callToActionText: ""
+---
+
+You must select your business structure in order to access the full list of business tasks. Your `business structure|business-structure-learn-more` can have a large impact on taxes, financing, liability, and closure of your business. We strongly suggest doing research on the best option for your business.
+
+**You can change your intended business structure anytime before you formally file with the NJ Department of Treasury.**
+
+---
+
+${businessStructureSelectionComponent}

--- a/shared/src/domain-logic/hasCompletedFormation.ts
+++ b/shared/src/domain-logic/hasCompletedFormation.ts
@@ -1,0 +1,5 @@
+import { UserData } from "../userData";
+
+export const hasCompletedFormation = (userData: UserData): boolean => {
+  return userData.formationData.completedFilingPayment;
+};

--- a/shared/src/domain-logic/taskIds.ts
+++ b/shared/src/domain-logic/taskIds.ts
@@ -11,6 +11,7 @@ export const isTaxTask = (id: string): boolean => {
 };
 
 export const einTaskId = "register-for-ein";
+export const businessStructureTaskId = "business-structure";
 
 export const isEinTask = (id: string): boolean => {
   return id === einTaskId;

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -4,6 +4,7 @@ export * from "./businessUser";
 export * from "./countries";
 export * from "./dateHelpers";
 export * from "./defaultConstants";
+export * from "./domain-logic/hasCompletedFormation";
 export * from "./domain-logic/onboarding";
 export * from "./domain-logic/opportunityFields";
 export * from "./domain-logic/taskIds";

--- a/shared/src/userData.ts
+++ b/shared/src/userData.ts
@@ -28,7 +28,9 @@ export const createEmptyUserData = (user: BusinessUser): UserData => {
     user: user,
     profileData: createEmptyProfileData(),
     onboardingFormProgress: "UNSTARTED",
-    taskProgress: {},
+    taskProgress: {
+      "business-structure": "COMPLETED",
+    },
     taskItemChecklist: {},
     licenseData: undefined,
     lastUpdatedISO: undefined,

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -2351,6 +2351,55 @@ collections:
                   widget: string,
                 }
               - { label: NAICS Description External URL, name: naicsDescriptionURL, widget: string }
+  - name: "business-structure-section"
+    label: "Tasks - Business Structure"
+    delete: false
+    create: false
+    files:
+      - label: "Select Your Business Structure - Task Metadata"
+        name: "business-structure-task"
+        file: "content/src/roadmaps/tasks/business-structure.md"
+        identifier_field: "{{fields.slug}}"
+        slug: "{{fields.slug}}"
+        editor:
+          preview: true
+        fields:
+          - { label: "Content", name: "body", widget: "markdown" }
+          - { label: "Url Slug", name: "urlSlug", widget: "nospace" }
+          - { label: "Filename", name: "filename", widget: "nospace", required: false }
+          - { label: "Name", name: "name", widget: "string" }
+          - { label: "Id", name: "id", widget: "nospace" }
+          - { label: "Call To Action Link", name: "callToActionLink", widget: "string", required: false }
+          - { label: "Call To Action Text", name: "callToActionText", widget: "string", required: false }
+          - label: Industry
+            name: industryId
+            widget: "relation"
+            collection: "roadmaps"
+            search_fields: ["{{id}}"]
+            value_field: "{{id}}"
+            display_fields: ["{{id}}"]
+            required: false
+            options_length: 500
+          - { label: "Required", name: "required", widget: "boolean", required: false }
+          - { label: "Issuing Agency", name: "issuingAgency", widget: "string", required: false }
+          - { label: "Form Name", name: "formName", widget: "string", required: false }
+      - label: "Business Structure Selection Component"
+        name: "business-structure-selection"
+        file: content/src/fieldConfig/business-structure-task.json
+        editor:
+          preview: true
+        fields:
+          - label: Business Structure Config
+            name: businessStructureTask
+            collapsed: false
+            widget: object
+            fields:
+              - { label: Tooltip - Not Complete, name: uncompletedTooltip, widget: text }
+              - { label: Header - Not Complete, name: radioQuestionHeader, widget: string }
+              - { label: Tooltip - Completed, name: completedTooltip, widget: text }
+              - { label: Header - Complete, name: completedHeader, widget: string }
+              - { label: Save Button, name: saveButton, widget: string }
+              - { label: SuccessMessage, name: successMessage, widget: string }
   - name: nexus
     label: "Tasks - Nexus"
     delete: false

--- a/web/src/components/TaskHeader.tsx
+++ b/web/src/components/TaskHeader.tsx
@@ -15,10 +15,13 @@ interface Props {
 }
 
 export const TaskHeader = (props: Props): ReactElement => {
-  const { userData } = useUserData();
+  const { userData, updateQueue } = useUserData();
   const { roadmap } = useRoadmap();
 
-  const currentTaskProgress: TaskProgress = userData?.taskProgress[props.task.id] || "NOT_STARTED";
+  const currentTaskProgress: TaskProgress =
+    updateQueue?.current().taskProgress[props.task.id] ??
+    userData?.taskProgress[props.task.id] ??
+    "NOT_STARTED";
 
   const { Config } = useConfig();
 

--- a/web/src/components/TaskProgressCheckbox.tsx
+++ b/web/src/components/TaskProgressCheckbox.tsx
@@ -2,10 +2,10 @@ import { ArrowTooltip } from "@/components/ArrowTooltip";
 import { Content } from "@/components/Content";
 import { FormationDateModal } from "@/components/FormationDateModal";
 import { ModalTwoButton } from "@/components/ModalTwoButton";
-import { SnackbarAlert } from "@/components/njwds-extended/SnackbarAlert";
 import { Icon } from "@/components/njwds/Icon";
 import { RegisteredForTaxesModal } from "@/components/RegisteredForTaxesModal";
 import { TaskProgressTagLookup } from "@/components/TaskProgressTagLookup";
+import { TaskStatusChangeSnackbar } from "@/components/TaskStatusChangeSnackbar";
 import { AuthAlertContext } from "@/contexts/authAlertContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -37,7 +37,10 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
   const { Config } = useConfig();
 
   const currentTaskProgress: TaskProgress =
-    props.STORYBOOK_ONLY_currentTaskProgress || userData?.taskProgress[props.taskId] || "NOT_STARTED";
+    props.STORYBOOK_ONLY_currentTaskProgress ??
+    updateQueue?.current().taskProgress[props.taskId] ??
+    userData?.taskProgress[props.taskId] ??
+    "NOT_STARTED";
   const isDisabled = !!props.disabledTooltipText;
 
   const getNextStatus = (): TaskProgress => {
@@ -227,13 +230,10 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
 
       <span className="flex flex-align-center">{TaskProgressTagLookup[currentTaskProgress]}</span>
 
-      <SnackbarAlert
-        variant="success"
+      <TaskStatusChangeSnackbar
         isOpen={successSnackbarIsOpen}
         close={(): void => setSuccessSnackbarIsOpen(false)}
-      >
-        {Config.taskDefaults.taskProgressSuccessSnackbarBody}
-      </SnackbarAlert>
+      />
 
       <FormationDateModal
         isOpen={currentOpenModal === "formation"}

--- a/web/src/components/TaskStatusChangeSnackbar.tsx
+++ b/web/src/components/TaskStatusChangeSnackbar.tsx
@@ -1,0 +1,17 @@
+import { SnackbarAlert } from "@/components/njwds-extended/SnackbarAlert";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { ReactElement } from "react";
+
+interface Props {
+  isOpen: boolean;
+  close: () => void;
+}
+
+export const TaskStatusChangeSnackbar = (props: Props): ReactElement => {
+  const { Config } = useConfig();
+  return (
+    <SnackbarAlert variant="success" isOpen={props.isOpen} close={props.close}>
+      {Config.taskDefaults.taskProgressSuccessSnackbarBody}
+    </SnackbarAlert>
+  );
+};

--- a/web/src/components/tasks/BusinessStructureTask.test.tsx
+++ b/web/src/components/tasks/BusinessStructureTask.test.tsx
@@ -1,0 +1,171 @@
+import { BusinessStructureTask } from "@/components/tasks/BusinessStructureTask";
+import { getMergedConfig } from "@/contexts/configContext";
+import { templateEval } from "@/lib/utils/helpers";
+import { generateTask } from "@/test/factories";
+import { useMockRoadmap } from "@/test/mock/mockUseRoadmap";
+import {
+  currentUserData,
+  setupStatefulUserDataContext,
+  triggerQueueUpdate,
+  WithStatefulUserData,
+} from "@/test/mock/withStatefulUserData";
+import { LookupLegalStructureById } from "@businessnjgovnavigator/shared/legalStructure";
+import {
+  generateFormationData,
+  generateProfileData,
+  generateUserData,
+  randomLegalStructure,
+} from "@businessnjgovnavigator/shared/test";
+import { UserData } from "@businessnjgovnavigator/shared/userData";
+import { createTheme, ThemeProvider } from "@mui/material";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const Config = getMergedConfig();
+
+jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
+jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
+
+describe("<BusinessStructureTask />", () => {
+  const content = "some content here\n\n" + "${businessStructureSelectionComponent}\n\n" + "more content";
+  const taskId = "12345";
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    useMockRoadmap({});
+    setupStatefulUserDataContext();
+  });
+
+  const renderTask = (initialUserData?: UserData): void => {
+    const task = generateTask({ contentMd: content, id: taskId });
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <WithStatefulUserData initialUserData={initialUserData || generateUserData({})}>
+          <BusinessStructureTask task={task} />
+        </WithStatefulUserData>
+      </ThemeProvider>
+    );
+  };
+
+  it("shows tooltip text on task progress checkbox", async () => {
+    const userData = generateUserData({ taskProgress: { [taskId]: "IN_PROGRESS" } });
+    renderTask(userData);
+    expect(screen.queryByText(Config.businessStructureTask.uncompletedTooltip)).not.toBeInTheDocument();
+    expect(screen.queryByText(Config.businessStructureTask.completedTooltip)).not.toBeInTheDocument();
+
+    fireEvent.mouseOver(screen.getByTestId("status-info-tooltip"));
+    expect(screen.queryByText(Config.businessStructureTask.completedTooltip)).not.toBeInTheDocument();
+    await screen.findByText(Config.businessStructureTask.uncompletedTooltip);
+  });
+
+  it("shows completed tooltip text on task progress checkbox when task is completed", async () => {
+    const userData = generateUserData({
+      taskProgress: { [taskId]: "COMPLETED" },
+      formationData: generateFormationData({ completedFilingPayment: true }),
+    });
+    renderTask(userData);
+    expect(screen.queryByText(Config.businessStructureTask.completedTooltip)).not.toBeInTheDocument();
+    expect(screen.queryByText(Config.businessStructureTask.uncompletedTooltip)).not.toBeInTheDocument();
+    expect(screen.queryByText(Config.profileDefaults.lockedFieldTooltipText)).not.toBeInTheDocument();
+
+    fireEvent.mouseOver(screen.getByTestId("status-info-tooltip"));
+    expect(screen.queryByText(Config.businessStructureTask.uncompletedTooltip)).not.toBeInTheDocument();
+    expect(screen.queryByText(Config.businessStructureTask.completedTooltip)).not.toBeInTheDocument();
+    await screen.findByText(Config.profileDefaults.lockedFieldTooltipText);
+  });
+
+  it("shows locked formation tooltip text on task progress checkbox when formation is completed", async () => {
+    const userData = generateUserData({ taskProgress: { [taskId]: "COMPLETED" } });
+    renderTask(userData);
+    expect(screen.queryByText(Config.businessStructureTask.completedTooltip)).not.toBeInTheDocument();
+    expect(screen.queryByText(Config.businessStructureTask.uncompletedTooltip)).not.toBeInTheDocument();
+
+    fireEvent.mouseOver(screen.getByTestId("status-info-tooltip"));
+    expect(screen.queryByText(Config.businessStructureTask.uncompletedTooltip)).not.toBeInTheDocument();
+    await screen.findByText(Config.businessStructureTask.completedTooltip);
+  });
+
+  it("shows successful business structure alert when userData has a legal structure", () => {
+    const legalStructure = randomLegalStructure();
+    const userData = generateUserData({
+      profileData: generateProfileData({ legalStructureId: legalStructure.id }),
+    });
+    renderTask(userData);
+    const successMessage = templateEval(Config.businessStructureTask.successMessage, {
+      legalStructure: legalStructure.name,
+    });
+    expect(screen.getByText(successMessage)).toBeInTheDocument();
+  });
+
+  it("shows radio question when edit button is clicked in alter", () => {
+    const legalStructure = randomLegalStructure();
+    const userData = generateUserData({
+      profileData: generateProfileData({ legalStructureId: legalStructure.id }),
+    });
+    renderTask(userData);
+    fireEvent.click(screen.getByText(Config.taskDefaults.editText));
+    expect(screen.queryByText(Config.taskDefaults.editText)).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Business structure")).toBeInTheDocument();
+  });
+
+  it("does not allow editing when formation is completed", () => {
+    const legalStructure = randomLegalStructure();
+    const userData = generateUserData({
+      profileData: generateProfileData({ legalStructureId: legalStructure.id }),
+      formationData: generateFormationData({ completedFilingPayment: true }),
+    });
+    renderTask(userData);
+    expect(screen.queryByText(Config.taskDefaults.editText)).not.toBeInTheDocument();
+  });
+
+  it("saves and shows success banner when save button clicked", async () => {
+    const userData = generateUserData({ profileData: generateProfileData({ legalStructureId: undefined }) });
+    renderTask(userData);
+    expect(screen.getByLabelText("Business structure")).toBeInTheDocument();
+    expect(screen.getByText(Config.businessStructureTask.radioQuestionHeader)).toBeInTheDocument();
+    expect(screen.queryByText(Config.businessStructureTask.completedHeader)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("limited-liability-company"));
+    fireEvent.click(screen.getByText(Config.businessStructureTask.saveButton));
+
+    expect(currentUserData().profileData.legalStructureId).toEqual("limited-liability-company");
+    const name = LookupLegalStructureById("limited-liability-company").name;
+    const successMessage = templateEval(Config.businessStructureTask.successMessage, {
+      legalStructure: name,
+    });
+    await waitFor(() => {
+      expect(screen.getByText(successMessage)).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText("Business structure")).not.toBeInTheDocument();
+    expect(screen.getByText(Config.businessStructureTask.completedHeader)).toBeInTheDocument();
+    expect(screen.queryByText(Config.businessStructureTask.radioQuestionHeader)).not.toBeInTheDocument();
+
+    expect(currentUserData().profileData.legalStructureId).toEqual("limited-liability-company");
+  });
+
+  it("updates task progress to in-progress when editing", async () => {
+    const legalStructure = randomLegalStructure();
+    const userData = generateUserData({
+      profileData: generateProfileData({ legalStructureId: legalStructure.id }),
+      taskProgress: { [taskId]: "COMPLETED" },
+    });
+    renderTask(userData);
+    fireEvent.click(screen.getByText(Config.taskDefaults.editText));
+    triggerQueueUpdate();
+    await waitFor(() => {
+      expect(currentUserData().taskProgress[taskId]).toEqual("IN_PROGRESS");
+    });
+  });
+
+  it("updates task progress to completed when saving", async () => {
+    const userData = generateUserData({
+      profileData: generateProfileData({ legalStructureId: undefined }),
+      taskProgress: { [taskId]: "IN_PROGRESS" },
+    });
+    renderTask(userData);
+    fireEvent.click(screen.getByLabelText("limited-liability-company"));
+    fireEvent.click(screen.getByText(Config.businessStructureTask.saveButton));
+    await waitFor(() => {
+      expect(currentUserData().taskProgress[taskId]).toEqual("COMPLETED");
+    });
+  });
+});

--- a/web/src/components/tasks/BusinessStructureTask.tsx
+++ b/web/src/components/tasks/BusinessStructureTask.tsx
@@ -1,0 +1,169 @@
+import { ArrowTooltip } from "@/components/ArrowTooltip";
+import { Content } from "@/components/Content";
+import { Alert } from "@/components/njwds-extended/Alert";
+import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
+import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
+import { Icon } from "@/components/njwds/Icon";
+import { OnboardingLegalStructure } from "@/components/onboarding/OnboardingLegalStructure";
+import { TaskHeader } from "@/components/TaskHeader";
+import { UnlockedBy } from "@/components/tasks/UnlockedBy";
+import { TaskStatusChangeSnackbar } from "@/components/TaskStatusChangeSnackbar";
+import { ProfileDataContext } from "@/contexts/profileDataContext";
+import { profileFormContext } from "@/contexts/profileFormContext";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
+import { useUpdateTaskProgress } from "@/lib/data-hooks/useUpdateTaskProgress";
+import { useUserData } from "@/lib/data-hooks/useUserData";
+import { createProfileFieldErrorMap, Task } from "@/lib/types/types";
+import { getFlow, templateEval, useMountEffectWhenDefined } from "@/lib/utils/helpers";
+import { hasCompletedFormation, UserData } from "@businessnjgovnavigator/shared";
+import { LookupLegalStructureById } from "@businessnjgovnavigator/shared/legalStructure";
+import { createEmptyProfileData, ProfileData } from "@businessnjgovnavigator/shared/profileData";
+import { ReactElement, useEffect, useState } from "react";
+
+interface Props {
+  task: Task;
+  CMS_ONLY_fakeUserData?: UserData; // for CMS only
+}
+
+export const BusinessStructureTask = (props: Props): ReactElement => {
+  const [profileData, setProfileData] = useState<ProfileData>(createEmptyProfileData());
+  const [showRadioQuestion, setShowRadioQuestion] = useState<boolean>(true);
+  const [successSnackbarIsOpen, setSuccessSnackbarIsOpen] = useState<boolean>(false);
+  const { Config } = useConfig();
+  const { queueUpdateTaskProgress } = useUpdateTaskProgress();
+  const userDataFromHook = useUserData();
+  const userData = props.CMS_ONLY_fakeUserData ?? userDataFromHook.userData;
+  const updateQueue = userDataFromHook.updateQueue;
+
+  const {
+    FormFuncWrapper,
+    onSubmit,
+    state: formContextState,
+  } = useFormContextHelper(createProfileFieldErrorMap());
+
+  useEffect(() => {
+    if (!userData) {
+      return;
+    }
+    setProfileData(userData.profileData);
+  }, [userData]);
+
+  useMountEffectWhenDefined(() => {
+    if (!userData) {
+      return;
+    }
+    setShowRadioQuestion(!userData.profileData.legalStructureId);
+  }, userData);
+
+  FormFuncWrapper(async () => {
+    if (!updateQueue || !userData) {
+      return;
+    }
+    const profileDataHasNotChanged = JSON.stringify(profileData) === JSON.stringify(userData.profileData);
+    if (profileDataHasNotChanged) {
+      return;
+    }
+
+    queueUpdateTaskProgress(props.task.id, "COMPLETED");
+    await updateQueue.queueProfileData(profileData).update();
+    setShowRadioQuestion(false);
+    setSuccessSnackbarIsOpen(true);
+  });
+
+  const setBackToEditing = (): void => {
+    if (!userData || !updateQueue) {
+      return;
+    }
+    setShowRadioQuestion(true);
+    queueUpdateTaskProgress(props.task.id, "IN_PROGRESS");
+  };
+
+  const preLookupContent = props.task.contentMd.split("${businessStructureSelectionComponent}")[0];
+  const postLookupContent = props.task.contentMd.split("${businessStructureSelectionComponent}")[1];
+
+  const isCompleted = (): boolean => {
+    if (!userData) return false;
+    return userData.taskProgress[props.task.id] === "COMPLETED";
+  };
+
+  const canEdit = (): boolean => {
+    if (!userData) return false;
+    return !hasCompletedFormation(userData);
+  };
+
+  const getTaskProgressTooltip = (): string => {
+    if (!userData) return "";
+    if (!isCompleted()) {
+      return Config.businessStructureTask.uncompletedTooltip;
+    } else if (hasCompletedFormation(userData)) {
+      return Config.profileDefaults.lockedFieldTooltipText;
+    } else {
+      return Config.businessStructureTask.completedTooltip;
+    }
+  };
+
+  return (
+    <div className="minh-38">
+      <TaskHeader task={props.task} tooltipText={getTaskProgressTooltip()} />
+      <UnlockedBy task={props.task} />
+      <Content>{preLookupContent}</Content>
+      {showRadioQuestion && (
+        <profileFormContext.Provider value={formContextState}>
+          <ProfileDataContext.Provider
+            value={{
+              state: {
+                profileData: profileData,
+                flow: getFlow(profileData),
+              },
+              setUser: (): void => {},
+              setProfileData,
+              onBack: (): void => {},
+            }}
+          >
+            <h3>{Config.businessStructureTask.radioQuestionHeader}</h3>
+            <OnboardingLegalStructure />
+            <div className="margin-top-4">
+              <SecondaryButton isColor="primary" onClick={onSubmit}>
+                {Config.businessStructureTask.saveButton}
+              </SecondaryButton>
+            </div>
+          </ProfileDataContext.Provider>
+        </profileFormContext.Provider>
+      )}
+      {userData && !showRadioQuestion && (
+        <>
+          <h3>{Config.businessStructureTask.completedHeader}</h3>
+          <Alert variant="success">
+            <div className="flex flex-row">
+              {templateEval(Config.businessStructureTask.successMessage, {
+                legalStructure: LookupLegalStructureById(userData.profileData.legalStructureId).name,
+              })}
+              {canEdit() ? (
+                <UnStyledButton
+                  className="margin-left-2"
+                  style="tertiary"
+                  underline
+                  onClick={setBackToEditing}
+                >
+                  {Config.taskDefaults.editText}
+                </UnStyledButton>
+              ) : (
+                <ArrowTooltip title={Config.profileDefaults.lockedFieldTooltipText}>
+                  <div className="fdr fac margin-left-2 font-body-lg">
+                    <Icon>help_outline</Icon>
+                  </div>
+                </ArrowTooltip>
+              )}
+            </div>
+          </Alert>
+        </>
+      )}
+      <Content>{postLookupContent}</Content>
+      <TaskStatusChangeSnackbar
+        isOpen={successSnackbarIsOpen}
+        close={(): void => setSuccessSnackbarIsOpen(false)}
+      />
+    </div>
+  );
+};

--- a/web/src/contexts/configContext.ts
+++ b/web/src/contexts/configContext.ts
@@ -1,4 +1,5 @@
 import * as BusinessFormation from "@businessnjgovnavigator/content/fieldConfig/business-formation.json";
+import * as BusinessStructureTask from "@businessnjgovnavigator/content/fieldConfig/business-structure-task.json";
 import * as CannabisLicenseAnnualTab2 from "@businessnjgovnavigator/content/fieldConfig/cannabis-license-annual-tab2.json";
 import * as CannabisLicenseConditionalTab2 from "@businessnjgovnavigator/content/fieldConfig/cannabis-license-conditional-tab2.json";
 import * as CannabisLicenseEligibilityModal from "@businessnjgovnavigator/content/fieldConfig/cannabis-license-eligibility-modal.json";
@@ -48,7 +49,8 @@ const merged = JSON.parse(
       DashboardCalendar,
       DashboardTabs,
       DashboardModals,
-      BusinessFormation
+      BusinessFormation,
+      BusinessStructureTask
     )
   )
 );
@@ -74,6 +76,7 @@ export type ConfigType = typeof ConfigOriginal &
   typeof DashboardModals &
   typeof DashboardTabs &
   typeof BusinessFormation &
+  typeof BusinessStructureTask &
   typeof DashboardSnackbars;
 
 export const getMergedConfig = (): ConfigType => {
@@ -99,7 +102,8 @@ export const getMergedConfig = (): ConfigType => {
     DashboardModals,
     DashboardTabs,
     DashboardCalendar,
-    BusinessFormation
+    BusinessFormation,
+    BusinessStructureTask
   );
 };
 

--- a/web/src/lib/cms/previews/BusinessStructurePreview.tsx
+++ b/web/src/lib/cms/previews/BusinessStructurePreview.tsx
@@ -1,0 +1,34 @@
+import { BusinessStructureTask } from "@/components/tasks/BusinessStructureTask";
+import { ConfigContext } from "@/contexts/configContext";
+import { PreviewProps } from "@/lib/cms/helpers/previewHelpers";
+import { usePreviewConfig } from "@/lib/cms/helpers/usePreviewConfig";
+import { usePreviewRef } from "@/lib/cms/helpers/usePreviewRef";
+import { generateTask } from "@/test/factories";
+import { generateProfileData, generateUserData } from "@businessnjgovnavigator/shared/test";
+import { ReactElement } from "react";
+
+const BusinessStructurePreview = (props: PreviewProps): ReactElement => {
+  const { config, setConfig } = usePreviewConfig(props);
+  const ref = usePreviewRef(props);
+
+  const task = generateTask({
+    name: "Name is controlled by Task Metadata",
+    contentMd: "Body content is controlled by Task Metadata\n\n---",
+  });
+
+  const missingLegalStructure = generateUserData({
+    profileData: generateProfileData({ legalStructureId: undefined }),
+  });
+
+  return (
+    <ConfigContext.Provider value={{ config, setOverrides: setConfig }}>
+      <div className="cms" ref={ref} style={{ margin: 40, pointerEvents: "none" }}>
+        <BusinessStructureTask task={task} CMS_ONLY_fakeUserData={generateUserData({})} />
+        <hr className="margin-y-6" />
+        <BusinessStructureTask task={task} CMS_ONLY_fakeUserData={missingLegalStructure} />
+      </div>
+    </ConfigContext.Provider>
+  );
+};
+
+export default BusinessStructurePreview;

--- a/web/src/lib/search/cmsCollections.ts
+++ b/web/src/lib/search/cmsCollections.ts
@@ -27,6 +27,7 @@ export const cmsCollections = [
       "Tasks - EIN",
       "Tasks - Tax ID",
       "Tasks - NAICS Code",
+      "Tasks - Business Structure",
       "Tasks - Nexus",
     ],
   },

--- a/web/src/pages/mgmt/cms.tsx
+++ b/web/src/pages/mgmt/cms.tsx
@@ -31,6 +31,7 @@ import TaskPreview from "@/lib/cms/previews/TaskPreview";
 import TaxInputPreview from "@/lib/cms/previews/TaxInputPreview";
 import { useMountEffect } from "@/lib/utils/helpers";
 
+import BusinessStructurePreview from "@/lib/cms/previews/BusinessStructurePreview";
 import { GetStaticPropsResult } from "next";
 import dynamic from "next/dynamic";
 import { ReactElement } from "react";
@@ -97,6 +98,9 @@ const CMS = dynamic(
 
       registerPreview(CMS, "tax-task-metadata", TaskPreview);
       registerPreview(CMS, "tax-input-section", TaxInputPreview);
+
+      registerPreview(CMS, "business-structure-task", TaskPreview);
+      registerPreview(CMS, "business-structure-selection", BusinessStructurePreview);
 
       // ----- Cannabis License -----
       registerPreview(CMS, "cannabis-eligibility-modal", CannabisEligibilityModalPreview);

--- a/web/src/pages/tasks/[taskUrlSlug].tsx
+++ b/web/src/pages/tasks/[taskUrlSlug].tsx
@@ -8,6 +8,7 @@ import { RadioQuestion } from "@/components/post-onboarding/RadioQuestion";
 import { TaskCTA } from "@/components/TaskCTA";
 import { TaskHeader } from "@/components/TaskHeader";
 import { BusinessFormation } from "@/components/tasks/business-formation/BusinessFormation";
+import { BusinessStructureTask } from "@/components/tasks/BusinessStructureTask";
 import { CannabisApplyForLicenseTask } from "@/components/tasks/cannabis/CannabisApplyForLicenseTask";
 import { CannabisPriorityStatusTask } from "@/components/tasks/cannabis/CannabisPriorityStatusTask";
 import { EinTask } from "@/components/tasks/EinTask";
@@ -134,6 +135,9 @@ const TaskPage = (props: Props): ReactElement => {
             "annual-license-cannabis": <CannabisApplyForLicenseTask task={props.task} />,
             "register-for-ein": <EinTask task={props.task} />,
             "register-for-taxes": <TaxTask task={getTaskFromRoadmap(roadmap, props.task.id) ?? props.task} />,
+            "business-structure": (
+              <BusinessStructureTask task={getTaskFromRoadmap(roadmap, props.task.id) ?? props.task} />
+            ),
             [formationTaskId]: renderFormationTask(),
             default: getTaskBody(),
           })}

--- a/web/test/pages/profile.test.tsx
+++ b/web/test/pages/profile.test.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/test/pages/onboarding/helpers-onboarding";
 import {
   businessPersonas,
+  businessStructureTaskId,
   createEmptyUserData,
   defaultDateFormat,
   einTaskId,
@@ -479,7 +480,11 @@ describe("profile", () => {
           employerId: "023456780",
           notes: "whats appppppp",
         },
-        taskProgress: { [einTaskId]: "COMPLETED", "determine-naics-code": "NOT_STARTED" },
+        taskProgress: {
+          [businessStructureTaskId]: "COMPLETED",
+          [einTaskId]: "COMPLETED",
+          [naicsCodeTaskId]: "NOT_STARTED",
+        },
         taskItemChecklist: {},
       });
     });


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

- Added a new task to all roadmaps for business structure
- Task starts as completed in the `emptyUserData` object (this will change with the next story in this chain)
- Task shows saved legal structure & allows user to edit and save it
- Task progress automatically updates when clicking edit and when clicking save
- Task status checkbox is locked, tooltip text depends on state

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#184858230](https://www.pivotaltracker.com/story/show/184858230)

### Approach

One interesting piece to flag here:

I used the updateQueue _without_ triggering a save for when the user clicks "edit" and the task status goes from Complete to In-Progress. Because if they are editing & leave the task without saving, it needs to revert back to the old, saved, completed state. So I queue up the task-progress change without actually saving it in the backend.

This meant I needed to change `TaskHeader` and `TaskProgressCheckbox` to decide their state (ie, the grey/blue/green header background color and the text it displays) based on the state of the queue, not the state of the saved userData. Hence the change in these files from `userData` to `updateQueue.current()`

### Notes

I made the same exact change to all 50+ industry json files so you can probably skip all that to make reviewing easier


## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
