### PR TITLE
feat: [#185212073] adjust tooltip mobile behavior to stay open until …

### DIFF
--- a/web/src/components/ArrowTooltip.test.tsx
+++ b/web/src/components/ArrowTooltip.test.tsx
@@ -1,0 +1,64 @@
+import { ArrowTooltip } from "@/components/ArrowTooltip";
+import * as materialUi from "@mui/material";
+import { createTheme, Icon, ThemeProvider, useMediaQuery } from "@mui/material";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+jest.mock("@mui/material", () => mockMaterialUI());
+
+function mockMaterialUI(): typeof materialUi {
+  return {
+    ...jest.requireActual("@mui/material"),
+    useMediaQuery: jest.fn(),
+  };
+}
+
+const isMobile = (value: boolean): void => {
+  (useMediaQuery as jest.Mock).mockImplementation(() => {
+    return value;
+  });
+};
+
+const testString = "test_string";
+
+const renderToolTip = (): void => {
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <ArrowTooltip title={testString}>
+        <div className="fdr fac font-body-lg text-green" data-testid="tooltip">
+          <Icon>help_outline</Icon>
+        </div>
+      </ArrowTooltip>
+    </ThemeProvider>
+  );
+};
+
+describe("<ArrowTooltip />", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("shows onClick on mobile", async () => {
+    isMobile(true);
+
+    renderToolTip();
+
+    expect(screen.queryByText(testString)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("tooltip"));
+    await waitFor(() => {
+      expect(screen.getByText(testString)).toBeInTheDocument();
+    });
+  });
+
+  it("shows on hover on desktop", async () => {
+    isMobile(false);
+    renderToolTip();
+
+    expect(screen.queryByText(testString)).not.toBeInTheDocument();
+
+    fireEvent.mouseOver(screen.getByTestId("tooltip"));
+    await waitFor(() => {
+      expect(screen.getByText(testString)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/components/ArrowTooltip.tsx
+++ b/web/src/components/ArrowTooltip.tsx
@@ -1,7 +1,9 @@
+import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
+import { MediaQueries } from "@/lib/PageSizes";
 import analytics from "@/lib/utils/analytics";
-import { Theme, Tooltip, TooltipProps } from "@mui/material";
+import { ClickAwayListener, Theme, Tooltip, TooltipProps, useMediaQuery } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
-import { ReactElement } from "react";
+import { ReactElement, useState } from "react";
 
 const useStylesBootstrap = makeStyles((theme: Theme) => {
   return {
@@ -19,13 +21,47 @@ const useStylesBootstrap = makeStyles((theme: Theme) => {
 export const ArrowTooltip = (props: TooltipProps): ReactElement => {
   const classes = useStylesBootstrap();
 
+  const isMobile = useMediaQuery(MediaQueries.isMobile);
+
+  const [open, setOpen] = useState(false);
+
   return (
-    <Tooltip
-      arrow
-      enterTouchDelay={0}
-      classes={classes}
-      {...props}
-      onOpen={analytics.event.tooltip.mouseover.view_tooltip}
-    />
+    <>
+      {isMobile ? (
+        <ClickAwayListener onClickAway={(): void => setOpen(false)}>
+          <div className="display-flex">
+            <Tooltip
+              arrow
+              enterTouchDelay={0}
+              classes={classes}
+              onOpen={analytics.event.tooltip.mouseover.view_tooltip}
+              PopperProps={{
+                disablePortal: true,
+              }}
+              onClose={(): void => setOpen(false)}
+              open={open}
+              disableFocusListener
+              disableHoverListener
+              disableTouchListener
+              {...props}
+            >
+              <div>
+                <UnStyledButton style="tertiary" onClick={(): void => setOpen(true)}>
+                  {props.children}
+                </UnStyledButton>
+              </div>
+            </Tooltip>
+          </div>
+        </ClickAwayListener>
+      ) : (
+        <Tooltip
+          arrow
+          enterTouchDelay={0}
+          classes={classes}
+          {...props}
+          onOpen={analytics.event.tooltip.mouseover.view_tooltip}
+        />
+      )}
+    </>
   );
 };

--- a/web/src/components/TaskProgressCheckbox.tsx
+++ b/web/src/components/TaskProgressCheckbox.tsx
@@ -196,7 +196,7 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
         data-testid="change-task-progress-checkbox"
         aria-label="update task status"
         onClick={isDisabled ? undefined : (): void => setToNextStatus()}
-        className={`cursor-pointer margin-neg-105 padding-105 usa-button--unstyled task-checkbox-base margin-right-05 ${styles.hover}`}
+        className={`cursor-pointer margin-neg-105 padding-105 usa-button--unstyled task-checkbox-base ${styles.hover}`}
         {...(isDisabled ? { disabled: true } : {})}
       >
         <span
@@ -217,15 +217,17 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
     <div className={"flex flex-align-center"}>
       <>{congratulatoryModal}</>
 
-      {isDisabled ? (
-        <ArrowTooltip title={props.disabledTooltipText || ""}>
-          <div data-testid="status-info-tooltip" className={"line-height-100"}>
-            {Checkbox()}
-          </div>
-        </ArrowTooltip>
-      ) : (
-        <>{Checkbox()}</>
-      )}
+      <div className="margin-right-2">
+        {isDisabled ? (
+          <ArrowTooltip title={props.disabledTooltipText || ""}>
+            <div data-testid="status-info-tooltip" className={"line-height-100"}>
+              {Checkbox()}
+            </div>
+          </ArrowTooltip>
+        ) : (
+          <>{Checkbox()}</>
+        )}
+      </div>
 
       <span className="flex flex-align-center">{TaskProgressTagLookup[currentTaskProgress]}</span>
 

--- a/web/src/components/filings-calendar/FilingsCalendar.tsx
+++ b/web/src/components/filings-calendar/FilingsCalendar.tsx
@@ -133,12 +133,9 @@ export const FilingsCalendar = (props: Props): ReactElement => {
         <div className="flex mobile-lg:flex-align-end flex-justify flex-column mobile-lg:flex-row">
           <div className="flex flex-align-end">
             <h2 className="margin-bottom-0 text-medium">{Config.dashboardDefaults.calendarHeader}</h2>
-            <div className="margin-top-05">
+            <div className="margin-top-05 margin-left-1 margin-bottom-05">
               <ArrowTooltip title={Config.dashboardDefaults.calendarTooltip}>
-                <div
-                  className="fdr fac margin-left-1 margin-bottom-05 font-body-lg text-green"
-                  data-testid="calendar-tooltip"
-                >
+                <div className="fdr fac font-body-lg text-green" data-testid="calendar-tooltip">
                   <Icon>help_outline</Icon>
                 </div>
               </ArrowTooltip>

--- a/web/src/components/onboarding/FieldLabelProfile.tsx
+++ b/web/src/components/onboarding/FieldLabelProfile.tsx
@@ -58,11 +58,13 @@ export const FieldLabelProfile = (props: Props): ReactElement => {
           </div>
         )}
         {showLockedTooltip && (
-          <ArrowTooltip title={Config.profileDefaults.lockedFieldTooltipText}>
-            <div className="fdr fac margin-left-1 margin-bottom-2 font-body-lg">
-              <Icon>help_outline</Icon>
-            </div>
-          </ArrowTooltip>
+          <div className="margin-left-1 margin-bottom-2">
+            <ArrowTooltip title={Config.profileDefaults.lockedFieldTooltipText}>
+              <div className="fdr fac  font-body-lg">
+                <Icon>help_outline</Icon>
+              </div>
+            </ArrowTooltip>
+          </div>
         )}
       </div>
       {showDescription && (

--- a/web/src/components/onboarding/taxId/DisabledTaxId.tsx
+++ b/web/src/components/onboarding/taxId/DisabledTaxId.tsx
@@ -1,7 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { ArrowTooltip } from "@/components/ArrowTooltip";
-import { Icon } from "@/components/njwds/Icon";
 import { EncryptionStatus, TaxIdDisplayStatus } from "@/components/onboarding/taxId/OnboardingTaxIdHelpers";
 import { ShowHideToggleButton } from "@/components/ShowHideToggleButton";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
@@ -103,11 +101,6 @@ export const DisabledTaxId = (props: Props): ReactElement => {
   const SimpleDiv = (props: { children: ReactNode }): ReactElement => (
     <div className="flex">
       <div>{props.children}</div>
-      <ArrowTooltip title={Config.profileDefaults.lockedFieldTooltipText}>
-        <div className="fdr fac margin-left-1 margin-bottom-1 font-body-lg">
-          <Icon>help_outline</Icon>
-        </div>
-      </ArrowTooltip>
     </div>
   );
   const Element = props.template ?? SimpleDiv;

--- a/web/src/components/tasks/BusinessStructureTask.tsx
+++ b/web/src/components/tasks/BusinessStructureTask.tsx
@@ -159,11 +159,13 @@ export const BusinessStructureTask = (props: Props): ReactElement => {
                   {Config.taskDefaults.editText}
                 </UnStyledButton>
               ) : (
-                <ArrowTooltip title={Config.profileDefaults.lockedFieldTooltipText}>
-                  <div className="fdr fac margin-left-2 font-body-lg">
-                    <Icon>help_outline</Icon>
-                  </div>
-                </ArrowTooltip>
+                <div className="margin-left-2">
+                  <ArrowTooltip title={Config.profileDefaults.lockedFieldTooltipText}>
+                    <div className="fdr fac font-body-lg">
+                      <Icon>help_outline</Icon>
+                    </div>
+                  </ArrowTooltip>
+                </div>
               )}
             </div>
           </Alert>

--- a/web/src/components/tasks/TaxInput.tsx
+++ b/web/src/components/tasks/TaxInput.tsx
@@ -96,12 +96,16 @@ export const TaxInput = (props: Props): ReactElement => {
     <div className={`flex ${isTabletAndUp ? "flex-row" : "flex-column margin-right-2"} no-wrap`}>
       <div className={`${isTabletAndUp ? "padding-right-1" : ""}`}>{Config.tax.lockedPreText}</div>
       <div>{props.children}</div>
-      <div className={`${isTabletAndUp ? "padding-left-1" : ""}`}>{Config.tax.lockedPostText}</div>
-      <ArrowTooltip title={Config.profileDefaults.lockedFieldTooltipText}>
-        <div className="fdr fac margin-left-1 margin-bottom-1 font-body-lg">
-          <Icon>help_outline</Icon>
-        </div>
-      </ArrowTooltip>
+      <div className={`${isTabletAndUp ? "padding-left-1" : ""} margin-right-1`}>
+        {Config.tax.lockedPostText}
+      </div>
+      <div className={"text-wrap margin-bottom-1"}>
+        <ArrowTooltip title={Config.profileDefaults.lockedFieldTooltipText}>
+          <div className="fdr fac  font-body-lg">
+            <Icon>help_outline</Icon>
+          </div>
+        </ArrowTooltip>
+      </div>
       {isTabletAndUp ? <div className="margin-x-2">|</div> : <></>}
     </div>
   );

--- a/web/src/pages/filings/[filingUrlSlug].tsx
+++ b/web/src/pages/filings/[filingUrlSlug].tsx
@@ -49,14 +49,13 @@ export const FilingElement = (props: {
                   {parseDateWithFormat(props.dueDate, defaultDateFormat).format("MMMM D, YYYY").toUpperCase()}
                 </span>
                 {props.filing.urlSlug === "annual-report" ? (
-                  <ArrowTooltip title={Config.filingDefaults.dueDateToolTip}>
-                    <div
-                      className="fdr fac margin-left-1 margin-bottom-05 font-body-lg text-green"
-                      data-testid="due-date-tooltip"
-                    >
-                      <Icon>help_outline</Icon>
-                    </div>
-                  </ArrowTooltip>
+                  <div className="margin-left-1 margin-bottom-05">
+                    <ArrowTooltip title={Config.filingDefaults.dueDateToolTip}>
+                      <div className="fdr fac font-body-lg text-green" data-testid="due-date-tooltip">
+                        <Icon>help_outline</Icon>
+                      </div>
+                    </ArrowTooltip>
+                  </div>
                 ) : (
                   <></>
                 )}


### PR DESCRIPTION
…clicked off

<!-- Please complete the following sections as necessary. -->

## Description

We wanted tooltips on mobile to open on click and not disappear until clicked off. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/185212073)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Go into the app and go to anywhere that we get tool tips. Some appear in profile after we finish formation because fields are locked and we have tool tips to explain. Also the tax calendar has some and a few other places. 
Confirm that on desktop you still hover as normal.
Then on mobile you click on the tool tip and it appears and stays forever and then you can click off to get rid of it. 

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

So we realized that the focus state of the tool tips when clicked was a bit awkward because it was inside of the tool tip. So I made a minor change to take the margins and put them outside of the tool tips when they occur. 

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
