### PR TITLE
feat: created a separate welcome page content method

### DIFF
--- a/content/src/fieldConfig/config.json
+++ b/content/src/fieldConfig/config.json
@@ -241,6 +241,7 @@
     "IN_PROGRESS": "In progress",
     "COMPLETED": "Completed"
   },
+  "landingPageExperienceWelcome": {},
   "landingPageExperienceB": {
     "section5FirstSupportingText": "Knowing exactly what your business needs to do to start can be difficult. Our starter kit is unique to your industry and even includes Cannabis retailers. Find what licenses, forms, and permits you need to start your business in New Jersey. Learn the requirements of each application, find out what you get after submitting your application, and store critical business identification numbers all in one place. ",
     "section2HeaderText": "Starting a Business Has Never Been Faster or Easier!",

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -3053,6 +3053,163 @@ collections:
               - { label: Section 5 - First Supporting Text, name: section5FirstSupportingText, widget: text }
               - { label: Section 5 - Third Supporting Text, name: section5ThirdSupportingText, widget: text }
               - { label: Section 5 - First Header Text, name: section5FirstHeaderText, widget: string }
+          - label: Landing Page Welcome Experience
+            name: landingPageExperienceWelcome
+            collapsed: true
+            widget: object
+            summary: "{{landingPageExperienceWelcome}}"
+            fields:
+              - { label: Hero - First Line, name: heroCallOutFirstLineText, widget: string, required: false }
+              - { label: Hero - Supporting Text, name: heroSupportingText, widget: string, required: false }
+              - { label: Section 2 - Header, name: section2HeaderText, widget: string, required: false }
+              - {
+                  label: Section 2 - Supporting Text,
+                  name: section2SupportingText,
+                  widget: text,
+                  required: false,
+                }
+              - {
+                  label: Section 2 - Call to Action,
+                  name: section2CallToActionText,
+                  widget: string,
+                  required: false,
+                }
+              - { label: Section 3 - Header, name: section3HeaderText, widget: string, required: false }
+              - {
+                  label: Section 3 - Supporting Text,
+                  name: section3SupportingText,
+                  widget: string,
+                  required: false,
+                }
+              - {
+                  label: Section 3 - Call to Action,
+                  name: section3CallToActionText,
+                  widget: string,
+                  required: false,
+                }
+              - { label: Section 4 - Header Text, name: section4HeaderText, widget: string, required: false }
+              - {
+                  label: Section 4 - First Icon Text,
+                  name: section4FirstIconText,
+                  widget: string,
+                  required: false,
+                }
+              - {
+                  label: Section 4 - Second Icon Text,
+                  name: section4SecondIconText,
+                  widget: string,
+                  required: false,
+                }
+              - {
+                  label: Section 4 - Third Icon Text,
+                  name: section4ThirdIconText,
+                  widget: string,
+                  required: false,
+                }
+              - {
+                  label: Section 5 - First Header Text,
+                  name: section5FirstHeaderText,
+                  widget: string,
+                  required: false,
+                }
+              - {
+                  label: Section 5 - First Supporting Text,
+                  name: section5FirstSupportingText,
+                  widget: text,
+                  required: false,
+                }
+              - {
+                  label: Section 5 - Second Header Text,
+                  name: section5SecondHeaderText,
+                  widget: string,
+                  required: false,
+                }
+              - {
+                  label: Section 5 - Second Supporting Text,
+                  name: section5SecondSupportingText,
+                  widget: text,
+                  required: false,
+                }
+              - {
+                  label: Section 5 - Third Header Text,
+                  name: section5ThirdHeaderText,
+                  widget: string,
+                  required: false,
+                }
+              - {
+                  label: Section 5 - Third Supporting Text,
+                  name: section5ThirdSupportingText,
+                  widget: text,
+                  required: false,
+                }
+              - { label: Section 6 - Header Text, name: section6Header, widget: string, required: false }
+              - { label: Card 1 - Header Line 1, name: card1HeaderLine1, widget: string, required: false }
+              - { label: Card 1 - Header Line 2, name: card1HeaderLine2, widget: string, required: false }
+              - {
+                  label: Card 1 - Supporting Text,
+                  name: card1SupportingText,
+                  widget: string,
+                  required: false,
+                }
+              - { label: Card 1 - Button Text, name: card1Button, widget: string, required: false }
+              - { label: Card 1 - Button Link, name: card1ButtonLink, widget: string, required: false }
+              - { label: Card 2 - Header Line 2, name: card2HeaderLine1, widget: string, required: false }
+              - { label: Card 2 - Header Line 2, name: card2HeaderLine2, widget: string, required: false }
+              - { label: Card 2 - Supporting Text, name: card2SupportingText, widget: text, required: false }
+              - { label: Card 2 - Button Text, name: card2Button, widget: string, required: false }
+              - { label: Card 2 - Button Link, name: card2ButtonLink, widget: string, required: false }
+              - { label: Card 3 - Header Line 3, name: card3HeaderLine1, widget: string, required: false }
+              - { label: Card 3 - Header Line 3, name: card3HeaderLine2, widget: string, required: false }
+              - { label: Card 3 - Supporting Text, name: card3SupportingText, widget: text, required: false }
+              - { label: Card 3 - Button Text, name: card3Button, widget: string, required: false }
+              - {
+                  label: Landing Page - Tile 1 Line 1 Text,
+                  name: landingPageTile1Line1Text,
+                  widget: string,
+                  required: false,
+                }
+              - {
+                  label: Landing Page - Tile 1 Line 2 Text,
+                  name: landingPageTile1Line2Text,
+                  widget: string,
+                  required: false,
+                }
+              - {
+                  label: Landing Page - Tile 2 Text,
+                  name: landingPageTile2Text,
+                  widget: string,
+                  required: false,
+                }
+              - {
+                  label: Landing Page - Tile 3 Text,
+                  name: landingPageTile3Text,
+                  widget: string,
+                  required: false,
+                }
+              - {
+                  label: Landing Page - Tile 4 Text,
+                  name: landingPageTile4Text,
+                  widget: string,
+                  required: false,
+                }
+              - {
+                  label: Landing Page - Tile 5 Text,
+                  name: landingPageTile5Text,
+                  widget: string,
+                  required: false,
+                }
+              - {
+                  label: Landing Page - Tile 6 Text,
+                  name: landingPageTile6Text,
+                  widget: string,
+                  required: false,
+                }
+              - {
+                  label: Landing Page - Tile 7 Text,
+                  name: landingPageTile7Text,
+                  widget: string,
+                  required: false,
+                }
           - label: Legal Messages
             name: legalMessageDefaults
             collapsed: true

--- a/web/src/components/LandingPageTiles.test.tsx
+++ b/web/src/components/LandingPageTiles.test.tsx
@@ -1,5 +1,5 @@
 import { LandingPageTiles } from "@/components/LandingPageTiles";
-import { getMergedConfig } from "@/contexts/configContext";
+import { ConfigContext, getMergedConfig } from "@/contexts/configContext";
 import { mockPush, useMockRouter } from "@/test/mock/mockRouter";
 import { fireEvent, render, screen } from "@testing-library/react";
 
@@ -35,6 +35,20 @@ describe("<LandingPageTiles />", () => {
     fireEvent.click(screen.getByText(Config.landingPage.landingPageTile3Text));
 
     expect(mockPush).toHaveBeenCalledWith({ pathname: "/onboarding", query: { flow: "up-and-running" } });
+  });
+
+  it('overrides the "Pay Taxes" tile text when visiting welcome page URL', () => {
+    render(
+      <ConfigContext.Provider
+        value={{
+          config: { ...Config, landingPageExperienceWelcome: { landingPageTile3Text: "lol" } },
+          setOverrides: (): undefined => void {},
+        }}
+      >
+        <LandingPageTiles isWelcomePage={true} />
+      </ConfigContext.Provider>
+    );
+    expect(screen.getByText("lol")).toBeInTheDocument();
   });
 
   it("shows only 'Get Started' and 'Pay Taxes' tiles when visiting welcome page URL", () => {

--- a/web/src/components/LandingPageTiles.tsx
+++ b/web/src/components/LandingPageTiles.tsx
@@ -18,6 +18,15 @@ export const LandingPageTiles = (props: Props): ReactElement => {
   const istabletAndUp = useMediaQuery(MediaQueries.tabletAndUp);
   const { Config } = useConfig();
 
+  let landingPageConfig = Config.landingPage;
+
+  if (props.isWelcomePage) {
+    landingPageConfig = {
+      ...landingPageConfig,
+      ...Config.landingPageExperienceWelcome,
+    };
+  }
+
   const routeToOnboarding = (): void => {
     router.push(ROUTES.onboarding);
     analytics.event.landing_page_hero_get_started.click.go_to_onboarding();
@@ -33,46 +42,46 @@ export const LandingPageTiles = (props: Props): ReactElement => {
   const actionTiles: ActionTile[] = [
     {
       imgPath: "/img/getStarted-icon.svg",
-      tileText: Config.landingPage.landingPageTile1Line1Text,
-      tileText2: Config.landingPage.landingPageTile1Line2Text,
+      tileText: landingPageConfig.landingPageTile1Line1Text,
+      tileText2: landingPageConfig.landingPageTile1Line2Text,
       dataTestId: "get-started-tile",
       onClick: routeToOnboarding,
       isPrimary: true,
     },
     {
       imgPath: "/img/briefcase-icon.svg",
-      tileText: Config.landingPage.landingPageTile2Text,
+      tileText: landingPageConfig.landingPageTile2Text,
       dataTestId: "register-biz-tile",
       onClick: (): void => setFlowAndRouteUser("starting"),
     },
     {
       imgPath: "/img/payTaxes-icon.svg",
-      tileText: Config.landingPage.landingPageTile3Text,
+      tileText: landingPageConfig.landingPageTile3Text,
       dataTestId: "pay-taxes-tile",
       onClick: (): void => setFlowAndRouteUser("up-and-running"),
     },
     {
       imgPath: "/img/outOfState-icon.svg",
       dataTestId: "out-of-state-tile",
-      tileText: Config.landingPage.landingPageTile4Text,
+      tileText: landingPageConfig.landingPageTile4Text,
       onClick: (): void => setFlowAndRouteUser("out-of-state"),
     },
     {
       imgPath: "/img/eligibleFunding-icon.svg",
       dataTestId: "eligible-funding-tile",
-      tileText: Config.landingPage.landingPageTile5Text,
+      tileText: landingPageConfig.landingPageTile5Text,
       onClick: (): void => setFlowAndRouteUser("up-and-running"),
     },
     {
       imgPath: "/img/startBusiness-icon.svg",
       dataTestId: "start-biz-tile",
-      tileText: Config.landingPage.landingPageTile6Text,
+      tileText: landingPageConfig.landingPageTile6Text,
       onClick: (): void => setFlowAndRouteUser("starting"),
     },
     {
       imgPath: "/img/runBusiness-icon.svg",
       dataTestId: "run-biz-tile",
-      tileText: Config.landingPage.landingPageTile7Text,
+      tileText: landingPageConfig.landingPageTile7Text,
       onClick: (): void => setFlowAndRouteUser("up-and-running"),
     },
   ];

--- a/web/src/components/njwds/Hero.tsx
+++ b/web/src/components/njwds/Hero.tsx
@@ -1,10 +1,10 @@
 import { LandingPageTiles } from "@/components/LandingPageTiles";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { ROUTES } from "@/lib/domain-logic/routes";
 import { MediaQueries } from "@/lib/PageSizes";
 import { ABStorageFactory } from "@/lib/storage/ABStorage";
 import analytics from "@/lib/utils/analytics";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { useMediaQuery } from "@mui/material";
 import { useRouter } from "next/router";
 import { ReactElement } from "react";
@@ -17,12 +17,20 @@ export const Hero = (props: Props): ReactElement => {
   const isDesktopAndUp = useMediaQuery(MediaQueries.desktopAndUp);
   const isTabletAndUp = useMediaQuery(MediaQueries.tabletAndUp);
   const router = useRouter();
+  const { Config } = useConfig();
 
   let landingPageConfig = Config.landingPage;
   if (ABStorageFactory().getExperience() === "ExperienceB") {
     landingPageConfig = {
       ...Config.landingPage,
       ...Config.landingPageExperienceB,
+    };
+  }
+
+  if (props.isWelcomePage) {
+    landingPageConfig = {
+      ...landingPageConfig,
+      ...Config.landingPageExperienceWelcome,
     };
   }
 

--- a/web/src/pages/index.tsx
+++ b/web/src/pages/index.tsx
@@ -5,6 +5,7 @@ import { PageSkeleton } from "@/components/PageSkeleton";
 import { SupportExploreSignUpChatCards } from "@/components/SupportExploreSignUpChatCards";
 import { AuthContext } from "@/contexts/authContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { checkQueryValue, QUERIES, ROUTES } from "@/lib/domain-logic/routes";
 import { MediaQueries } from "@/lib/PageSizes";
@@ -12,7 +13,6 @@ import { ABStorageFactory } from "@/lib/storage/ABStorage";
 import analytics from "@/lib/utils/analytics";
 import { setABExperienceDimension } from "@/lib/utils/analytics-helpers";
 import { useIntersectionOnElement } from "@/lib/utils/useIntersectionOnElement";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { ABExperience, decideABExperience } from "@businessnjgovnavigator/shared/";
 import { useMediaQuery } from "@mui/material";
 import { useRouter } from "next/router";
@@ -25,6 +25,7 @@ interface Props {
 const Home = (props: Props): ReactElement => {
   const { userData, error } = useUserData();
   const { state } = useContext(AuthContext);
+  const { Config } = useConfig();
   const router = useRouter();
   const isDesktopAndUp = useMediaQuery(MediaQueries.desktopAndUp);
   const sectionHowItWorks = useRef(null);
@@ -67,7 +68,12 @@ const Home = (props: Props): ReactElement => {
       };
     }
   }
-
+  if (props.isWelcomePage) {
+    landingPageConfig = {
+      ...landingPageConfig,
+      ...Config.landingPageExperienceWelcome,
+    };
+  }
   useEffect(() => {
     const landingPageAlternateUrl = process.env.ALTERNATE_LANDING_PAGE_URL || ROUTES.landing;
     const alternateLandingPageEnabled = process.env.FEATURE_LANDING_PAGE_REDIRECT === "true";

--- a/web/test/pages/welcome.test.tsx
+++ b/web/test/pages/welcome.test.tsx
@@ -1,0 +1,38 @@
+import { ConfigContext, getMergedConfig } from "@/contexts/configContext";
+import WelcomePage from "@/pages/welcome";
+import { useMockRouter } from "@/test/mock/mockRouter";
+import { useMockUserData } from "@/test/mock/mockUseUserData";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("next/router", () => ({ useRouter: jest.fn() }));
+jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
+jest.mock("@/lib/utils/useIntersectionOnElement", () => ({ useIntersectionOnElement: jest.fn() }));
+
+const Config = getMergedConfig();
+
+describe("HomePage", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    useMockRouter({});
+    useMockUserData({});
+  });
+
+  it("renders landingPageExperienceWelcome content when visiting welcome page URL", () => {
+    render(
+      <ConfigContext.Provider
+        value={{
+          config: {
+            ...Config,
+            landingPageExperienceWelcome: {
+              section3SupportingText: "Soma is available to help all new business Users globally",
+            },
+          },
+          setOverrides: (): undefined => void {},
+        }}
+      >
+        <WelcomePage />
+      </ConfigContext.Provider>
+    );
+    expect(screen.getByText("Soma is available to help all new business Users globally")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION

## Description

Added a new Landing Page content key that overrides primary landing page content when used

### Ticket

[#184998185](https://www.pivotaltracker.com/story/show/184998185)

### Approach

We imitated how we approached the ABExperience copy integration, note to remove the AB experience code as we no longer use that feature

### Steps to Test

Go to /welcome
