### PR TITLE
fix: [#185473530] business name saved in tax access modal

### DIFF
--- a/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepTwo.test.tsx
+++ b/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepTwo.test.tsx
@@ -156,7 +156,7 @@ describe("<TaxAccessStepTwo />", () => {
       fireEvent.change(screen.getByTestId("businessName"), { target: { value: "MrFakesHotDogBonanza" } });
     });
 
-    it("updates taxId but not BusinessName on submit", async () => {
+    it("updates taxId but not businessName on submit", async () => {
       renderComponent(userDataWithPrefilledFields);
       mockApi.postTaxFilingsOnboarding.mockResolvedValue({
         ...userDataWithPrefilledFields,
@@ -180,12 +180,36 @@ describe("<TaxAccessStepTwo />", () => {
       await waitFor(() => {
         return expect(currentUserData().profileData.businessName).not.toEqual("zoom");
       });
-      await waitFor(() => {
-        return expect(currentUserData().profileData.taxId).toEqual("999888777666");
+      return expect(currentUserData().profileData.taxId).toEqual("999888777666");
+      return expect(currentUserData().profileData.encryptedTaxId).toEqual(undefined);
+    });
+
+    it("updates businessName on submit if tax filing is success", async () => {
+      renderComponent(userDataWithPrefilledFields);
+      mockApi.postTaxFilingsOnboarding.mockResolvedValue({
+        ...userDataWithPrefilledFields,
+        profileData: {
+          ...userDataWithPrefilledFields.profileData,
+          municipality: undefined,
+        },
+        taxFilingData: generateTaxFilingData({
+          state: "SUCCESS",
+          businessName: userDataWithPrefilledFields.profileData.businessName,
+          errorField: undefined,
+        }),
       });
-      await waitFor(() => {
-        return expect(currentUserData().profileData.encryptedTaxId).toEqual(undefined);
+      fireEvent.change(screen.getByLabelText("Business name"), {
+        target: { value: "zoom" },
       });
+      fireEvent.change(screen.getByLabelText("Tax id"), {
+        target: { value: "999888777666" },
+      });
+      clickSave();
+      await waitFor(() => {
+        return expect(currentUserData().profileData.businessName).toEqual("zoom");
+      });
+      return expect(currentUserData().profileData.taxId).toEqual("999888777666");
+      return expect(currentUserData().profileData.encryptedTaxId).toEqual(undefined);
     });
 
     it("displays in-line error and alert when businessName field is empty and save button is clicked", async () => {

--- a/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepTwo.tsx
+++ b/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepTwo.tsx
@@ -175,15 +175,27 @@ export const TaxAccessStepTwo = (props: Props): ReactElement => {
           displayName: record?.townDisplayName || profileData.municipality?.displayName || "",
         };
 
-        await updateQueue
-          .queue(userDataToSet)
-          .queueProfileData({
-            taxId: profileData.taxId,
-            encryptedTaxId: encryptedTaxId,
-            responsibleOwnerName: profileData.responsibleOwnerName,
-            municipality: municipalityToSet,
-          })
-          .update();
+        updateQueue.queue(userDataToSet).queueProfileData({
+          taxId: profileData.taxId,
+          encryptedTaxId: encryptedTaxId,
+          municipality: municipalityToSet,
+        });
+
+        if (userDataToSet.taxFilingData.state === "SUCCESS") {
+          if (displayBusinessName()) {
+            updateQueue.queueProfileData({
+              businessName: profileData.businessName,
+            });
+          }
+
+          if (displayResponsibleOwnerName()) {
+            updateQueue.queueProfileData({
+              responsibleOwnerName: profileData.responsibleOwnerName,
+            });
+          }
+        }
+
+        await updateQueue.update();
       } catch {
         setOnAPIfailed("UNKNOWN");
         setIsLoading(false);


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Bug fix to save business name in the tax access modal.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#185473530](https://www.pivotaltracker.com/story/show/185473530)

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
