### PR TITLE
fix: [#185191909] no redirect to alt landing if on welcome landing

### DIFF
--- a/web/src/pages/index.tsx
+++ b/web/src/pages/index.tsx
@@ -86,10 +86,14 @@ const Home = (props: Props): ReactElement => {
       } else if (userData === undefined && error !== undefined) {
         router.replace(`${ROUTES.dashboard}?error=true`);
       }
-    } else if (state.isAuthenticated === IsAuthenticated.FALSE && alternateLandingPageEnabled) {
+    } else if (
+      state.isAuthenticated === IsAuthenticated.FALSE &&
+      alternateLandingPageEnabled &&
+      !props.isWelcomePage
+    ) {
       router.replace(landingPageAlternateUrl);
     }
-  }, [userData, error, router, state.isAuthenticated]);
+  }, [userData, error, router, state.isAuthenticated, props.isWelcomePage]);
 
   useEffect(() => {
     if (!router.isReady || !router.query[QUERIES.signUp]) {

--- a/web/test/pages/index.test.tsx
+++ b/web/test/pages/index.test.tsx
@@ -102,5 +102,11 @@ describe("HomePage", () => {
       render(withAuth(<Home />, { isAuthenticated: IsAuthenticated.FALSE }));
       expect(mockPush).toHaveBeenCalledWith("www.example.com");
     });
+
+    it("doesn't redirect to alternate landing page when user is on the welcome page", () => {
+      setMockUserDataResponse({ error: undefined, userData: undefined });
+      render(withAuth(<Home isWelcomePage={true} />, { isAuthenticated: IsAuthenticated.FALSE }));
+      expect(mockPush).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Bug fix for the welcome landing page. If a user is on the welcome version on the landing page, then they are not redirected to the webflow landing page.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#185191909](https://www.pivotaltracker.com/story/show/185191909)

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
