### PR TITLE
feat: [#184125120] reset naics codes when changing Industry

### DIFF
--- a/shared/src/domain-logic/taskIds.ts
+++ b/shared/src/domain-logic/taskIds.ts
@@ -15,3 +15,5 @@ export const einTaskId = "register-for-ein";
 export const isEinTask = (id: string): boolean => {
   return id === einTaskId;
 };
+
+export const naicsCodeTaskId = "determine-naics-code";

--- a/web/src/components/onboarding/IndustryDropdown.tsx
+++ b/web/src/components/onboarding/IndustryDropdown.tsx
@@ -77,6 +77,7 @@ export const IndustryDropdown = (props: Props): ReactElement => {
       cannabisLicenseType,
       industryId: industryId,
       sectorId: newSector,
+      naicsCode: state.profileData.industryId === industryId ? state.profileData.naicsCode : "",
     });
   };
 

--- a/web/src/components/onboarding/OnboardingIndustry.test.tsx
+++ b/web/src/components/onboarding/OnboardingIndustry.test.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/test/factories";
 import { useMockUserData } from "@/test/mock/mockUseUserData";
 import { currentProfileData, WithStatefulProfileData } from "@/test/mock/withStatefulProfileData";
-import { randomFilteredIndustry, randomIndustry } from "@businessnjgovnavigator/shared";
+import { generateProfileData, randomFilteredIndustry, randomIndustry } from "@businessnjgovnavigator/shared";
 import {
   createEmptyProfileData,
   emptyIndustrySpecificData,
@@ -163,6 +163,12 @@ describe("<OnboardingIndustry />", () => {
         });
       });
     });
+  });
+
+  it("resets NAICs code in userdata when industry is changed", () => {
+    renderComponent(generateProfileData({ industryId: "home-contractor", naicsCode: "111111" }));
+    selectIndustry("e-commerce");
+    expect(currentProfileData().naicsCode).toEqual("");
   });
 
   const selectIndustry = (value: string): void => {

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -62,6 +62,7 @@ import {
   LookupLegalStructureById,
   LookupOperatingPhaseById,
   Municipality,
+  naicsCodeTaskId,
   ProfileData,
   UserData,
 } from "@businessnjgovnavigator/shared";
@@ -99,7 +100,6 @@ const ProfilePage = (props: Props): ReactElement => {
   const businessPersona: BusinessPersona = props.CMS_ONLY_businessPersona ?? profileData.businessPersona;
   const foreignBusinessType: ForeignBusinessType =
     props.CMS_ONLY_foreignBusinessType ?? profileData.foreignBusinessType;
-
   const {
     FormFuncWrapper,
     onSubmit,
@@ -196,6 +196,10 @@ const ProfilePage = (props: Props): ReactElement => {
 
       if (updateQueue.current().profileData.taxId !== profileData.taxId) {
         updateQueue.queueTaxFilingData({ state: undefined, registeredISO: undefined, filings: [] });
+      }
+
+      if (updateQueue.current().profileData.industryId !== profileData.industryId) {
+        updateQueue.queueTaskProgress({ [naicsCodeTaskId]: "NOT_STARTED" });
       }
 
       updateQueue.queueProfileData(profileData);


### PR DESCRIPTION
## Description
When the user changes their industry and saves their data, the naics code values in the user data are removed, also the determine your naics code task is reset back to not started.

### Ticket
https://www.pivotaltracker.com/story/show/184125120


### Approach


## Code author checklist

- [ ] I have performed a self-review of my code
- [ ] I have created and/or updated relevant documentation, if necessary
- [ ] I have not used any relative imports
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
