### PR TITLE
fix: [#185362965] green box bug fix

### DIFF
--- a/web/src/components/Content.tsx
+++ b/web/src/components/Content.tsx
@@ -44,6 +44,9 @@ export const Content = (props: ContentProps): ReactElement => {
       return <HorizontalLine />;
     },
     blockquote: GreenBox,
+    greenBox: (props: any): ReactElement => {
+      return <GreenBox>{props.children}</GreenBox>;
+    },
     infoAlert: (props: any): ReactElement => {
       return (
         <Alert variant="info" heading={props.header}>

--- a/web/src/components/PureMarkdownContent.tsx
+++ b/web/src/components/PureMarkdownContent.tsx
@@ -42,6 +42,13 @@ function customRemarkPlugin():
             header: node.attributes.header,
           };
         }
+        if (node.name === "greenBox") {
+          const data = node.data || (node.data = {});
+          data.hName = "greenBox";
+          data.hProperties = {
+            header: node.attributes.header,
+          };
+        }
         if (node.name === "icon") {
           const data = node.data || (node.data = {});
           data.hName = "icon";

--- a/web/src/lib/cms/editors/greenBox.tsx
+++ b/web/src/lib/cms/editors/greenBox.tsx
@@ -1,0 +1,34 @@
+export default {
+  id: "greenBox",
+  label: "Green Box Block",
+  fields: [
+    {
+      name: "body",
+      label: "Body Text",
+      required: true,
+      widget: "markdown",
+    },
+  ],
+
+  pattern: /:::greenBox[^:]+:::/g,
+  collapsed: false,
+  summary: "{{fields.title}}",
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fromBlock: (match: any): { body: string } => {
+    const string = match[0];
+    const startLength = ":::greenBox".length;
+    const endLength = ":::".length;
+    const body = string.slice(startLength, -1 * endLength);
+    return {
+      body: body,
+    };
+  },
+  // Function to create a text block from an instance of this component
+  toBlock: (obj: { body: string }): string => {
+    return `:::greenBox \n ${obj.body ? obj.body.trim() : ""}\n:::`;
+  },
+
+  toPreview: (obj: { body: string }): string => {
+    return `:::greenBox \n ${obj.body ? obj.body.trim() : ""}\n:::`;
+  },
+};

--- a/web/src/pages/mgmt/cms.tsx
+++ b/web/src/pages/mgmt/cms.tsx
@@ -1,4 +1,5 @@
 import ContextEditor from "@/lib/cms/editors/context-info";
+import GreenBox from "@/lib/cms/editors/greenBox";
 import IconWidgetEditor from "@/lib/cms/editors/icon";
 import AlertEditor from "@/lib/cms/editors/infoAlert";
 import { NoSpaceControl } from "@/lib/cms/fields/nospacefield";
@@ -62,6 +63,8 @@ const CMS = dynamic(
       CMS.registerEditorComponent(ContextEditor);
       // @ts-expect-error: No type definition available
       CMS.registerEditorComponent(AlertEditor);
+      // @ts-expect-error: No type definition available
+      CMS.registerEditorComponent(GreenBox);
       // @ts-expect-error: No type definition available
       CMS.registerEditorComponent(IconWidgetEditor);
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

We talked with content and to get around the weird bug where we have back to back green block and switching between markdown and causing them to combine. They preffered a more robust solution to using <br/>, so I added a block for the green text

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/185355762)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

Go into the app and add the code block via the markdown section 

<img width="741" alt="image" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22485301/4cfda196-ef80-43cc-904d-2c9c5ed04a38">
see that the preview and such works as expected


### Notes

<!-- Additional information, key learnings, and future development considerations. -->

I wanted to try and do try and do this with just an inner block and no outer block, but while it looks like its probably possible, not worth the effort

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
