### PR TITLE
feat: [#185214542] blue profile page alert should be within the busin…

### DIFF
--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -263,12 +263,9 @@ const ProfilePage = (props: Props): ReactElement => {
     return LookupLegalStructureById(userData.profileData.legalStructureId).hasTradeName;
   };
 
-  const displayOpportunityAlert = (): boolean => {
-    return (
-      profileTab === "info" &&
-      LookupOperatingPhaseById(profileData.operatingPhase).displayProfileOpportunityAlert
-    );
-  };
+  const displayOpportunityAlert = LookupOperatingPhaseById(
+    profileData.operatingPhase
+  ).displayProfileOpportunityAlert;
 
   const shouldLockMunicipality = (): boolean => {
     return !!profileData.municipality && userData?.taxFilingData.state === "SUCCESS";
@@ -298,6 +295,7 @@ const ProfilePage = (props: Props): ReactElement => {
     info: (
       <>
         <ProfileTabHeader tab="info" />
+        {displayOpportunityAlert && <ProfileOpportunitiesAlert />}
 
         <ProfileField fieldName="foreignBusinessTypeIds">
           <OnboardingForeignBusinessType required />
@@ -404,6 +402,7 @@ const ProfilePage = (props: Props): ReactElement => {
     info: (
       <>
         <ProfileTabHeader tab="info" />
+        {displayOpportunityAlert && <ProfileOpportunitiesAlert />}
 
         <ProfileField fieldName="foreignBusinessTypeIds">
           <OnboardingForeignBusinessType required />
@@ -468,6 +467,8 @@ const ProfilePage = (props: Props): ReactElement => {
     info: (
       <>
         <ProfileTabHeader tab="info" />
+        {displayOpportunityAlert && <ProfileOpportunitiesAlert />}
+
         <ProfileField
           fieldName="businessName"
           locked={shouldLockFormationFields}
@@ -599,6 +600,7 @@ const ProfilePage = (props: Props): ReactElement => {
     info: (
       <>
         <ProfileTabHeader tab="info" />
+        {displayOpportunityAlert && <ProfileOpportunitiesAlert />}
 
         <ProfileField fieldName="businessName" isVisible={!shouldShowTradeNameElements()}>
           <ProfileBusinessName />
@@ -753,7 +755,6 @@ const ProfilePage = (props: Props): ReactElement => {
                       </div>
                     ) : (
                       <>
-                        {displayOpportunityAlert() && <ProfileOpportunitiesAlert />}
                         <form onSubmit={onSubmit} className={`usa-prose onboarding-form margin-top-2`}>
                           {getElements()}
                           <div className="margin-top-2">


### PR DESCRIPTION
…ess info header

<!-- Please complete the following sections as necessary. -->

## Description

We wanted to have the blue profile header but shown in the Business Info header rather than above

before: 
<img width="915" alt="image" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22485301/5597476d-cd54-4443-bac6-79f74116ea6f">


after: 
<img width="1284" alt="image" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22485301/aa1c1661-1730-4a7c-b855-fd88ec3a5d35">


<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/185214542)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
