### PR TITLE
fix: [#184305929] review page address section only appears when required

### DIFF
--- a/shared/src/formationData.ts
+++ b/shared/src/formationData.ts
@@ -346,6 +346,11 @@ export const BusinessSuffixMap: Record<
 };
 
 export const corpLegalStructures: FormationLegalType[] = ["s-corporation", "c-corporation"];
+
+export const foreignCorpLegalStructures: FormationLegalType[] = [
+  "foreign-c-corporation",
+  "foreign-s-corporation",
+];
 export const incorporationLegalStructures: FormationLegalType[] = [
   ...corpLegalStructures,
   "limited-partnership",

--- a/web/src/components/tasks/business-formation/review/ReviewBusinessSuffixAndStartDate.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewBusinessSuffixAndStartDate.tsx
@@ -63,7 +63,6 @@ export const ReviewBusinessSuffixAndStartDate = (): ReactElement => {
           value={state.formationFormData.businessTotalStock}
         />
       )}
-      <hr className="margin-y-205" />
     </div>
   );
 };

--- a/web/src/components/tasks/business-formation/review/ReviewMainBusinessLocation.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewMainBusinessLocation.tsx
@@ -2,7 +2,7 @@ import { ReviewLineItem } from "@/components/tasks/business-formation/review/sec
 import { ReviewSubSection } from "@/components/tasks/business-formation/review/section/ReviewSubSection";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
-import { arrayOfCountriesObjects } from "@businessnjgovnavigator/shared/countries";
+import { getAddressCity, getAddressCountry, getAddressState } from "@/lib/utils/formation-helpers";
 import { ReactElement, useContext } from "react";
 
 export const ReviewMainBusinessLocation = (): ReactElement => {
@@ -10,48 +10,40 @@ export const ReviewMainBusinessLocation = (): ReactElement => {
   const { state } = useContext(BusinessFormationContext);
   const businessLocationType = state.formationFormData.businessLocationType;
 
-  const getAddressCity = (): string | undefined => {
-    return businessLocationType === "NJ"
-      ? state.formationFormData.addressMunicipality?.displayName
-      : state.formationFormData.addressCity;
-  };
-
-  const getAddressState = (): string | undefined => {
-    return businessLocationType === "INTL"
-      ? state.formationFormData.addressProvince
-      : state.formationFormData.addressState?.name;
-  };
-
-  const getAddressCountry = (): string | undefined => {
-    return businessLocationType === "INTL"
-      ? arrayOfCountriesObjects.find(
-          (country) => country.shortCode === state.formationFormData.addressCountry
-        )?.name
-      : undefined;
-  };
-
   return (
-    <ReviewSubSection header={Config.formation.sections.addressHeader} marginOverride="margin-top-0">
-      <ReviewLineItem
-        label={Config.formation.fields.addressLine1.label}
-        value={state.formationFormData.addressLine1}
-      />
-      {state.formationFormData.addressLine2 && (
+    <>
+      <hr className="margin-y-205" />
+      <ReviewSubSection header={Config.formation.sections.addressHeader} marginOverride="margin-top-0">
         <ReviewLineItem
-          label={Config.formation.fields.addressLine2.label}
-          value={state.formationFormData.addressLine2}
-          dataTestId={"business-address-line-two"}
+          label={Config.formation.fields.addressLine1.label}
+          value={state.formationFormData.addressLine1}
         />
-      )}
-      <ReviewLineItem label={Config.formation.fields.addressCity.label} value={getAddressCity()} />
-      <ReviewLineItem label={Config.formation.fields.addressState.label} value={getAddressState()} />
-      <ReviewLineItem
-        label={Config.formation.fields.addressZipCode.label}
-        value={state.formationFormData.addressZipCode}
-      />
-      {businessLocationType === "INTL" && (
-        <ReviewLineItem label={Config.formation.fields.addressCountry.label} value={getAddressCountry()} />
-      )}
-    </ReviewSubSection>
+        {state.formationFormData.addressLine2 && (
+          <ReviewLineItem
+            label={Config.formation.fields.addressLine2.label}
+            value={state.formationFormData.addressLine2}
+            dataTestId={"business-address-line-two"}
+          />
+        )}
+        <ReviewLineItem
+          label={Config.formation.fields.addressCity.label}
+          value={getAddressCity(state.formationFormData)}
+        />
+        <ReviewLineItem
+          label={Config.formation.fields.addressState.label}
+          value={getAddressState(state.formationFormData)}
+        />
+        <ReviewLineItem
+          label={Config.formation.fields.addressZipCode.label}
+          value={state.formationFormData.addressZipCode}
+        />
+        {businessLocationType === "INTL" && (
+          <ReviewLineItem
+            label={Config.formation.fields.addressCountry.label}
+            value={getAddressCountry(state.formationFormData)}
+          />
+        )}
+      </ReviewSubSection>
+    </>
   );
 };

--- a/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
@@ -141,6 +141,56 @@ describe("Formation - ReviewStep", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("doesn't display the primary business address if user has not inputted anything", async () => {
+    const initialProfileData: Partial<ProfileData> = {
+      legalStructureId: "limited-liability-company",
+      municipality: undefined,
+    };
+    const formationFormData = {
+      addressMunicipality: undefined,
+      addressZipCode: "",
+      addressCountry: undefined,
+      addressLine1: "",
+      addressLine2: "",
+    };
+    await renderStep(initialProfileData, formationFormData);
+    expect(screen.queryByText(Config.formation.sections.addressHeader)).not.toBeInTheDocument();
+  });
+
+  it("displays the primary business address if user has inputted any address field", async () => {
+    const initialProfileData: Partial<ProfileData> = {
+      legalStructureId: "limited-liability-company",
+      municipality: undefined,
+    };
+    const formationFormData = {
+      addressMunicipality: undefined,
+      addressZipCode: "",
+      addressCountry: undefined,
+      addressLine1: "address-line-1",
+      addressLine2: "",
+    };
+    await renderStep(initialProfileData, formationFormData);
+    expect(screen.getByText(Config.formation.sections.addressHeader)).toBeInTheDocument();
+  });
+
+  it("displays the primary business address section for foreign corporations even when no address input has been made", async () => {
+    const initialProfileData: Partial<ProfileData> = {
+      businessPersona: "FOREIGN",
+      legalStructureId: "c-corporation",
+    };
+    const formationData: Partial<FormationFormData> = {
+      businessName: "nexus-business",
+      legalType: "foreign-c-corporation",
+      addressCity: undefined,
+      addressZipCode: "",
+      addressCountry: "US",
+      addressLine2: "",
+      addressLine1: "",
+    };
+    await renderStep(initialProfileData, formationData);
+    expect(screen.getByText(Config.formation.sections.addressHeader)).toBeInTheDocument();
+  });
+
   it("displays the business step when the edit button in the main business section is clicked", async () => {
     await renderStep({}, {});
     fireEvent.click(screen.getByTestId("edit-business-name-step"));

--- a/web/src/components/tasks/business-formation/review/ReviewStep.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.tsx
@@ -18,6 +18,7 @@ import { ReviewText } from "@/components/tasks/business-formation/review/section
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import analytics from "@/lib/utils/analytics";
+import { shouldDisplayAddressSection } from "@/lib/utils/formation-helpers";
 import { isForeignCorporation } from "@/lib/utils/helpers";
 import { corpLegalStructures } from "@businessnjgovnavigator/shared/formationData";
 import { ReactElement, useContext } from "react";
@@ -43,8 +44,7 @@ export const ReviewStep = (): ReactElement => {
               <ReviewForeignCertificate foreignGoodStandingFile={state.foreignGoodStandingFile} />
             </>
           )}
-          <ReviewMainBusinessLocation />
-
+          {shouldDisplayAddressSection(state.formationFormData) && <ReviewMainBusinessLocation />}
           {isLP && (
             <>
               <ReviewSubSection header={Config.formation.fields.combinedInvestment.label}>

--- a/web/src/lib/utils/formation-helpers.ts
+++ b/web/src/lib/utils/formation-helpers.ts
@@ -1,0 +1,32 @@
+import { arrayOfCountriesObjects } from "@businessnjgovnavigator/shared";
+import { FormationFormData } from "@businessnjgovnavigator/shared/";
+import { foreignCorpLegalStructures } from "@businessnjgovnavigator/shared/index";
+
+export const getAddressCity = (formationFormData: FormationFormData): string | undefined => {
+  return formationFormData.businessLocationType === "NJ"
+    ? formationFormData.addressMunicipality?.displayName
+    : formationFormData.addressCity;
+};
+
+export const getAddressState = (formationFormData: FormationFormData): string | undefined => {
+  return formationFormData.businessLocationType === "INTL"
+    ? formationFormData.addressProvince
+    : formationFormData.addressState?.name;
+};
+
+export const getAddressCountry = (formationFormData: FormationFormData): string | undefined => {
+  return formationFormData.businessLocationType === "INTL"
+    ? arrayOfCountriesObjects.find((country) => country.shortCode === formationFormData.addressCountry)?.name
+    : undefined;
+};
+
+export const shouldDisplayAddressSection = (formationFormData: FormationFormData): boolean => {
+  return (
+    foreignCorpLegalStructures.includes(formationFormData.legalType) ||
+    !!formationFormData.addressLine1 ||
+    !!formationFormData.addressLine2 ||
+    !!getAddressCity(formationFormData) ||
+    !!formationFormData.addressZipCode ||
+    !!getAddressCountry(formationFormData)
+  );
+};


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Fix to only display the address section on review page when it's required or when the user has inputted something into one of the address fields.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[184305929](https://www.pivotaltracker.com/story/show/184305929)

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
