### PR TITLE
Remove Business Structure Description overrides

### DIFF
--- a/content/src/fieldConfig/profile.json
+++ b/content/src/fieldConfig/profile.json
@@ -284,19 +284,6 @@
               }
             }
           }
-        },
-        "overrides": {
-          "FOREIGN": {
-            "optionContent": {
-              "general-partnership": "",
-              "c-corporation": "",
-              "limited-liability-company": "",
-              "limited-liability-partnership": "",
-              "limited-partnership": "",
-              "s-corporation": "",
-              "sole-proprietorship": ""
-            }
-          }
         }
       },
       "employerId": {


### PR DESCRIPTION
## Description

This is a continuation of #5963 based on feedback from a design review.

### Ticket

[184822307](https://www.pivotaltracker.com/story/show/184822307)

### Approach

The design review asked for license names to be bolded. Names were not bolded because we were using an alternate style due to differences in the content.

There was business structure description override in place for foreign businesses. It appears as though this was in place for the business structure dropdown that was on the profile page. The PR removes those overrides.

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
