### PR TITLE
fix: default import for LookupIndustryById in license sync

### DIFF
--- a/web/src/scripts/webflow/licenseSync.mjs
+++ b/web/src/scripts/webflow/licenseSync.mjs
@@ -12,8 +12,9 @@ import {
 import { argsInclude, contentToStrings, getHtml, wait } from "./helpers.mjs";
 import { LicenseClassificationLookup } from "./licenseClassifications.mjs";
 import { createItem, getAllItems, modifyItem } from "./methods.mjs";
-import { LookupIndustryById } from "@businessnjgovnavigator/shared";
+import * as industryHelpers from "../../../../shared/lib/shared/src/industry.js";
 
+const { LookupIndustryById } = industryHelpers;
 const licenseCollectionId = "5e31b06cb76b830c0c358aa8";
 
 const getLicenseFromMd = (licenseMd) => {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have performed a self-review of my code
- [ ] I have created and/or updated relevant documentation, if necessary
- [ ] I have not used any relative imports
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
