### PR TITLE
fix: date logic in getLicenseCalendarEvent tests should not depend on current date

### DIFF
--- a/web/src/lib/domain-logic/getLicenseCalendarEvents.test.ts
+++ b/web/src/lib/domain-logic/getLicenseCalendarEvents.test.ts
@@ -2,6 +2,9 @@ import { getLicenseCalendarEvents } from "@/lib/domain-logic/getLicenseCalendarE
 import { getCurrentDate } from "@businessnjgovnavigator/shared/dateHelpers";
 import { defaultDateFormat } from "@businessnjgovnavigator/shared/defaultConstants";
 import { generateLicenseData } from "@businessnjgovnavigator/shared/test";
+import dayjs from "dayjs";
+import objectSupport from "dayjs/plugin/objectSupport";
+dayjs.extend(objectSupport);
 
 describe("getLicenseCalendarEvent", () => {
   const currentDate = getCurrentDate();
@@ -21,15 +24,16 @@ describe("getLicenseCalendarEvent", () => {
   });
 
   it("returns an array containing expiration event when within the current month", () => {
+    const tenthOfMonthDate = dayjs({ year: currentDate.year(), month: currentDate.month(), day: 10 });
     expect(
       getLicenseCalendarEvents(
-        generateLicenseData({ expirationISO: currentDate.toISOString() }),
+        generateLicenseData({ expirationISO: tenthOfMonthDate.toISOString() }),
         currentDate.year(),
         currentDate.month()
       )
     ).toEqual([
       {
-        dueDate: currentDate.format(defaultDateFormat),
+        dueDate: tenthOfMonthDate.format(defaultDateFormat),
         licenseEventSubtype: "expiration",
         calendarEventType: "LICENSE",
       },
@@ -37,15 +41,16 @@ describe("getLicenseCalendarEvent", () => {
   });
 
   it("returns an array containing renewal event when within the month after expiration", () => {
+    const tenthOfMonthDate = dayjs({ year: currentDate.year(), month: currentDate.month(), day: 10 });
     expect(
       getLicenseCalendarEvents(
-        generateLicenseData({ expirationISO: currentDate.toISOString() }),
+        generateLicenseData({ expirationISO: tenthOfMonthDate.toISOString() }),
         currentDate.year(),
         currentDate.add(1, "month").month()
       )
     ).toEqual([
       {
-        dueDate: currentDate.add(30, "days").format(defaultDateFormat),
+        dueDate: tenthOfMonthDate.add(30, "days").format(defaultDateFormat),
         licenseEventSubtype: "renewal",
         calendarEventType: "LICENSE",
       },
@@ -73,15 +78,15 @@ describe("getLicenseCalendarEvent", () => {
   });
 
   it("returns an array containing only license events within the year", () => {
-    const expirationDate = currentDate.month(11);
+    const tenthOfDecemberDate = dayjs({ year: currentDate.year(), month: 11, day: 10 });
     expect(
       getLicenseCalendarEvents(
-        generateLicenseData({ expirationISO: expirationDate.toISOString() }),
-        expirationDate.year()
+        generateLicenseData({ expirationISO: tenthOfDecemberDate.toISOString() }),
+        currentDate.year()
       )
     ).toEqual([
       {
-        dueDate: expirationDate.format(defaultDateFormat),
+        dueDate: tenthOfDecemberDate.format(defaultDateFormat),
         licenseEventSubtype: "expiration",
         calendarEventType: "LICENSE",
       },


### PR DESCRIPTION
 
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have performed a self-review of my code
- [ ] I have created and/or updated relevant documentation, if necessary
- [ ] I have not used any relative imports
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
