### PR TITLE
chore(release): 5.23.1 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [5.23.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v5.23.0...v5.23.1) (2023-07-11)
+
+
+### Bug Fixes
+
+* updated mismatched webflow ids ([e5ba2a8](https://github.com/newjersey/navigator.business.nj.gov/commit/e5ba2a83f8f0abae2655d9717133a34a56153a3b))
+
 # [5.23.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v5.22.1...v5.23.0) (2023-07-07)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businessnjgovnavigator/root",
-  "version": "5.23.0",
+  "version": "5.23.1",
   "description": "This is the development repository for the work-in-progress business navigator from the New Jersey Office of Innovation. For info on the existing [Business.NJ.gov](https://business.nj.gov) site, please see the [bottom of this document](https://github.com/newjersey/navigator.business.nj.gov#businessnjgov)",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
## [5.23.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v5.23.0...v5.23.1) (2023-07-11)

### Bug Fixes

* updated mismatched webflow ids ([e5ba2a8](https://github.com/newjersey/navigator.business.nj.gov/commit/e5ba2a83f8f0abae2655d9717133a34a56153a3b))
