### PR TITLE
fix: [#184836745] generate municipality data for cms preview

### DIFF
--- a/web/src/components/DeferredLocationQuestion.test.tsx
+++ b/web/src/components/DeferredLocationQuestion.test.tsx
@@ -52,17 +52,22 @@ describe("<DeferredLocationQuestion />", () => {
     initialUserData,
     innerContent,
     municipalities,
+    fakeUserData,
   }: {
     initialUserData?: UserData;
     innerContent?: string;
     municipalities?: Municipality[];
+    fakeUserData?: UserData;
   }): void => {
     render(
       withRoadmap({
         component: (
           <MunicipalitiesContext.Provider value={{ municipalities: municipalities ?? [] }}>
             <WithStatefulUserData initialUserData={initialUserData ?? generateUserData({})}>
-              <DeferredLocationQuestion innerContent={innerContent ?? ""} />
+              <DeferredLocationQuestion
+                innerContent={innerContent ?? ""}
+                CMS_ONLY_fakeUserData={fakeUserData}
+              />
             </WithStatefulUserData>
           </MunicipalitiesContext.Provider>
         ),
@@ -84,6 +89,15 @@ describe("<DeferredLocationQuestion />", () => {
     const municipality = generateMunicipality({});
     const userData = generateUserData({ profileData: generateProfileData({ municipality }) });
     renderComponent({ initialUserData: userData, innerContent: "inner-content" });
+    expect(screen.queryByText(Config.deferredLocation.header)).not.toBeInTheDocument();
+    expect(screen.getByText("inner-content")).toBeInTheDocument();
+    expect(screen.queryByTestId("city-success-banner")).not.toBeInTheDocument();
+  });
+
+  it("uses fake userData if provided", () => {
+    const municipality = generateMunicipality({});
+    const userData = generateUserData({ profileData: generateProfileData({ municipality }) });
+    renderComponent({ innerContent: "inner-content", fakeUserData: userData });
     expect(screen.queryByText(Config.deferredLocation.header)).not.toBeInTheDocument();
     expect(screen.getByText("inner-content")).toBeInTheDocument();
     expect(screen.queryByTestId("city-success-banner")).not.toBeInTheDocument();

--- a/web/src/components/DeferredLocationQuestion.tsx
+++ b/web/src/components/DeferredLocationQuestion.tsx
@@ -90,7 +90,7 @@ export const DeferredLocationQuestion = (props: Props): ReactElement => {
           <ProfileMunicipality hideErrorLabel={true} />
         </DeferredOnboardingQuestion>
       ) : (
-        <div className="padding-3">
+        <div data-testid="deferred-location-content" className="padding-3">
           {showSuccessBanner && successBanner()}
           <Content>{props.innerContent}</Content>
         </div>

--- a/web/src/lib/cms/previews/TaskPreview.tsx
+++ b/web/src/lib/cms/previews/TaskPreview.tsx
@@ -11,7 +11,7 @@ const TaskPreview = (props: PreviewProps): ReactElement => {
 
   return (
     <div className="cms" ref={ref} style={{ margin: 40, pointerEvents: "none" }}>
-      <TaskElement task={task} />
+      <TaskElement task={task} overrides={{ skipDeferredLocationPrompt: true }} />
     </div>
   );
 };

--- a/web/src/pages/tasks/[taskUrlSlug].tsx
+++ b/web/src/pages/tasks/[taskUrlSlug].tsx
@@ -32,6 +32,9 @@ import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import {
   businessStructureTaskId,
   formationTaskId,
+  generateMunicipality,
+  generateProfileData,
+  generateUserData,
   hasCompletedBusinessStructure,
   Municipality,
   UserData,
@@ -175,7 +178,15 @@ const getPostOnboardingQuestion = (task: Task): ReactElement => {
   });
 };
 
-export const TaskElement = (props: { task: Task; children?: ReactNode | ReactNode[] }): ReactElement => {
+interface TaskElementProps {
+  task: Task;
+  children?: ReactNode | ReactNode[];
+  overrides?: {
+    skipDeferredLocationPrompt: boolean;
+  };
+}
+
+export const TaskElement = (props: TaskElementProps): ReactElement => {
   const hasPostOnboardingQuestion = !!props.task.postOnboardingQuestion;
   const shouldShowDeferredQuestion = props.task.requiresLocation;
   let hasDeferredLocationQuestion = false;
@@ -226,6 +237,14 @@ export const TaskElement = (props: { task: Task; children?: ReactNode | ReactNod
     return "";
   };
 
+  const getFakeUserDataWithMunicipality = (): UserData => {
+    return generateUserData({
+      profileData: generateProfileData({
+        municipality: generateMunicipality({}),
+      }),
+    });
+  };
+
   return (
     <div id="taskElement" className="flex flex-column space-between minh-38">
       <div>
@@ -237,7 +256,17 @@ export const TaskElement = (props: { task: Task; children?: ReactNode | ReactNod
           <>
             <Content>{deferredLocationQuestion.before}</Content>
             {shouldShowDeferredQuestion && (
-              <DeferredLocationQuestion innerContent={deferredLocationQuestion.innerContent} />
+              <>
+                {props.overrides?.skipDeferredLocationPrompt && (
+                  <DeferredLocationQuestion
+                    innerContent={deferredLocationQuestion.innerContent}
+                    CMS_ONLY_fakeUserData={getFakeUserDataWithMunicipality()}
+                  />
+                )}
+                {!props.overrides?.skipDeferredLocationPrompt && (
+                  <DeferredLocationQuestion innerContent={deferredLocationQuestion.innerContent} />
+                )}
+              </>
             )}
             <Content>{deferredLocationQuestion.after}</Content>
           </>

--- a/web/test/pages/taskUrlSlug.test.tsx
+++ b/web/test/pages/taskUrlSlug.test.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/test/mock/withStatefulUserData";
 import {
   formationTaskId,
+  generateMunicipality,
   generateProfileData,
   generateUserData,
   LookupTaskAgencyById,
@@ -506,6 +507,23 @@ describe("task page", () => {
       });
       renderPage(task);
       expect(screen.getByTestId("deferred-location-task")).toBeInTheDocument();
+    });
+
+    it("shows deferred location content if task requiresLocation=true and user has municipalities set", () => {
+      const task = generateTask({
+        requiresLocation: true,
+        contentMd: contentWithLocationSection,
+        postOnboardingQuestion: undefined,
+      });
+      const userDataWithMunicipality = generateUserData({
+        profileData: generateProfileData({
+          municipality: generateMunicipality({}),
+        }),
+      });
+
+      renderPage(task, userDataWithMunicipality);
+      expect(screen.getByTestId("deferred-location-task")).toBeInTheDocument();
+      expect(screen.getByTestId("deferred-location-content")).toBeInTheDocument();
     });
 
     it("does not show deferred location question if task requiresLocation=false", () => {

--- a/web/test/pages/taskUrlSlug.test.tsx
+++ b/web/test/pages/taskUrlSlug.test.tsx
@@ -507,6 +507,7 @@ describe("task page", () => {
       });
       renderPage(task);
       expect(screen.getByTestId("deferred-location-task")).toBeInTheDocument();
+      expect(screen.queryByTestId("deferred-location-content")).not.toBeInTheDocument();
     });
 
     it("shows deferred location content if task requiresLocation=true and user has municipalities set", () => {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
Adds in fake user data with municipalities for CMS preview rendering

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have performed a self-review of my code
- [ ] I have created and/or updated relevant documentation, if necessary
- [ ] I have not used any relative imports
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
