### PR TITLE
fix: revert storybook-addon-pseudo-states back to v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "serverless-offline-ssm": "6.2.0",
     "serverless-webpack": "5.11.0",
     "storybook-addon-designs": "6.3.1",
-    "storybook-addon-pseudo-states": "2.1.0",
+    "storybook-addon-pseudo-states": "1.15.5",
     "style-loader": "3.3.2",
     "supertest": "6.3.3",
     "ts-jest": "29.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -168,7 +168,7 @@
     "rimraf": "4.4.1",
     "sass": "1.62.0",
     "sass-loader": "13.2.2",
-    "storybook-addon-pseudo-states": "2.1.0",
+    "storybook-addon-pseudo-states": "1.15.5",
     "style-loader": "3.3.2",
     "ts-jest": "29.1.0",
     "ts-loader": "9.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4879,7 +4879,7 @@ __metadata:
     simple-oauth2: 5.0.0
     slick-carousel: ^1.8.1
     storybook-addon-designs: 6.3.1
-    storybook-addon-pseudo-states: 2.1.0
+    storybook-addon-pseudo-states: 1.15.5
     style-loader: 3.3.2
     supertest: 6.3.3
     swr: 1.3.0
@@ -5061,7 +5061,7 @@ __metadata:
     sass: 1.62.0
     sass-loader: 13.2.2
     slick-carousel: ^1.8.1
-    storybook-addon-pseudo-states: 2.1.0
+    storybook-addon-pseudo-states: 1.15.5
     style-loader: 3.3.2
     swr: 1.3.0
     ts-jest: 29.1.0
@@ -32871,15 +32871,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"storybook-addon-pseudo-states@npm:2.1.0":
-  version: 2.1.0
-  resolution: "storybook-addon-pseudo-states@npm:2.1.0"
+"storybook-addon-pseudo-states@npm:1.15.5":
+  version: 1.15.5
+  resolution: "storybook-addon-pseudo-states@npm:1.15.5"
   peerDependencies:
-    "@storybook/components": ^7.0.0
-    "@storybook/core-events": ^7.0.0
-    "@storybook/manager-api": ^7.0.0
-    "@storybook/preview-api": ^7.0.0
-    "@storybook/theming": ^7.0.0
+    "@storybook/addons": ^6.5.0
+    "@storybook/api": ^6.5.0
+    "@storybook/components": ^6.5.0
+    "@storybook/core-events": ^6.5.0
+    "@storybook/theming": ^6.5.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   peerDependenciesMeta:
@@ -32887,7 +32887,7 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: a58c8ea2a58275e95264ebf92d2f7eb20d738b6caf18c64844f245723dc8e5c144d8c165ec353c7c24914a3982a277d3b26e90268b7b74d987e24e6cf53195e6
+  checksum: 5ba5022ee5082a1b9ce3bc244172f059a20f5c0824ce37306e4169c880613be2513e1bf13d1dce4fee458a02eb09ebd4638273d2f80e4ef23fe9f1e315f3deed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have performed a self-review of my code
- [ ] I have created and/or updated relevant documentation, if necessary
- [ ] I have not used any relative imports
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
