### PR TITLE
chore: [#184606533] bold home based alt description text in profile

### DIFF
--- a/web/src/components/onboarding/FieldLabelProfile.tsx
+++ b/web/src/components/onboarding/FieldLabelProfile.tsx
@@ -13,6 +13,7 @@ interface Props {
   isAltDescriptionDisplayed?: boolean;
   locked?: boolean;
   hideHeader?: boolean;
+  boldAltDescription?: boolean;
 }
 
 export const FieldLabelProfile = (props: Props): ReactElement => {
@@ -72,7 +73,11 @@ export const FieldLabelProfile = (props: Props): ReactElement => {
       </div>
       {showDescription && (
         <>
-          {props.isAltDescriptionDisplayed && altDescription && <Content>{altDescription}</Content>}
+          {props.isAltDescriptionDisplayed && altDescription && (
+            <div className={props.boldAltDescription ? "text-bold" : ""}>
+              <Content>{altDescription}</Content>
+            </div>
+          )}
           {!props.isAltDescriptionDisplayed && description && <Content>{description}</Content>}
         </>
       )}

--- a/web/src/components/profile/ProfileField.tsx
+++ b/web/src/components/profile/ProfileField.tsx
@@ -12,6 +12,7 @@ interface Props {
   displayAltDescription?: boolean;
   noLabel?: boolean;
   hideHeader?: boolean;
+  boldAltDescription?: boolean;
 }
 
 export const ProfileField = (props: Props): ReactElement => {
@@ -30,6 +31,7 @@ export const ProfileField = (props: Props): ReactElement => {
                 fieldName={props.fieldName}
                 isAltDescriptionDisplayed={props.displayAltDescription}
                 hideHeader={props.hideHeader}
+                boldAltDescription={props.boldAltDescription}
               />
             )}
             <div className={props.noLabel ? "margin-bottom-05" : ""}>{props.children}</div>

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -354,6 +354,7 @@ const ProfilePage = (props: Props): ReactElement => {
           displayAltDescription={displayAltHomeBasedBusinessDescription}
           isVisible={displayHomedBaseBusinessQuestion()}
           hideHeader={true}
+          boldAltDescription={true}
         >
           <OnboardingHomeBasedBusiness />
         </ProfileField>
@@ -519,6 +520,7 @@ const ProfilePage = (props: Props): ReactElement => {
           isVisible={displayHomedBaseBusinessQuestion()}
           displayAltDescription={displayAltHomeBasedBusinessDescription}
           hideHeader={true}
+          boldAltDescription={true}
         >
           <OnboardingHomeBasedBusiness />
         </ProfileField>
@@ -639,6 +641,7 @@ const ProfilePage = (props: Props): ReactElement => {
           isVisible={displayHomedBaseBusinessQuestion()}
           displayAltDescription={displayAltHomeBasedBusinessDescription}
           hideHeader={true}
+          boldAltDescription={true}
         >
           <OnboardingHomeBasedBusiness />
         </ProfileField>


### PR DESCRIPTION
Content is requesting we bold the label for home based in profile, it should not be bolded in other places like the dashboard.

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
