### PR TITLE
chore: [#184834138] update summaryDescription format to prevent breaking CMS

### DIFF
--- a/content/src/roadmaps/license-tasks/annual-license-cannabis.md
+++ b/content/src/roadmaps/license-tasks/annual-license-cannabis.md
@@ -11,5 +11,6 @@ callToActionText: Apply for My Annual Cannabis License
 webflowType: business-license
 webflowId: 6414793b9b4d2bcc74edb3a0
 licenseCertificationClassification: LICENSE
-summaryDescriptionMd: "An annual license applicant is ready to manufacture, cultivate or sell cannabis. Your application will need to include information on your business location, local zoning approval, and a summary of your operations."
+summaryDescriptionMd: >
+  An annual license applicant is ready to manufacture, cultivate or sell cannabis. Your application will need to include information on your business location, local zoning approval, and a summary of your operations.
 ---

--- a/content/src/roadmaps/license-tasks/apply-for-food-truck-license.md
+++ b/content/src/roadmaps/license-tasks/apply-for-food-truck-license.md
@@ -11,8 +11,11 @@ webflowType: business-license
 webflowId: 64120ab148da55fdb9c3b1c4
 localLevelTask: Local Department of Health
 licenseCertificationClassification: LICENSE
-summaryDescriptionMd: "Food trucks need to be cleaned and sanitized according to the guidelines from your local Department of Health. The regulation and licensing of food trucks vary by location.
-You'll need to check license requirements with the county and/or local Department of Health in every county where you plan to do business."
+summaryDescriptionMd: >
+  Food trucks need to be cleaned and sanitized according to the guidelines from your local Department of Health. The regulation and licensing of food trucks vary by location.
+
+
+  You'll need to check license requirements with the county and/or local Department of Health in every county where you plan to do business.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/apply-for-shop-license.md
+++ b/content/src/roadmaps/license-tasks/apply-for-shop-license.md
@@ -16,7 +16,8 @@ callToActionText: Apply for My Cosmetology Shop License
 webflowType: business-license
 webflowId: 5f77298fd2749a78af9cf7df
 licenseCertificationClassification: LICENSE
-summaryDescriptionMd: "New shops, relocated shops, or shops that have transferred ownership are required to obtain a license. After your application is submitted and reviewed, your shop will be inspected."
+summaryDescriptionMd: >
+  New shops, relocated shops, or shops that have transferred ownership are required to obtain a license. After your application is submitted and reviewed, your shop will be inspected.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/appraiser-certification.md
+++ b/content/src/roadmaps/license-tasks/appraiser-certification.md
@@ -13,7 +13,8 @@ callToActionText: "Apply ​for My Appraiser Certification "
 webflowType: individual-license
 webflowId: 6414793bb48ba7e9395c9540
 licenseCertificationClassification: CERTIFICATION
-summaryDescriptionMd: "You need a certification to appraise real estate with one to four residential units—regardless of value or complexity. If you are opening an `Appraisal Management Company|appraisal-management-company` you must have a certified appraiser."
+summaryDescriptionMd: >
+  You need a certification to appraise real estate with one to four residential units—regardless of value or complexity. If you are opening an `Appraisal Management Company|appraisal-management-company` you must have a certified appraiser.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/appraiser-company-register.md
+++ b/content/src/roadmaps/license-tasks/appraiser-company-register.md
@@ -11,7 +11,8 @@ callToActionLink: https://www.njconsumeraffairs.gov/rea/Pages/applications.aspx
 id: appraiser-company-register
 webflowId: 64147a42c6eb18daf545d290
 licenseCertificationClassification: REGISTRATION
-summaryDescriptionMd: "Your appraisal management company must be registered with the state before offering professional services."
+summaryDescriptionMd: >
+  Your appraisal management company must be registered with the state before offering professional services.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/appraiser-license.md
+++ b/content/src/roadmaps/license-tasks/appraiser-license.md
@@ -14,7 +14,8 @@ callToActionText: "Apply ​for My Appraiser License "
 webflowType: business-license
 webflowId: 640b8467b7c8237f0cdd1541
 licenseCertificationClassification: LICENSE
-summaryDescriptionMd: "You need a real estate appraiser license if you open an `appraisal management company|appraisal-management-company` and plan to appraise real estate that includes either: A) non-complex one to four residential units having a transaction value less than $1 million, or B) complex one to four residential units (such as those with atypical ownership or market conditions) having a transaction value less than $250,000."
+summaryDescriptionMd: >
+  You need a real estate appraiser license if you open an `appraisal management company|appraisal-management-company` and plan to appraise real estate that includes either: A) non-complex one to four residential units having a transaction value less than $1 million, or B) complex one to four residential units (such as those with atypical ownership or market conditions) having a transaction value less than $250,000.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/architect-license.md
+++ b/content/src/roadmaps/license-tasks/architect-license.md
@@ -14,7 +14,8 @@ callToActionText: Apply for My Architect License
 webflowType: individual-license
 webflowId: 5f772971b0544fd3d536617b
 licenseCertificationClassification: LICENSE
-summaryDescriptionMd: "You or any staff providing architectural services need an architect license."
+summaryDescriptionMd: >
+  You or any staff providing architectural services need an architect license.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/authorization-architect-firm.md
+++ b/content/src/roadmaps/license-tasks/authorization-architect-firm.md
@@ -14,7 +14,8 @@ callToActionText: Apply for My Certificate of Authorization
 webflowType: business-license
 webflowId: 5f772971eb55580500feb5a2
 licenseCertificationClassification: LICENSE
-summaryDescriptionMd: "You need a certificate of authorization to open an architecture firm."
+summaryDescriptionMd: >
+  You need a certificate of authorization to open an architecture firm.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/auto-body-repair-license.md
+++ b/content/src/roadmaps/license-tasks/auto-body-repair-license.md
@@ -13,7 +13,8 @@ callToActionText: Apply for My Auto-Body Repair License
 webflowType: business-license
 webflowId: 5f7729541a08097ccbbb2ecb
 licenseCertificationClassification: LICENSE
-summaryDescriptionMd: "You need a license to open an auto-body repair business."
+summaryDescriptionMd: >
+  You need a license to open an auto-body repair business."
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/conditional-permit-cannabis.md
+++ b/content/src/roadmaps/license-tasks/conditional-permit-cannabis.md
@@ -10,7 +10,8 @@ issuingAgency: Cannabis Regulatory Commission
 callToActionText: Apply for My Conditional Cannabis License
 webflowId: 6414793bde13b38246c4dfb3
 licenseCertificationClassification: LICENSE
-summaryDescriptionMd: "To start your cannabis application prior to opening a site, you may apply for a conditional license that gives you 120 days to find a location, get municipal approval, and apply for a conversion license (which will give your business approval to operate)."
+summaryDescriptionMd: >
+  To start your cannabis application prior to opening a site, you may apply for a conditional license that gives you 120 days to find a location, get municipal approval, and apply for a conversion license (which will give your business approval to operate).
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/conversion-license-cannabis.md
+++ b/content/src/roadmaps/license-tasks/conversion-license-cannabis.md
@@ -10,7 +10,7 @@ issuingAgency: Cannabis Regulatory Commission
 callToActionText: Apply for My Conversion License
 webflowId: 640b852c9a5e4f6a4de2ae45
 licenseCertificationClassification: LICENSE
-summaryDescriptionMd: "If you have a Conditional License, you will need to obtain a Conversion License. A Conditional License limits the activities your business can do. It may take ~90 days for your application to be reviewed."
+summaryDescriptionMd: If you have a Conditional License, you will need to obtain a Conversion License. A Conditional License limits the activities your business can do. It may take ~90 days for your application to be reviewed.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/daycare-license.md
+++ b/content/src/roadmaps/license-tasks/daycare-license.md
@@ -13,7 +13,8 @@ issuingAgency: New Jersey Department of Children and Families
 callToActionText: Apply for My License
 webflowId: 5f7728f5e8bf507c5e317899
 licenseCertificationClassification: LICENSE
-summaryDescriptionMd: "If you have more than six children under your care you must run your child care services outside of your home and will need a child care center license."
+summaryDescriptionMd: >
+  If you have more than six children under your care you must run your child care services outside of your home and will need a child care center license.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/detective-agency-license.md
+++ b/content/src/roadmaps/license-tasks/detective-agency-license.md
@@ -13,8 +13,8 @@ callToActionText: Apply for My Agency License
 webflowType: business-license
 webflowId: 5f772960a67e4a21735c0f36
 licenseCertificationClassification: LICENSE
-summaryDescriptionMd: "You need a license to operate a detective agency. To prepare for the application, consider reading the [Private Detective License Application Instructions](https://www.nj.gov/njsp/private-detective/pdf/sp-171-instructions_2020.pdf) and the [New Jersey State Police Private Detective Information](https://www.nj.gov/njsp/private-detective/index.shtml).
-"
+summaryDescriptionMd: >
+  You need a license to operate a detective agency. To prepare for the application, consider reading the [Private Detective License Application Instructions](https://www.nj.gov/njsp/private-detective/pdf/sp-171-instructions_2020.pdf) and the [New Jersey State Police Private Detective Information](https://www.nj.gov/njsp/private-detective/index.shtml).
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/electrical-business-license.md
+++ b/content/src/roadmaps/license-tasks/electrical-business-license.md
@@ -13,10 +13,11 @@ callToActionText: Apply for My Business Permit
 webflowType: business-license
 webflowId: 6414793c685ea9e0d858aa8f
 licenseCertificationClassification: PERMIT
-summaryDescriptionMd: "You need a permit to operate an electrical contracting business.
+summaryDescriptionMd: >
+  You need a permit to operate an electrical contracting business.
 
-Business applications are reviewed monthly. Your application must be received ten days prior to the [Board of Examiners of Electrical Contractors monthly meeting](https://www.njconsumeraffairs.gov/elec/Pages/meetings.aspx) to be reviewed during the current month.
-"
+
+  Business applications are reviewed monthly. Your application must be received ten days prior to the [Board of Examiners of Electrical Contractors monthly meeting](https://www.njconsumeraffairs.gov/elec/Pages/meetings.aspx) to be reviewed during the current month.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/firm-engineer.md
+++ b/content/src/roadmaps/license-tasks/firm-engineer.md
@@ -12,7 +12,8 @@ licenseCertificationClassification: undefined
 divisionPhone: 973-504-6460
 id: firm-engineer
 webflowId: 6414793b798bdb29a5fe9567
-summaryDescriptionMd: "You need a certificate of authorization to operate an engineering firm."
+summaryDescriptionMd: >
+  You need a certificate of authorization to operate an engineering firm.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/home-baker-license.md
+++ b/content/src/roadmaps/license-tasks/home-baker-license.md
@@ -12,7 +12,8 @@ callToActionText: Apply for Your Permit
 webflowType: business-license
 webflowId: 6414793b7e0fbe2794b95bfe
 licenseCertificationClassification: ""
-summaryDescriptionMd: "You need a cottage food operator (home baker) permit to sell food/baked goods prepared in your home. See the [application instructions](https://www.nj.gov/health/forms/cfo-1instr.pdf) and the [Department of Health code for cottage industries](https://www.nj.gov/health/ceohs/phfpp/retailfood/cottagefood.shtml#5) for important information on allowed ingredients, allergens, and labeling requirements."
+summaryDescriptionMd: >
+  You need a cottage food operator (home baker) permit to sell food/baked goods prepared in your home. See the [application instructions](https://www.nj.gov/health/forms/cfo-1instr.pdf) and the [Department of Health code for cottage industries](https://www.nj.gov/health/ceohs/phfpp/retailfood/cottagefood.shtml#5) for important information on allowed ingredients, allergens, and labeling requirements.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/home-health-aide-license.md
+++ b/content/src/roadmaps/license-tasks/home-health-aide-license.md
@@ -9,7 +9,8 @@ callToActionLink: "https://www.njconsumeraffairs.gov/epservices"
 callToActionText: "Contact the Division of Consumer Affairs"
 issuingAgency: "New Jersey’s Division of Consumer Affairs Employment and Personnel Services"
 licenseCertificationClassification: "LICENSE"
-summaryDescriptionMd: "You may need to apply for an Employment Agency License prior to offering caregiving services. You will need to speak with a New Jersey Employment and Personnel Services representative to determine if this license is necessary."
+summaryDescriptionMd: >
+  You may need to apply for an Employment Agency License prior to offering caregiving services. You will need to speak with a New Jersey Employment and Personnel Services representative to determine if this license is necessary.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/hvac-license.md
+++ b/content/src/roadmaps/license-tasks/hvac-license.md
@@ -15,7 +15,8 @@ callToActionText: Apply for My HVACR License
 webflowType: individual-license
 webflowId: 5f772993a195c8849e15b18f
 licenseCertificationClassification: ""
-summaryDescription: "You or any staff providing HVACR services must be licensed as an HVACR contractor."
+summaryDescription: >
+  You or any staff providing HVACR services must be licensed as an HVACR contractor.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/individual-staff-licenses-cosmetology.md
+++ b/content/src/roadmaps/license-tasks/individual-staff-licenses-cosmetology.md
@@ -13,10 +13,11 @@ callToActionText: Apply for a Cosmetology License
 webflowType: individual-license
 webflowId: 641370d262d9de2b82a85d95
 licenseCertificationClassification: ""
-summaryDescriptionMd: "Any staff providing cosmetology services will need a cosmetology license. If the business owner of a cosmetology shop does not have a cosmetology license, the shop manager must have a license and at least two years of experience.
+summaryDescriptionMd: >
+  Any staff providing cosmetology services will need a cosmetology license. If the business owner of a cosmetology shop does not have a cosmetology license, the shop manager must have a license and at least two years of experience. 
+
 
   Licenses are required for cosmetologists, hairstylists, manicurists, skincare specialists, barbers, hair braiders, and beauticians. It is the shop owner's responsibility to ensure their staff is licensed.
-"
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/license-accounting.md
+++ b/content/src/roadmaps/license-tasks/license-accounting.md
@@ -14,7 +14,8 @@ issuingDivision: NJ State Board of Accountancy
 divisionPhone: (973) 504-6380
 id: license-accounting
 webflowId: 5f7729d28aa6e3de76f1e60c
-summaryDescriptionMd: "New accounting firms must register and obtain certification."
+summaryDescriptionMd: >
+  New accounting firms must register and obtain certification.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/license-acupuncture.md
+++ b/content/src/roadmaps/license-tasks/license-acupuncture.md
@@ -14,7 +14,8 @@ callToActionText: Apply for My License
 webflowType: individual-license
 webflowId: 5f77296edd6a49eae99b6067
 licenseCertificationClassification: ""
-summaryDescriptionMd: "You need an acupuncturist license to offer services as an acupuncturist."
+summaryDescriptionMd: >
+  You need an acupuncturist license to offer services as an acupuncturist.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/license-broker.md
+++ b/content/src/roadmaps/license-tasks/license-broker.md
@@ -12,7 +12,8 @@ issuingAgency: State of New Jersey Department of Banking and Insurance Real Esta
 callToActionText: Submit a Real Estate Broker License Application
 webflowId: 5f77292da6bfb58d9402edff
 licenseCertificationClassification: ""
-summaryDescriptionMd: "If you own or plan to own a real estate agency, you need a real estate broker license."
+summaryDescriptionMd: >
+  If you own or plan to own a real estate agency, you need a real estate broker license.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/license-engineer.md
+++ b/content/src/roadmaps/license-tasks/license-engineer.md
@@ -15,7 +15,8 @@ callToActionText: Apply for My Engineer License
 webflowType: individual-license
 webflowId: 640b84674c4b70b5b2420c3b
 licenseCertificationClassification: ""
-summaryDescriptionMd: "You or any staff providing engineering services will need an engineer license."
+summaryDescriptionMd: >
+  You or any staff providing engineering services will need an engineer license.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/license-massage-therapy.md
+++ b/content/src/roadmaps/license-tasks/license-massage-therapy.md
@@ -15,7 +15,8 @@ callToActionText: Get My Massage Therapy Business License
 webflowType: business-license
 webflowId: 5f77299ae10dec7f6a025080
 licenseCertificationClassification: ""
-summaryDescriptionMd: "If you will employ others to offer massage therapy services, you need to register your business as a massage therapy employer."
+summaryDescriptionMd: >
+  If you will employ others to offer massage therapy services, you need to register your business as a massage therapy employer."
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/moving-company-license.md
+++ b/content/src/roadmaps/license-tasks/moving-company-license.md
@@ -14,7 +14,8 @@ issuingAgency: New Jersey Division of Consumer Affairs,  Office of Consumer
 callToActionText: Apply for My Public Movers License
 webflowId: 640b84670945bdf4cfd63f2c
 licenseCertificationClassification: ""
-summaryDescriptionMd: "If you transport household goods or special commodities by motor vehicle for compensation within New Jersey you need a public movers license."
+summaryDescriptionMd: >
+  If you transport household goods or special commodities by motor vehicle for compensation within New Jersey you need a public movers license.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/notary-register.md
+++ b/content/src/roadmaps/license-tasks/notary-register.md
@@ -15,7 +15,8 @@ callToActionText: Apply for My Notary Public Certificate
 webflowType: individual-license
 webflowId: 5f77296c2edc674c7cb4a708
 licenseCertificationClassification: ""
-summaryDescriptionMd: "You or any staff providing notary services must be registered as a notary public."
+summaryDescriptionMd: >
+  You or any staff providing notary services must be registered as a notary public.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/register-consumer-affairs.md
+++ b/content/src/roadmaps/license-tasks/register-consumer-affairs.md
@@ -16,7 +16,8 @@ callToActionText: Complete My Contractor Registration
 webflowType: individual-license
 webflowId: 5f7729927fe89d43ed054794
 licenseCertificationClassification: ""
-summaryDescriptionMd: "Home improvement contractors are individuals and companies involved in repairing, renovating, modernizing, installing, replacing, improving, restoring, painting, constructing, remodeling, moving, or demolishing residential or noncommercial properties. If you or your business is involved in any of the activities mentioned above you must register as a Home Improvement Contractor."
+summaryDescriptionMd: >
+  Home improvement contractors are individuals and companies involved in repairing, renovating, modernizing, installing, replacing, improving, restoring, painting, constructing, remodeling, moving, or demolishing residential or noncommercial properties. If you or your business is involved in any of the activities mentioned above you must register as a Home Improvement Contractor.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/register-firm-accounting.md
+++ b/content/src/roadmaps/license-tasks/register-firm-accounting.md
@@ -14,9 +14,8 @@ callToActionText: Apply for My License
 webflowType: individual-license
 webflowId: 5f77296ee10dec7593024f1c
 licenseCertificationClassification: ""
-summaryDescriptionMd:
-  "You or any staff conducting financial audits in accordance with the Statements on Auditing Standards (SAS), the Statements on Standards for Attestation Engagements (SSAE), or the the Public Company Accounting
-  Oversight Board (PCAOB) must obtain a certified public accountant license."
+summaryDescriptionMd: >
+  You or any staff conducting financial audits in accordance with the Statements on Auditing Standards (SAS), the Statements on Standards for Attestation Engagements (SSAE), or the the Public Company Accounting Oversight Board (PCAOB) must obtain a certified public accountant license.
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/search-licenses-employment-agency.md
+++ b/content/src/roadmaps/license-tasks/search-licenses-employment-agency.md
@@ -10,10 +10,9 @@ webflowName: "Employment Agency"
 issuingDivision: "Regulated Business Unit"
 divisionPhone: "(973) 504-6370"
 webflowIndustry: "Employment Agency"
-licenseCertificationClassification: "LICENSE"
-summaryDescriptionMd: "
+summaryDescriptionMd: >
   You will need to obtain an employment agency license prior to offering staffing services. To do this, you must speak with a representative from New Jersey's Employment and Personnel Services.
-"
+licenseCertificationClassification: "LICENSE"
 ---
 
 ---

--- a/content/src/roadmaps/license-tasks/town-mercantile-license.md
+++ b/content/src/roadmaps/license-tasks/town-mercantile-license.md
@@ -11,10 +11,11 @@ webflowId: 64147a42689e2308a6b2252a
 localLevelTask: Municipal Clerk
 licenseCertificationClassification: ""
 requiresLocation: true
-summaryDescriptionMd: "Prior to opening your physical location, you may need to get a mercantile license. The mercantile license provides your local government with information on how to reach you in an emergency.
+summaryDescriptionMd: >
+  Prior to opening your physical location, you may need to get a mercantile license. The mercantile license provides your local government with information on how to reach you in an emergency.
+
 
   Each town or city will have its own application process for the mercantile license, some governments do not require this.
-"
 ---
 
 ---

--- a/web/src/components/tasks/LicenseTask.tsx
+++ b/web/src/components/tasks/LicenseTask.tsx
@@ -133,6 +133,7 @@ export const LicenseTask = (props: Props): ReactElement => {
             <TabPanel value="0" sx={{ paddingX: 0 }}>
               <div className="margin-top-3">
                 <UnlockedBy task={props.task} />
+                <Content>{props.task.summaryDescriptionMd || ""}</Content>
                 <Content>{getModifiedTaskContent(roadmap, props.task, "contentMd")}</Content>
               </div>
               <div className="flex flex-column margin-top-4 margin-bottom-1">

--- a/web/src/components/tasks/cannabis/CannabisApplyForLicenseTask.tsx
+++ b/web/src/components/tasks/cannabis/CannabisApplyForLicenseTask.tsx
@@ -1,3 +1,4 @@
+import { Content } from "@/components/Content";
 import { SnackbarAlert } from "@/components/njwds-extended/SnackbarAlert";
 import { TaskHeader } from "@/components/TaskHeader";
 import { CannabisApplicationQuestionsTab } from "@/components/tasks/cannabis/CannabisApplicationQuestionsTab";
@@ -132,6 +133,7 @@ export const CannabisApplyForLicenseTask = (props: Props): ReactElement => {
       {displayFirstTab ? (
         <>
           <UnlockedBy task={props.task} />
+          <Content className="margin-bottom-2">{props.task.summaryDescriptionMd || ""}</Content>
           <CannabisApplicationQuestionsTab
             onNextTab={handleNextTabButtonClick}
             priorityStatusState={priorityStatusState}

--- a/web/src/pages/tasks/[taskUrlSlug].tsx
+++ b/web/src/pages/tasks/[taskUrlSlug].tsx
@@ -202,6 +202,7 @@ export const TaskElement = (props: { task: Task; children?: ReactNode | ReactNod
       <div>
         <TaskHeader task={props.task} />
         {props.children}
+        <Content>{props.task.summaryDescriptionMd || ""}</Content>
 
         {hasDeferredLocationQuestion && (
           <>
@@ -223,7 +224,6 @@ export const TaskElement = (props: { task: Task; children?: ReactNode | ReactNod
 
         {!hasPostOnboardingQuestion && !hasDeferredLocationQuestion && (
           <>
-            <Content>{props.task.summaryDescriptionMd || ""}</Content>
             <Content>{props.task.contentMd}</Content>
           </>
         )}


### PR DESCRIPTION

## Description

Fixes the following bug in CMS where multi-line summaries would entirely break the CMS editability of that task. See screenshots below where some tasks would be missing their content (no title in list view) and all of the internal content:

![Screenshot 2023-05-12 at 3 54 16 PM](https://github.com/newjersey/navigator.business.nj.gov/assets/6563663/7f3a7d85-2dc4-4415-ab69-0d57d7088d83)

![Screenshot 2023-05-12 at 3 54 06 PM](https://github.com/newjersey/navigator.business.nj.gov/assets/6563663/e6e76084-4575-45b3-a380-45df7a24f41d)

### Additional

Also fixes ensuring that the summary shows up all of the time, not just on the "default" task. See comments in code below