### PR TITLE
chore: [#184978365] fix grid for city, state, and zip in formation

### DIFF
--- a/web/src/components/tasks/business-formation/business/MainBusinessAddressIntl.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusinessAddressIntl.tsx
@@ -31,9 +31,13 @@ export const MainBusinessIntl = (): ReactElement => {
         validationText={getFieldErrorLabel("addressLine2")}
         className="margin-bottom-2"
       />
-      <WithErrorBar hasError={doSomeFieldsHaveError(["addressCity", "addressProvince"])} type="DESKTOP-ONLY">
+      <WithErrorBar
+        hasError={doSomeFieldsHaveError(["addressCity", "addressProvince"])}
+        type="DESKTOP-ONLY"
+        className="margin-bottom-2"
+      >
         <div className="grid-row grid-gap-1">
-          <div className="tablet:grid-col-6">
+          <div className="tablet:grid-col-6 margin-bottom-2 tablet:margin-bottom-0">
             <BusinessFormationTextField
               label={Config.formation.fields.addressCity.label}
               fieldName="addressCity"
@@ -53,11 +57,7 @@ export const MainBusinessIntl = (): ReactElement => {
           </div>
         </div>
       </WithErrorBar>
-      <WithErrorBar
-        hasError={doSomeFieldsHaveError(["addressCountry"])}
-        className={`margin-top-2`}
-        type="ALWAYS"
-      >
+      <WithErrorBar hasError={doSomeFieldsHaveError(["addressCountry"])} type="ALWAYS">
         <strong>
           <ModifiedContent>{Config.formation.fields.addressCountry.label}</ModifiedContent>
         </strong>

--- a/web/src/components/tasks/business-formation/business/MainBusinessAddressNj.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusinessAddressNj.tsx
@@ -85,32 +85,36 @@ export const MainBusinessAddressNj = (): ReactElement => {
                   <FormationMunicipality />
                 </WithErrorBar>
               </div>
-              <div className="margin-top-2 tablet:margin-top-0 grid-col-5 tablet:grid-col-2">
+              <div className="grid-col-12 tablet:grid-col-6 margin-top-2 tablet:margin-top-0">
                 <WithErrorBar
                   hasError={doSomeFieldsHaveError(["addressState", "addressZipCode"])}
                   type="MOBILE-ONLY"
                 >
-                  <strong>
-                    <ModifiedContent>{Config.formation.fields.addressState.label}</ModifiedContent>
-                  </strong>
-                  <StateDropdown
-                    fieldName="addressState"
-                    value={"New Jersey"}
-                    validationText={Config.formation.fields.addressState.error}
-                    disabled={true}
-                    onSelect={(): void => {}}
-                  />
+                  <div className="grid-row grid-gap-1">
+                    <div className="grid-col-5">
+                      <strong>
+                        <ModifiedContent>{Config.formation.fields.addressState.label}</ModifiedContent>
+                      </strong>
+                      <StateDropdown
+                        fieldName="addressState"
+                        value={"New Jersey"}
+                        validationText={Config.formation.fields.addressState.error}
+                        disabled={true}
+                        onSelect={(): void => {}}
+                      />
+                    </div>
+                    <div className="grid-col-7">
+                      <BusinessFormationTextField
+                        label={Config.formation.fields.addressZipCode.label}
+                        numericProps={{ maxLength: 5 }}
+                        required={true}
+                        errorBarType="NEVER"
+                        fieldName={"addressZipCode"}
+                        validationText={getFieldErrorLabel("addressZipCode")}
+                      />
+                    </div>
+                  </div>
                 </WithErrorBar>
-              </div>
-              <div className="margin-top-2 tablet:margin-top-0 grid-col-7 tablet:grid-col-4">
-                <BusinessFormationTextField
-                  label={Config.formation.fields.addressZipCode.label}
-                  numericProps={{ maxLength: 5 }}
-                  required={true}
-                  errorBarType="NEVER"
-                  fieldName={"addressZipCode"}
-                  validationText={getFieldErrorLabel("addressZipCode")}
-                />
               </div>
             </div>
           </WithErrorBar>

--- a/web/src/components/tasks/business-formation/business/MainBusinessAddressUs.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusinessAddressUs.tsx
@@ -44,42 +44,46 @@ export const MainBusinessUs = (): ReactElement => {
               validationText={getFieldErrorLabel("addressCity")}
             />
           </div>
-          <div className="margin-top-2 tablet:margin-top-0 grid-col-5 tablet:grid-col-2">
+          <div className="grid-col-12 tablet:grid-col-6 margin-top-2 tablet:margin-top-0">
             <WithErrorBar
               hasError={doSomeFieldsHaveError(["addressState", "addressZipCode"])}
               type="MOBILE-ONLY"
             >
-              <strong>
-                <ModifiedContent>{Config.formation.fields.addressState.label}</ModifiedContent>
-              </strong>
-              <StateDropdown
-                fieldName="addressState"
-                value={state.formationFormData.addressState?.name}
-                error={doesFieldHaveError("addressState")}
-                validationText={Config.formation.fields.addressState.error}
-                required
-                onValidation={(): void => setFieldsInteracted(["addressState"])}
-                onSelect={(stateObject): void => {
-                  setFormationFormData((previousFormationData) => {
-                    return {
-                      ...previousFormationData,
-                      addressState: stateObject,
-                    };
-                  });
-                  setFieldsInteracted(["addressState"]);
-                }}
-              />
+              <div className="grid-row grid-gap-1">
+                <div className="grid-col-5">
+                  <strong>
+                    <ModifiedContent>{Config.formation.fields.addressState.label}</ModifiedContent>
+                  </strong>
+                  <StateDropdown
+                    fieldName="addressState"
+                    value={state.formationFormData.addressState?.name}
+                    error={doesFieldHaveError("addressState")}
+                    validationText={Config.formation.fields.addressState.error}
+                    required
+                    onValidation={(): void => setFieldsInteracted(["addressState"])}
+                    onSelect={(stateObject): void => {
+                      setFormationFormData((previousFormationData) => {
+                        return {
+                          ...previousFormationData,
+                          addressState: stateObject,
+                        };
+                      });
+                      setFieldsInteracted(["addressState"]);
+                    }}
+                  />
+                </div>
+                <div className="grid-col-7">
+                  <BusinessFormationTextField
+                    label={Config.formation.fields.addressZipCode.label}
+                    numericProps={{ maxLength: 5 }}
+                    required={true}
+                    errorBarType="NEVER"
+                    fieldName={"addressZipCode"}
+                    validationText={Config.formation.fields.addressZipCode.foreign.errorUS}
+                  />
+                </div>
+              </div>
             </WithErrorBar>
-          </div>
-          <div className="margin-top-2 tablet:margin-top-0 grid-col-7 tablet:grid-col-4">
-            <BusinessFormationTextField
-              label={Config.formation.fields.addressZipCode.label}
-              numericProps={{ maxLength: 5 }}
-              required={true}
-              errorBarType="NEVER"
-              fieldName={"addressZipCode"}
-              validationText={Config.formation.fields.addressZipCode.foreign.errorUS}
-            />
           </div>
         </div>
       </WithErrorBar>

--- a/web/src/components/tasks/business-formation/contacts/AddressModal.tsx
+++ b/web/src/components/tasks/business-formation/contacts/AddressModal.tsx
@@ -320,16 +320,16 @@ export const AddressModal = <T extends FormationMember | FormationIncorporator>(
               }}
             />
           </WithErrorBar>
-          <div className="grid-row grid-gap-1 margin-y-2">
-            <div className="grid-col-12 tablet:grid-col-6">
-              <WithErrorBar
-                hasError={
-                  !!addressErrorMap["addressCity"].invalid ||
-                  !!addressErrorMap["addressState"].invalid ||
-                  !!addressErrorMap["addressZipCode"].invalid
-                }
-                type="DESKTOP-ONLY"
-              >
+          <WithErrorBar
+            hasError={
+              !!addressErrorMap["addressCity"].invalid ||
+              !!addressErrorMap["addressState"].invalid ||
+              !!addressErrorMap["addressZipCode"].invalid
+            }
+            type="DESKTOP-ONLY"
+          >
+            <div className="grid-row grid-gap-1">
+              <div className="grid-col-12 tablet:grid-col-6">
                 <WithErrorBar hasError={!!addressErrorMap["addressCity"].invalid} type="MOBILE-ONLY">
                   <strong>
                     <ModifiedContent>{Config.formation.addressModal.addressCity.label}</ModifiedContent>
@@ -351,62 +351,66 @@ export const AddressModal = <T extends FormationMember | FormationIncorporator>(
                     validationText={addressErrorMap["addressCity"].label}
                   />
                 </WithErrorBar>
-              </WithErrorBar>
+              </div>
+              <div className="grid-col-12 tablet:grid-col-6 margin-top-2 tablet:margin-top-0">
+                <WithErrorBar
+                  hasError={
+                    !!addressErrorMap["addressState"].invalid || !!addressErrorMap["addressZipCode"].invalid
+                  }
+                  type="MOBILE-ONLY"
+                >
+                  <div className="grid-row grid-gap-1">
+                    <div className="grid-col-5">
+                      <strong>
+                        <ModifiedContent>{Config.formation.addressModal.addressState.label}</ModifiedContent>
+                      </strong>
+                      <StateDropdown
+                        fieldName="addressState"
+                        value={addressData.addressState?.name ?? ""}
+                        validationText={addressErrorMap["addressState"].label}
+                        onSelect={(value: StateObject | undefined): void => {
+                          setAddressData((prevAddressData) => {
+                            return { ...prevAddressData, addressState: value };
+                          });
+                        }}
+                        error={addressErrorMap["addressState"].invalid}
+                        autoComplete
+                        disabled={shouldBeDisabled("addressState")}
+                        onValidation={onValidation}
+                        required={true}
+                      />
+                    </div>
+                    <div className="grid-col-7">
+                      <strong>
+                        <ModifiedContent>
+                          {Config.formation.addressModal.addressZipCode.label}
+                        </ModifiedContent>
+                      </strong>
+                      <GenericTextField
+                        inputWidth="full"
+                        numericProps={{
+                          maxLength: 5,
+                        }}
+                        disabled={shouldBeDisabled("addressZipCode")}
+                        fieldName={"addressZipCode"}
+                        autoComplete="postal-code"
+                        error={addressErrorMap["addressZipCode"].invalid}
+                        handleChange={(value: string): void => {
+                          setAddressData((prevAddressData) => {
+                            return { ...prevAddressData, addressZipCode: value };
+                          });
+                        }}
+                        value={addressData.addressZipCode}
+                        validationText={addressErrorMap["addressZipCode"].label}
+                        onValidation={onValidation}
+                        required={true}
+                      />
+                    </div>
+                  </div>
+                </WithErrorBar>
+              </div>
             </div>
-            <div className="grid-col-6 tablet:grid-col-3">
-              <WithErrorBar
-                hasError={
-                  !!addressErrorMap["addressState"].invalid || !!addressErrorMap["addressZipCode"].invalid
-                }
-                type="MOBILE-ONLY"
-              >
-                <div className={"margin-top-2 tablet:margin-top-0"}>
-                  <strong>
-                    <ModifiedContent>{Config.formation.addressModal.addressState.label}</ModifiedContent>
-                  </strong>
-                  <StateDropdown
-                    fieldName="addressState"
-                    value={addressData.addressState?.name ?? ""}
-                    validationText={addressErrorMap["addressState"].label}
-                    onSelect={(value: StateObject | undefined): void => {
-                      setAddressData((prevAddressData) => {
-                        return { ...prevAddressData, addressState: value };
-                      });
-                    }}
-                    error={addressErrorMap["addressState"].invalid}
-                    autoComplete
-                    disabled={shouldBeDisabled("addressState")}
-                    onValidation={onValidation}
-                    required={true}
-                  />
-                </div>
-              </WithErrorBar>
-            </div>
-            <div className="grid-col-6 tablet:grid-col-3 margin-top-2 tablet:margin-top-0">
-              <strong>
-                <ModifiedContent>{Config.formation.addressModal.addressZipCode.label}</ModifiedContent>
-              </strong>
-              <GenericTextField
-                inputWidth="full"
-                numericProps={{
-                  maxLength: 5,
-                }}
-                disabled={shouldBeDisabled("addressZipCode")}
-                fieldName={"addressZipCode"}
-                autoComplete="postal-code"
-                error={addressErrorMap["addressZipCode"].invalid}
-                handleChange={(value: string): void => {
-                  setAddressData((prevAddressData) => {
-                    return { ...prevAddressData, addressZipCode: value };
-                  });
-                }}
-                value={addressData.addressZipCode}
-                validationText={addressErrorMap["addressZipCode"].label}
-                onValidation={onValidation}
-                required={true}
-              />
-            </div>
-          </div>
+          </WithErrorBar>
         </div>
       </>
     </ModalTwoButton>

--- a/web/src/components/tasks/business-formation/contacts/RegisteredAgent.tsx
+++ b/web/src/components/tasks/business-formation/contacts/RegisteredAgent.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { ModifiedContent } from "@/components/ModifiedContent";
 import { MunicipalityDropdown } from "@/components/profile/MunicipalityDropdown";
 import { StateDropdown } from "@/components/StateDropdown";
 import { BusinessFormationTextField } from "@/components/tasks/business-formation/BusinessFormationTextField";
@@ -253,7 +254,11 @@ export const RegisteredAgent = (): ReactElement => {
                       hasError={doesFieldHaveError("agentOfficeAddressMunicipality")}
                       type="MOBILE-ONLY"
                     >
-                      <Content>{Config.formation.fields.agentOfficeAddressMunicipality.label}</Content>
+                      <strong>
+                        <ModifiedContent>
+                          {Config.formation.fields.agentOfficeAddressMunicipality.label}
+                        </ModifiedContent>
+                      </strong>
                       <MunicipalityDropdown
                         municipalities={municipalities}
                         fieldName={"agentOfficeAddressMunicipality"}
@@ -272,32 +277,39 @@ export const RegisteredAgent = (): ReactElement => {
                       />
                     </WithErrorBar>
                   </div>
-
-                  <div className="grid-col-5 tablet:grid-col-2">
+                  <div className="grid-col-12 tablet:grid-col-6 margin-top-2 tablet:margin-top-0">
                     <WithErrorBar
                       hasError={doesFieldHaveError("agentOfficeAddressZipCode")}
                       type="MOBILE-ONLY"
                     >
-                      <Content>{Config.formation.fields.agentOfficeAddressState.label}</Content>
-                      <StateDropdown
-                        fieldName="agentOfficeAddressState"
-                        value={"New Jersey"}
-                        validationText={Config.formation.fields.agentOfficeAddressState.error}
-                        disabled={true}
-                        onSelect={(): void => {}}
-                      />
+                      <div className="grid-row grid-gap-1">
+                        <div className="grid-col-5">
+                          <strong>
+                            <ModifiedContent>
+                              {Config.formation.fields.agentOfficeAddressState.label}
+                            </ModifiedContent>
+                          </strong>
+                          <StateDropdown
+                            fieldName="agentOfficeAddressState"
+                            value={"New Jersey"}
+                            validationText={Config.formation.fields.agentOfficeAddressState.error}
+                            disabled={true}
+                            onSelect={(): void => {}}
+                          />
+                        </div>
+                        <div className="grid-col-7">
+                          <BusinessFormationTextField
+                            errorBarType="NEVER"
+                            numericProps={{ maxLength: 5 }}
+                            fieldName="agentOfficeAddressZipCode"
+                            label={Config.formation.fields.agentOfficeAddressZipCode.label}
+                            validationText={Config.formation.fields.agentOfficeAddressZipCode.error}
+                            required={true}
+                            disabled={shouldBeDisabled("agentOfficeAddressZipCode", "ADDRESS")}
+                          />
+                        </div>
+                      </div>
                     </WithErrorBar>
-                  </div>
-                  <div className="grid-col-7 tablet:grid-col-4">
-                    <BusinessFormationTextField
-                      errorBarType="NEVER"
-                      numericProps={{ maxLength: 5 }}
-                      fieldName="agentOfficeAddressZipCode"
-                      label={Config.formation.fields.agentOfficeAddressZipCode.label}
-                      validationText={Config.formation.fields.agentOfficeAddressZipCode.error}
-                      required={true}
-                      disabled={shouldBeDisabled("agentOfficeAddressZipCode", "ADDRESS")}
-                    />
                   </div>
                 </div>
               </WithErrorBar>


### PR DESCRIPTION
Whenever we are using the city, state, and ZIP Code inputs together in formation and error text renders - the text extends beyond the height of the red bar. I updated the logic so that the text renders within the red bar.

https://www.pivotaltracker.com/story/show/184978365