### PR TITLE
[184306224] Dakota Auto-Name Check During Formation

### DIFF
--- a/api/src/api/userRouter.ts
+++ b/api/src/api/userRouter.ts
@@ -1,3 +1,4 @@
+import { NameAvailability } from "@shared/businessNameSearch";
 import { decideABExperience } from "@shared/businessUser";
 import { getCurrentDate, getCurrentDateISOString, parseDate } from "@shared/dateHelpers";
 import { createEmptyFormationFormData } from "@shared/formationData";
@@ -60,15 +61,27 @@ const shouldCheckLicense = (userData: UserData): boolean => {
 };
 
 const shouldUpdateBusinessNameSearch = (userData: UserData): boolean => {
-  if (!userData.formationData.businessNameAvailability?.lastUpdatedTimeStamp) {
+  if (
+    !userData.formationData.businessNameAvailability?.lastUpdatedTimeStamp &&
+    !userData.formationData.dbaBusinessNameAvailability?.lastUpdatedTimeStamp
+  ) {
     return false;
   }
-  return (
+
+  const dbaNameIsOlderThanAnHour =
+    userData.profileData.nexusDbaName !== undefined &&
+    userData.formationData.dbaBusinessNameAvailability !== undefined &&
+    hasBeenMoreThanOneHour(userData.formationData.dbaBusinessNameAvailability.lastUpdatedTimeStamp);
+
+  const businessNameIsOlderThanAnHour =
     userData.profileData.businessName !== undefined &&
     userData.formationData.businessNameAvailability !== undefined &&
-    hasBeenMoreThanOneHour(userData.formationData.businessNameAvailability.lastUpdatedTimeStamp) &&
-    userData.formationData.completedFilingPayment !== true
-  );
+    hasBeenMoreThanOneHour(userData.formationData.businessNameAvailability.lastUpdatedTimeStamp);
+
+  const isDba = userData.profileData.needsNexusDbaName;
+  const shouldUpdateNameAvailability = isDba ? dbaNameIsOlderThanAnHour : businessNameIsOlderThanAnHour;
+
+  return shouldUpdateNameAvailability && userData.formationData.completedFilingPayment !== true;
 };
 
 export const getSignedInUser = (req: Request): CognitoJWTPayload => {
@@ -236,17 +249,35 @@ export const userRouterFactory = (
       return userData;
     }
     try {
-      const response = await timeStampBusinessSearch.search(userData.profileData.businessName);
+      const isForeign = userData.profileData.businessPersona === "FOREIGN";
+      const needsDba = userData.profileData.needsNexusDbaName;
+      const nameToSearch = needsDba ? userData.profileData.nexusDbaName : userData.profileData.businessName;
+      const response = await timeStampBusinessSearch.search(nameToSearch);
+
+      const nameAvailability: NameAvailability = {
+        status: response.status,
+        similarNames: response.similarNames ?? [],
+        lastUpdatedTimeStamp: response.lastUpdatedTimeStamp,
+        invalidWord: response.invalidWord,
+      };
+
+      const nameIsAvailable = response.status === "AVAILABLE";
+      const needsNexusDbaName = isForeign && !needsDba ? !nameIsAvailable : needsDba;
+
       return {
         ...userData,
+        profileData: {
+          ...userData.profileData,
+          needsNexusDbaName,
+        },
         formationData: {
           ...userData.formationData,
-          businessNameAvailability: {
-            status: response.status,
-            similarNames: response.similarNames ?? [],
-            lastUpdatedTimeStamp: response.lastUpdatedTimeStamp,
-            invalidWord: response.invalidWord,
-          },
+          businessNameAvailability: needsDba
+            ? userData.formationData.businessNameAvailability
+            : nameAvailability,
+          dbaBusinessNameAvailability: needsDba
+            ? nameAvailability
+            : userData.formationData.dbaBusinessNameAvailability,
         },
       };
     } catch {

--- a/api/src/api/userRouter.ts
+++ b/api/src/api/userRouter.ts
@@ -198,6 +198,7 @@ export const userRouterFactory = (
               completedFilingPayment: false,
               formationFormData: createEmptyFormationFormData(),
               businessNameAvailability: undefined,
+              dbaBusinessNameAvailability: undefined,
               lastVisitedPageIndex: 0,
             },
           };

--- a/api/src/db/migrations/migrations.ts
+++ b/api/src/db/migrations/migrations.ts
@@ -17,6 +17,7 @@ import { migrate_v111_to_v112 } from "./v112_add_last_visited_formation_page_to_
 import { migrate_v112_to_v113 } from "./v113_add_business_structure_task_completion";
 import { migrate_v113_to_v114 } from "./v114_add_expired_iso_field_to_license";
 import { migrate_v114_to_v115 } from "./v115_rename_tax_filings";
+import { migrate_v115_to_v116 } from "./v116_add_dba_business_name_availability";
 import { migrate_v10_to_v11 } from "./v11_change_license_statuses";
 import { migrate_v11_to_v12 } from "./v12_remove_scorp";
 import { migrate_v12_to_v13 } from "./v13_add_construction_renovation_plan";
@@ -234,4 +235,5 @@ export const Migrations: MigrationFunction[] = [
   migrate_v112_to_v113,
   migrate_v113_to_v114,
   migrate_v114_to_v115,
+  migrate_v115_to_v116,
 ];

--- a/api/src/db/migrations/v116_add_dba_business_name_availability.ts
+++ b/api/src/db/migrations/v116_add_dba_business_name_availability.ts
@@ -1,0 +1,404 @@
+import { v115UserData } from "./v115_rename_tax_filings";
+
+export interface v116UserData {
+  user: v116BusinessUser;
+  profileData: v116ProfileData;
+  onboardingFormProgress: v116OnboardingFormProgress;
+  taskProgress: Record<string, v116TaskProgress>;
+  taskItemChecklist: Record<string, boolean>;
+  licenseData: v116LicenseData | undefined;
+  preferences: v116Preferences;
+  taxFilingData: v116TaxFilingData;
+  formationData: v116FormationData;
+  lastUpdatedISO: string | undefined;
+  version: number;
+  dateCreatedISO: string | undefined;
+  versionWhenCreated: number;
+}
+
+export const migrate_v115_to_v116 = (v115Data: v115UserData): v116UserData => {
+  return {
+    ...v115Data,
+    formationData: {
+      ...v115Data.formationData,
+      dbaBusinessNameAvailability: undefined,
+    },
+    version: 116,
+  };
+};
+
+// ---------------- v116 types ----------------
+type v116TaskProgress = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+type v116OnboardingFormProgress = "UNSTARTED" | "COMPLETED";
+type v116ABExperience = "ExperienceA" | "ExperienceB";
+
+type v116BusinessUser = {
+  name?: string;
+  email: string;
+  id: string;
+  receiveNewsletter: boolean;
+  userTesting: boolean;
+  externalStatus: v116ExternalStatus;
+  myNJUserKey?: string;
+  intercomHash?: string;
+  abExperience: v116ABExperience;
+};
+
+interface v116ProfileDocuments {
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+}
+
+type v116BusinessPersona = "STARTING" | "OWNING" | "FOREIGN" | undefined;
+type v116ForeignBusinessType = "REMOTE_WORKER" | "REMOTE_SELLER" | "NEXUS" | "NONE" | undefined;
+type v116OperatingPhase =
+  | "GUEST_MODE"
+  | "NEEDS_TO_FORM"
+  | "NEEDS_TO_REGISTER_FOR_TAXES"
+  | "FORMED_AND_REGISTERED"
+  | "UP_AND_RUNNING"
+  | "UP_AND_RUNNING_OWNING"
+  | undefined;
+
+type v116CarServiceType = "STANDARD" | "HIGH_CAPACITY" | "BOTH" | undefined;
+
+interface v116IndustrySpecificData {
+  liquorLicense: boolean;
+  requiresCpa: boolean;
+  homeBasedBusiness: boolean | undefined;
+  cannabisLicenseType: "CONDITIONAL" | "ANNUAL" | undefined;
+  cannabisMicrobusiness: boolean | undefined;
+  constructionRenovationPlan: boolean | undefined;
+  providesStaffingService: boolean;
+  certifiedInteriorDesigner: boolean;
+  realEstateAppraisalManagement: boolean;
+  carService: v116CarServiceType | undefined;
+  interstateTransport: boolean;
+  isInterstateLogisticsApplicable: boolean | undefined;
+  isInterstateMovingApplicable: boolean | undefined;
+  isChildcareForSixOrMore: boolean | undefined;
+  willSellPetCareItems: boolean | undefined;
+  petCareHousing: boolean | undefined;
+}
+
+interface v116ProfileData extends v116IndustrySpecificData {
+  businessPersona: v116BusinessPersona;
+  businessName: string;
+  industryId: string | undefined;
+  legalStructureId: string | undefined;
+  municipality: v116Municipality | undefined;
+  dateOfFormation: string | undefined;
+  entityId: string | undefined;
+  employerId: string | undefined;
+  taxId: string | undefined;
+  encryptedTaxId: string | undefined;
+  notes: string;
+  documents: v116ProfileDocuments;
+  ownershipTypeIds: string[];
+  existingEmployees: string | undefined;
+  taxPin: string | undefined;
+  sectorId: string | undefined;
+  naicsCode: string;
+  foreignBusinessType: v116ForeignBusinessType;
+  foreignBusinessTypeIds: string[];
+  nexusLocationInNewJersey: boolean | undefined;
+  nexusDbaName: string;
+  needsNexusDbaName: boolean;
+  operatingPhase: v116OperatingPhase;
+}
+
+type v116Municipality = {
+  name: string;
+  displayName: string;
+  county: string;
+  id: string;
+};
+
+type v116TaxFilingState = "SUCCESS" | "FAILED" | "UNREGISTERED" | "PENDING" | "API_ERROR";
+type v116TaxFilingErrorFields = "businessName" | "formFailure";
+
+type v116TaxFilingData = {
+  state?: v116TaxFilingState;
+  lastUpdatedISO?: string;
+  registeredISO?: string;
+  errorField?: v116TaxFilingErrorFields;
+  businessName?: string;
+  filings: v116TaxFiling[];
+};
+
+type v116TaxFiling = {
+  identifier: string;
+  dueDate: string;
+};
+
+type v116NameAndAddress = {
+  name: string;
+  addressLine1: string;
+  addressLine2: string;
+  zipCode: string;
+};
+
+type v116LicenseData = {
+  nameAndAddress: v116NameAndAddress;
+  completedSearch: boolean;
+  lastUpdatedISO: string;
+  status: v116LicenseStatus;
+  items: v116LicenseStatusItem[];
+};
+
+type v116Preferences = {
+  roadmapOpenSections: v116SectionType[];
+  roadmapOpenSteps: number[];
+  hiddenFundingIds: string[];
+  hiddenCertificationIds: string[];
+  visibleSidebarCards: string[];
+  isCalendarFullView: boolean;
+  returnToLink: string;
+  isHideableRoadmapOpen: boolean;
+};
+
+type v116LicenseStatusItem = {
+  title: string;
+  status: v116CheckoffStatus;
+};
+
+type v116CheckoffStatus = "ACTIVE" | "PENDING" | "UNKNOWN";
+
+type v116LicenseStatus =
+  | "ACTIVE"
+  | "PENDING"
+  | "UNKNOWN"
+  | "EXPIRED"
+  | "BARRED"
+  | "OUT_OF_BUSINESS"
+  | "REINSTATEMENT_PENDING"
+  | "CLOSED"
+  | "DELETED"
+  | "DENIED"
+  | "VOLUNTARY_SURRENDER"
+  | "WITHDRAWN";
+
+const v116SectionNames = ["PLAN", "START"] as const;
+type v116SectionType = (typeof v116SectionNames)[number];
+
+type v116ExternalStatus = {
+  newsletter?: v116NewsletterResponse;
+  userTesting?: v116UserTestingResponse;
+};
+
+interface v116NewsletterResponse {
+  success?: boolean;
+  status: v116NewsletterStatus;
+}
+
+interface v116UserTestingResponse {
+  success?: boolean;
+  status: v116UserTestingStatus;
+}
+
+type v116NewsletterStatus = (typeof newsletterStatusList)[number];
+
+const externalStatusList = ["SUCCESS", "IN_PROGRESS", "CONNECTION_ERROR"] as const;
+
+const userTestingStatusList = [...externalStatusList] as const;
+
+type v116UserTestingStatus = (typeof userTestingStatusList)[number];
+
+const newsletterStatusList = [
+  ...externalStatusList,
+  "EMAIL_ERROR",
+  "TOPIC_ERROR",
+  "RESPONSE_WARNING",
+  "RESPONSE_ERROR",
+  "RESPONSE_FAIL",
+  "QUESTION_WARNING",
+] as const;
+
+type v116NameAvailabilityStatus =
+  | "AVAILABLE"
+  | "DESIGNATOR_ERROR"
+  | "SPECIAL_CHARACTER_ERROR"
+  | "UNAVAILABLE"
+  | "RESTRICTED_ERROR"
+  | undefined;
+
+interface v116NameAvailabilityResponse {
+  status: v116NameAvailabilityStatus;
+  similarNames: string[];
+  invalidWord?: string;
+}
+
+interface v116NameAvailability extends v116NameAvailabilityResponse {
+  lastUpdatedTimeStamp: string;
+}
+
+interface v116FormationData {
+  formationFormData: v116FormationFormData;
+  businessNameAvailability: v116NameAvailability | undefined;
+  dbaBusinessNameAvailability: v116NameAvailability | undefined;
+  formationResponse: v116FormationSubmitResponse | undefined;
+  getFilingResponse: v116GetFilingResponse | undefined;
+  completedFilingPayment: boolean;
+  lastVisitedPageIndex: number;
+}
+
+interface v116FormationFormData extends v116FormationAddress {
+  readonly businessName: string;
+  readonly businessSuffix: v116BusinessSuffix | undefined;
+  readonly businessTotalStock: string;
+  readonly businessStartDate: string; // YYYY-MM-DD
+  readonly businessPurpose: string;
+  readonly withdrawals: string;
+  readonly combinedInvestment: string;
+  readonly dissolution: string;
+  readonly canCreateLimitedPartner: boolean | undefined;
+  readonly createLimitedPartnerTerms: string;
+  readonly canGetDistribution: boolean | undefined;
+  readonly getDistributionTerms: string;
+  readonly canMakeDistribution: boolean | undefined;
+  readonly makeDistributionTerms: string;
+  readonly provisions: string[] | undefined;
+  readonly agentNumberOrManual: "NUMBER" | "MANUAL_ENTRY";
+  readonly agentNumber: string;
+  readonly agentName: string;
+  readonly agentEmail: string;
+  readonly agentOfficeAddressLine1: string;
+  readonly agentOfficeAddressLine2: string;
+  readonly agentOfficeAddressMunicipality: v116Municipality | undefined;
+  readonly agentOfficeAddressCity: string | undefined;
+  readonly agentOfficeAddressZipCode: string;
+  readonly agentUseAccountInfo: boolean;
+  readonly agentUseBusinessAddress: boolean;
+  readonly members: v116FormationMember[] | undefined;
+  readonly incorporators: v116FormationIncorporator[] | undefined;
+  readonly signers: v116FormationSigner[] | undefined;
+  readonly paymentType: v116PaymentType;
+  readonly annualReportNotification: boolean;
+  readonly corpWatchNotification: boolean;
+  readonly officialFormationDocument: boolean;
+  readonly certificateOfStanding: boolean;
+  readonly certifiedCopyOfFormationDocument: boolean;
+  readonly contactFirstName: string;
+  readonly contactLastName: string;
+  readonly contactPhoneNumber: string;
+  readonly foreignStateOfFormation: v116StateObject | undefined;
+  readonly foreignDateOfFormation: string | undefined; // YYYY-MM-DD
+  readonly foreignGoodStandingFile: v116ForeignGoodStandingFileObject | undefined;
+}
+
+type v116ForeignGoodStandingFileObject = {
+  Extension: "PDF" | "PNG";
+  Content: string;
+};
+
+type v116StateObject = {
+  shortCode: string;
+  name: string;
+};
+
+interface v116FormationAddress {
+  readonly addressLine1: string;
+  readonly addressLine2: string;
+  readonly addressCity?: string;
+  readonly addressState?: v116StateObject;
+  readonly addressMunicipality?: v116Municipality;
+  readonly addressProvince?: string;
+  readonly addressZipCode: string;
+  readonly addressCountry: string;
+}
+
+type v116SignerTitle =
+  | "Authorized Representative"
+  | "Authorized Partner"
+  | "Incorporator"
+  | "General Partner"
+  | "President"
+  | "Vice-President"
+  | "Chairman of the Board"
+  | "CEO";
+
+interface v116FormationSigner {
+  readonly name: string;
+  readonly signature: boolean;
+  readonly title: v116SignerTitle;
+}
+
+interface v116FormationIncorporator extends v116FormationSigner, v116FormationAddress {}
+
+interface v116FormationMember extends v116FormationAddress {
+  readonly name: string;
+}
+
+type v116PaymentType = "CC" | "ACH" | undefined;
+
+const llcBusinessSuffix = [
+  "LLC",
+  "L.L.C.",
+  "LTD LIABILITY CO",
+  "LTD LIABILITY CO.",
+  "LTD LIABILITY COMPANY",
+  "LIMITED LIABILITY CO",
+  "LIMITED LIABILITY CO.",
+  "LIMITED LIABILITY COMPANY",
+] as const;
+
+const llpBusinessSuffix = [
+  "Limited Liability Partnership",
+  "LLP",
+  "L.L.P.",
+  "Registered Limited Liability Partnership",
+  "RLLP",
+  "R.L.L.P.",
+] as const;
+
+export const lpBusinessSuffix = ["LIMITED PARTNERSHIP", "LP", "L.P."] as const;
+
+const corpBusinessSuffix = [
+  "Corporation",
+  "Incorporated",
+  "Company",
+  "LTD",
+  "CO",
+  "CO.",
+  "CORP",
+  "CORP.",
+  "INC",
+  "INC.",
+] as const;
+
+const foreignCorpBusinessSuffix = [...corpBusinessSuffix, "P.C.", "P.A."] as const;
+
+const AllBusinessSuffixes = [
+  ...llcBusinessSuffix,
+  ...llpBusinessSuffix,
+  ...lpBusinessSuffix,
+  ...foreignCorpBusinessSuffix,
+] as const;
+
+type v116BusinessSuffix = (typeof AllBusinessSuffixes)[number];
+
+type v116FormationSubmitResponse = {
+  success: boolean;
+  token: string | undefined;
+  formationId: string | undefined;
+  redirect: string | undefined;
+  errors: v116FormationSubmitError[];
+  lastUpdatedISO: string | undefined;
+};
+
+type v116FormationSubmitError = {
+  field: string;
+  type: "FIELD" | "UNKNOWN" | "RESPONSE";
+  message: string;
+};
+
+type v116GetFilingResponse = {
+  success: boolean;
+  entityId: string;
+  transactionDate: string;
+  confirmationNumber: string;
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+};

--- a/shared/src/formationData.ts
+++ b/shared/src/formationData.ts
@@ -71,6 +71,7 @@ export interface FormationData {
   readonly getFilingResponse: GetFilingResponse | undefined;
   readonly completedFilingPayment: boolean;
   readonly businessNameAvailability: NameAvailability | undefined;
+  readonly dbaBusinessNameAvailability: NameAvailability | undefined;
   readonly lastVisitedPageIndex: number;
 }
 

--- a/shared/src/test/factories.ts
+++ b/shared/src/test/factories.ts
@@ -55,6 +55,7 @@ export const generateFormationData = (
   return {
     formationFormData: generateFormationFormData({}, { legalStructureId }),
     businessNameAvailability: undefined,
+    dbaBusinessNameAvailability: undefined,
     formationResponse: undefined,
     getFilingResponse: undefined,
     completedFilingPayment: false,
@@ -279,6 +280,7 @@ export const generateUserData = (overrides: Partial<UserData>): UserData => {
     : {
         formationFormData: createEmptyFormationFormData(),
         businessNameAvailability: undefined,
+        dbaBusinessNameAvailability: undefined,
         formationResponse: undefined,
         getFilingResponse: undefined,
         completedFilingPayment: false,

--- a/shared/src/userData.ts
+++ b/shared/src/userData.ts
@@ -20,7 +20,7 @@ export interface UserData {
   versionWhenCreated: number;
 }
 
-export const CURRENT_VERSION = 115;
+export const CURRENT_VERSION = 116;
 
 export const createEmptyUserData = (user: BusinessUser): UserData => {
   return {
@@ -60,6 +60,7 @@ export const createEmptyUserData = (user: BusinessUser): UserData => {
       getFilingResponse: undefined,
       completedFilingPayment: false,
       businessNameAvailability: undefined,
+      dbaBusinessNameAvailability: undefined,
       lastVisitedPageIndex: 0,
     },
   };

--- a/web/src/components/filings-calendar/FilingsCalendarTaxAccess.test.tsx
+++ b/web/src/components/filings-calendar/FilingsCalendarTaxAccess.test.tsx
@@ -90,6 +90,7 @@ describe("<FilingsCalendarTaxAccess />", () => {
       getFilingResponse: undefined,
       completedFilingPayment: false,
       businessNameAvailability: undefined,
+      dbaBusinessNameAvailability: undefined,
       lastVisitedPageIndex: 0,
     };
 

--- a/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepTwo.test.tsx
+++ b/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepTwo.test.tsx
@@ -72,6 +72,7 @@ describe("<TaxAccessStepTwo />", () => {
       getFilingResponse: undefined,
       completedFilingPayment: false,
       businessNameAvailability: undefined,
+      dbaBusinessNameAvailability: undefined,
       lastVisitedPageIndex: 0,
     };
 

--- a/web/src/components/tasks/business-formation/BusinessFormation.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormation.tsx
@@ -62,6 +62,9 @@ export const BusinessFormation = (props: Props): ReactElement => {
   const [businessNameAvailability, setBusinessNameAvailability] = useState<NameAvailability | undefined>(
     undefined
   );
+  const [dbaBusinessNameAvailability, setDbaBusinessNameAvailability] = useState<
+    NameAvailability | undefined
+  >(undefined);
   const [foreignGoodStandingFile, setForeignGoodStandingFile] = useState<InputFile | undefined>(undefined);
 
   const legalStructureId: FormationLegalType = useMemo(() => {
@@ -109,6 +112,11 @@ export const BusinessFormation = (props: Props): ReactElement => {
     if (userData.formationData.businessNameAvailability) {
       setBusinessNameAvailability({
         ...userData.formationData.businessNameAvailability,
+      });
+    }
+    if (userData.formationData.dbaBusinessNameAvailability) {
+      setDbaBusinessNameAvailability({
+        ...userData.formationData.dbaBusinessNameAvailability,
       });
     }
 
@@ -233,11 +241,12 @@ export const BusinessFormation = (props: Props): ReactElement => {
     <BusinessFormationContext.Provider
       value={{
         state: {
-          stepIndex: stepIndex,
-          formationFormData: formationFormData,
-          businessNameAvailability: businessNameAvailability,
+          stepIndex,
+          formationFormData,
+          businessNameAvailability,
+          dbaBusinessNameAvailability,
           dbaContent: props.displayContent.formationDbaContent,
-          showResponseAlert: showResponseAlert,
+          showResponseAlert,
           interactedFields,
           hasBeenSubmitted,
           hasSetStateFirstTime,
@@ -245,6 +254,7 @@ export const BusinessFormation = (props: Props): ReactElement => {
         },
         setFormationFormData,
         setBusinessNameAvailability,
+        setDbaBusinessNameAvailability,
         setStepIndex,
         setShowResponseAlert,
         setFieldsInteracted,

--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
@@ -2075,6 +2075,7 @@ describe("<BusinessFormationPaginator />", () => {
         formationData: {
           ...initialUserData.formationData,
           businessNameAvailability: undefined,
+          dbaBusinessNameAvailability: undefined,
         },
       };
       const page = preparePage(userDataWithName, displayContent);

--- a/web/src/components/tasks/business-formation/DbaFormationPaginator.tsx
+++ b/web/src/components/tasks/business-formation/DbaFormationPaginator.tsx
@@ -161,7 +161,11 @@ export const DbaFormationPaginator = (): ReactElement => {
   };
 
   const displayButtons = (): ReactNode => {
-    if (state.stepIndex === 0 && state.businessNameAvailability?.status === "AVAILABLE") {
+    if (
+      state.stepIndex === 0 &&
+      ((isNotDba && state.businessNameAvailability?.status === "AVAILABLE") ||
+        (!isNotDba && state.dbaBusinessNameAvailability?.status === "AVAILABLE"))
+    ) {
       return (
         <ButtonWrapper>
           <HelpButton />

--- a/web/src/components/tasks/business-formation/DbaFormationPaginator.tsx
+++ b/web/src/components/tasks/business-formation/DbaFormationPaginator.tsx
@@ -63,7 +63,7 @@ export const DbaFormationPaginator = (): ReactElement => {
     moveToStep(state.stepIndex - 1);
   };
 
-  const isNotDba = userData?.profileData.businessName && !userData.profileData.needsNexusDbaName;
+  const isDba = userData?.profileData.businessName && userData.profileData.needsNexusDbaName;
 
   const onMoveToStep = async (
     stepIndex: number,
@@ -74,7 +74,7 @@ export const DbaFormationPaginator = (): ReactElement => {
     if (
       config.moveType === "NEXT_BUTTON" &&
       stepIndex === 1 &&
-      isNotDba &&
+      !isDba &&
       isAuthenticated === IsAuthenticated.FALSE
     ) {
       setRegistrationModalIsVisible(true);
@@ -115,7 +115,7 @@ export const DbaFormationPaginator = (): ReactElement => {
   };
   const ForwardButton = (): ReactElement => {
     const getForwardButtonText = (): string => {
-      if (isAuthenticated === IsAuthenticated.FALSE && isNotDba) {
+      if (isAuthenticated === IsAuthenticated.FALSE && !isDba) {
         return `Register & ${Config.formation.general.initialNextButtonText}`;
       } else {
         return Config.formation.general.initialNextNexusButtonText;
@@ -161,11 +161,11 @@ export const DbaFormationPaginator = (): ReactElement => {
   };
 
   const displayButtons = (): ReactNode => {
-    if (
-      state.stepIndex === 0 &&
-      ((isNotDba && state.businessNameAvailability?.status === "AVAILABLE") ||
-        (!isNotDba && state.dbaBusinessNameAvailability?.status === "AVAILABLE"))
-    ) {
+    const nameIsAvailable = isDba
+      ? state.dbaBusinessNameAvailability?.status === "AVAILABLE"
+      : state.businessNameAvailability?.status === "AVAILABLE";
+
+    if (state.stepIndex === 0 && nameIsAvailable) {
       return (
         <ButtonWrapper>
           <HelpButton />

--- a/web/src/components/tasks/business-formation/NexusFormation.test.tsx
+++ b/web/src/components/tasks/business-formation/NexusFormation.test.tsx
@@ -320,13 +320,15 @@ describe("<NexusFormationFlow />", () => {
           );
         });
 
-        it("does not save availablity state when switching back to step", async () => {
+        it("saves availablity state when switching back to step", async () => {
           fillText("Pizza Joint");
           await page.searchBusinessName({ status: "AVAILABLE" });
           await screen.findByTestId("available-text");
+          expect(screen.getByTestId("available-text").innerHTML.includes("Pizza Joint")).toBeTruthy();
           clickNext();
           await page.stepperClickToNexusBusinessNameStep();
-          expect(screen.queryByTestId("available-text")).not.toBeInTheDocument();
+          expect(screen.getByTestId("available-text")).toBeInTheDocument();
+          expect(screen.getByTestId("available-text").innerHTML.includes("Pizza Joint")).toBeTruthy();
         });
 
         it("goes back to nexus name step on back button", async () => {

--- a/web/src/components/tasks/business-formation/billing/BillingStep.test.tsx
+++ b/web/src/components/tasks/business-formation/billing/BillingStep.test.tsx
@@ -68,6 +68,7 @@ describe("Formation - BillingStep", () => {
       getFilingResponse: undefined,
       completedFilingPayment: false,
       businessNameAvailability: undefined,
+      dbaBusinessNameAvailability: undefined,
       lastVisitedPageIndex: 0,
     };
     const user = initialUser ? generateUser(initialUser) : generateUser({});

--- a/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
@@ -76,6 +76,7 @@ describe("Formation - BusinessStep", () => {
       getFilingResponse: undefined,
       completedFilingPayment: false,
       businessNameAvailability: undefined,
+      dbaBusinessNameAvailability: undefined,
       lastVisitedPageIndex: 0,
     };
     const page = preparePage(

--- a/web/src/components/tasks/business-formation/business/MainBusinessAddressNj.test.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusinessAddressNj.test.tsx
@@ -50,6 +50,7 @@ const getPageHelper = async (
     completedFilingPayment: false,
     businessNameSearch: undefined,
     businessNameAvailability: undefined,
+    dbaBusinessNameAvailability: undefined,
     lastVisitedPageIndex: 0,
   };
 

--- a/web/src/components/tasks/business-formation/contacts/testHelpers.tsx
+++ b/web/src/components/tasks/business-formation/contacts/testHelpers.tsx
@@ -33,6 +33,7 @@ export const getPageHelper = async (
       ),
     }),
     businessNameAvailability: undefined,
+    dbaBusinessNameAvailability: undefined,
     formationResponse: undefined,
     getFilingResponse: undefined,
     completedFilingPayment: false,

--- a/web/src/components/tasks/business-formation/name/BusinessNameStep.test.tsx
+++ b/web/src/components/tasks/business-formation/name/BusinessNameStep.test.tsx
@@ -57,6 +57,7 @@ describe("Formation - BusinessNameStep", () => {
       getFilingResponse: undefined,
       completedFilingPayment: false,
       businessNameAvailability: businessNameAvailability ?? undefined,
+      dbaBusinessNameAvailability: undefined,
       lastVisitedPageIndex: 0,
     };
     return preparePage(generateUserData({ profileData, formationData }), {
@@ -224,6 +225,7 @@ describe("Formation - BusinessNameStep", () => {
           getFilingResponse: undefined,
           completedFilingPayment: false,
           businessNameAvailability: undefined,
+          dbaBusinessNameAvailability: undefined,
           lastVisitedPageIndex: 0,
         };
 

--- a/web/src/components/tasks/business-formation/name/DbaNameSearch.tsx
+++ b/web/src/components/tasks/business-formation/name/DbaNameSearch.tsx
@@ -7,35 +7,16 @@ import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import analytics from "@/lib/utils/analytics";
 import { useMountEffect } from "@/lib/utils/helpers";
-import { NameAvailability } from "@businessnjgovnavigator/shared/";
 import { ReactElement, useContext } from "react";
 
 export const DbaNameSearch = (): ReactElement => {
   const { Config } = useConfig();
-  const { updateQueue } = useUserData();
-  const { setBusinessNameAvailability } = useContext(BusinessFormationContext);
+  const { state } = useContext(BusinessFormationContext);
+  const { updateQueue: userData } = useUserData();
 
   useMountEffect(() => {
     analytics.event.business_formation_dba_name_search_field.appears.dba_name_search_field_appears();
   });
-
-  const _setBusinessNameAvailability = (nameAvailability: NameAvailability | undefined): void => {
-    setBusinessNameAvailability(nameAvailability);
-  };
-
-  const onSubmit = async (submittedName: string, nameAvailability: NameAvailability): Promise<void> => {
-    if (!nameAvailability || !updateQueue) {
-      return;
-    }
-    setBusinessNameAvailability(nameAvailability);
-    if (nameAvailability.status === "AVAILABLE") {
-      await updateQueue
-        .queueProfileData({
-          nexusDbaName: submittedName,
-        })
-        .update();
-    }
-  };
 
   return (
     <>
@@ -43,15 +24,15 @@ export const DbaNameSearch = (): ReactElement => {
       <SearchBusinessNameForm
         unavailable={DbaUnavailable}
         available={DbaAvailable}
-        onChange={_setBusinessNameAvailability}
         isBusinessFormation
         isDba
+        businessName={userData?.current().profileData.nexusDbaName ?? ""}
+        nameAvailability={state.dbaBusinessNameAvailability}
         config={{
           searchButtonText: Config.nexusNameSearch.dbaNameSearchSubmitButton,
           searchButtonTestId: "search-dba-availability",
           inputLabel: Config.nexusNameSearch.dbaNameSearchLabel,
         }}
-        onSubmit={onSubmit}
       />
     </>
   );

--- a/web/src/components/tasks/business-formation/name/DbaNameSearch.tsx
+++ b/web/src/components/tasks/business-formation/name/DbaNameSearch.tsx
@@ -12,7 +12,7 @@ import { ReactElement, useContext } from "react";
 export const DbaNameSearch = (): ReactElement => {
   const { Config } = useConfig();
   const { state } = useContext(BusinessFormationContext);
-  const { updateQueue: userData } = useUserData();
+  const { updateQueue } = useUserData();
 
   useMountEffect(() => {
     analytics.event.business_formation_dba_name_search_field.appears.dba_name_search_field_appears();
@@ -26,7 +26,7 @@ export const DbaNameSearch = (): ReactElement => {
         available={DbaAvailable}
         isBusinessFormation
         isDba
-        businessName={userData?.current().profileData.nexusDbaName ?? ""}
+        businessName={updateQueue?.current().profileData.nexusDbaName ?? ""}
         nameAvailability={state.dbaBusinessNameAvailability}
         config={{
           searchButtonText: Config.nexusNameSearch.dbaNameSearchSubmitButton,

--- a/web/src/components/tasks/business-formation/name/NexusSearchBusinessNameStep.test.tsx
+++ b/web/src/components/tasks/business-formation/name/NexusSearchBusinessNameStep.test.tsx
@@ -1,36 +1,45 @@
-import { NexusSearchBusinessNameStep } from "@/components/tasks/business-formation/name/NexusSearchBusinessNameStep";
 import { getMergedConfig } from "@/contexts/configContext";
 import analytics from "@/lib/utils/analytics";
+import { generateFormationDbaContent } from "@/test/factories";
+import {
+  FormationPageHelpers,
+  generateFormationProfileData,
+  preparePage,
+  useSetupInitialMocks,
+} from "@/test/helpers/helpers-formation";
 import { markdownToText } from "@/test/helpers/helpers-utilities";
+import { dbaInputField } from "@/test/helpers/helpersSearchBusinessName";
+import { currentUserData, userDataWasNotUpdated } from "@/test/mock/withStatefulUserData";
 import {
-  dbaInputField,
-  fillText,
-  mockSearchReturnValue,
-  searchAndGetValue,
-} from "@/test/helpers/helpersSearchBusinessName";
-import { useMockRoadmap } from "@/test/mock/mockUseRoadmap";
-import { useMockUserData } from "@/test/mock/mockUseUserData";
-import {
-  currentUserData,
-  setupStatefulUserDataContext,
-  userDataWasNotUpdated,
-  WithStatefulUserData,
-} from "@/test/mock/withStatefulUserData";
-import { createEmptyFormationFormData } from "@businessnjgovnavigator/shared/index";
-import {
-  generateFormationData,
-  generateProfileData,
+  castPublicFilingLegalTypeToFormationType,
+  generateFormationFormData,
   generateUserData,
-} from "@businessnjgovnavigator/shared/test";
-import { UserData } from "@businessnjgovnavigator/shared/userData";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+  ProfileData,
+  PublicFilingLegalType,
+} from "@businessnjgovnavigator/shared";
+import * as materialUi from "@mui/material";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 
-jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
-jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
-jest.mock("@/lib/api-client/apiClient", () => ({ searchBusinessName: jest.fn() }));
-jest.mock("@/lib/utils/analytics", () => setupMockAnalytics());
+function mockMaterialUI(): typeof materialUi {
+  return {
+    ...jest.requireActual("@mui/material"),
+    useMediaQuery: jest.fn(),
+  };
+}
 
 const Config = getMergedConfig();
+
+jest.mock("@mui/material", () => mockMaterialUI());
+jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
+jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
+jest.mock("@/lib/data-hooks/useDocuments");
+jest.mock("next/router", () => ({ useRouter: jest.fn() }));
+jest.mock("@/lib/api-client/apiClient", () => ({
+  postBusinessFormation: jest.fn(),
+  getCompletedFiling: jest.fn(),
+  searchBusinessName: jest.fn(),
+}));
+jest.mock("@/lib/utils/analytics", () => setupMockAnalytics());
 
 function setupMockAnalytics(): typeof analytics {
   return {
@@ -52,34 +61,55 @@ function setupMockAnalytics(): typeof analytics {
 }
 const mockAnalytics = analytics as jest.Mocked<typeof analytics>;
 
-describe("<NexusSearchBusinessNameStep />", () => {
-  const initialUserData = generateUserData({
-    formationData: generateFormationData({ formationFormData: createEmptyFormationFormData() }),
-    profileData: generateProfileData({
-      businessName: "",
-      nexusDbaName: "",
-      needsNexusDbaName: false,
-    }),
-  });
+describe("Formation - NexusSearchBusinessNameStep", () => {
+  const displayContent = {
+    formationDbaContent: generateFormationDbaContent({}),
+  };
 
   beforeEach(() => {
     jest.resetAllMocks();
-    setupStatefulUserDataContext();
-    useMockRoadmap({});
+    useSetupInitialMocks();
   });
 
-  const renderTask = (userData?: UserData): void => {
-    render(
-      <WithStatefulUserData initialUserData={userData || initialUserData}>
-        <NexusSearchBusinessNameStep />
-      </WithStatefulUserData>
-    );
+  const getPageHelper = async (initialProfileData: Partial<ProfileData>): Promise<FormationPageHelpers> => {
+    const profileData = generateFormationProfileData(initialProfileData);
+    const formationData = {
+      formationFormData: generateFormationFormData(
+        {},
+        {
+          legalStructureId: castPublicFilingLegalTypeToFormationType(
+            profileData.legalStructureId as PublicFilingLegalType,
+            initialProfileData.businessPersona
+          ),
+        }
+      ),
+      formationResponse: undefined,
+      getFilingResponse: undefined,
+      completedFilingPayment: false,
+      businessNameAvailability: undefined,
+      dbaBusinessNameAvailability: undefined,
+      lastVisitedPageIndex: 0,
+    };
+    const page = preparePage(generateUserData({ profileData, formationData }), displayContent);
+    return page;
   };
 
+  it("displays modal when legal structure Edit button clicked", async () => {
+    const page = await getPageHelper({
+      legalStructureId: "limited-liability-company",
+      businessPersona: "FOREIGN",
+    });
+    await page.searchBusinessName({ status: "AVAILABLE" });
+
+    expect(true).toBe(true);
+  });
+
   it("lets you click to search again when unavailable", async () => {
-    renderTask();
-    fillText("My Cool Business");
-    await searchAndGetValue({ status: "UNAVAILABLE" });
+    const page = await getPageHelper({
+      legalStructureId: "limited-liability-company",
+      businessPersona: "FOREIGN",
+    });
+    await page.searchBusinessName({ status: "UNAVAILABLE" });
     expect(screen.queryByLabelText("Search business name")).not.toBeInTheDocument();
     fireEvent.click(screen.getByText(Config.nexusNameSearch.searchAgainButtonText));
     expect(
@@ -89,13 +119,16 @@ describe("<NexusSearchBusinessNameStep />", () => {
   });
 
   it("sets nexusDbaName as empty and needsDbaName as false in profile when search again comes back as available", async () => {
-    renderTask();
-    fillText("some unavailable name");
-    await searchAndGetValue({ status: "UNAVAILABLE" });
+    const page = await getPageHelper({
+      legalStructureId: "limited-liability-company",
+      businessPersona: "FOREIGN",
+    });
+    page.fillText("Search business name", "some unavailable name");
+    await page.searchBusinessName({ status: "UNAVAILABLE" });
 
     fireEvent.click(screen.getByText(Config.nexusNameSearch.searchAgainButtonText));
-    fillText("My Cool Business");
-    await searchAndGetValue({ status: "AVAILABLE" });
+    page.fillText("Search business name", "My Cool Business");
+    await page.searchBusinessName({ status: "AVAILABLE" });
 
     expect(currentUserData().profileData.nexusDbaName).toEqual("");
     expect(currentUserData().profileData.needsNexusDbaName).toEqual(false);
@@ -103,36 +136,48 @@ describe("<NexusSearchBusinessNameStep />", () => {
   });
 
   it("sets businessName in formationFormData on submit", async () => {
-    renderTask();
-    fillText("some unavailable name");
-    await searchAndGetValue({ status: "UNAVAILABLE" });
+    const page = await getPageHelper({
+      legalStructureId: "limited-liability-company",
+      businessPersona: "FOREIGN",
+    });
+    page.fillText("Search business name", "some unavailable name");
+    await page.searchBusinessName({ status: "UNAVAILABLE" });
 
     fireEvent.click(screen.getByText(Config.nexusNameSearch.searchAgainButtonText));
-    fillText("My Cool Business");
-    await searchAndGetValue({ status: "AVAILABLE" });
+    page.fillText("Search business name", "My Cool Business");
+    await page.searchBusinessName({ status: "AVAILABLE" });
     expect(currentUserData().formationData.formationFormData.businessName).toEqual("My Cool Business");
   });
 
   it("sets needsDbaName in profile to true when unavailable", async () => {
-    renderTask();
-    fillText("My Cool Business");
-    await searchAndGetValue({ status: "UNAVAILABLE" });
+    const page = await getPageHelper({
+      legalStructureId: "limited-liability-company",
+      businessPersona: "FOREIGN",
+    });
+    page.fillText("Search business name", "My Cool Business");
+    await page.searchBusinessName({ status: "UNAVAILABLE" });
     expect(currentUserData().profileData.nexusDbaName).toEqual("");
     expect(currentUserData().profileData.needsNexusDbaName).toEqual(true);
     expect(currentUserData().profileData.businessName).toEqual("My Cool Business");
   });
 
   it("does not save business name if designator error", async () => {
-    renderTask();
-    fillText("My Cool Business");
-    await searchAndGetValue({ status: "DESIGNATOR_ERROR" });
+    const page = await getPageHelper({
+      legalStructureId: "limited-liability-company",
+      businessPersona: "FOREIGN",
+    });
+    page.fillText("Search business name", "My Cool Business");
+    await page.searchBusinessName({ status: "DESIGNATOR_ERROR" });
     expect(userDataWasNotUpdated()).toEqual(true);
   });
 
   it("shows DBA name when unavailable", async () => {
-    renderTask();
-    fillText("My Cool Business");
-    await searchAndGetValue({ status: "UNAVAILABLE" });
+    const page = await getPageHelper({
+      legalStructureId: "limited-liability-company",
+      businessPersona: "FOREIGN",
+    });
+    page.fillText("Search business name", "My Cool Business");
+    await page.searchBusinessName({ status: "UNAVAILABLE" });
     expect(screen.getByText(markdownToText(Config.nexusNameSearch.dbaNameHeader))).toBeInTheDocument();
     expect(screen.getByText(Config.nexusNameSearch.dbaNameSearchSubmitButton)).toBeInTheDocument();
     expect(
@@ -140,64 +185,52 @@ describe("<NexusSearchBusinessNameStep />", () => {
     ).toHaveBeenCalled();
   });
 
-  it("shows DBA search immediately if needsDbaName is true", async () => {
-    useMockUserData({
-      profileData: generateProfileData({
-        businessName: "some cool name",
-        needsNexusDbaName: true,
-      }),
+  it("does not show DBA search immediately if it is needsNexusDbaName is false in profile", async () => {
+    await getPageHelper({
+      legalStructureId: "limited-liability-company",
+      businessPersona: "FOREIGN",
+      businessName: "some cool name",
+      needsNexusDbaName: false,
     });
-    mockSearchReturnValue({ status: "UNAVAILABLE" });
-    renderTask();
-    await waitFor(() => {
-      expect(screen.getByText(markdownToText(Config.nexusNameSearch.dbaNameHeader))).toBeInTheDocument();
-    });
-  });
 
-  it("does not show DBA search immediately if it is needsNexusDbaName is false in profile", () => {
-    useMockUserData({
-      profileData: generateProfileData({
-        businessName: "some cool name",
-        needsNexusDbaName: false,
-      }),
-    });
-    renderTask();
     expect(screen.queryByText(markdownToText(Config.nexusNameSearch.dbaNameHeader))).not.toBeInTheDocument();
   });
 
   it("does not overwrite existing DBA name when doing initial search", async () => {
-    useMockUserData({
-      profileData: generateProfileData({
-        businessName: "some cool name",
-        nexusDbaName: "existing dba name",
-        needsNexusDbaName: true,
-      }),
+    const page = await getPageHelper({
+      legalStructureId: "limited-liability-company",
+      businessPersona: "FOREIGN",
+      businessName: "some cool name",
+      nexusDbaName: "existing dba name",
     });
-    mockSearchReturnValue({ status: "UNAVAILABLE" });
-    renderTask();
+    await page.searchBusinessName({ status: "UNAVAILABLE" });
     await waitFor(() => {
       expect((dbaInputField() as HTMLInputElement).value).toEqual("existing dba name");
     });
   });
 
   describe("on DBA search", () => {
-    const setupForDBA = async (): Promise<void> => {
-      renderTask();
-      fillText("My Cool Business");
-      await searchAndGetValue({ status: "UNAVAILABLE" });
+    const setupForDBA = async (): Promise<FormationPageHelpers> => {
+      const page = await getPageHelper({
+        legalStructureId: "limited-liability-company",
+        businessPersona: "FOREIGN",
+      });
+      page.fillText("Search business name", "My Cool Business");
+      await page.searchBusinessName({ status: "UNAVAILABLE" });
+      return page;
     };
 
     it("saves DBA name to profile on successful search", async () => {
-      await setupForDBA();
-      fillText("My Cool DBA Name", { dba: true });
-      await searchAndGetValue({ status: "AVAILABLE" }, { dba: true });
+      const page = await setupForDBA();
+      page.fillText("DBA Name Search", "My Cool DBA Name");
+      await page.searchBusinessName({ status: "AVAILABLE" });
       expect(currentUserData().profileData.nexusDbaName).toEqual("My Cool DBA Name");
     });
 
     it("does not save DBA name to profile on unsuccessful search", async () => {
-      await setupForDBA();
-      fillText("My Cool DBA Name", { dba: true });
-      await searchAndGetValue({ status: "UNAVAILABLE" }, { dba: true });
+      const page = await setupForDBA();
+      page.fillText("DBA Name Search", "My Cool DBA Name");
+      await page.searchBusinessName({ status: "UNAVAILABLE" });
       expect(currentUserData().profileData.nexusDbaName).toEqual("");
     });
   });

--- a/web/src/components/tasks/business-formation/name/NexusSearchBusinessNameStep.tsx
+++ b/web/src/components/tasks/business-formation/name/NexusSearchBusinessNameStep.tsx
@@ -4,69 +4,11 @@ import { NexusUnavailable } from "@/components/tasks/business-formation/name/Nex
 import { SearchBusinessNameForm } from "@/components/tasks/search-business-name/SearchBusinessNameForm";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
-import { useUserData } from "@/lib/data-hooks/useUserData";
-import { NameAvailability } from "@businessnjgovnavigator/shared/";
-import { emptyProfileData } from "@businessnjgovnavigator/shared/profileData";
 import { ReactElement, useContext } from "react";
 
 export const NexusSearchBusinessNameStep = (): ReactElement => {
-  const { setFormationFormData, setFieldsInteracted, setBusinessNameAvailability } =
-    useContext(BusinessFormationContext);
-  const { updateQueue } = useUserData();
   const { Config } = useConfig();
-  const FIELD_NAME = "businessName";
-
-  const _setBusinessNameAvailability = (nameAvailability: NameAvailability | undefined): void => {
-    setBusinessNameAvailability(nameAvailability);
-  };
-
-  const onSubmit = async (
-    submittedName: string,
-    nameAvailability: NameAvailability,
-    isInitialSubmit: boolean
-  ): Promise<void> => {
-    if (!nameAvailability || !updateQueue || isInitialSubmit) {
-      return;
-    }
-    setFieldsInteracted([FIELD_NAME]);
-    if (nameAvailability.status === "AVAILABLE") {
-      await updateQueue
-        .queueFormationData({
-          formationFormData: {
-            ...updateQueue.current().formationData.formationFormData,
-            businessName: submittedName,
-          },
-          businessNameAvailability: nameAvailability,
-        })
-        .queueProfileData({
-          businessName: submittedName,
-          nexusDbaName: emptyProfileData.nexusDbaName,
-          needsNexusDbaName: emptyProfileData.needsNexusDbaName,
-        })
-        .update();
-    } else if (nameAvailability.status === "UNAVAILABLE") {
-      await updateQueue
-        .queueFormationData({
-          formationFormData: {
-            ...updateQueue.current().formationData.formationFormData,
-            businessName: submittedName,
-          },
-          businessNameAvailability: nameAvailability,
-        })
-        .queueProfileData({
-          businessName: submittedName,
-          needsNexusDbaName: true,
-        })
-        .update();
-    }
-
-    setFormationFormData((previousFormationData) => {
-      return {
-        ...previousFormationData,
-        businessName: submittedName,
-      };
-    });
-  };
+  const { state } = useContext(BusinessFormationContext);
 
   return (
     <div data-testid={"nexus-name-step"}>
@@ -76,9 +18,9 @@ export const NexusSearchBusinessNameStep = (): ReactElement => {
         unavailable={NexusUnavailable}
         available={NexusAvailable}
         hideTextFieldWhenUnavailable={true}
-        onSubmit={onSubmit}
         isBusinessFormation={true}
-        onChange={_setBusinessNameAvailability}
+        businessName={state.formationFormData.businessName}
+        nameAvailability={state.businessNameAvailability}
         className="grid-col-12"
         config={{
           searchButtonText: Config.searchBusinessNameTask.searchButtonText,

--- a/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
@@ -68,6 +68,7 @@ describe("Formation - ReviewStep", () => {
       getFilingResponse: undefined,
       completedFilingPayment: false,
       businessNameAvailability: undefined,
+      dbaBusinessNameAvailability: undefined,
       lastVisitedPageIndex: 0,
     };
     const page = preparePage(

--- a/web/src/components/tasks/search-business-name/SearchBusinessNameForm.test.tsx
+++ b/web/src/components/tasks/search-business-name/SearchBusinessNameForm.test.tsx
@@ -1,5 +1,4 @@
 import * as api from "@/lib/api-client/apiClient";
-import analytics from "@/lib/utils/analytics";
 import { generateFormationDbaContent } from "@/test/factories";
 import {
   FormationPageHelpers,
@@ -42,28 +41,8 @@ jest.mock("@/lib/api-client/apiClient", () => ({
   getCompletedFiling: jest.fn(),
   searchBusinessName: jest.fn(),
 }));
-jest.mock("@/lib/utils/analytics", () => setupMockAnalytics());
 
 const mockApi = api as jest.Mocked<typeof api>;
-
-function setupMockAnalytics(): typeof analytics {
-  return {
-    ...jest.requireActual("@/lib/utils/analytics").default,
-    event: {
-      ...jest.requireActual("@/lib/utils/analytics").default.event,
-      business_formation_search_existing_name_again: {
-        click: {
-          refresh_name_search_field: jest.fn(),
-        },
-      },
-      business_formation_dba_name_search_field: {
-        appears: {
-          dba_name_search_field_appears: jest.fn(),
-        },
-      },
-    },
-  };
-}
 
 describe("SearchBusinessNameForm", () => {
   const displayContent = {
@@ -109,7 +88,7 @@ describe("SearchBusinessNameForm", () => {
     expect(true).toBe(true);
   });
 
-  it("pre-fills the text field with the business name entered in onboarding", async () => {
+  it("pre-fills the text field with the business name entered in profile", async () => {
     await getPageHelper({
       businessName: "Best Pizza",
     });

--- a/web/src/components/tasks/search-business-name/SearchBusinessNameForm.test.tsx
+++ b/web/src/components/tasks/search-business-name/SearchBusinessNameForm.test.tsx
@@ -1,6 +1,12 @@
-import { SearchBusinessNameForm } from "@/components/tasks/search-business-name/SearchBusinessNameForm";
-import { getMergedConfig } from "@/contexts/configContext";
 import * as api from "@/lib/api-client/apiClient";
+import analytics from "@/lib/utils/analytics";
+import { generateFormationDbaContent } from "@/test/factories";
+import {
+  FormationPageHelpers,
+  generateFormationProfileData,
+  preparePage,
+  useSetupInitialMocks,
+} from "@/test/helpers/helpers-formation";
 import {
   fillText,
   getSearchValue,
@@ -9,73 +15,124 @@ import {
   searchAndReject,
   searchButton,
 } from "@/test/helpers/helpersSearchBusinessName";
-import { useMockRoadmap } from "@/test/mock/mockUseRoadmap";
-import { useMockProfileData, useMockUserData } from "@/test/mock/mockUseUserData";
-import { fireEvent, render, screen, within } from "@testing-library/react";
-import { ReactElement } from "react";
+import {
+  castPublicFilingLegalTypeToFormationType,
+  generateFormationFormData,
+  generateUserData,
+  ProfileData,
+  PublicFilingLegalType,
+} from "@businessnjgovnavigator/shared";
+import * as materialUi from "@mui/material";
+import { fireEvent, screen, within } from "@testing-library/react";
 
+function mockMaterialUI(): typeof materialUi {
+  return {
+    ...jest.requireActual("@mui/material"),
+    useMediaQuery: jest.fn(),
+  };
+}
+
+jest.mock("@mui/material", () => mockMaterialUI());
 jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
 jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
+jest.mock("@/lib/data-hooks/useDocuments");
+jest.mock("next/router", () => ({ useRouter: jest.fn() }));
 jest.mock("@/lib/api-client/apiClient", () => ({
+  postBusinessFormation: jest.fn(),
+  getCompletedFiling: jest.fn(),
   searchBusinessName: jest.fn(),
 }));
+jest.mock("@/lib/utils/analytics", () => setupMockAnalytics());
+
 const mockApi = api as jest.Mocked<typeof api>;
 
-const Config = getMergedConfig();
-const onChange = jest.fn();
+function setupMockAnalytics(): typeof analytics {
+  return {
+    ...jest.requireActual("@/lib/utils/analytics").default,
+    event: {
+      ...jest.requireActual("@/lib/utils/analytics").default.event,
+      business_formation_search_existing_name_again: {
+        click: {
+          refresh_name_search_field: jest.fn(),
+        },
+      },
+      business_formation_dba_name_search_field: {
+        appears: {
+          dba_name_search_field_appears: jest.fn(),
+        },
+      },
+    },
+  };
+}
 
-describe("<SearchBusinessNameForm />", () => {
+describe("SearchBusinessNameForm", () => {
+  const displayContent = {
+    formationDbaContent: generateFormationDbaContent({}),
+  };
+
   beforeEach(() => {
     jest.resetAllMocks();
-    useMockUserData({});
-    useMockRoadmap({});
+    useSetupInitialMocks();
   });
 
-  const availableText = "AVAILABLE!";
-  const unavailableText = "UNAVAILABLE!";
-  const FakeAvailable = (): ReactElement => {
-    return <div>{availableText}</div>;
-  };
-  const FakeUnavailable = (): ReactElement => {
-    return <div>{unavailableText}</div>;
+  const getPageHelper = async (initialProfileData?: Partial<ProfileData>): Promise<FormationPageHelpers> => {
+    const profileData = generateFormationProfileData({
+      ...initialProfileData,
+      legalStructureId: "limited-liability-company",
+      businessPersona: "FOREIGN",
+    });
+    const formationData = {
+      formationFormData: generateFormationFormData(
+        {},
+        {
+          legalStructureId: castPublicFilingLegalTypeToFormationType(
+            profileData.legalStructureId as PublicFilingLegalType,
+            profileData.businessPersona
+          ),
+        }
+      ),
+      formationResponse: undefined,
+      getFilingResponse: undefined,
+      completedFilingPayment: false,
+      businessNameAvailability: undefined,
+      dbaBusinessNameAvailability: undefined,
+      lastVisitedPageIndex: 0,
+    };
+    const page = preparePage(generateUserData({ profileData, formationData }), displayContent);
+    return page;
   };
 
-  const renderForm = (): void => {
-    render(
-      <SearchBusinessNameForm
-        available={FakeAvailable}
-        unavailable={FakeUnavailable}
-        onChange={onChange}
-        config={{
-          searchButtonText: Config.searchBusinessNameTask.searchButtonText,
-          searchButtonTestId: "search-availability",
-        }}
-      />
-    );
-  };
+  it("displays modal when legal structure Edit button clicked", async () => {
+    const page = await getPageHelper();
+    await page.searchBusinessName({ status: "AVAILABLE" });
 
-  it("pre-fills the text field with the business name entered in onboarding", () => {
-    useMockProfileData({ businessName: "Best Pizza" });
-    renderForm();
+    expect(true).toBe(true);
+  });
+
+  it("pre-fills the text field with the business name entered in onboarding", async () => {
+    await getPageHelper({
+      businessName: "Best Pizza",
+    });
     expect(getSearchValue()).toEqual("Best Pizza");
   });
 
-  it("types a new potential name", () => {
-    useMockProfileData({ businessName: "Best Pizza" });
-    renderForm();
+  it("types a new potential name", async () => {
+    await getPageHelper({
+      businessName: "Best Pizza",
+    });
     fillText("My other new name");
     expect(getSearchValue()).toEqual("My other new name");
   });
 
   it("checks availability of typed name", async () => {
-    renderForm();
+    await getPageHelper();
     fillText("Pizza Joint");
     await searchAndGetValue({});
     expect(mockApi.searchBusinessName).toHaveBeenCalledWith("Pizza Joint");
   });
 
   it("shows available component if name is available", async () => {
-    renderForm();
+    await getPageHelper();
     fillText("Pizza Joint");
     await searchAndGetValue({ status: "AVAILABLE" });
     expect(availableTextExists()).toBe(true);
@@ -83,28 +140,21 @@ describe("<SearchBusinessNameForm />", () => {
     expect(designatorErrorTextExists()).toBe(false);
     expect(specialCharacterErrorTextExists()).toBe(false);
     expect(restrictedWordErrorTextExists()).toBe(false);
-    expect(onChange).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        status: "AVAILABLE",
-      })
-    );
   });
 
-  it("updates onChange with undefined when new values are typed into the field", async () => {
-    renderForm();
+  it("removes availabile component when new values are typed into the field", async () => {
+    await getPageHelper();
     fillText("Pizza Joint");
     await searchAndGetValue({ status: "AVAILABLE" });
-    expect(onChange).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        status: "AVAILABLE",
-      })
-    );
+    expect(availableTextExists()).toBe(true);
+    expect(unavailableTextExists()).toBe(false);
     fillText("Pizza Place");
-    expect(onChange).toHaveBeenLastCalledWith(undefined);
+    expect(availableTextExists()).toBe(false);
+    expect(unavailableTextExists()).toBe(false);
   });
 
   it("shows unavailable component if name is not available", async () => {
-    renderForm();
+    await getPageHelper();
     fillText("Pizza Joint");
     await searchAndGetValue({ status: "UNAVAILABLE" });
     expect(availableTextExists()).toBe(false);
@@ -115,7 +165,7 @@ describe("<SearchBusinessNameForm />", () => {
   });
 
   it("shows designator error text if name includes the designator", async () => {
-    renderForm();
+    await getPageHelper();
     fillText("Pizza Joint LLC");
     await searchAndGetValue({ status: "DESIGNATOR_ERROR" });
     expect(availableTextExists()).toBe(false);
@@ -126,7 +176,7 @@ describe("<SearchBusinessNameForm />", () => {
   });
 
   it("shows special character error text if name includes a special character", async () => {
-    renderForm();
+    await getPageHelper();
     fillText("Pizza Joint LLC");
     await searchAndGetValue({ status: "SPECIAL_CHARACTER_ERROR" });
     expect(availableTextExists()).toBe(false);
@@ -137,7 +187,7 @@ describe("<SearchBusinessNameForm />", () => {
   });
 
   it("shows restricted word error text if name includes a restricted word", async () => {
-    renderForm();
+    await getPageHelper();
     fillText("Pizza Joint LLC");
     await searchAndGetValue({ status: "RESTRICTED_ERROR", invalidWord: "JOINT" });
     expect(availableTextExists()).toBe(false);
@@ -150,18 +200,15 @@ describe("<SearchBusinessNameForm />", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows message if user searches empty name", async () => {
-    renderForm();
+  it("does not search empty name", async () => {
+    await getPageHelper();
     fillText("");
     fireEvent.click(searchButton());
-    expect(screen.getByTestId("error-alert-BAD_INPUT")).toBeInTheDocument();
-    fillText("anything");
-    await searchAndGetValue({ status: "AVAILABLE", similarNames: [] });
-    expect(screen.queryByTestId("error-alert-BAD_INPUT")).not.toBeInTheDocument();
+    expect(mockApi.searchBusinessName).not.toHaveBeenCalled();
   });
 
   it("shows message if search returns 400", async () => {
-    renderForm();
+    await getPageHelper();
     fillText("LLC");
     await searchAndReject();
     expect(screen.getByTestId("error-alert-BAD_INPUT")).toBeInTheDocument();
@@ -171,7 +218,7 @@ describe("<SearchBusinessNameForm />", () => {
   });
 
   it("shows error if search fails", async () => {
-    renderForm();
+    await getPageHelper();
     fillText("whatever");
     await searchAndFail();
     expect(screen.getByTestId("error-alert-SEARCH_FAILED")).toBeInTheDocument();
@@ -181,10 +228,10 @@ describe("<SearchBusinessNameForm />", () => {
   });
 
   const availableTextExists = (): boolean => {
-    return screen.queryByText(availableText) !== null;
+    return screen.queryByTestId("available-text") !== null;
   };
   const unavailableTextExists = (): boolean => {
-    return screen.queryByText(unavailableText) !== null;
+    return screen.queryAllByTestId("unavailable-text").length > 0;
   };
   const designatorErrorTextExists = (): boolean => {
     return screen.queryByTestId("designator-error-text") !== null;

--- a/web/src/components/tasks/search-business-name/SearchBusinessNameForm.tsx
+++ b/web/src/components/tasks/search-business-name/SearchBusinessNameForm.tsx
@@ -4,14 +4,15 @@ import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
 import { AvailableProps } from "@/components/tasks/search-business-name/AvailableProps";
 import { UnavailableProps } from "@/components/tasks/search-business-name/UnavailableProps";
 import { WithErrorBar } from "@/components/WithErrorBar";
+import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useBusinessNameSearch } from "@/lib/data-hooks/useBusinessNameSearch";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { SearchBusinessNameError } from "@/lib/types/types";
 import { templateEval } from "@/lib/utils/helpers";
-import { NameAvailability } from "@businessnjgovnavigator/shared/";
+import { emptyProfileData, NameAvailability } from "@businessnjgovnavigator/shared/";
 import { FormControl, TextField } from "@mui/material";
-import { FormEvent, ReactElement, useCallback, useEffect, useRef, useState } from "react";
+import { FormEvent, ReactElement, useCallback, useContext, useEffect, useRef } from "react";
 
 type SearchBusinessNameFormConfig = {
   searchButtonText: string;
@@ -22,17 +23,13 @@ type SearchBusinessNameFormConfig = {
 interface Props {
   unavailable: (props: UnavailableProps) => ReactElement;
   available: (props: AvailableProps) => ReactElement;
+  businessName: string;
   config: SearchBusinessNameFormConfig;
   className?: string;
   isBusinessFormation?: boolean;
   hideTextFieldWhenUnavailable?: boolean;
-  onChange?: (nameAvailability: NameAvailability | undefined) => void;
-  onSubmit?: (
-    submittedName: string,
-    nameAvailability: NameAvailability,
-    isInitialSubmit: boolean
-  ) => Promise<void>;
   isDba?: boolean;
+  nameAvailability: NameAvailability | undefined;
 }
 
 export const SearchBusinessNameForm = (props: Props): ReactElement => {
@@ -41,7 +38,7 @@ export const SearchBusinessNameForm = (props: Props): ReactElement => {
     isLoading,
     error,
     updateButtonClicked,
-    updateCurrentName,
+    onChangeNameField,
     searchBusinessName,
     resetSearch,
   } = useBusinessNameSearch({
@@ -51,23 +48,24 @@ export const SearchBusinessNameForm = (props: Props): ReactElement => {
 
   const { Config } = useConfig();
   const didInitialSearch = useRef<boolean>(false);
-  const { userData } = useUserData();
-  const [nameAvailability, setNameAvailability] = useState<NameAvailability | undefined>(undefined);
-  const [submittedName, setSubmittedName] = useState<string>("");
+  const { userData, updateQueue } = useUserData();
+  const {
+    setFormationFormData,
+    setBusinessNameAvailability,
+    setDbaBusinessNameAvailability,
+    setFieldsInteracted,
+  } = useContext(BusinessFormationContext);
 
+  const setNameAvailability = props.isDba ? setDbaBusinessNameAvailability : setBusinessNameAvailability;
+
+  const FIELD_NAME = "businessName";
   const SearchBusinessNameErrorLookup: Record<SearchBusinessNameError, string> = {
     BAD_INPUT: Config.searchBusinessNameTask.errorTextBadInput,
     SEARCH_FAILED: Config.searchBusinessNameTask.errorTextSearchFailed,
   };
 
-  useEffect(() => {
-    props.onChange && props.onChange(nameAvailability);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nameAvailability]);
-
   const Unavailable = props.unavailable;
   const Available = props.available;
-  const onSubmit = props.onSubmit;
 
   const doSearch = useCallback(
     async (
@@ -75,16 +73,67 @@ export const SearchBusinessNameForm = (props: Props): ReactElement => {
       { isInitialSubmit }: { isInitialSubmit: boolean }
     ): Promise<void> => {
       searchBusinessName(event)
-        .then(({ nameAvailability, submittedName }) => {
-          setNameAvailability(nameAvailability);
-          setSubmittedName(submittedName);
-          if (onSubmit) {
-            onSubmit(submittedName, nameAvailability, isInitialSubmit);
+        .then(async ({ nameAvailability, submittedName }) => {
+          if (props.isDba) {
+            if (!nameAvailability || !updateQueue) {
+              return;
+            }
+            setNameAvailability(nameAvailability);
+            if (nameAvailability.status === "AVAILABLE") {
+              await updateQueue
+                .queueProfileData({
+                  nexusDbaName: submittedName,
+                })
+                .update();
+            }
+          } else {
+            if (!nameAvailability || !updateQueue || isInitialSubmit) {
+              return;
+            }
+            setFieldsInteracted([FIELD_NAME]);
+            if (nameAvailability.status === "AVAILABLE") {
+              await updateQueue
+                .queueFormationData({
+                  formationFormData: {
+                    ...updateQueue.current().formationData.formationFormData,
+                    businessName: submittedName,
+                  },
+                  businessNameAvailability: nameAvailability,
+                })
+                .queueProfileData({
+                  businessName: submittedName,
+                  nexusDbaName: emptyProfileData.nexusDbaName,
+                  needsNexusDbaName: emptyProfileData.needsNexusDbaName,
+                })
+                .update();
+            } else if (nameAvailability.status === "UNAVAILABLE") {
+              await updateQueue
+                .queueFormationData({
+                  formationFormData: {
+                    ...updateQueue.current().formationData.formationFormData,
+                    businessName: submittedName,
+                  },
+                  businessNameAvailability: nameAvailability,
+                })
+                .queueProfileData({
+                  businessName: submittedName,
+                  needsNexusDbaName: true,
+                })
+                .update();
+            }
+
+            setFormationFormData((previousFormationData) => {
+              return {
+                ...previousFormationData,
+                businessName: submittedName,
+              };
+            });
           }
         })
         .catch(() => {});
     },
-    [onSubmit, searchBusinessName]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [searchBusinessName]
   );
 
   useEffect(() => {
@@ -105,7 +154,7 @@ export const SearchBusinessNameForm = (props: Props): ReactElement => {
 
   const shouldShowTextField = (): boolean => {
     if (props.hideTextFieldWhenUnavailable) {
-      return nameAvailability?.status !== "UNAVAILABLE";
+      return props.nameAvailability?.status !== "UNAVAILABLE";
     }
 
     return true;
@@ -141,8 +190,7 @@ export const SearchBusinessNameForm = (props: Props): ReactElement => {
                   margin="dense"
                   value={currentName}
                   onChange={(event): void => {
-                    setNameAvailability(undefined);
-                    updateCurrentName(event.target.value);
+                    onChangeNameField(event.target.value);
                   }}
                   variant="outlined"
                   inputProps={{
@@ -174,42 +222,41 @@ export const SearchBusinessNameForm = (props: Props): ReactElement => {
         </WithErrorBar>
       )}
       <div className="margin-top-2">
-        {nameAvailability?.status === "AVAILABLE" && (
-          <Available submittedName={submittedName} updateButtonClicked={updateButtonClicked} />
+        {props.nameAvailability?.status === "AVAILABLE" && (
+          <Available submittedName={props.businessName} updateButtonClicked={updateButtonClicked} />
         )}
-        {nameAvailability?.status === "DESIGNATOR_ERROR" && (
+        {props.nameAvailability?.status === "DESIGNATOR_ERROR" && (
           <Alert variant="error" dataTestid="designator-error-text">
             <p className="font-sans-xs">{Config.searchBusinessNameTask.designatorText}</p>
           </Alert>
         )}
-        {nameAvailability?.status === "SPECIAL_CHARACTER_ERROR" && (
+        {props.nameAvailability?.status === "SPECIAL_CHARACTER_ERROR" && (
           <Alert variant="error" dataTestid="special-character-error-text">
             <Content className="font-sans-xs">
               {templateEval(Config.formation.fields.businessName.alertSpecialCharacters, {
-                name: submittedName,
+                name: props.businessName,
               })}
             </Content>
           </Alert>
         )}
-        {nameAvailability?.status === "RESTRICTED_ERROR" && (
+        {props.nameAvailability?.status === "RESTRICTED_ERROR" && (
           <Alert variant="error" dataTestid="restricted-word-error-text">
             <Content className="font-sans-xs">
               {templateEval(Config.formation.fields.businessName.alertRestrictedWord, {
-                name: submittedName,
-                word: nameAvailability.invalidWord ?? "*unknown*",
+                name: currentName,
+                word: props.nameAvailability.invalidWord ?? "*unknown*",
               })}
             </Content>
           </Alert>
         )}
 
-        {nameAvailability?.status === "UNAVAILABLE" && (
+        {props.nameAvailability?.status === "UNAVAILABLE" && (
           <Unavailable
             resetSearch={(): void => {
               resetSearch();
-              setNameAvailability(undefined);
             }}
-            submittedName={submittedName}
-            nameAvailability={nameAvailability}
+            submittedName={props.businessName}
+            nameAvailability={props.nameAvailability}
           />
         )}
       </div>

--- a/web/src/contexts/businessFormationContext.ts
+++ b/web/src/contexts/businessFormationContext.ts
@@ -12,6 +12,7 @@ interface BusinessFormationState {
   stepIndex: number;
   formationFormData: FormationFormData;
   businessNameAvailability: NameAvailability | undefined;
+  dbaBusinessNameAvailability: NameAvailability | undefined;
   showResponseAlert: boolean;
   hasBeenSubmitted: boolean;
   dbaContent: FormationDbaContent;
@@ -28,6 +29,7 @@ interface BusinessFormationContextType {
   setFieldsInteracted: (fields: FieldsForErrorHandling[], config?: { setToUninteracted: boolean }) => void;
   setHasBeenSubmitted: (hasBeenSubmitted: boolean) => void;
   setBusinessNameAvailability: React.Dispatch<React.SetStateAction<NameAvailability | undefined>>;
+  setDbaBusinessNameAvailability: React.Dispatch<React.SetStateAction<NameAvailability | undefined>>;
   setForeignGoodStandingFile: (file: InputFile | undefined) => void;
 }
 
@@ -42,6 +44,7 @@ export const BusinessFormationContext = createContext<BusinessFormationContextTy
     foreignGoodStandingFile: undefined,
     hasSetStateFirstTime: false,
     businessNameAvailability: undefined,
+    dbaBusinessNameAvailability: undefined,
   },
   setFormationFormData: () => {},
   setStepIndex: () => {},
@@ -49,5 +52,6 @@ export const BusinessFormationContext = createContext<BusinessFormationContextTy
   setFieldsInteracted: () => {},
   setHasBeenSubmitted: () => {},
   setBusinessNameAvailability: () => {},
+  setDbaBusinessNameAvailability: () => {},
   setForeignGoodStandingFile: () => {},
 });

--- a/web/src/lib/UpdateQueue.ts
+++ b/web/src/lib/UpdateQueue.ts
@@ -7,7 +7,7 @@ import {
   TaxFilingData,
   UserData,
 } from "@businessnjgovnavigator/shared";
-import { FormationData } from "@businessnjgovnavigator/shared/formationData";
+import { FormationData, FormationFormData } from "@businessnjgovnavigator/shared/formationData";
 
 export class UpdateQueueFactory implements UpdateQueue {
   private internalQueue: UserData;
@@ -54,6 +54,20 @@ export class UpdateQueueFactory implements UpdateQueue {
       formationData: {
         ...this.internalQueue.formationData,
         ...formationData,
+      },
+    };
+    return this;
+  }
+
+  queueFormationFormData(formationFormData: Partial<FormationFormData>): UpdateQueue {
+    this.internalQueue = {
+      ...this.internalQueue,
+      formationData: {
+        ...this.internalQueue.formationData,
+        formationFormData: {
+          ...this.internalQueue.formationData.formationFormData,
+          ...formationFormData,
+        },
       },
     };
     return this;

--- a/web/src/lib/types/types.ts
+++ b/web/src/lib/types/types.ts
@@ -7,6 +7,7 @@ import {
   emptyProfileData,
   FieldsForErrorHandling,
   FormationData,
+  FormationFormData,
   FormationMember,
   FormationSigner,
   IndustrySpecificData,
@@ -478,6 +479,7 @@ export interface UpdateQueue {
   queuePreferences: (preferences: Partial<Preferences>) => UpdateQueue;
   queueTaxFilingData: (taxFilingData: Partial<TaxFilingData>) => UpdateQueue;
   queueFormationData: (formationData: Partial<FormationData>) => UpdateQueue;
+  queueFormationFormData: (formatdionFormData: Partial<FormationFormData>) => UpdateQueue;
   queueTaskItemChecklist: (taskItemChecklist: Record<string, boolean>) => UpdateQueue;
   update: (config?: { local?: boolean }) => Promise<void>;
   current: () => UserData;

--- a/web/test/factories.ts
+++ b/web/test/factories.ts
@@ -215,6 +215,7 @@ export const generateEmptyFormationData = (): FormationData => {
     getFilingResponse: undefined,
     completedFilingPayment: false,
     businessNameAvailability: undefined,
+    dbaBusinessNameAvailability: undefined,
     lastVisitedPageIndex: 0,
   };
 };


### PR DESCRIPTION
## Description

Updates Dakota formation flow to check if a submitted business name or DBA name has become unavailable since it was originally submitted.

### Ticket

[184306224](https://www.pivotaltracker.com/story/show/184306224)

### Approach

Builds off the work that currently exists to do this for Oscar and Poppy users. Additionally, includes a partial refactor to consolidate Nexus and DBA business name search.

### Steps to Test


### Notes


## Code author checklist

- [ ] I have performed a self-review of my code
- [ ] I have created and/or updated relevant documentation, if necessary
- [ ] I have not used any relative imports
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
