### PR TITLE
fix:[185617245] - fix tax id hide show on profile

### DIFF
--- a/web/src/components/njwds-extended/UnStyledButton.tsx
+++ b/web/src/components/njwds-extended/UnStyledButton.tsx
@@ -52,6 +52,7 @@ export const UnStyledButton = forwardRef(
     return (
       <button
         className={className}
+        type={"button"}
         ref={ref}
         onClick={props.onClick}
         {...(props.dataTestid ? { "data-testid": props.dataTestid } : {})}


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Steps to Reproduce

Onboard as Poppy, Oscar or Dakota
Save a Tax ID to the userData
Navigate to business profile
Click show on the hidden Tax ID field
Expected
The plain text Tax ID should be displayed to the user so they can use it as a point of reference.

Current
The click triggers an save which then navigates the user back to dashboard not allowing the user to properly refer to the plain text Tax ID.


<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#185617245](https://www.pivotaltracker.com/story/show/)

### Approach
Added type button to button tag
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

1. Onboard as Poppy, Oscar or Dakota
2. Save a Tax ID to the userData
3. Navigate to business profile
4. Click show on the hidden Tax ID field
5. Expected - The plain text Tax ID should be displayed to the user so they can use it as a point of reference.
<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
