### PR TITLE
Formation refactoring - review section

### DIFF
--- a/content/src/fieldConfig/business-formation.json
+++ b/content/src/fieldConfig/business-formation.json
@@ -265,16 +265,8 @@
         "description": "Is your Domestic Non-Profit a `Veteran Corporation|veteran-corporation`?",
         "radioNoText": "No",
         "radioYesText": "Yes",
-        "error": "Select 'Yes' or 'No'."
-      },
-      "nonprofit": {
-        "domNpVetCorpReviewText": "**Yes**, my Domestic Non-Profit is a Veteran Corporation.",
-        "yesBoardMembersReviewText": "**Yes**, my Non-Profit will have board members.",
-        "noBoardMembersReviewText": "**No**, my Non-Profit will not have board members.",
-        "boardMembersQualificationsReviewText": "Board member qualifications are specified",
-        "rightsAndLimitationsReviewText": "Rights and limitations of the board members are specified",
-        "choosingTrusteesReviewText": "The method for choosing trustees are specified",
-        "distributingAssetsReviewText": "The method for distributing assets are specified"
+        "error": "Select 'Yes' or 'No'.",
+        "reviewText": "**Yes**, my Domestic Non-Profit is a Veteran Corporation."
       },
       "contactPhoneNumber": {
         "label": "Phone Number",
@@ -346,7 +338,9 @@
       },
       "hasNonprofitBoardMembers": {
         "label": "Provisions - Board Members",
-        "body": "Will your Non-Profit have `board members|board-member`?"
+        "body": "Will your Non-Profit have `board members|board-member`?",
+        "yesReviewText": "**Yes**, my Non-Profit will have board members.",
+        "noReviewText": "**No**, my Non-Profit will not have board members."
       },
       "nonprofitBoardMemberQualificationsSpecified": {
         "label": "Provisions - Board Member Qualifications",

--- a/content/src/fieldConfig/business-formation.json
+++ b/content/src/fieldConfig/business-formation.json
@@ -266,7 +266,8 @@
         "radioNoText": "No",
         "radioYesText": "Yes",
         "error": "Select 'Yes' or 'No'.",
-        "reviewText": "**Yes**, my Domestic Non-Profit is a Veteran Corporation."
+        "reviewTextYes": "**Yes**, my Domestic Non-Profit is a Veteran Corporation.",
+        "reviewTextNo": "**No**, my Domestic Non-Profit is not a Veteran Corporation."
       },
       "contactPhoneNumber": {
         "label": "Phone Number",

--- a/content/src/fieldConfig/business-formation.json
+++ b/content/src/fieldConfig/business-formation.json
@@ -272,7 +272,7 @@
         "yesBoardMembersReviewText": "**Yes**, my Non-Profit will have board members.",
         "noBoardMembersReviewText": "**No**, my Non-Profit will not have board members.",
         "boardMembersQualificationsReviewText": "Board member qualifications are specified",
-        "rightsAndLimitationsReviewText": "**Rights and limitations of the** board **members are specified**",
+        "rightsAndLimitationsReviewText": "Rights and limitations of the board members are specified",
         "choosingTrusteesReviewText": "The method for choosing trustees are specified",
         "distributingAssetsReviewText": "The method for distributing assets are specified"
       },

--- a/shared/src/formationData.ts
+++ b/shared/src/formationData.ts
@@ -105,6 +105,8 @@ export interface FormationMember extends FormationAddress {
   readonly name: string;
 }
 
+export type InFormInBylaws = "IN_BYLAWS" | "IN_FORM" | undefined;
+
 export interface FormationFormData extends FormationAddress {
   readonly legalType: FormationLegalType;
   readonly businessName: string;
@@ -123,13 +125,13 @@ export interface FormationFormData extends FormationAddress {
   readonly makeDistributionTerms: string;
   readonly hasNonprofitBoardMembers: boolean | undefined;
   readonly nonprofitBoardMembersTerms: string;
-  readonly nonprofitBoardMemberQualificationsSpecified: "IN_BYLAWS" | "IN_FORM" | undefined;
+  readonly nonprofitBoardMemberQualificationsSpecified: InFormInBylaws;
   readonly nonprofitBoardMemberQualificationsTerms: string;
-  readonly nonprofitBoardMemberRightsSpecified: "IN_BYLAWS" | "IN_FORM" | undefined;
+  readonly nonprofitBoardMemberRightsSpecified: InFormInBylaws;
   readonly nonprofitBoardMemberRightsTerms: string;
-  readonly nonprofitTrusteesMethodSpecified: "IN_BYLAWS" | "IN_FORM" | undefined;
+  readonly nonprofitTrusteesMethodSpecified: InFormInBylaws;
   readonly nonprofitTrusteesMethodTerms: string;
-  readonly nonprofitAssetDistributionSpecified: "IN_BYLAWS" | "IN_FORM" | undefined;
+  readonly nonprofitAssetDistributionSpecified: InFormInBylaws;
   readonly nonprofitAssetDistributionTerms: string;
   readonly provisions: string[] | undefined;
   readonly agentNumberOrManual: "NUMBER" | "MANUAL_ENTRY";

--- a/shared/src/formationData.ts
+++ b/shared/src/formationData.ts
@@ -124,7 +124,6 @@ export interface FormationFormData extends FormationAddress {
   readonly canMakeDistribution: boolean | undefined;
   readonly makeDistributionTerms: string;
   readonly hasNonprofitBoardMembers: boolean | undefined;
-  readonly nonprofitBoardMembersTerms: string;
   readonly nonprofitBoardMemberQualificationsSpecified: InFormInBylaws;
   readonly nonprofitBoardMemberQualificationsTerms: string;
   readonly nonprofitBoardMemberRightsSpecified: InFormInBylaws;
@@ -262,7 +261,6 @@ export const createEmptyFormationFormData = (): FormationFormData => {
     canMakeDistribution: undefined,
     makeDistributionTerms: "",
     hasNonprofitBoardMembers: undefined,
-    nonprofitBoardMembersTerms: "",
     nonprofitBoardMemberQualificationsSpecified: undefined,
     nonprofitBoardMemberQualificationsTerms: "",
     nonprofitBoardMemberRightsSpecified: undefined,

--- a/shared/src/test/formationFactories.ts
+++ b/shared/src/test/formationFactories.ts
@@ -233,7 +233,6 @@ export const generateFormationFormData = (
     canMakeDistribution: !!(randomInt() % 2),
     makeDistributionTerms: `some-makeDistributionTerms-text-${randomInt()}`,
     hasNonprofitBoardMembers: !!(randomInt() % 2),
-    nonprofitBoardMembersTerms: `some-nonprofitBoardMembersTerms-text-${randomInt()}`,
     nonprofitBoardMemberQualificationsSpecified: randomInt() % 2 ? "IN_BYLAWS" : "IN_FORM",
     nonprofitBoardMemberQualificationsTerms: `some-nonprofitBoardMemberQualificationsTerms-text-${randomInt()}`,
     nonprofitBoardMemberRightsSpecified: randomInt() % 2 ? "IN_BYLAWS" : "IN_FORM",

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -554,6 +554,67 @@ collections:
                       - { label: "Placeholder", name: "placeholder", widget: "string" }
                       - { label: "Address checkbox label", name: "addressCheckboxText", widget: "string" }
                       - { label: "Expand text", name: "expandText", widget: "string" }
+                  - label: Nonprofit Provisions - Board Members
+                    name: hasNonprofitBoardMembers
+                    collapsed: true
+                    widget: object
+                    fields:
+                      - { label: "Label", name: "label", widget: "string" }
+                      - { label: "Body", name: "body", widget: "markdown" }
+                      - { label: "Yes Review Text", name: "yesReviewText", widget: "markdown" }
+                      - { label: "No Review Text", name: "noReviewText", widget: "markdown" }
+                  - label: Nonprofit Provisions - Board Member Qualifications
+                    name: nonprofitBoardMemberQualificationsSpecified
+                    collapsed: true
+                    widget: object
+                    fields:
+                      - { label: "Label", name: "label", widget: "string" }
+                      - { label: "Body", name: "body", widget: "string" }
+                  - label: Nonprofit Provisions - Board Member Qualifications Terms
+                    name: nonprofitBoardMemberQualificationsTerms
+                    collapsed: true
+                    widget: object
+                    fields:
+                      - { label: "Label", name: "label", widget: "string" }
+                  - label: Nonprofit Provisions - Board Member Rights
+                    name: nonprofitBoardMemberRightsSpecified
+                    collapsed: true
+                    widget: object
+                    fields:
+                      - { label: "Label", name: "label", widget: "string" }
+                      - { label: "Body", name: "body", widget: "string" }
+                  - label: Nonprofit Provisions - Board Member Rights Terms
+                    name: nonprofitBoardMemberRightsTerms
+                    collapsed: true
+                    widget: object
+                    fields:
+                      - { label: "Label", name: "label", widget: "string" }
+                  - label: Nonprofit Provisions - Trustees
+                    name: nonprofitTrusteesMethodSpecified
+                    collapsed: true
+                    widget: object
+                    fields:
+                      - { label: "Label", name: "label", widget: "string" }
+                      - { label: "Body", name: "body", widget: "string" }
+                  - label: Nonprofit Provisions - Trustees Terms
+                    name: nonprofitTrusteesMethodTerms
+                    collapsed: true
+                    widget: object
+                    fields:
+                      - { label: "Label", name: "label", widget: "string" }
+                  - label: Nonprofit Provisions - Asset Distribution
+                    name: nonprofitAssetDistributionSpecified
+                    collapsed: true
+                    widget: object
+                    fields:
+                      - { label: "Label", name: "label", widget: "string" }
+                      - { label: "Body", name: "body", widget: "string" }
+                  - label: Nonprofit Provisions - Asset Distribution Terms
+                    name: nonprofitAssetDistributionTerms
+                    collapsed: true
+                    widget: object
+                    fields:
+                      - { label: "Label", name: "label", widget: "string" }
                   - label: Payment Type
                     name: paymentType
                     collapsed: true
@@ -686,57 +747,16 @@ collections:
                       - { label: "Label", name: "label", widget: "string" }
                       - { label: "Body", name: "body", widget: "markdown" }
                   - label: Veteran Nonprofit
-                    name: veteranNonprofit
+                    name: isVeteranNonprofit
                     collapsed: true
                     widget: object
                     fields:
                       - { label: "Label", name: "label", widget: "string" }
-                      - { label: "Description", name: "description", widget: "string" }
+                      - { label: "Description", name: "description", widget: "markdown" }
                       - { label: "Radio no text", name: "radioNoText", widget: "string" }
                       - { label: "Radio yes text", name: "radioYesText", widget: "string" }
                       - { label: "Error", name: "error", widget: "string" }
-                      - { label: "In form", name: "inForm", widget: "string" }
-                      - { label: "In bylaws", name: "inByLaws", widget: "string" }
-              - label: Nonprofit
-                name: nonprofit
-                collapsed: true
-                widget: object
-                fields:
-                  - {
-                    label: "Board members yes review text",
-                    name: "yesBoardMembersReviewText",
-                    widget: "markdown",
-                  }
-                  - {
-                    label: "Board members no review text",
-                    name: "noBoardMembersReviewText",
-                    widget: "markdown",
-                  }
-                  - {
-                    label: "Board members qualifications review text",
-                    name: "boardMembersQualificationsReviewText",
-                    widget: "text",
-                  }
-                  - {
-                    label: "Rights and limitations review text",
-                    name: "rightsAndLimitationsReviewText",
-                    widget: "markdown",
-                  }
-                  - {
-                    label: "Choosing trustees review text",
-                    name: "choosingTrusteesReviewText",
-                    widget: "text",
-                  }
-                  - {
-                    label: "Domestic nonprofit veteran corp review text",
-                    name: "domNpVetCorpReviewText",
-                    widget: markdown",
-                  }
-                  - {
-                    label: "Distributing assets review text",
-                    name: "distributingAssetsReviewText",
-                    widget: "text",
-                  }
+                      - { label: "Review Text", name: "reviewText", widget: "markdown" }
               - label: Address Modal
                 name: addressModal
                 collapsed: true

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -756,7 +756,8 @@ collections:
                       - { label: "Radio no text", name: "radioNoText", widget: "string" }
                       - { label: "Radio yes text", name: "radioYesText", widget: "string" }
                       - { label: "Error", name: "error", widget: "string" }
-                      - { label: "Review Text", name: "reviewText", widget: "markdown" }
+                      - { label: "Review Text - Yes", name: "reviewTextYes", widget: "markdown" }
+                      - { label: "Review Text - No", name: "reviewTextNo", widget: "markdown" }
               - label: Address Modal
                 name: addressModal
                 collapsed: true

--- a/web/src/components/tasks/business-formation/business/IsVeteranNonprofit.tsx
+++ b/web/src/components/tasks/business-formation/business/IsVeteranNonprofit.tsx
@@ -15,7 +15,7 @@ export const IsVeteranNonprofit = (): ReactElement => {
   const hasError = doesFieldHaveError(fieldName);
 
   return (
-    <WithErrorBar hasError={hasError} type="ALWAYS">
+    <WithErrorBar hasError={hasError} type="ALWAYS" className="margin-top-2">
       <FormControl variant="outlined" fullWidth className="padding-bottom-2">
         <label className="margin-right-3 text-bold">
           <Content>{Config.formation.fields.isVeteranNonprofit.description}</Content>

--- a/web/src/components/tasks/business-formation/review/ReviewIsVeteranNonprofit.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewIsVeteranNonprofit.tsx
@@ -1,0 +1,27 @@
+import { Content } from "@/components/Content";
+import { ReviewLineItem } from "@/components/tasks/business-formation/review/section/ReviewLineItem";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { ReactElement } from "rehype-react/lib";
+
+interface Props {
+  value: boolean | undefined;
+}
+
+export const ReviewIsVeteranNonprofit = (props: Props): ReactElement => {
+  const { Config } = useConfig();
+
+  const displayResponse = (): ReactElement => {
+    if (props.value) {
+      return <Content>{Config.formation.fields.isVeteranNonprofit.reviewTextYes}</Content>;
+    } else if (props.value === false) {
+      return <Content>{Config.formation.fields.isVeteranNonprofit.reviewTextNo}</Content>;
+    } else {
+      return <ReviewLineItem label={Config.formation.fields.isVeteranNonprofit.label} value={""} />;
+    }
+  };
+  return (
+    <div className="margin-top-1" data-testid="isVeteranNonprofit">
+      {displayResponse()}
+    </div>
+  );
+};

--- a/web/src/components/tasks/business-formation/review/ReviewNonprofitProvisions.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewNonprofitProvisions.tsx
@@ -14,7 +14,6 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
 
   const {
     hasNonprofitBoardMembers,
-    nonprofitBoardMembersTerms,
     nonprofitBoardMemberQualificationsSpecified,
     nonprofitBoardMemberQualificationsTerms,
     nonprofitBoardMemberRightsSpecified,
@@ -77,15 +76,6 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
           {hasNonprofitBoardMembers === undefined && (
             <ReviewLineItem label={Config.formation.fields.hasNonprofitBoardMembers.label} value="" />
           )}
-        </div>
-
-        <div className="margin-top-2 margin-left-3">
-          <ExpandCollapseString
-            text={nonprofitBoardMembersTerms}
-            viewMoreText={Config.formation.general.viewMoreButtonText}
-            viewLessText={Config.formation.general.viewLessButtonText}
-            lines={2}
-          />
         </div>
 
         <div className="margin-top-2">

--- a/web/src/components/tasks/business-formation/review/ReviewNonprofitProvisions.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewNonprofitProvisions.tsx
@@ -30,13 +30,11 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
   };
 
   const showQuestionAnswer = ({
-    testId,
+    fieldName,
     value,
-    reviewText,
   }: {
-    testId: string;
+    fieldName: keyof typeof Config.formation.fields;
     value: InFormInBylaws;
-    reviewText: string;
   }): ReactElement => {
     const endOfSentence = ((): string => {
       switch (value) {
@@ -49,10 +47,12 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
       }
     })();
 
+    const bodyText = (Config.formation.fields[fieldName] as any).body;
+
     return (
       <>
-        <div data-testid={testId} style={{ display: "inline-block" }}>
-          <strong>{reviewText}</strong>{" "}
+        <div data-testid={fieldName} style={{ display: "inline-block" }}>
+          <strong>{bodyText}</strong>{" "}
           {endOfSentence && (
             <>
               <span>{endOfSentence}</span>.
@@ -74,10 +74,10 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
       <ReviewSubSection header={"Provisions"}>
         <div className="margin-top-2" data-testid="hasNonprofitBoardMembers">
           {hasNonprofitBoardMembers === true && (
-            <Content>{Config.formation.fields.nonprofit.yesBoardMembersReviewText}</Content>
+            <Content>{Config.formation.fields.hasNonprofitBoardMembers.yesReviewText}</Content>
           )}
           {hasNonprofitBoardMembers === false && (
-            <Content>{Config.formation.fields.nonprofit.noBoardMembersReviewText}</Content>
+            <Content>{Config.formation.fields.hasNonprofitBoardMembers.noReviewText}</Content>
           )}
           {hasNonprofitBoardMembers === undefined && (
             <ReviewLineItem label={Config.formation.fields.hasNonprofitBoardMembers.label} value="" />
@@ -96,9 +96,8 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
         <div className="margin-top-2">
           {hasNonprofitBoardMembers &&
             showQuestionAnswer({
-              testId: "nonprofitBoardMemberQualificationsSpecified",
+              fieldName: "nonprofitBoardMemberQualificationsSpecified",
               value: nonprofitBoardMemberQualificationsSpecified,
-              reviewText: Config.formation.fields.nonprofit.boardMembersQualificationsReviewText,
             })}
         </div>
 
@@ -116,9 +115,8 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
         <div className="margin-top-2">
           {hasNonprofitBoardMembers &&
             showQuestionAnswer({
-              testId: "nonprofitBoardMemberRightsSpecified",
+              fieldName: "nonprofitBoardMemberRightsSpecified",
               value: nonprofitBoardMemberRightsSpecified,
-              reviewText: Config.formation.fields.nonprofit.rightsAndLimitationsReviewText,
             })}
         </div>
 
@@ -136,9 +134,8 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
         <div className="margin-top-2">
           {hasNonprofitBoardMembers &&
             showQuestionAnswer({
-              testId: "nonprofitTrusteesMethodSpecified",
+              fieldName: "nonprofitTrusteesMethodSpecified",
               value: nonprofitTrusteesMethodSpecified,
-              reviewText: Config.formation.fields.nonprofit.choosingTrusteesReviewText,
             })}
         </div>
 
@@ -156,9 +153,8 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
         <div className="margin-top-2">
           {hasNonprofitBoardMembers &&
             showQuestionAnswer({
-              testId: "nonprofitAssetDistributionSpecified",
+              fieldName: "nonprofitAssetDistributionSpecified",
               value: nonprofitAssetDistributionSpecified,
-              reviewText: Config.formation.fields.nonprofit.distributingAssetsReviewText,
             })}
         </div>
 

--- a/web/src/components/tasks/business-formation/review/ReviewNonprofitProvisions.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewNonprofitProvisions.tsx
@@ -5,34 +5,20 @@ import { ReviewNotEntered } from "@/components/tasks/business-formation/review/s
 import { ReviewSubSection } from "@/components/tasks/business-formation/review/section/ReviewSubSection";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
-import { InFormInBylaws } from "@businessnjgovnavigator/shared";
-import { ReactElement, useContext } from "react";
+import { FormationFields, InFormInBylaws } from "@businessnjgovnavigator/shared";
+import { Fragment, ReactElement, useContext } from "react";
 
 export const ReviewNonprofitProvisions = (): ReactElement => {
   const { state } = useContext(BusinessFormationContext);
   const { Config } = useConfig();
 
-  const {
-    hasNonprofitBoardMembers,
-    nonprofitBoardMemberQualificationsSpecified,
-    nonprofitBoardMemberQualificationsTerms,
-    nonprofitBoardMemberRightsSpecified,
-    nonprofitBoardMemberRightsTerms,
-    nonprofitTrusteesMethodSpecified,
-    nonprofitTrusteesMethodTerms,
-    nonprofitAssetDistributionSpecified,
-    nonprofitAssetDistributionTerms,
-  } = state.formationFormData;
-
-  const isVisibleInReview = (value: InFormInBylaws): boolean => {
-    return value === "IN_FORM";
-  };
+  const { hasNonprofitBoardMembers } = state.formationFormData;
 
   const showQuestionAnswer = ({
     fieldName,
     value,
   }: {
-    fieldName: keyof typeof Config.formation.fields;
+    fieldName: FormationFields;
     value: InFormInBylaws;
   }): ReactElement => {
     const endOfSentence = ((): string => {
@@ -46,7 +32,8 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
       }
     })();
 
-    const bodyText = (Config.formation.fields[fieldName] as any).body;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const bodyText = ((Config.formation.fields as any)[fieldName] as any).body;
 
     return (
       <div data-testid={fieldName}>
@@ -61,6 +48,16 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
       </div>
     );
   };
+
+  const provisionsToDisplay: Array<{ radioField: FormationFields; termsField: FormationFields }> = [
+    {
+      radioField: "nonprofitBoardMemberQualificationsSpecified",
+      termsField: "nonprofitBoardMemberQualificationsTerms",
+    },
+    { radioField: "nonprofitBoardMemberRightsSpecified", termsField: "nonprofitBoardMemberRightsTerms" },
+    { radioField: "nonprofitTrusteesMethodSpecified", termsField: "nonprofitTrusteesMethodTerms" },
+    { radioField: "nonprofitAssetDistributionSpecified", termsField: "nonprofitAssetDistributionTerms" },
+  ];
 
   return (
     <>
@@ -78,81 +75,42 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
           )}
         </div>
 
-        <div className="margin-top-2">
-          {hasNonprofitBoardMembers &&
-            showQuestionAnswer({
-              fieldName: "nonprofitBoardMemberQualificationsSpecified",
-              value: nonprofitBoardMemberQualificationsSpecified,
-            })}
-        </div>
+        {provisionsToDisplay.map(({ radioField, termsField }) => {
+          const radioValue = state.formationFormData[radioField] as InFormInBylaws;
+          const termsValue = state.formationFormData[termsField] as string;
 
-        {isVisibleInReview(nonprofitBoardMemberQualificationsSpecified) && (
-          <div className="margin-top-2 margin-left-3">
-            <ExpandCollapseString
-              text={nonprofitBoardMemberQualificationsTerms}
-              viewMoreText={Config.formation.general.viewMoreButtonText}
-              viewLessText={Config.formation.general.viewLessButtonText}
-              lines={2}
-            />
-          </div>
-        )}
+          return (
+            <Fragment key={radioField}>
+              <div className="margin-top-2">
+                {hasNonprofitBoardMembers &&
+                  showQuestionAnswer({
+                    fieldName: radioField,
+                    value: radioValue,
+                  })}
+              </div>
 
-        <div className="margin-top-2">
-          {hasNonprofitBoardMembers &&
-            showQuestionAnswer({
-              fieldName: "nonprofitBoardMemberRightsSpecified",
-              value: nonprofitBoardMemberRightsSpecified,
-            })}
-        </div>
-
-        {isVisibleInReview(nonprofitBoardMemberRightsSpecified) && (
-          <div className="margin-top-2 margin-left-3">
-            <ExpandCollapseString
-              text={nonprofitBoardMemberRightsTerms}
-              viewMoreText={Config.formation.general.viewMoreButtonText}
-              viewLessText={Config.formation.general.viewLessButtonText}
-              lines={2}
-            />
-          </div>
-        )}
-
-        <div className="margin-top-2">
-          {hasNonprofitBoardMembers &&
-            showQuestionAnswer({
-              fieldName: "nonprofitTrusteesMethodSpecified",
-              value: nonprofitTrusteesMethodSpecified,
-            })}
-        </div>
-
-        {isVisibleInReview(nonprofitTrusteesMethodSpecified) && (
-          <div className="margin-top-2 margin-left-3">
-            <ExpandCollapseString
-              text={nonprofitTrusteesMethodTerms}
-              viewMoreText={Config.formation.general.viewMoreButtonText}
-              viewLessText={Config.formation.general.viewLessButtonText}
-              lines={2}
-            />
-          </div>
-        )}
-
-        <div className="margin-top-2">
-          {hasNonprofitBoardMembers &&
-            showQuestionAnswer({
-              fieldName: "nonprofitAssetDistributionSpecified",
-              value: nonprofitAssetDistributionSpecified,
-            })}
-        </div>
-
-        {isVisibleInReview(nonprofitAssetDistributionSpecified) && (
-          <div className="margin-top-2 margin-left-3">
-            <ExpandCollapseString
-              text={nonprofitAssetDistributionTerms}
-              viewMoreText={Config.formation.general.viewMoreButtonText}
-              viewLessText={Config.formation.general.viewLessButtonText}
-              lines={2}
-            />
-          </div>
-        )}
+              {radioValue === "IN_FORM" && (
+                <div className="margin-top-2 margin-left-3" data-testid={`${radioField}-terms`}>
+                  {termsValue ? (
+                    <ExpandCollapseString
+                      text={termsValue}
+                      viewMoreText={Config.formation.general.viewMoreButtonText}
+                      viewLessText={Config.formation.general.viewLessButtonText}
+                      lines={2}
+                    />
+                  ) : (
+                    <div className="display-flex flex-row">
+                      <span className="margin-right-1">
+                        <strong>{Config.formation.nonprofitProvisions.description}:</strong>
+                      </span>
+                      <ReviewNotEntered />
+                    </div>
+                  )}
+                </div>
+              )}
+            </Fragment>
+          );
+        })}
       </ReviewSubSection>
     </>
   );

--- a/web/src/components/tasks/business-formation/review/ReviewNonprofitProvisions.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewNonprofitProvisions.tsx
@@ -50,21 +50,16 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
     const bodyText = (Config.formation.fields[fieldName] as any).body;
 
     return (
-      <>
-        <div data-testid={fieldName} style={{ display: "inline-block" }}>
-          <strong>{bodyText}</strong>{" "}
-          {endOfSentence && (
-            <>
-              <span>{endOfSentence}</span>.
-            </>
-          )}
-        </div>
+      <div data-testid={fieldName}>
+        <span>
+          <strong>{bodyText}</strong> {endOfSentence && <>{endOfSentence}.</>}
+        </span>
         {value === undefined && (
-          <div style={{ display: "inline-block", paddingLeft: "5px" }}>
+          <div className="display-inline-block padding-left-1">
             <ReviewNotEntered />
           </div>
         )}
-      </>
+      </div>
     );
   };
 

--- a/web/src/components/tasks/business-formation/review/ReviewNonprofitProvisions.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewNonprofitProvisions.tsx
@@ -5,22 +5,12 @@ import { ReviewNotEntered } from "@/components/tasks/business-formation/review/s
 import { ReviewSubSection } from "@/components/tasks/business-formation/review/section/ReviewSubSection";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
+import { InFormInBylaws } from "@businessnjgovnavigator/shared";
 import { ReactElement, useContext } from "react";
 
 export const ReviewNonprofitProvisions = (): ReactElement => {
   const { state } = useContext(BusinessFormationContext);
   const { Config } = useConfig();
-
-  const checkIfInFormOrBylaw = (stringToCompare: string | undefined): string => {
-    if (stringToCompare === "IN_BYLAWS") {
-      return ` ${Config.formation.nonprofitProvisions.radioInBylawsText.toLowerCase().replace('"', "")}.`;
-    }
-
-    if (stringToCompare === "IN_FORM") {
-      return ` ${Config.formation.nonprofitProvisions.radioInFormText.toLowerCase().replace('"', "")}.`;
-    }
-    return " ";
-  };
 
   const {
     hasNonprofitBoardMembers,
@@ -35,44 +25,43 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
     nonprofitAssetDistributionTerms,
   } = state.formationFormData;
 
-  const fillInByLawFormText = (stringToCompare: string | undefined, outputText: string): string => {
-    return `${outputText}  ${checkIfInFormOrBylaw(`${stringToCompare}`)}`;
+  const isVisibleInReview = (value: InFormInBylaws): boolean => {
+    return value === "IN_FORM";
   };
 
-  const isVisibleInReview = (stringToCompare: string | undefined): boolean => {
-    if (stringToCompare === "IN_FORM") {
-      return true;
-    } else {
-      return false;
-    }
-  };
+  const showQuestionAnswer = ({
+    testId,
+    value,
+    reviewText,
+  }: {
+    testId: string;
+    value: InFormInBylaws;
+    reviewText: string;
+  }): ReactElement => {
+    const endOfSentence = ((): string => {
+      switch (value) {
+        case "IN_FORM":
+          return Config.formation.nonprofitProvisions.radioInFormText.toLowerCase();
+        case "IN_BYLAWS":
+          return Config.formation.nonprofitProvisions.radioInBylawsText.toLowerCase();
+        default:
+          return "";
+      }
+    })();
 
-  const showQuestionAnswer = (
-    testId: string,
-    questionString: string | undefined,
-    outputText: string,
-    isBold?: boolean
-  ): ReactElement => {
     return (
       <>
-        {isBold && (
-          <div data-testid={testId} style={{ display: "inline-block" }}>
-            <strong>{outputText}</strong>
-            <div style={{ display: "inline-block" }}>{checkIfInFormOrBylaw(questionString)}</div>
-          </div>
-        )}
-        {!isBold && (
-          <div data-testid={testId}>
-            <Content style={{ display: "inline-block" }}>
-              {fillInByLawFormText(questionString, outputText)}
-            </Content>
-          </div>
-        )}
-        {questionString === undefined && (
-          <div data-testid={testId} style={{ display: "inline-block", paddingLeft: "5px" }}>
-            <span className={"bg-accent-warm-extra-light text-italic"}>
-              <ReviewNotEntered />
-            </span>
+        <div data-testid={testId} style={{ display: "inline-block" }}>
+          <strong>{reviewText}</strong>{" "}
+          {endOfSentence && (
+            <>
+              <span>{endOfSentence}</span>.
+            </>
+          )}
+        </div>
+        {value === undefined && (
+          <div style={{ display: "inline-block", paddingLeft: "5px" }}>
+            <ReviewNotEntered />
           </div>
         )}
       </>
@@ -106,12 +95,11 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
 
         <div className="margin-top-2">
           {hasNonprofitBoardMembers &&
-            showQuestionAnswer(
-              "nonprofitBoardMemberQualificationsSpecified",
-              nonprofitBoardMemberQualificationsSpecified,
-              Config.formation.fields.nonprofit.boardMembersQualificationsReviewText,
-              true
-            )}
+            showQuestionAnswer({
+              testId: "nonprofitBoardMemberQualificationsSpecified",
+              value: nonprofitBoardMemberQualificationsSpecified,
+              reviewText: Config.formation.fields.nonprofit.boardMembersQualificationsReviewText,
+            })}
         </div>
 
         {isVisibleInReview(nonprofitBoardMemberQualificationsSpecified) && (
@@ -127,11 +115,11 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
 
         <div className="margin-top-2">
           {hasNonprofitBoardMembers &&
-            showQuestionAnswer(
-              "nonprofitBoardMemberRightsSpecified",
-              nonprofitBoardMemberRightsSpecified,
-              Config.formation.fields.nonprofit.rightsAndLimitationsReviewText
-            )}
+            showQuestionAnswer({
+              testId: "nonprofitBoardMemberRightsSpecified",
+              value: nonprofitBoardMemberRightsSpecified,
+              reviewText: Config.formation.fields.nonprofit.rightsAndLimitationsReviewText,
+            })}
         </div>
 
         {isVisibleInReview(nonprofitBoardMemberRightsSpecified) && (
@@ -147,12 +135,11 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
 
         <div className="margin-top-2">
           {hasNonprofitBoardMembers &&
-            showQuestionAnswer(
-              "nonprofitTrusteesMethodSpecified",
-              nonprofitTrusteesMethodSpecified,
-              Config.formation.fields.nonprofit.choosingTrusteesReviewText,
-              true
-            )}
+            showQuestionAnswer({
+              testId: "nonprofitTrusteesMethodSpecified",
+              value: nonprofitTrusteesMethodSpecified,
+              reviewText: Config.formation.fields.nonprofit.choosingTrusteesReviewText,
+            })}
         </div>
 
         {isVisibleInReview(nonprofitTrusteesMethodSpecified) && (
@@ -168,12 +155,11 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
 
         <div className="margin-top-2">
           {hasNonprofitBoardMembers &&
-            showQuestionAnswer(
-              "nonprofitAssetDistributionSpecified",
-              nonprofitAssetDistributionSpecified,
-              Config.formation.fields.nonprofit.distributingAssetsReviewText,
-              true
-            )}
+            showQuestionAnswer({
+              testId: "nonprofitAssetDistributionSpecified",
+              value: nonprofitAssetDistributionSpecified,
+              reviewText: Config.formation.fields.nonprofit.distributingAssetsReviewText,
+            })}
         </div>
 
         {isVisibleInReview(nonprofitAssetDistributionSpecified) && (

--- a/web/src/components/tasks/business-formation/review/ReviewNonprofitProvisions.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewNonprofitProvisions.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@/components/Content";
 import { ExpandCollapseString } from "@/components/ExpandCollapseString";
+import { ReviewLineItem } from "@/components/tasks/business-formation/review/section/ReviewLineItem";
 import { ReviewNotEntered } from "@/components/tasks/business-formation/review/section/ReviewNotEntered";
 import { ReviewSubSection } from "@/components/tasks/business-formation/review/section/ReviewSubSection";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
@@ -82,12 +83,15 @@ export const ReviewNonprofitProvisions = (): ReactElement => {
     <>
       <hr className="margin-y-205" />
       <ReviewSubSection header={"Provisions"}>
-        <div className="margin-top-2">
-          {hasNonprofitBoardMembers && (
+        <div className="margin-top-2" data-testid="hasNonprofitBoardMembers">
+          {hasNonprofitBoardMembers === true && (
             <Content>{Config.formation.fields.nonprofit.yesBoardMembersReviewText}</Content>
           )}
-          {!hasNonprofitBoardMembers && (
+          {hasNonprofitBoardMembers === false && (
             <Content>{Config.formation.fields.nonprofit.noBoardMembersReviewText}</Content>
+          )}
+          {hasNonprofitBoardMembers === undefined && (
+            <ReviewLineItem label={Config.formation.fields.hasNonprofitBoardMembers.label} value="" />
           )}
         </div>
 

--- a/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
@@ -582,7 +582,7 @@ describe("Formation - ReviewStep", () => {
       await renderStep({ legalStructureId }, { hasNonprofitBoardMembers: true });
       const getByMarkup = withMarkup(screen.getByText);
       expect(
-        getByMarkup(markdownToText(Config.formation.fields.nonprofit.yesBoardMembersReviewText))
+        getByMarkup(markdownToText(Config.formation.fields.hasNonprofitBoardMembers.yesReviewText))
       ).toBeInTheDocument();
     });
 
@@ -590,7 +590,7 @@ describe("Formation - ReviewStep", () => {
       await renderStep({ legalStructureId }, { hasNonprofitBoardMembers: false });
       const getByMarkup = withMarkup(screen.getByText);
       expect(
-        getByMarkup(markdownToText(Config.formation.fields.nonprofit.noBoardMembersReviewText))
+        getByMarkup(markdownToText(Config.formation.fields.hasNonprofitBoardMembers.noReviewText))
       ).toBeInTheDocument();
     });
 
@@ -598,10 +598,10 @@ describe("Formation - ReviewStep", () => {
       await renderStep({ legalStructureId }, { hasNonprofitBoardMembers: undefined });
       const queryByMarkup = withMarkup(screen.queryByText);
       expect(
-        queryByMarkup(markdownToText(Config.formation.fields.nonprofit.yesBoardMembersReviewText))
+        queryByMarkup(markdownToText(Config.formation.fields.hasNonprofitBoardMembers.yesReviewText))
       ).not.toBeInTheDocument();
       expect(
-        queryByMarkup(markdownToText(Config.formation.fields.nonprofit.noBoardMembersReviewText))
+        queryByMarkup(markdownToText(Config.formation.fields.hasNonprofitBoardMembers.noReviewText))
       ).not.toBeInTheDocument();
       const boardMemberSection = within(screen.getByTestId("hasNonprofitBoardMembers"));
       expect(boardMemberSection.getByText(Config.formation.general.notEntered)).toBeInTheDocument();
@@ -617,7 +617,7 @@ describe("Formation - ReviewStep", () => {
       );
       expect(
         nonprofitBoardMemberQualificationsSpecifiedSection.getByText(
-          Config.formation.fields.nonprofit.boardMembersQualificationsReviewText
+          Config.formation.fields.nonprofitBoardMemberQualificationsSpecified.body
         )
       ).toBeInTheDocument();
       expect(
@@ -642,7 +642,7 @@ describe("Formation - ReviewStep", () => {
       );
       expect(
         nonprofitBoardMemberQualificationsSpecifiedSection.getByText(
-          Config.formation.fields.nonprofit.boardMembersQualificationsReviewText
+          Config.formation.fields.nonprofitBoardMemberQualificationsSpecified.body
         )
       ).toBeInTheDocument();
       expect(
@@ -680,7 +680,7 @@ describe("Formation - ReviewStep", () => {
       );
       const choosingTrusteesReviewSection = within(screen.getByTestId("nonprofitTrusteesMethodSpecified"));
       expect(
-        choosingTrusteesReviewSection.getByText(Config.formation.fields.nonprofit.choosingTrusteesReviewText)
+        choosingTrusteesReviewSection.getByText(Config.formation.fields.nonprofitTrusteesMethodSpecified.body)
       ).toBeInTheDocument();
       expect(
         choosingTrusteesReviewSection.getByText(
@@ -701,7 +701,7 @@ describe("Formation - ReviewStep", () => {
       );
       const choosingTrusteesReviewSection = within(screen.getByTestId("nonprofitTrusteesMethodSpecified"));
       expect(
-        choosingTrusteesReviewSection.getByText(Config.formation.fields.nonprofit.choosingTrusteesReviewText)
+        choosingTrusteesReviewSection.getByText(Config.formation.fields.nonprofitTrusteesMethodSpecified.body)
       ).toBeInTheDocument();
       expect(
         choosingTrusteesReviewSection.getByText(
@@ -720,7 +720,7 @@ describe("Formation - ReviewStep", () => {
       );
       expect(
         nonprofitAssetDistributionSpecifiedReviewSection.getByText(
-          Config.formation.fields.nonprofit.distributingAssetsReviewText
+          Config.formation.fields.nonprofitAssetDistributionSpecified.body
         )
       ).toBeInTheDocument();
       expect(
@@ -745,7 +745,7 @@ describe("Formation - ReviewStep", () => {
       );
       expect(
         nonprofitAssetDistributionSpecifiedReviewSection.getByText(
-          Config.formation.fields.nonprofit.distributingAssetsReviewText
+          Config.formation.fields.nonprofitAssetDistributionSpecified.body
         )
       ).toBeInTheDocument();
       expect(
@@ -758,7 +758,7 @@ describe("Formation - ReviewStep", () => {
     it("terms do not display when there are no board members", async () => {
       await renderStep({ legalStructureId }, { hasNonprofitBoardMembers: false });
       expect(
-        screen.queryByText(Config.formation.fields.nonprofit.distributingAssetsReviewText)
+        screen.queryByText(Config.formation.fields.nonprofitAssetDistributionSpecified.body)
       ).not.toBeInTheDocument();
     });
   });

--- a/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { getMergedConfig } from "@/contexts/configContext";
 import { generateFormationDbaContent } from "@/test/factories";
 import {
@@ -679,6 +681,22 @@ describe("Formation - ReviewStep", () => {
           )
         ).toBeInTheDocument();
         expect(screen.getByText(terms)).toBeInTheDocument();
+      });
+
+      it(`displays Not Entered for empty terms when IN_FORM`, async () => {
+        await renderStep(
+          { legalStructureId },
+          {
+            hasNonprofitBoardMembers: true,
+            [args.radio]: "IN_FORM",
+            [args.terms]: "",
+          }
+        );
+        const termsReviewSection = within(screen.getByTestId(`${args.radio}-terms`));
+        expect(termsReviewSection.getByText(Config.formation.general.notEntered)).toBeInTheDocument();
+        expect(
+          termsReviewSection.getByText(`${Config.formation.nonprofitProvisions.description}:`)
+        ).toBeInTheDocument();
       });
     });
   });

--- a/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
@@ -622,7 +622,7 @@ describe("Formation - ReviewStep", () => {
       ).toBeInTheDocument();
       expect(
         nonprofitBoardMemberQualificationsSpecifiedSection.getByText(
-          `${Config.formation.nonprofitProvisions.radioInBylawsText.toLowerCase()}.`
+          `${Config.formation.nonprofitProvisions.radioInBylawsText.toLowerCase()}`
         )
       ).toBeInTheDocument();
     });
@@ -647,7 +647,7 @@ describe("Formation - ReviewStep", () => {
       ).toBeInTheDocument();
       expect(
         nonprofitBoardMemberQualificationsSpecifiedSection.getByText(
-          `${Config.formation.nonprofitProvisions.radioInFormText.toLowerCase()}.`
+          `${Config.formation.nonprofitProvisions.radioInFormText.toLowerCase()}`
         )
       ).toBeInTheDocument();
     });
@@ -684,7 +684,7 @@ describe("Formation - ReviewStep", () => {
       ).toBeInTheDocument();
       expect(
         choosingTrusteesReviewSection.getByText(
-          `${Config.formation.nonprofitProvisions.radioInBylawsText.toLowerCase()}.`
+          `${Config.formation.nonprofitProvisions.radioInBylawsText.toLowerCase()}`
         )
       ).toBeInTheDocument();
     });
@@ -705,7 +705,7 @@ describe("Formation - ReviewStep", () => {
       ).toBeInTheDocument();
       expect(
         choosingTrusteesReviewSection.getByText(
-          `${Config.formation.nonprofitProvisions.radioInFormText.toLowerCase()}.`
+          `${Config.formation.nonprofitProvisions.radioInFormText.toLowerCase()}`
         )
       ).toBeInTheDocument();
     });
@@ -725,7 +725,7 @@ describe("Formation - ReviewStep", () => {
       ).toBeInTheDocument();
       expect(
         nonprofitAssetDistributionSpecifiedReviewSection.getByText(
-          `${Config.formation.nonprofitProvisions.radioInBylawsText.toLowerCase()}.`
+          `${Config.formation.nonprofitProvisions.radioInBylawsText.toLowerCase()}`
         )
       ).toBeInTheDocument();
     });
@@ -750,7 +750,7 @@ describe("Formation - ReviewStep", () => {
       ).toBeInTheDocument();
       expect(
         nonprofitAssetDistributionSpecifiedReviewSection.getByText(
-          `${Config.formation.nonprofitProvisions.radioInFormText.toLowerCase()}.`
+          `${Config.formation.nonprofitProvisions.radioInFormText.toLowerCase()}`
         )
       ).toBeInTheDocument();
     });

--- a/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
@@ -631,7 +631,7 @@ describe("Formation - ReviewStep", () => {
         ).toBeInTheDocument();
         expect(
           radioReviewSection.getByText(
-            `${Config.formation.nonprofitProvisions.radioInBylawsText.toLowerCase()}`
+            `${Config.formation.nonprofitProvisions.radioInBylawsText.toLowerCase()}.`
           )
         ).toBeInTheDocument();
       });
@@ -642,6 +642,21 @@ describe("Formation - ReviewStep", () => {
           { hasNonprofitBoardMembers: true, [args.radio]: "IN_BYLAWS", [args.terms]: "some-random-terms" }
         );
         expect(screen.queryByText("some-random-terms")).not.toBeInTheDocument();
+      });
+
+      it(`displays Not Entered when radio unanswered for ${args.radio}`, async () => {
+        await renderStep(
+          { legalStructureId },
+          {
+            hasNonprofitBoardMembers: true,
+            [args.radio]: undefined,
+          }
+        );
+        const radioReviewSection = within(screen.getByTestId(args.radio));
+        expect(
+          radioReviewSection.getByText(((Config.formation.fields as any)[args.radio] as any).body)
+        ).toBeInTheDocument();
+        expect(radioReviewSection.getByText(Config.formation.general.notEntered)).toBeInTheDocument();
       });
 
       it(`displays as IN_FORM for ${args.radio}`, async () => {
@@ -660,7 +675,7 @@ describe("Formation - ReviewStep", () => {
         ).toBeInTheDocument();
         expect(
           radioReviewSection.getByText(
-            `${Config.formation.nonprofitProvisions.radioInFormText.toLowerCase()}`
+            `${Config.formation.nonprofitProvisions.radioInFormText.toLowerCase()}.`
           )
         ).toBeInTheDocument();
         expect(screen.getByText(terms)).toBeInTheDocument();

--- a/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
@@ -607,159 +607,64 @@ describe("Formation - ReviewStep", () => {
       expect(boardMemberSection.getByText(Config.formation.general.notEntered)).toBeInTheDocument();
     });
 
-    it("in the by laws are specified and is displayed in the Board member qualifications in the Provisions section", async () => {
-      await renderStep(
-        { legalStructureId },
-        { hasNonprofitBoardMembers: true, nonprofitBoardMemberQualificationsSpecified: "IN_BYLAWS" }
-      );
-      const nonprofitBoardMemberQualificationsSpecifiedSection = within(
-        screen.getByTestId("nonprofitBoardMemberQualificationsSpecified")
-      );
-      expect(
-        nonprofitBoardMemberQualificationsSpecifiedSection.getByText(
-          Config.formation.fields.nonprofitBoardMemberQualificationsSpecified.body
-        )
-      ).toBeInTheDocument();
-      expect(
-        nonprofitBoardMemberQualificationsSpecifiedSection.getByText(
-          `${Config.formation.nonprofitProvisions.radioInBylawsText.toLowerCase()}`
-        )
-      ).toBeInTheDocument();
-    });
+    describe.each([
+      {
+        radio: "nonprofitBoardMemberQualificationsSpecified",
+        terms: "nonprofitBoardMemberQualificationsTerms",
+      },
+      { radio: "nonprofitBoardMemberRightsSpecified", terms: "nonprofitBoardMemberRightsTerms" },
+      { radio: "nonprofitTrusteesMethodSpecified", terms: "nonprofitTrusteesMethodTerms" },
+      { radio: "nonprofitAssetDistributionSpecified", terms: "nonprofitAssetDistributionTerms" },
+    ])("provisions radio questions", (args) => {
+      it(`does not display ${args.radio} when no board members`, async () => {
+        await renderStep({ legalStructureId }, { hasNonprofitBoardMembers: false, [args.radio]: "IN_FORM" });
+        expect(
+          screen.queryByText(((Config.formation.fields as any)[args.radio] as any).body)
+        ).not.toBeInTheDocument();
+      });
 
-    it("in the form are specified and is displayed in the Board member qualifications in the Provisions section", async () => {
-      const boardMembersQualificationsTerms = "Board members qualifications specified";
-      await renderStep(
-        { legalStructureId },
-        {
-          hasNonprofitBoardMembers: true,
-          nonprofitBoardMemberQualificationsSpecified: "IN_FORM",
-          nonprofitBoardMemberQualificationsTerms: boardMembersQualificationsTerms,
-        }
-      );
-      const nonprofitBoardMemberQualificationsSpecifiedSection = within(
-        screen.getByTestId("nonprofitBoardMemberQualificationsSpecified")
-      );
-      expect(
-        nonprofitBoardMemberQualificationsSpecifiedSection.getByText(
-          Config.formation.fields.nonprofitBoardMemberQualificationsSpecified.body
-        )
-      ).toBeInTheDocument();
-      expect(
-        nonprofitBoardMemberQualificationsSpecifiedSection.getByText(
-          `${Config.formation.nonprofitProvisions.radioInFormText.toLowerCase()}`
-        )
-      ).toBeInTheDocument();
-    });
+      it(`displays as IN_BYLAWS for ${args.radio}`, async () => {
+        await renderStep({ legalStructureId }, { hasNonprofitBoardMembers: true, [args.radio]: "IN_BYLAWS" });
+        const radioReviewSection = within(screen.getByTestId(args.radio));
+        expect(
+          radioReviewSection.getByText(((Config.formation.fields as any)[args.radio] as any).body)
+        ).toBeInTheDocument();
+        expect(
+          radioReviewSection.getByText(
+            `${Config.formation.nonprofitProvisions.radioInBylawsText.toLowerCase()}`
+          )
+        ).toBeInTheDocument();
+      });
 
-    it("in the by laws are specified and is displayed in the Board member rights specification in the Provisions section", async () => {
-      await renderStep(
-        { legalStructureId },
-        { hasNonprofitBoardMembers: true, nonprofitBoardMemberRightsSpecified: "IN_BYLAWS" }
-      );
-      expect(screen.getByTestId("nonprofitBoardMemberRightsSpecified")).toBeInTheDocument();
-    });
+      it("does not display terms when not IN_FORM", async () => {
+        await renderStep(
+          { legalStructureId },
+          { hasNonprofitBoardMembers: true, [args.radio]: "IN_BYLAWS", [args.terms]: "some-random-terms" }
+        );
+        expect(screen.queryByText("some-random-terms")).not.toBeInTheDocument();
+      });
 
-    it("in the form are specified and is displayed in the Board member rights specification in the Provisions section", async () => {
-      const boardMembersQualificationsRight = "Board members rights are specified";
-      await renderStep(
-        { legalStructureId },
-        {
-          hasNonprofitBoardMembers: true,
-          nonprofitBoardMemberRightsSpecified: "IN_FORM",
-          nonprofitBoardMemberRightsTerms: boardMembersQualificationsRight,
-        }
-      );
-      expect(screen.getByTestId("nonprofitBoardMemberRightsSpecified")).toBeInTheDocument();
-    });
-
-    it("in the by laws are specified and is displayed in the Choosing trustees in the Provisions section", async () => {
-      await renderStep(
-        { legalStructureId },
-        { hasNonprofitBoardMembers: true, nonprofitTrusteesMethodSpecified: "IN_BYLAWS" }
-      );
-      const choosingTrusteesReviewSection = within(screen.getByTestId("nonprofitTrusteesMethodSpecified"));
-      expect(
-        choosingTrusteesReviewSection.getByText(Config.formation.fields.nonprofitTrusteesMethodSpecified.body)
-      ).toBeInTheDocument();
-      expect(
-        choosingTrusteesReviewSection.getByText(
-          `${Config.formation.nonprofitProvisions.radioInBylawsText.toLowerCase()}`
-        )
-      ).toBeInTheDocument();
-    });
-
-    it("in the form are specified and is displayed in the Choosing trustees in the Provisions section", async () => {
-      const trusteesMethodTerms = "Trustees method terms are specified";
-      await renderStep(
-        { legalStructureId },
-        {
-          hasNonprofitBoardMembers: true,
-          nonprofitTrusteesMethodSpecified: "IN_FORM",
-          nonprofitTrusteesMethodTerms: trusteesMethodTerms,
-        }
-      );
-      const choosingTrusteesReviewSection = within(screen.getByTestId("nonprofitTrusteesMethodSpecified"));
-      expect(
-        choosingTrusteesReviewSection.getByText(Config.formation.fields.nonprofitTrusteesMethodSpecified.body)
-      ).toBeInTheDocument();
-      expect(
-        choosingTrusteesReviewSection.getByText(
-          `${Config.formation.nonprofitProvisions.radioInFormText.toLowerCase()}`
-        )
-      ).toBeInTheDocument();
-    });
-
-    it("in the by laws are specified and is displayed in assets in the Provisions section", async () => {
-      await renderStep(
-        { legalStructureId },
-        { hasNonprofitBoardMembers: true, nonprofitAssetDistributionSpecified: "IN_BYLAWS" }
-      );
-      const nonprofitAssetDistributionSpecifiedReviewSection = within(
-        screen.getByTestId("nonprofitAssetDistributionSpecified")
-      );
-      expect(
-        nonprofitAssetDistributionSpecifiedReviewSection.getByText(
-          Config.formation.fields.nonprofitAssetDistributionSpecified.body
-        )
-      ).toBeInTheDocument();
-      expect(
-        nonprofitAssetDistributionSpecifiedReviewSection.getByText(
-          `${Config.formation.nonprofitProvisions.radioInBylawsText.toLowerCase()}`
-        )
-      ).toBeInTheDocument();
-    });
-
-    it("in the form are specified and is displayed in assets in the Provisions section", async () => {
-      const assetTerms = "Asset terms are specified";
-      await renderStep(
-        { legalStructureId },
-        {
-          hasNonprofitBoardMembers: true,
-          nonprofitAssetDistributionSpecified: "IN_FORM",
-          nonprofitAssetDistributionTerms: assetTerms,
-        }
-      );
-      const nonprofitAssetDistributionSpecifiedReviewSection = within(
-        screen.getByTestId("nonprofitAssetDistributionSpecified")
-      );
-      expect(
-        nonprofitAssetDistributionSpecifiedReviewSection.getByText(
-          Config.formation.fields.nonprofitAssetDistributionSpecified.body
-        )
-      ).toBeInTheDocument();
-      expect(
-        nonprofitAssetDistributionSpecifiedReviewSection.getByText(
-          `${Config.formation.nonprofitProvisions.radioInFormText.toLowerCase()}`
-        )
-      ).toBeInTheDocument();
-    });
-
-    it("terms do not display when there are no board members", async () => {
-      await renderStep({ legalStructureId }, { hasNonprofitBoardMembers: false });
-      expect(
-        screen.queryByText(Config.formation.fields.nonprofitAssetDistributionSpecified.body)
-      ).not.toBeInTheDocument();
+      it(`displays as IN_FORM for ${args.radio}`, async () => {
+        const terms = "some-random-terms";
+        await renderStep(
+          { legalStructureId },
+          {
+            hasNonprofitBoardMembers: true,
+            [args.radio]: "IN_FORM",
+            [args.terms]: terms,
+          }
+        );
+        const radioReviewSection = within(screen.getByTestId(args.radio));
+        expect(
+          radioReviewSection.getByText(((Config.formation.fields as any)[args.radio] as any).body)
+        ).toBeInTheDocument();
+        expect(
+          radioReviewSection.getByText(
+            `${Config.formation.nonprofitProvisions.radioInFormText.toLowerCase()}`
+          )
+        ).toBeInTheDocument();
+        expect(screen.getByText(terms)).toBeInTheDocument();
+      });
     });
   });
 });

--- a/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
@@ -575,6 +575,35 @@ describe("Formation - ReviewStep", () => {
   describe("when nonprofit", () => {
     const legalStructureId = "nonprofit";
 
+    it("displays yes for Is Veteran Nonprofit", async () => {
+      await renderStep({ legalStructureId }, { isVeteranNonprofit: true });
+      const getByMarkup = withMarkup(screen.getByText);
+      expect(
+        getByMarkup(markdownToText(Config.formation.fields.isVeteranNonprofit.reviewTextYes))
+      ).toBeInTheDocument();
+    });
+
+    it("displays no for Is Veteran Nonprofit", async () => {
+      await renderStep({ legalStructureId }, { isVeteranNonprofit: false });
+      const getByMarkup = withMarkup(screen.getByText);
+      expect(
+        getByMarkup(markdownToText(Config.formation.fields.isVeteranNonprofit.reviewTextNo))
+      ).toBeInTheDocument();
+    });
+
+    it("displays Not Entered for Is Veteran Nonprofit when undefined", async () => {
+      await renderStep({ legalStructureId }, { isVeteranNonprofit: undefined });
+      const queryByMarkup = withMarkup(screen.queryByText);
+      expect(
+        queryByMarkup(markdownToText(Config.formation.fields.isVeteranNonprofit.reviewTextNo))
+      ).not.toBeInTheDocument();
+      expect(
+        queryByMarkup(markdownToText(Config.formation.fields.isVeteranNonprofit.reviewTextYes))
+      ).not.toBeInTheDocument();
+      const section = within(screen.getByTestId("isVeteranNonprofit"));
+      expect(section.getByText(Config.formation.general.notEntered)).toBeInTheDocument();
+    });
+
     it("displays the Provisions section", async () => {
       await renderStep({ legalStructureId }, {});
       expect(screen.getByText(Config.formation.fields.provisions.label)).toBeInTheDocument();

--- a/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
@@ -578,7 +578,7 @@ describe("Formation - ReviewStep", () => {
       expect(screen.getByText(Config.formation.fields.provisions.label)).toBeInTheDocument();
     });
 
-    it("yes for board members is displayed in the Provisions section", async () => {
+    it("displays yes for board members in the Provisions section", async () => {
       await renderStep({ legalStructureId }, { hasNonprofitBoardMembers: true });
       const getByMarkup = withMarkup(screen.getByText);
       expect(
@@ -586,12 +586,25 @@ describe("Formation - ReviewStep", () => {
       ).toBeInTheDocument();
     });
 
-    it("no for board members is displayed in the Provisions section", async () => {
+    it("displays no for board members in the Provisions section", async () => {
       await renderStep({ legalStructureId }, { hasNonprofitBoardMembers: false });
       const getByMarkup = withMarkup(screen.getByText);
       expect(
         getByMarkup(markdownToText(Config.formation.fields.nonprofit.noBoardMembersReviewText))
       ).toBeInTheDocument();
+    });
+
+    it("displays Not Entered for board members in the Provisions section when undefined", async () => {
+      await renderStep({ legalStructureId }, { hasNonprofitBoardMembers: undefined });
+      const queryByMarkup = withMarkup(screen.queryByText);
+      expect(
+        queryByMarkup(markdownToText(Config.formation.fields.nonprofit.yesBoardMembersReviewText))
+      ).not.toBeInTheDocument();
+      expect(
+        queryByMarkup(markdownToText(Config.formation.fields.nonprofit.noBoardMembersReviewText))
+      ).not.toBeInTheDocument();
+      const boardMemberSection = within(screen.getByTestId("hasNonprofitBoardMembers"));
+      expect(boardMemberSection.getByText(Config.formation.general.notEntered)).toBeInTheDocument();
     });
 
     it("in the by laws are specified and is displayed in the Board member qualifications in the Provisions section", async () => {

--- a/web/src/components/tasks/business-formation/review/ReviewStep.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.tsx
@@ -43,7 +43,7 @@ export const ReviewStep = (): ReactElement => {
           <ReviewBusinessSuffixAndStartDate />
           {state.formationFormData.isVeteranNonprofit && (
             <Content className="margin-top-2">
-              {Config.formation.fields.nonprofit.domNpVetCorpReviewText}
+              {Config.formation.fields.isVeteranNonprofit.reviewText}
             </Content>
           )}
           {isForeignCorporation(state.formationFormData.legalType) && (

--- a/web/src/components/tasks/business-formation/review/ReviewStep.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.tsx
@@ -5,6 +5,7 @@ import { ReviewBillingContact } from "@/components/tasks/business-formation/revi
 import { ReviewBillingServices } from "@/components/tasks/business-formation/review/ReviewBillingServices";
 import { ReviewBusinessSuffixAndStartDate } from "@/components/tasks/business-formation/review/ReviewBusinessSuffixAndStartDate";
 import { ReviewForeignCertificate } from "@/components/tasks/business-formation/review/ReviewForeignCertificate";
+import { ReviewIsVeteranNonprofit } from "@/components/tasks/business-formation/review/ReviewIsVeteranNonprofit";
 import { ReviewMainBusinessLocation } from "@/components/tasks/business-formation/review/ReviewMainBusinessLocation";
 import { ReviewMembers } from "@/components/tasks/business-formation/review/ReviewMembers";
 import { ReviewNonprofitProvisions } from "@/components/tasks/business-formation/review/ReviewNonprofitProvisions";
@@ -41,11 +42,7 @@ export const ReviewStep = (): ReactElement => {
         <ReviewSection stepName={"Business"} testId="edit-business-name-step">
           <BusinessNameAndLegalStructure isReviewStep />
           <ReviewBusinessSuffixAndStartDate />
-          {state.formationFormData.isVeteranNonprofit && (
-            <Content className="margin-top-2">
-              {Config.formation.fields.isVeteranNonprofit.reviewText}
-            </Content>
-          )}
+          {isNonProfit && <ReviewIsVeteranNonprofit value={state.formationFormData.isVeteranNonprofit} />}
           {isForeignCorporation(state.formationFormData.legalType) && (
             <>
               <ReviewWillPracticeLaw willPracticeLaw={state.formationFormData.willPracticeLaw} />


### PR DESCRIPTION
## Issues fixed / changed:

- [chore: [#185153256] display Not Entered when board members question not entered](https://github.com/newjersey/navigator.business.nj.gov/pull/6138/commits/0907b553c1ed922c290574f50aacd9adfe4ffde9) Before this change, when board member question was undefined, it showed "No, ..." in the review text when it should have shown "Not Entered" (per conversation with Amanda)
- [chore: [#185153256] fix sentence display of provisions questions and remove unnecessary bold](https://github.com/newjersey/navigator.business.nj.gov/pull/6138/commits/ffa067d547ee2e9bd9d2714f8f1cc9e674092b44) Before this change, the sentences that ended with "in this form" / "in the bylaws" were squished against the sentence with no space in between. Also, the way bolding was done was inaccurate and unnecessary. I refactored the function to use named parameters and consolidated / renamed the function that created the sentence, to make it easier to read and understand.
- [chore: [#185153256] fix incorrect CMS config and consolidate config for review text](https://github.com/newjersey/navigator.business.nj.gov/pull/6138/commits/a12ac72410ebe2f40cac4e397e714b22430949e7) Before this change, the CMS was not displaying any of the values because the keys were set incorrectly. I fixed this for the veteran question. For the review text, I put the text in the correct field key subheading where it belongs, instead of being in a separate other object. This also allowed consolidating because there were some duplicated pieces of config for each provision question that did not need to exist twice.
- [chore: [#185153256] refactor tests for nonprofit provisions using each](https://github.com/newjersey/navigator.business.nj.gov/pull/6138/commits/f8ae997eb31b9b214aa289c73a7724a6b44a80a5) This refactor of the tests simplified the tests by using a describe.each because the same test logic was duplicated for each of the four provisions.
- [chore: [#185153256] add missing test for not entered case](https://github.com/newjersey/navigator.business.nj.gov/pull/6138/commits/6465e099845390d74278cfe950ee04806e92e91b) The previous refactor made it much easier to notice (and add) a missing untested case 
- [chore: [#185153256] remove unused boardMemberTerms field](https://github.com/newjersey/navigator.business.nj.gov/pull/6138/commits/5126f6eb48ee8efe9759c4d9784ab5392e263ad7) This field was created at the beginning of the feature before the understanding of requirements changed. It is never used and does not exist, and the field should not be kept in our data object (let alone displayed in the component also!)
- [fix: [#185153256] config text for veteran](https://github.com/newjersey/navigator.business.nj.gov/pull/6138/commits/d515b975a93abd802d0da77282f18e1847c06b8e) A fix from the previous CMS commit, where the location of veteran config text changed and needed to be updated
- [chore: [#185153256] display terms with Not Entered when in_form and empty](https://github.com/newjersey/navigator.business.nj.gov/pull/6138/commits/dbd7c92b43291d5c77d349fce6670f5e83f11071) A missing feature. the Terms are a required field if the user has selected "In Form" and therefore they need to be displayed in Review with "not entered" text if they are required but empty. Confirmed this missing feature with Amanda.
- [chore: [#185153256] display Veteran Nonprofit in review section](https://github.com/newjersey/navigator.business.nj.gov/pull/6138/commits/cced14cff8e699dd09772ba217dc620e1642a57e) A missing feature. The logic had it so the veteran question only appeared in Review if it was `true`. It needs to appear if it is true, or false, or if it is undefined (then, it should show Not Entered). Confirmed this with Amanda.
- [chore: [#185153256] fix spacing for nonprofit question](https://github.com/newjersey/navigator.business.nj.gov/pull/6138/commits/b6fb474d76193c3c93457e84274ad3e51de8393b) Noticed an issue where the nonprofit question on Step 2 had no spacing between it and the element above.