### PR TITLE
Remove duplicate meta-data keys from license

### DIFF
--- a/content/src/roadmaps/license-tasks/verify-license-massage-therapy.md
+++ b/content/src/roadmaps/license-tasks/verify-license-massage-therapy.md
@@ -24,10 +24,6 @@ industryId:
 callToActionText: Apply for My License
 callToActionLink: https://www.njconsumeraffairs.gov/mbt/Pages/individual.aspx
 licenseCertificationClassification: ""
-agencyId: nj-consumer-affairs
-agencyAdditionalContext: Board of Massage and Bodywork Therapy
-id: verify-license-massage-therapy
-webflowId: 648c97318fac0894d3500c32
 ---
 
 ---


### PR DESCRIPTION
Removing duplicate keys from `verify-license-massage-therapy.md` to fix `main`.