### PR TITLE
Fix ${oos} bug in Dakota onboarding flow

### DIFF
--- a/web/src/lib/data-hooks/useContentModifiedByUserData.test.ts
+++ b/web/src/lib/data-hooks/useContentModifiedByUserData.test.ts
@@ -24,6 +24,19 @@ describe("useContentModifiedByUserData", () => {
       );
 
       const result = useContentModifiedByUserData("You have a ${oos} business");
+      expect(result).toEqual(expect.not.stringContaining("${oos}"));
+      expect(result).toEqual(expect.not.stringContaining("out-of-state"));
+    });
+
+    it("does not render out of state designation when businessPersona is undefined", () => {
+      useMockUserData(
+        generateUserData({
+          profileData: generateProfileData({ businessPersona: randomInt() % 2 ? "STARTING" : "OWNING" }),
+        })
+      );
+
+      const result = useContentModifiedByUserData("You have a ${oos} business");
+      expect(result).toEqual(expect.not.stringContaining("${oos}"));
       expect(result).toEqual(expect.not.stringContaining("out-of-state"));
     });
   });
@@ -43,6 +56,19 @@ describe("useContentModifiedByUserData", () => {
       );
 
       const result = useContentModifiedByUserData("You have a ${OoS} business");
+      expect(result).toEqual(expect.not.stringContaining("${OoS}"));
+      expect(result).toEqual(expect.not.stringContaining("Out-of-State"));
+    });
+
+    it("does not render out of state designation when businessPersona is undefined", () => {
+      useMockUserData(
+        generateUserData({
+          profileData: generateProfileData({ businessPersona: undefined }),
+        })
+      );
+
+      const result = useContentModifiedByUserData("You have a ${OoS} business");
+      expect(result).toEqual(expect.not.stringContaining("${OoS}"));
       expect(result).toEqual(expect.not.stringContaining("Out-of-State"));
     });
   });

--- a/web/src/lib/data-hooks/useContentModifiedByUserData.ts
+++ b/web/src/lib/data-hooks/useContentModifiedByUserData.ts
@@ -2,7 +2,8 @@ import { useUserData } from "@/lib/data-hooks/useUserData";
 import { templateEval, templateEvalWithExtraSpaceRemoval } from "@/lib/utils/helpers";
 
 export const useContentModifiedByUserData = (content: string): string => {
-  const { userData } = useUserData();
+  const { updateQueue } = useUserData();
+  const userData = updateQueue?.current();
   let result = content;
   if (!userData || !result) return result;
 
@@ -11,7 +12,7 @@ export const useContentModifiedByUserData = (content: string): string => {
       result = templateEval(content, {
         oos: "out-of-state",
       });
-    } else if (userData?.profileData.businessPersona) {
+    } else {
       result = templateEvalWithExtraSpaceRemoval(content, {
         oos: "",
       });
@@ -23,7 +24,7 @@ export const useContentModifiedByUserData = (content: string): string => {
       result = templateEval(content, {
         OoS: "Out-of-State",
       });
-    } else if (userData?.profileData.businessPersona) {
+    } else {
       result = templateEvalWithExtraSpaceRemoval(content, {
         OoS: "",
       });


### PR DESCRIPTION
## Description

During the Dakota onboarding flow, the Industry question text was not replacing the ${oos} substring correctly. The hook responsible for this behavior has been updated to reference the `updateQueue` over the `userData` object.

![Pasted Image at 2023_05_25_11_12 am](https://github.com/newjersey/navigator.business.nj.gov/assets/22647707/5d3a34d8-cbf5-4d02-8240-ecb459deb504)

### Ticket

[185266819](https://www.pivotaltracker.com/story/show/185266819)

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
