### PR TITLE
release 20230711

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [5.23.3](https://github.com/newjersey/navigator.business.nj.gov/compare/v5.23.2...v5.23.3) (2023-07-12)
+
+
+### Bug Fixes
+
+* enabling alert outage bar ([c0b6d29](https://github.com/newjersey/navigator.business.nj.gov/commit/c0b6d2954bf5a982e4f52f715ccd1374ef152e8e))
+
 ## [5.23.2](https://github.com/newjersey/navigator.business.nj.gov/compare/v5.23.1...v5.23.2) (2023-07-12)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businessnjgovnavigator/root",
-  "version": "5.23.2",
+  "version": "5.23.3",
   "description": "This is the development repository for the work-in-progress business navigator from the New Jersey Office of Innovation. For info on the existing [Business.NJ.gov](https://business.nj.gov) site, please see the [bottom of this document](https://github.com/newjersey/navigator.business.nj.gov#businessnjgov)",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
- fix: enabling alert outage bar
- chore(release): 5.23.3 [skip ci]
