### PR TITLE
chore: [#184780329] fix industry dropdown typeahead in tasks and lice…

### DIFF
--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -1737,7 +1737,7 @@ collections:
         name: industryId
         widget: "relation"
         collection: "roadmaps"
-        search_fields: ["{{id}}"]
+        search_fields: ["id"]
         value_field: "{{id}}"
         display_fields: ["{{id}}"]
         required: false
@@ -1796,7 +1796,7 @@ collections:
         widget: "relation"
         multiple: true
         collection: "roadmaps"
-        search_fields: ["{{id}}"]
+        search_fields: ["id"]
         value_field: "{{id}}"
         display_fields: ["{{name}}"]
         options_length: 500


### PR DESCRIPTION
…nse-tasks

<!-- Please complete the following sections as necessary. -->

## Description

Changed the syntax of the search field to fix the typeahead on the industry dropdowns in tasks and license tasks.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#184780329](https://www.pivotaltracker.com/story/show/184780329)

### Notes

Referred to this [documentation](https://decapcms.org/docs/widgets/relation/) to change the syntax.

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
