### PR TITLE
Fix ${oos} bug in Dakota onboarding flow

### DIFF
--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -199,40 +199,42 @@ const OnboardingPage = (props: Props): ReactElement => {
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.isReady, state.user, state.isAuthenticated]);
+  }, [router.isReady, state.user, state.isAuthenticated, updateQueue]);
 
   const setIndustryAndRouteToPage = async (
     userData: UserData,
     industryId: string | undefined
   ): Promise<void> => {
-    setProfileData({
+    const newProfileData: ProfileData = {
       ...userData.profileData,
       businessPersona: "STARTING",
       industryId: industryId,
-    });
+    };
 
+    setProfileData(newProfileData);
     if (hasEssentialQuestion(industryId)) {
       setPage({ current: 2, previous: 1 });
     } else {
       setPage({ current: 3, previous: 2 });
     }
+    await updateQueue?.queueProfileData(newProfileData);
   };
 
   const setBusinessPersonaAndRouteToPage = async (flow: string): Promise<void> => {
     const flowType = mapFlowQueryToPersona[flow as QUERY_PARAMS_VALUES["flow"]];
+    const newProfileData: ProfileData = {
+      ...profileData,
+      businessPersona: flowType,
+    };
 
-    setProfileData((previousProfileData) => {
-      return {
-        ...previousProfileData,
-        businessPersona: flowType,
-      };
-    });
+    setProfileData(newProfileData);
     setCurrentFlow(flowType);
     if (flowType === "OWNING") {
       setPage({ current: 1, previous: 1 });
     } else {
       setPage({ current: 2, previous: 1 });
     }
+    await updateQueue?.queueProfileData(newProfileData);
   };
 
   FormFuncWrapper(


### PR DESCRIPTION
## Description

Follow up for #5849. Previous PR only addressed ${oos} for Dakota formation when user was logged in. Fixes state issue for users forming through marketing link containing industry query string.

### Ticket

[185266819](https://www.pivotaltracker.com/story/show/185266819)

### Steps to Test

1. Open incognito window
1. Go to https://navigator.business.nj.gov/onboarding?industry=cannabis
1. See ${oos} in the industry question (screenshot below)

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
