### PR TITLE
fix: [#185647571] override default date of formation label in modal

### DIFF
--- a/web/src/components/FormationDateModal.tsx
+++ b/web/src/components/FormationDateModal.tsx
@@ -88,6 +88,8 @@ export const FormationDateModal = (props: Props): ReactElement => {
               overrides={{
                 header: Config.formationDateModal.fieldLabel,
                 description: Config.formationDateModal.fieldDescription,
+                headerNotBolded: "",
+                postDescription: "",
               }}
             />
 

--- a/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepTwo.tsx
+++ b/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepTwo.tsx
@@ -302,6 +302,8 @@ export const TaxAccessStepTwo = (props: Props): ReactElement => {
                 overrides={{
                   header: Config.taxAccess.modalBusinessFieldHeader,
                   description: Config.taxAccess.modalBusinessFieldMarkdown,
+                  headerNotBolded: "",
+                  postDescription: "",
                 }}
               />
               <ProfileBusinessName validationText={Config.taxAccess.failedBusinessFieldHelper} required />
@@ -318,6 +320,8 @@ export const TaxAccessStepTwo = (props: Props): ReactElement => {
                 overrides={{
                   header: Config.taxAccess.modalBusinessOwnerName,
                   description: Config.taxAccess.modalBusinessOwnerDescription,
+                  headerNotBolded: "",
+                  postDescription: "",
                 }}
               />
               <ProfileResponsibleOwnerName
@@ -337,6 +341,7 @@ export const TaxAccessStepTwo = (props: Props): ReactElement => {
                 overrides={{
                   header: Config.taxAccess.modalTaxIdHeader,
                   description: Config.taxAccess.modalTaxIdMarkdown,
+                  headerNotBolded: "",
                   postDescription: LookupLegalStructureById(
                     business?.profileData.legalStructureId
                   ).elementsToDisplay.has("taxIdDisclaimer")

--- a/web/src/components/onboarding/FieldLabelModal.tsx
+++ b/web/src/components/onboarding/FieldLabelModal.tsx
@@ -6,10 +6,10 @@ import { ProfileContentField } from "@/lib/types/types";
 import { ReactElement, useContext } from "react";
 
 interface FieldOverrides {
-  header?: string;
-  description?: string;
-  headerNotBolded?: string;
-  postDescription?: string;
+  header: string | undefined;
+  description: string | undefined;
+  headerNotBolded: string | undefined;
+  postDescription: string | undefined;
 }
 
 interface Props {
@@ -27,9 +27,9 @@ export const FieldLabelModal = (props: Props): ReactElement => {
     fieldName: props.fieldName,
   });
 
-  const header = props.overrides?.header || contentFromConfig.header;
-  const description = props.overrides?.description || contentFromConfig.description;
-  const unboldedHeader = props.overrides?.headerNotBolded || contentFromConfig.headerNotBolded;
+  const header = props.overrides?.header ?? contentFromConfig.header;
+  const description = props.overrides?.description ?? contentFromConfig.description;
+  const unboldedHeader = props.overrides?.headerNotBolded ?? contentFromConfig.headerNotBolded;
   const postDescription = props.overrides?.postDescription;
 
   return (


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have performed a self-review of my code
- [ ] I have created and/or updated relevant documentation, if necessary
- [ ] I have not used any relative imports
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
