### PR TITLE
feat: [#185148836] tax filing home page - left align tiles

### DIFF
--- a/web/src/components/LandingPageTiles.tsx
+++ b/web/src/components/LandingPageTiles.tsx
@@ -104,7 +104,11 @@ export const LandingPageTiles = (props: Props): ReactElement => {
           </div>
         </div>
       ) : (
-        <div className={`fjc fac ${istabletAndUp ? "fdr" : "fdc"}`}>
+        <div
+          className={`fac desktop:padding-x-7 desktop:grid-container-widescreen ${
+            istabletAndUp ? "fdr padding-x-2" : "fdc"
+          }`}
+        >
           {filterActionTiles(actionTiles).map((actionTile, index) => {
             const actionTileObj = {
               ...actionTile,


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

We wanted our intro page tiles to be left aligned. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/185148836)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

logout and go to localhost:3000 
See that the tiles look left aligned
Test at tablet and mobile width
go to localhost:3000/welcome
See that the tiles look left aligned
Test at tablet and mobile width


<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
