### PR TITLE
fix: [#185522114] Board of Directors and Trustees incorrectly labeled as Members in error banner

### DIFF
--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.tsx
@@ -24,7 +24,7 @@ import { useUserData } from "@/lib/data-hooks/useUserData";
 import { MediaQueries } from "@/lib/PageSizes";
 import { FormationStepNames, StepperStep } from "@/lib/types/types";
 import analytics from "@/lib/utils/analytics";
-import { scrollToTopOfElement, useMountEffect } from "@/lib/utils/helpers";
+import { getConfigFieldByLegalStructure, scrollToTopOfElement, useMountEffect } from "@/lib/utils/helpers";
 import { Business, FormationFormData, getCurrentBusiness } from "@businessnjgovnavigator/shared";
 import { useMediaQuery } from "@mui/material";
 import { useRouter } from "next/router";
@@ -45,6 +45,8 @@ export const BusinessFormationPaginator = (): ReactElement => {
   const errorAlertRef = useRef<HTMLDivElement>(null);
   const isMounted = useRef(false);
   const isDesktop = useMediaQuery(MediaQueries.desktopAndUp);
+
+  type ConfigFormationFields = keyof typeof Config.formation.fields;
 
   useEffect(() => {
     if (isMounted.current) {
@@ -456,8 +458,14 @@ export const BusinessFormationPaginator = (): ReactElement => {
           <div>{Config.formation.errorBanner.errorOnStep}</div>
           <ul>
             {dedupedFieldErrors.map((fieldError) => {
+              let configFieldName = fieldError.field as ConfigFormationFields;
+
+              if (fieldError.field === "members") {
+                configFieldName = getConfigFieldByLegalStructure(state.formationFormData.legalType);
+              }
+
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const label = (Config.formation.fields as any)[fieldError.field].label;
+              const label = (Config.formation.fields as any)[configFieldName].label;
               return (
                 <li key={label}>
                   {label}

--- a/web/src/components/tasks/business-formation/contacts/Members.tsx
+++ b/web/src/components/tasks/business-formation/contacts/Members.tsx
@@ -1,6 +1,7 @@
 import { Addresses } from "@/components/tasks/business-formation/contacts/Addresses";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
+import { getConfigFieldByLegalStructure } from "@/lib/utils/helpers";
 import {
   corpLegalStructures,
   createEmptyFormationMember,
@@ -17,7 +18,6 @@ export const Members = (props: Props): ReactElement => {
   const { Config } = useConfig();
   const { state, setFormationFormData } = useContext(BusinessFormationContext);
   const isCorp = corpLegalStructures.includes(state.formationFormData.legalType);
-  const isNonprofit = state.formationFormData.legalType === "nonprofit";
 
   const defaultAddress = isCorp
     ? undefined
@@ -33,11 +33,7 @@ export const Members = (props: Props): ReactElement => {
         addressZipCode: state.formationFormData.addressZipCode,
       };
 
-  const configField = ((): "directors" | "trustees" | "members" => {
-    if (isCorp) return "directors";
-    else if (isNonprofit) return "trustees";
-    else return "members";
-  })();
+  const configField = getConfigFieldByLegalStructure(state.formationFormData.legalType);
 
   const displayContent = {
     header: Config.formation.fields[configField].label,

--- a/web/src/lib/utils/helpers.ts
+++ b/web/src/lib/utils/helpers.ts
@@ -218,3 +218,17 @@ export const mapMunicipalityDetailToMunicipality = (municipalityDetail: Municipa
 export const isForeignCorporation = (legalStructure: FormationLegalType): boolean => {
   return ["foreign-c-corporation", "foreign-s-corporation"].includes(legalStructure);
 };
+
+export const getConfigFieldByLegalStructure = (
+  legalType: FormationLegalType
+): "directors" | "trustees" | "members" => {
+  switch (legalType) {
+    case "c-corporation":
+    case "s-corporation":
+      return "directors";
+    case "nonprofit":
+      return "trustees";
+    default:
+      return "members";
+  }
+};


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
Updated logic to account for the members field error label in the `Contact Step` of formation:

- For a non-profit: the error label needs to be Board of Trustees
- For a corporation: the error label needs to be Board of Directors  

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#185522114](https://www.pivotaltracker.com/story/show/185522114)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
