### PR TITLE
release 20230519

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [5.20.3](https://github.com/newjersey/navigator.business.nj.gov/compare/v5.20.2...v5.20.3) (2023-05-24)
+
+
+### Bug Fixes
+
+* disable error outage bar in prod ([f4fcb8f](https://github.com/newjersey/navigator.business.nj.gov/commit/f4fcb8f1c7d589f1ebd0163009d428a6db38b147))
+
 ## [5.20.2](https://github.com/newjersey/navigator.business.nj.gov/compare/v5.20.1...v5.20.2) (2023-05-24)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businessnjgovnavigator/root",
-  "version": "5.20.2",
+  "version": "5.20.3",
   "description": "This is the development repository for the work-in-progress business navigator from the New Jersey Office of Innovation. For info on the existing [Business.NJ.gov](https://business.nj.gov) site, please see the [bottom of this document](https://github.com/newjersey/navigator.business.nj.gov#businessnjgov)",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
- fix: disable error outage bar in prod
- chore(release): 5.20.3 [skip ci]
