### PR TITLE
release 20230628

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [5.22.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v5.22.0...v5.22.1) (2023-07-06)
+
+
+### Bug Fixes
+
+* remove duplicate meta-data keys from license ([88e9708](https://github.com/newjersey/navigator.business.nj.gov/commit/88e970857a9361462e2761e0be4bb5cd6a9b9832))
+
 # [5.22.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v5.21.2...v5.22.0) (2023-06-28)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businessnjgovnavigator/root",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "This is the development repository for the work-in-progress business navigator from the New Jersey Office of Innovation. For info on the existing [Business.NJ.gov](https://business.nj.gov) site, please see the [bottom of this document](https://github.com/newjersey/navigator.business.nj.gov#businessnjgov)",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
- chore: update env variable to disable landing page redirect
- chore(release): 5.22.1 [skip ci]
