### PR TITLE
refactor: [#184882700] replace userData calls in profile and related files

### DIFF
--- a/web/src/components/SelfRegLink.tsx
+++ b/web/src/components/SelfRegLink.tsx
@@ -12,12 +12,12 @@ interface Props {
 
 export const SelfRegLink = (props: Props): ReactElement => {
   const router = useRouter();
-  const { updateQueue } = useUserData();
+  const { updateQueue, userData } = useUserData();
   const { setRegistrationAlertStatus } = useContext(AuthAlertContext);
 
   const onClick = (): void => {
     parseAndSendAnalyticsEvent(props.href);
-    onSelfRegister(router, updateQueue, setRegistrationAlertStatus);
+    onSelfRegister(router, updateQueue, userData, setRegistrationAlertStatus);
   };
 
   /* eslint-disable @typescript-eslint/ban-ts-comment */

--- a/web/src/components/TaskHeader.tsx
+++ b/web/src/components/TaskHeader.tsx
@@ -15,11 +15,10 @@ interface Props {
 }
 
 export const TaskHeader = (props: Props): ReactElement => {
-  const { userData, updateQueue } = useUserData();
+  const { userData } = useUserData();
   const { roadmap } = useRoadmap();
 
-  const currentTaskProgress: TaskProgress =
-    updateQueue?.current().taskProgress[props.task.id] ?? "NOT_STARTED";
+  const currentTaskProgress: TaskProgress = userData?.taskProgress[props.task.id] ?? "NOT_STARTED";
 
   const { Config } = useConfig();
 

--- a/web/src/components/auth/SignUpModal.tsx
+++ b/web/src/components/auth/SignUpModal.tsx
@@ -37,10 +37,10 @@ export const SignUpModal = (): ReactElement => {
   const selfRegister = (): void => {
     if (userData?.preferences.returnToLink === `${ROUTES.dashboard}?${QUERIES.openTaxFilingsModal}=true`) {
       analytics.event.myNJ_prompt_modal_complete_button.click.go_to_myNJ_registration();
-      onSelfRegister(router, updateQueue, setRegistrationAlertStatus, { useReturnToLink: true });
+      onSelfRegister(router, updateQueue, userData, setRegistrationAlertStatus, { useReturnToLink: true });
     } else {
       analytics.event.guest_modal.click.go_to_myNJ_registration();
-      onSelfRegister(router, updateQueue, setRegistrationAlertStatus);
+      onSelfRegister(router, updateQueue, userData, setRegistrationAlertStatus);
     }
   };
 

--- a/web/src/components/dashboard/Roadmap.tsx
+++ b/web/src/components/dashboard/Roadmap.tsx
@@ -3,22 +3,18 @@ import { SectionAccordion } from "@/components/dashboard/SectionAccordion";
 import { Step } from "@/components/Step";
 import { useRoadmap } from "@/lib/data-hooks/useRoadmap";
 import { useUserData } from "@/lib/data-hooks/useUserData";
-import {
-  hasCompletedBusinessStructure,
-  LookupOperatingPhaseById,
-  UserData,
-} from "@businessnjgovnavigator/shared/";
+import { hasCompletedBusinessStructure, LookupOperatingPhaseById } from "@businessnjgovnavigator/shared/";
 import { ReactElement } from "react";
 
 export const Roadmap = (): ReactElement => {
   const { roadmap, sectionNamesInRoadmap } = useRoadmap();
-  const { updateQueue } = useUserData();
+  const { userData } = useUserData();
 
   const displayBusinessStructurePrompt = LookupOperatingPhaseById(
-    updateQueue?.current().profileData.operatingPhase
+    userData?.profileData.operatingPhase
   ).displayBusinessStructurePrompt;
 
-  const completedBusinessStructure = hasCompletedBusinessStructure(updateQueue?.current() as UserData);
+  const completedBusinessStructure = hasCompletedBusinessStructure(userData);
 
   return (
     <>

--- a/web/src/components/filings-calendar/FilingsCalendar.tsx
+++ b/web/src/components/filings-calendar/FilingsCalendar.tsx
@@ -28,8 +28,8 @@ interface Props {
 
 export const FilingsCalendar = (props: Props): ReactElement => {
   const { Config } = useConfig();
-  const { updateQueue } = useUserData();
-  const userData = props.CMS_ONLY_fakeUserData ?? updateQueue?.current();
+  const { updateQueue, userData: userDataFromHook } = useUserData();
+  const userData = props.CMS_ONLY_fakeUserData ?? userDataFromHook;
 
   const currentDate = getCurrentDate();
   const currentYear = getCurrentDate().year().toString();

--- a/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepTwo.tsx
+++ b/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepTwo.tsx
@@ -39,9 +39,9 @@ interface Props {
 
 export const TaxAccessStepTwo = (props: Props): ReactElement => {
   const { Config } = useConfig();
-  const { updateQueue } = useUserData();
+  const { updateQueue, userData: userDataFromHook } = useUserData();
   const { queueUpdateTaskProgress } = useUpdateTaskProgress();
-  const userData = props.CMS_ONLY_fakeUserData ?? updateQueue?.current();
+  const userData = props.CMS_ONLY_fakeUserData ?? userDataFromHook;
 
   const [profileData, setProfileData] = useState<ProfileData>(createEmptyProfileData());
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/web/src/components/navbar/NavBarDesktop.tsx
+++ b/web/src/components/navbar/NavBarDesktop.tsx
@@ -81,7 +81,7 @@ export const NavBarDesktop = (): ReactElement => {
                       style="default"
                       onClick={(): void => {
                         analytics.event.guest_menu.click.go_to_myNJ_registration();
-                        onSelfRegister(router, updateQueue, setRegistrationAlertStatus);
+                        onSelfRegister(router, updateQueue, userData, setRegistrationAlertStatus);
                       }}
                     >
                       {Config.navigationDefaults.navBarGuestRegistrationText}

--- a/web/src/components/navbar/NavBarPopupMenu.tsx
+++ b/web/src/components/navbar/NavBarPopupMenu.tsx
@@ -92,7 +92,7 @@ export const NavBarPopupMenu = (props: Props): ReactElement => {
     return NavMenuItem({
       onClick: (): void => {
         analytics.event.guest_menu.click.go_to_myNJ_registration();
-        onSelfRegister(router, updateQueue, setRegistrationAlertStatus);
+        onSelfRegister(router, updateQueue, userData, setRegistrationAlertStatus);
       },
       icon: <ButtonIcon svgFilename="profile" sizePx="25px" />,
       itemText: Config.navigationDefaults.navBarGuestRegistrationText,

--- a/web/src/components/roadmap/MiniRoadmap.tsx
+++ b/web/src/components/roadmap/MiniRoadmap.tsx
@@ -19,9 +19,9 @@ export const MiniRoadmap = (props: Props): ReactElement => {
   const { updateQueue, userData } = useUserData();
 
   const displayBusinessStructurePrompt = LookupOperatingPhaseById(
-    updateQueue?.current().profileData.operatingPhase
+    userData?.profileData.operatingPhase
   ).displayBusinessStructurePrompt;
-  const completedBusinessStructure = hasCompletedBusinessStructure(updateQueue?.current());
+  const completedBusinessStructure = hasCompletedBusinessStructure(userData);
 
   const onToggleStep = useCallback(
     async (stepNumber: number, setOpen: boolean, click: boolean): Promise<void> => {

--- a/web/src/components/tasks/business-formation/name/DbaNameSearch.tsx
+++ b/web/src/components/tasks/business-formation/name/DbaNameSearch.tsx
@@ -12,7 +12,7 @@ import { ReactElement, useContext } from "react";
 export const DbaNameSearch = (): ReactElement => {
   const { Config } = useConfig();
   const { state } = useContext(BusinessFormationContext);
-  const { updateQueue } = useUserData();
+  const { userData } = useUserData();
 
   useMountEffect(() => {
     analytics.event.business_formation_dba_name_search_field.appears.dba_name_search_field_appears();
@@ -26,7 +26,7 @@ export const DbaNameSearch = (): ReactElement => {
         available={DbaAvailable}
         isBusinessFormation
         isDba
-        businessName={updateQueue?.current().profileData.nexusDbaName ?? ""}
+        businessName={userData?.profileData.nexusDbaName ?? ""}
         nameAvailability={state.dbaBusinessNameAvailability}
         config={{
           searchButtonText: Config.nexusNameSearch.dbaNameSearchSubmitButton,

--- a/web/src/components/tasks/business-structure/BusinessStructureTask.tsx
+++ b/web/src/components/tasks/business-structure/BusinessStructureTask.tsx
@@ -45,11 +45,10 @@ export const BusinessStructureTask = (props: Props): ReactElement => {
   } = useFormContextHelper(createProfileFieldErrorMap());
 
   useEffect(() => {
-    const current = userDataFromHook.userData;
     return () => {
-      if (current?.profileData.legalStructureId) {
+      if (userData?.profileData.legalStructureId) {
         queueUpdateTaskProgress(props.task.id, "COMPLETED");
-      } else if (!current?.profileData.legalStructureId) {
+      } else if (!userData?.profileData.legalStructureId) {
         queueUpdateTaskProgress(props.task.id, "NOT_STARTED");
       }
     };
@@ -99,7 +98,15 @@ export const BusinessStructureTask = (props: Props): ReactElement => {
     setShowRadioQuestion(true);
     await updateQueue.update();
 
-    setProfileData(updateQueue.current().profileData);
+    const updatedProfileState: ProfileData = {
+      ...profileData,
+      legalStructureId: undefined,
+      operatingPhase:
+        profileData.operatingPhase === "GUEST_MODE_WITH_BUSINESS_STRUCTURE"
+          ? "GUEST_MODE"
+          : profileData.operatingPhase,
+    };
+    setProfileData(updatedProfileState);
   };
 
   const preLookupContent = props.task.contentMd.split("${businessStructureSelectionComponent}")[0];

--- a/web/src/components/tasks/business-structure/BusinessStructureTask.tsx
+++ b/web/src/components/tasks/business-structure/BusinessStructureTask.tsx
@@ -45,7 +45,7 @@ export const BusinessStructureTask = (props: Props): ReactElement => {
   } = useFormContextHelper(createProfileFieldErrorMap());
 
   useEffect(() => {
-    const current = updateQueue?.current();
+    const current = userDataFromHook.userData;
     return () => {
       if (current?.profileData.legalStructureId) {
         queueUpdateTaskProgress(props.task.id, "COMPLETED");

--- a/web/src/lib/auth/signinHelper.test.ts
+++ b/web/src/lib/auth/signinHelper.test.ts
@@ -76,13 +76,13 @@ describe("SigninHelper", () => {
 
     it("sets registration alert to IN_PROGRESS", async () => {
       mockApi.postSelfReg.mockResolvedValue({ userData: userData, authRedirectURL: "" });
-      await onSelfRegister(fakeRouter, updateQueue, mockSetAlertStatus);
+      await onSelfRegister(fakeRouter, updateQueue, userData, mockSetAlertStatus);
       expect(mockSetAlertStatus).toHaveBeenCalledWith("IN_PROGRESS");
     });
 
     it("posts userData to api self-reg with current pathname included when useReturnToLink is not true", async () => {
       mockApi.postSelfReg.mockResolvedValue({ userData: userData, authRedirectURL: "" });
-      await onSelfRegister(fakeRouter, updateQueue, mockSetAlertStatus);
+      await onSelfRegister(fakeRouter, updateQueue, userData, mockSetAlertStatus);
       expect(mockApi.postSelfReg).toHaveBeenCalledWith({
         ...userData,
         preferences: { ...userData.preferences, returnToLink: "/tasks/some-url" },
@@ -95,7 +95,7 @@ describe("SigninHelper", () => {
       });
       updateQueue = new UpdateQueueFactory(userData, update);
       mockApi.postSelfReg.mockResolvedValue({ userData: userData, authRedirectURL: "" });
-      await onSelfRegister(fakeRouter, updateQueue, mockSetAlertStatus, { useReturnToLink: true });
+      await onSelfRegister(fakeRouter, updateQueue, userData, mockSetAlertStatus, { useReturnToLink: true });
       expect(mockApi.postSelfReg).toHaveBeenCalledWith({
         ...userData,
         preferences: { ...userData.preferences, returnToLink: "/pathname?query=true" },
@@ -108,7 +108,7 @@ describe("SigninHelper", () => {
         userData: returnedUserData,
         authRedirectURL: "/some-url",
       });
-      await onSelfRegister(fakeRouter, updateQueue, mockSetAlertStatus);
+      await onSelfRegister(fakeRouter, updateQueue, userData, mockSetAlertStatus);
       await waitFor(() => {
         return expect(mockPush).toHaveBeenCalledWith("/some-url");
       });
@@ -117,7 +117,7 @@ describe("SigninHelper", () => {
 
     it("sets alert to DUPLICATE_ERROR on 409 response code", async () => {
       mockApi.postSelfReg.mockRejectedValue(409);
-      await onSelfRegister(fakeRouter, updateQueue, mockSetAlertStatus);
+      await onSelfRegister(fakeRouter, updateQueue, userData, mockSetAlertStatus);
       await waitFor(() => {
         return expect(mockSetAlertStatus).toHaveBeenCalledWith("DUPLICATE_ERROR");
       });
@@ -127,7 +127,7 @@ describe("SigninHelper", () => {
 
     it("sets alert to RESPONSE_ERROR on generic error", async () => {
       mockApi.postSelfReg.mockRejectedValue(500);
-      await onSelfRegister(fakeRouter, updateQueue, mockSetAlertStatus);
+      await onSelfRegister(fakeRouter, updateQueue, userData, mockSetAlertStatus);
       await waitFor(() => {
         return expect(mockSetAlertStatus).toHaveBeenCalledWith("RESPONSE_ERROR");
       });

--- a/web/src/lib/auth/signinHelper.ts
+++ b/web/src/lib/auth/signinHelper.ts
@@ -11,7 +11,7 @@ import {
   setRegistrationDimension,
   setUserId,
 } from "@/lib/utils/analytics-helpers";
-import { createEmptyUser } from "@businessnjgovnavigator/shared/";
+import { createEmptyUser, UserData } from "@businessnjgovnavigator/shared/";
 import { Dispatch } from "react";
 import { UpdateQueue } from "../types/types";
 import { AuthAction } from "./AuthContext";
@@ -38,11 +38,10 @@ export type SelfRegRouter = {
 export const onSelfRegister = (
   router: SelfRegRouter,
   updateQueue: UpdateQueue | undefined,
+  userData: UserData | undefined,
   setRegistrationAlertStatus: AuthAlertContextType["setRegistrationAlertStatus"],
   options?: { useReturnToLink: boolean }
 ): void => {
-  const userData = updateQueue?.current();
-
   if (!userData || !updateQueue) {
     return;
   }

--- a/web/src/lib/auth/signinHelper.ts
+++ b/web/src/lib/auth/signinHelper.ts
@@ -13,10 +13,11 @@ import {
 } from "@/lib/utils/analytics-helpers";
 import { createEmptyUser, UserData } from "@businessnjgovnavigator/shared/";
 import { Dispatch } from "react";
-import { UpdateQueue } from "../types/types";
-import { AuthAction } from "./AuthContext";
-import * as session from "./sessionHelper";
-import { triggerSignOut } from "./sessionHelper";
+
+import { AuthAction } from "@/lib/auth/AuthContext";
+import * as session from "@/lib/auth/sessionHelper";
+import { triggerSignOut } from "@/lib/auth/sessionHelper";
+import { UpdateQueue } from "@/lib/types/types";
 
 export const onSignIn = async (dispatch: Dispatch<AuthAction>): Promise<void> => {
   const user = await session.getCurrentUser();

--- a/web/src/lib/types/types.ts
+++ b/web/src/lib/types/types.ts
@@ -470,7 +470,7 @@ export type ProfileTabs = (typeof _profileTabs)[number];
 export const profileTabs = _profileTabs as unknown as ProfileTabs[];
 
 export interface UpdateQueue {
-  queue: (userData: UserData) => UpdateQueue;
+  queue: (userData: Partial<UserData>) => UpdateQueue;
   queueTaskProgress: (taskProgress: Record<string, TaskProgress>) => UpdateQueue;
   queueUser: (user: Partial<BusinessUser>) => UpdateQueue;
   queueProfileData: (profileData: Partial<ProfileData>) => UpdateQueue;

--- a/web/src/pages/dashboard.tsx
+++ b/web/src/pages/dashboard.tsx
@@ -139,7 +139,7 @@ const DashboardPage = (props: Props): ReactElement => {
     return (
       isHomeBasedBusinessApplicable(userData.profileData.industryId) &&
       userData.profileData.homeBasedBusiness === undefined &&
-      LookupOperatingPhaseById(updateQueue?.current().profileData.operatingPhase).displayHomeBasedPrompt
+      LookupOperatingPhaseById(userData.profileData.operatingPhase).displayHomeBasedPrompt
     );
   };
 

--- a/web/src/pages/loading.tsx
+++ b/web/src/pages/loading.tsx
@@ -20,7 +20,7 @@ import { ReactElement, useContext, useEffect, useState } from "react";
 export const signInSamlError = "Name+ID+value+was+not+found+in+SAML";
 
 const LoadingPage = (): ReactElement => {
-  const { updateQueue } = useUserData();
+  const { updateQueue, userData } = useUserData();
   const router = useRouter();
   const { dispatch } = useContext(AuthContext);
   const [showLoginErrorModal, setShowLoginErrorModal] = useState<boolean>(false);
@@ -44,8 +44,8 @@ const LoadingPage = (): ReactElement => {
   }, [router, dispatch]);
 
   useMountEffectWhenDefined(() => {
-    if (!updateQueue) return;
-    const userData = updateQueue.current();
+    if (!updateQueue || !userData) return;
+
     if (!onboardingCompleted(userData)) {
       router.push(ROUTES.onboarding);
     } else if (userData.preferences.returnToLink) {
@@ -59,7 +59,7 @@ const LoadingPage = (): ReactElement => {
     } else {
       router.push(ROUTES.dashboard);
     }
-  }, updateQueue?.current());
+  }, userData);
 
   const sendToOnboarding = (): void => {
     setRedirectIsLoading(true);

--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -77,7 +77,7 @@ const OnboardingPage = (props: Props): ReactElement => {
   const [user, setUser] = useState<BusinessUser>(createEmptyUser(ABStorageFactory().getExperience()));
   const [error, setError] = useState<ProfileError | undefined>(undefined);
   const [alert, setAlert] = useState<OnboardingStatus | undefined>(undefined);
-  const { updateQueue, createUpdateQueue } = useUserData();
+  const { updateQueue, userData, createUpdateQueue } = useUserData();
   const isLargeScreen = useMediaQuery(MediaQueries.desktopAndUp);
   const headerRef = useRef<HTMLDivElement>(null);
   const [currentFlow, setCurrentFlow] = useState<FlowType>("STARTING");
@@ -161,7 +161,7 @@ const OnboardingPage = (props: Props): ReactElement => {
         return;
       }
 
-      let currentUserData = updateQueue?.current();
+      let currentUserData = userData;
       if (currentUserData) {
         setProfileData(currentUserData.profileData);
         setUser(currentUserData.user);

--- a/web/src/pages/tasks/[taskUrlSlug].tsx
+++ b/web/src/pages/tasks/[taskUrlSlug].tsx
@@ -90,7 +90,7 @@ const TaskPage = (props: Props): ReactElement => {
     }
 
     const hideNextUrlSlug =
-      props.task.id === businessStructureTaskId && !hasCompletedBusinessStructure(userData as UserData);
+      props.task.id === businessStructureTaskId && !hasCompletedBusinessStructure(userData);
 
     return (
       <div


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Continues the Ethan refactor work to stop directing fetching userData from the updateQueue

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[184882700](https://www.pivotaltracker.com/story/show/)

### Approach

As part of the refactor to allow for more than one business for users, we need to stop relying on the updateQueue's definition of userData and rely on the explicit userData object from the hook. This moves almost all remaining references to updateQueue.current() to use the hook

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
