### PR TITLE
release 20230711

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [5.23.2](https://github.com/newjersey/navigator.business.nj.gov/compare/v5.23.1...v5.23.2) (2023-07-12)
+
+
+### Bug Fixes
+
+* enabling alert outage bar ([345f64c](https://github.com/newjersey/navigator.business.nj.gov/commit/345f64cbd6945dc65ffbb9a129867132772e0f38))
+
 ## [5.23.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v5.23.0...v5.23.1) (2023-07-11)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businessnjgovnavigator/root",
-  "version": "5.23.1",
+  "version": "5.23.2",
   "description": "This is the development repository for the work-in-progress business navigator from the New Jersey Office of Innovation. For info on the existing [Business.NJ.gov](https://business.nj.gov) site, please see the [bottom of this document](https://github.com/newjersey/navigator.business.nj.gov#businessnjgov)",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
- fix: enabling alert outage bar
- chore(release): 5.23.2 [skip ci]
