### PR TITLE
chore: [#185109517] create dev-only reset user button

### DIFF
--- a/web/src/components/profile/DevOnlyResetUserDataButton.tsx
+++ b/web/src/components/profile/DevOnlyResetUserDataButton.tsx
@@ -1,0 +1,30 @@
+import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
+import { AuthContext } from "@/contexts/authContext";
+import { useUserData } from "@/lib/data-hooks/useUserData";
+import { ROUTES } from "@/lib/domain-logic/routes";
+import { createEmptyUserData } from "@businessnjgovnavigator/shared/userData";
+import { useRouter } from "next/router";
+import { ReactElement, useContext } from "react";
+
+export const DevOnlyResetUserDataButton = (): ReactElement => {
+  const { state } = useContext(AuthContext);
+  const { update } = useUserData();
+  const router = useRouter();
+
+  const resetUserData = async (): Promise<void> => {
+    if (state.user) {
+      const emptyUserData = createEmptyUserData(state.user);
+      await update(emptyUserData);
+      router.push(ROUTES.landing);
+    }
+  };
+  if (process.env.NODE_ENV === "development") {
+    return (
+      <SecondaryButton isColor="primary" onClick={resetUserData}>
+        Reset User Data
+      </SecondaryButton>
+    );
+  } else {
+    return <></>;
+  }
+};

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -15,6 +15,7 @@ import { OnboardingSectors } from "@/components/onboarding/OnboardingSectors";
 import { DisabledTaxId } from "@/components/onboarding/taxId/DisabledTaxId";
 import { OnboardingTaxId } from "@/components/onboarding/taxId/OnboardingTaxId";
 import { PageSkeleton } from "@/components/PageSkeleton";
+import { DevOnlyResetUserDataButton } from "@/components/profile/DevOnlyResetUserDataButton";
 import { Documents } from "@/components/profile/Documents";
 import { EscapeModal } from "@/components/profile/EscapeModal";
 import { ProfileBusinessName } from "@/components/profile/ProfileBusinessName";
@@ -694,25 +695,27 @@ const ProfilePage = (props: Props): ReactElement => {
                         {displayOpportunityAlert() && <ProfileOpportunitiesAlert />}
                         <form onSubmit={onSubmit} className={`usa-prose onboarding-form margin-top-2`}>
                           {getElements()}
-
-                          <div className="float-right fdr margin-top-2">
-                            <SecondaryButton
-                              isColor="primary"
-                              onClick={(): Promise<void> => onBack()}
-                              dataTestId="back"
-                            >
-                              {Config.profileDefaults.backButtonText}
-                            </SecondaryButton>
-                            <PrimaryButton
-                              isColor="primary"
-                              isSubmitButton={true}
-                              onClick={(): void => {}}
-                              isRightMarginRemoved={true}
-                              dataTestId="save"
-                              isLoading={isLoading}
-                            >
-                              {Config.profileDefaults.saveButtonText}
-                            </PrimaryButton>
+                          <div className="margin-top-2">
+                            <DevOnlyResetUserDataButton />
+                            <div className="float-right fdr">
+                              <SecondaryButton
+                                isColor="primary"
+                                onClick={(): Promise<void> => onBack()}
+                                dataTestId="back"
+                              >
+                                {Config.profileDefaults.backButtonText}
+                              </SecondaryButton>
+                              <PrimaryButton
+                                isColor="primary"
+                                isSubmitButton={true}
+                                onClick={(): void => {}}
+                                isRightMarginRemoved={true}
+                                dataTestId="save"
+                                isLoading={isLoading}
+                              >
+                                {Config.profileDefaults.saveButtonText}
+                              </PrimaryButton>
+                            </div>
                           </div>
                         </form>
                       </>


### PR DESCRIPTION
## Description

Create a button to reset the current user's data that is only accessible in a development environment.

### Ticket

[#185109517](https://www.pivotaltracker.com/story/show/185109517)

### Approach

Resets the userData obj using the `createEmptyUserData` function and then routes the user back to the landing page.

### Steps to Test

The button currently lives at the bottom of the profile page. Any data entered prior to clicking the "Reset User Data" button should be wiped.

<img width="761" alt="Screenshot 2023-05-05 at 11 09 29 AM" src="https://user-images.githubusercontent.com/22647707/236497091-07fb4bf1-7a9a-4611-bc4f-387ca4b44e94.png">

### Notes

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
