### PR TITLE
fix: [#185471630] tax filing calendar lookup overwriting municipality

### DIFF
--- a/web/src/components/filings-calendar/FilingsCalendarTaxAccess.tsx
+++ b/web/src/components/filings-calendar/FilingsCalendarTaxAccess.tsx
@@ -4,6 +4,7 @@ import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { SnackbarAlert } from "@/components/njwds-extended/SnackbarAlert";
 import { AuthAlertContext } from "@/contexts/authAlertContext";
 import { postTaxFilingsLookup } from "@/lib/api-client/apiClient";
+import { fetchMunicipalityByName } from "@/lib/async-content-fetchers/fetchMunicipalities";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
@@ -40,7 +41,21 @@ export const FilingsCalendarTaxAccess = (): ReactElement => {
           taxId: userData.profileData.taxId as string,
           encryptedTaxId: userData.profileData.encryptedTaxId as string,
         });
-        updateQueue?.queue(updatedUserData).update();
+
+        let record;
+
+        if (updatedUserData.profileData.municipality?.name) {
+          record = await fetchMunicipalityByName(updatedUserData.profileData.municipality?.name || "");
+        }
+
+        const municipalityToSet = {
+          name: record?.townName || userData.profileData.municipality?.name || "",
+          county: record?.countyName || userData.profileData.municipality?.county || "",
+          id: record?.id || userData.profileData.municipality?.id || "",
+          displayName: record?.townDisplayName || userData.profileData.municipality?.displayName || "",
+        };
+
+        updateQueue?.queue(updatedUserData).queueProfileData({ municipality: municipalityToSet }).update();
       }
     })();
   }, userData);


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

In the tax filing calendar component, we are doing a tax filing lookup which was overwriting the municipality data without properly processing it. The fix was adding the processing portion to the component as well so it now doesn't get overwritten.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#185471630](https://www.pivotaltracker.com/story/show/185471630)

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
