### PR TITLE
License tasks not rendering in cms 2 #185355437

### DIFF
--- a/content/src/roadmaps/add-ons/cannabis-conditional.json
+++ b/content/src/roadmaps/add-ons/cannabis-conditional.json
@@ -3,13 +3,13 @@
     {
       "step": 3,
       "weight": 4,
-      "task": "conditional-permit-cannabis",
+      "licenseTask": "conditional-permit-cannabis",
       "required": true
     },
     {
       "step": 4,
       "weight": 1,
-      "task": "conversion-license-cannabis",
+      "licenseTask": "conversion-license-cannabis",
       "required": true
     }
   ]

--- a/content/src/roadmaps/add-ons/cpa.json
+++ b/content/src/roadmaps/add-ons/cpa.json
@@ -3,13 +3,13 @@
     {
       "step": 4,
       "weight": 51,
-      "task": "license-accounting",
+      "licenseTask": "license-accounting",
       "required": true
     },
     {
       "step": 4,
       "weight": 50,
-      "task": "register-firm-accounting"
+      "licenseTask": "register-firm-accounting"
     }
   ],
   "modifications": []

--- a/content/src/roadmaps/add-ons/daycare.json
+++ b/content/src/roadmaps/add-ons/daycare.json
@@ -14,7 +14,7 @@
     {
       "step": 3,
       "weight": 20,
-      "task": "daycare-license",
+      "licenseTask": "daycare-license",
       "required": true
     }
   ]

--- a/content/src/roadmaps/add-ons/family-daycare.json
+++ b/content/src/roadmaps/add-ons/family-daycare.json
@@ -3,7 +3,7 @@
     {
       "step": 3,
       "weight": 30,
-      "task": "family-daycare-register"
+      "licenseTask": "family-daycare-register"
     }
   ]
 }

--- a/content/src/roadmaps/add-ons/petcare-license.json
+++ b/content/src/roadmaps/add-ons/petcare-license.json
@@ -3,7 +3,7 @@
     {
       "step": 3,
       "weight": 30,
-      "task": "petcare-license"
+      "licenseTask": "petcare-license"
     }
   ]
 }

--- a/content/src/roadmaps/add-ons/real-estate-appraisal-management.json
+++ b/content/src/roadmaps/add-ons/real-estate-appraisal-management.json
@@ -3,13 +3,13 @@
       {
         "step": 3,
         "weight": 20,
-        "task": "appraiser-certification",
+        "licenseTask": "appraiser-certification",
         "required": true
       },
       {
         "step": 3,
         "weight": 21,
-        "task": "appraiser-company-register",
+        "licenseTask": "appraiser-company-register",
         "required": true
       }
     ]

--- a/content/src/roadmaps/add-ons/real-estate-appraiser.json
+++ b/content/src/roadmaps/add-ons/real-estate-appraiser.json
@@ -3,7 +3,7 @@
       {
         "step": 3,
         "weight": 20,
-        "task": "appraiser-license",
+        "licenseTask": "appraiser-license",
         "required": true
       }
     ],

--- a/content/src/roadmaps/task-dependencies.json
+++ b/content/src/roadmaps/task-dependencies.json
@@ -1,8 +1,8 @@
 {
   "dependencies": [
     {
-      "name": "register-for-ein",
-      "dependencies": [
+      "task": "register-for-ein",
+      "taskDependencies": [
         "form-business-entity",
         "form-business-entity-nj",
         "form-business-entity-foreign",
@@ -10,14 +10,14 @@
       ]
     },
     {
-      "name": "form-business-entity",
-      "dependencies": [
+      "task": "form-business-entity",
+      "taskDependencies": [
         "register-for-ein"
       ]
     },
     {
-      "name": "register-for-taxes",
-      "dependencies": [
+      "task": "register-for-taxes",
+      "taskDependencies": [
         "form-business-entity",
         "form-business-entity-nj",
         "form-business-entity-foreign",
@@ -28,186 +28,188 @@
       ]
     },
     {
-      "name": "floor-plan-approval-doh",
-      "dependencies": [
+      "task": "floor-plan-approval-doh",
+      "taskDependencies": [
         "sign-lease"
       ]
     },
     {
-      "name": "individual-staff-licenses-health-aide",
-      "dependencies": [
+      "task": "individual-staff-licenses-health-aide",
+      "licenseTaskDependencies": [
         "home-health-aide-license"
       ]
     },
     {
-      "name": "site-safety-permits-cosmetology",
-      "dependencies": [
+      "task": "site-safety-permits-cosmetology",
+      "taskDependencies": [
         "sign-lease",
         "building-permit"
       ]
     },
     {
-      "name": "town-mercantile-license-liquor",
-      "dependencies": [
+      "task": "town-mercantile-license-liquor",
+      "taskDependencies": [
         "sign-lease",
         "liquor-license-availability"
       ]
     },
     {
-      "name": "zoning",
-      "dependencies": [
+      "task": "zoning",
+      "taskDependencies": [
         "sign-lease"
       ]
     },
     {
-      "name": "logisticare",
-      "dependencies": [
+      "task": "logisticare",
+      "licenseTaskDependencies": [
         "register-vehicle"
       ]
     },
     {
-      "name": "apply-scorp-federal",
-      "dependencies": [
+      "task": "apply-scorp-federal",
+      "taskDependencies": [
         "register-for-taxes"
       ]
     },
     {
-      "name": "apply-scorp-state",
-      "dependencies": [
+      "task": "apply-scorp-state",
+      "taskDependencies": [
         "apply-scorp-federal"
       ]
     },
     {
-      "name": "apply-for-shop-license",
-      "dependencies": [
+      "licenseTask": "apply-for-shop-license",
+      "taskDependencies": [
         "site-safety-permits-cosmetology"
       ]
     },
     {
-      "name": "Haul-Waste",
-      "dependencies": [
+      "licenseTask": "Haul-Waste",
+      "licenseTaskDependencies": [
         "register-consumer-affairs"
       ]
     },
     {
-      "name": "pharmacy-license",
-      "dependencies": [
+      "licenseTask": "pharmacy-license",
+      "taskDependencies": [
         "site-safety-permits"
       ]
     },
     {
-      "name": "conversion-license-cannabis",
-      "dependencies": [
-        "zoning-cannabis",
+      "licenseTask": "conversion-license-cannabis",
+      "taskDependencies": [
+        "zoning-cannabis"
+      ],
+      "licenseTaskDependencies": [
         "conditional-permit-cannabis"
       ]
     },
     {
-      "name": "annual-license-cannabis",
-      "dependencies": [
+      "licenseTask": "annual-license-cannabis",
+      "taskDependencies": [
         "zoning-cannabis",
         "priority-status-cannabis"
       ]
     },
     {
-      "name": "conditional-permit-cannabis",
-      "dependencies": [
+      "licenseTask": "conditional-permit-cannabis",
+      "taskDependencies": [
         "priority-status-cannabis"
       ]
     },
     {
-      "name": "trucking-irp",
-      "dependencies": [
+      "task": "trucking-irp",
+      "taskDependencies": [
         "trucking-usdot"
       ]
     },
     {
-      "name": "trucking-vehicle-registration",
-      "dependencies": [
+      "task": "trucking-vehicle-registration",
+      "taskDependencies": [
         "trucking-insurance"
       ]
     },
     {
-      "name": "register-for-taxes-foreign",
-      "dependencies": [
+      "task": "register-for-taxes-foreign",
+      "taskDependencies": [
         "form-business-entity-foreign"
       ]
     },
     {
-      "name": "apply-scorp-federal",
-      "dependencies": [
+      "task": "apply-scorp-federal",
+      "taskDependencies": [
         "register-for-taxes-foreign"
       ]
     },
     {
-      "name": "form-business-entity-foreign",
-      "dependencies": [
+      "task": "form-business-entity-foreign",
+      "taskDependencies": [
         "certificate-good-standing-foreign"
       ]
     },
     {
-      "name": "bus-inspection",
-      "dependencies": [
+      "licenseTask": "bus-inspection",
+      "taskDependencies": [
         "school-bus-insurance"
       ]
     },
     {
-      "name": "transportation-inspection",
-      "dependencies": [
+      "task": "transportation-inspection",
+      "taskDependencies": [
         "transport-insurance"
       ]
     },
     {
-      "name": "transportation-cpcn",
-      "dependencies": [
+      "task": "transportation-cpcn",
+      "taskDependencies": [
         "transportation-entity-id"
       ]
     },
     {
-      "name": "daycare-license",
-      "dependencies": [
+      "licenseTask": "daycare-license",
+      "taskDependencies": [
         "daycare-site-requirements"
       ]
     },
     {
-      "name": "architect-are-exam",
-      "dependencies": [
+      "task": "architect-are-exam",
+      "licenseTaskDependencies": [
         "architect-license"
       ]
     },
     {
-      "name": "authorization-architect-firm",
-      "dependencies": [
+      "licenseTask": "authorization-architect-firm",
+      "licenseTaskDependencies": [
         "architect-license"
       ]
     },
     {
-      "name": "auto-body-repair-license",
-      "dependencies": [
+      "licenseTask": "auto-body-repair-license",
+      "taskDependencies": [
         "register-for-taxes"
       ]
     },
     {
-      "name": "detective-employees",
-      "dependencies": [
+      "licenseTask": "detective-employees",
+      "licenseTaskDependencies": [
         "detective-agency-license"
       ]
     },
     {
-      "name": "hvac-license",
-      "dependencies": [
+      "licenseTask": "hvac-license",
+      "taskDependencies": [
         "hvac-insurance-surety-bond"
       ]
     },
     {
-      "name": "moving-company-license",
-      "dependencies": [
+      "licenseTask": "moving-company-license",
+      "taskDependencies": [
         "moving-company-insurance"
       ]
     },
     {
-      "name": "electrical-business-license",
-      "dependencies": [
+      "licenseTask": "electrical-business-license",
+      "taskDependencies": [
         "get-insurance"
       ]
     }

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -1555,7 +1555,7 @@ collections:
       - label: Roadmap Steps
         name: roadmapSteps
         widget: list
-        summary: "Step {{step}} - {{task}}"
+        summary: "Step {{step}} - {{task}} {{licenseTask}}"
         fields:
           - label: Roadmap Step
             name: step
@@ -1567,13 +1567,23 @@ collections:
           - label: Weight
             name: weight
             widget: number
-          - label: Task
+          - label: Task (this or License Task is required)
             name: task
             widget: "relation"
             collection: "tasks"
             search_fields: ["{{filename}}", "name", "urlSlug"]
             value_field: "{{filename}}"
             display_fields: ["{{filename}}"]
+            required: false
+            options_length: 500
+          - label: License Task (this or Task is required)
+            name: licenseTask
+            widget: "relation"
+            collection: "license-tasks"
+            search_fields: ["{{filename}}", "name", "urlSlug"]
+            value_field: "{{filename}}"
+            display_fields: ["{{filename}}"]
+            required: false
             options_length: 500
           - label: "Required"
             name: "required"

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -1676,23 +1676,45 @@ collections:
           - label: Tasks
             name: dependencies
             widget: list
+            summary: "{{task}} {{licenseTask}}"
             fields:
-              - label: Task
-                name: name
+              - label: Task (this or License Task is required)
+                name: task
                 widget: "relation"
                 collection: "tasks"
                 search_fields: ["{{filename}}", "name", "urlSlug"]
                 value_field: "{{filename}}"
                 display_fields: ["{{filename}}"]
+                required: false
                 options_length: 500
-              - label: Dependencies
-                name: dependencies
+              - label: License Task (this or Task is required)
+                name: licenseTask
+                widget: "relation"
+                collection: "license-tasks"
+                search_fields: ["{{filename}}", "name", "urlSlug"]
+                value_field: "{{filename}}"
+                display_fields: ["{{filename}}"]
+                required: false
+                options_length: 500
+              - label: Task Dependencies
+                name: taskDependencies
                 widget: "relation"
                 collection: "tasks"
                 search_fields: ["{{filename}}", "name", "urlSlug"]
                 value_field: "{{filename}}"
                 display_fields: ["{{filename}}"]
                 multiple: true
+                required: false
+                options_length: 500
+              - label: License Task Dependencies
+                name: licenseTaskDependencies
+                widget: "relation"
+                collection: "license-tasks"
+                search_fields: ["{{filename}}", "name", "urlSlug"]
+                value_field: "{{filename}}"
+                display_fields: ["{{filename}}"]
+                multiple: true
+                required: false
                 options_length: 500
 
   - name: "tasks-label"

--- a/web/src/lib/roadmap/fixtures/task-dependencies.json
+++ b/web/src/lib/roadmap/fixtures/task-dependencies.json
@@ -1,8 +1,8 @@
 {
   "dependencies": [
     {
-      "name": "blocked-task",
-      "dependencies": ["blocking-task-1", "blocking-task-2", "blocking-task-1-duplicate"]
+      "task": "blocked-task",
+      "taskDependencies": ["blocking-task-1", "blocking-task-2", "blocking-task-1-duplicate"]
     }
   ]
 }

--- a/web/src/lib/static/loadTasks.ts
+++ b/web/src/lib/static/loadTasks.ts
@@ -60,7 +60,7 @@ export const loadTaskByUrlSlug = (urlSlug: string): Task => {
   }
 };
 
-const loadTaskByFileName = (fileName: string, directory: string): Task => {
+export const loadTaskByFileName = (fileName: string, directory: string): Task => {
   const fullPath = path.join(directory, `${fileName}`);
   const fileContents = fs.readFileSync(fullPath, "utf8");
 
@@ -69,11 +69,14 @@ const loadTaskByFileName = (fileName: string, directory: string): Task => {
 
   const taskWithoutLinks = convertTaskMd(fileContents);
   const fileNameWithoutMd = fileName.split(".md")[0];
-  const unlockedByTaskLinks = (
-    dependencies.find((dependency) => {
-      return dependency.name === fileNameWithoutMd;
-    })?.dependencies || []
-  ).map((dependencyFileName) => {
+
+  const currentTaskDependencies = dependencies.find((dependency) => {
+    return dependency.task === fileNameWithoutMd || dependency.licenseTask === fileNameWithoutMd;
+  });
+  const taskDependencies = currentTaskDependencies?.taskDependencies || [];
+  const licenseTaskDependencies = currentTaskDependencies?.licenseTaskDependencies || [];
+  const combinedDependencies = [...taskDependencies, ...licenseTaskDependencies];
+  const unlockedByTaskLinks = combinedDependencies.map((dependencyFileName) => {
     return loadTaskLinkByFilename(dependencyFileName);
   });
 

--- a/web/src/lib/types/types.ts
+++ b/web/src/lib/types/types.ts
@@ -346,8 +346,10 @@ export interface TaskLink {
 }
 
 export type TaskDependencies = {
-  name: string;
-  dependencies: string[];
+  task?: string;
+  licenseTask?: string;
+  taskDependencies?: string[];
+  licenseTaskDependencies?: string[];
 };
 
 export const taxFilingMethod = [


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

We had issues where we want a dropdown to pull from both the license task folder and task folder. Since this is not possible in the CMS we will simply have 2 drop downs but this requires some code and test and CMS changes outlined in this story. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/185355437)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
