### PR TITLE
feat: [#185617818] left align description & text fields beneath nuber…

### DIFF
--- a/web/src/components/tasks/EinTask.tsx
+++ b/web/src/components/tasks/EinTask.tsx
@@ -64,7 +64,7 @@ export const EinTask = (props: Props): ReactElement => {
       <TaskHeader task={props.task} />
       <UnlockedBy task={props.task} />
       <Content>{preInputContent}</Content>
-      <div className="margin-left-5 margin-top-1">
+      <div className="margin-left-3ch margin-top-1">
         <Content>{Config.ein.descriptionText}</Content>
         {showInput && <EinInput isAuthenticated={isAuthenticated} onSave={onSave} task={props.task} />}
         {!showInput && (

--- a/web/src/components/tasks/TaxTask.tsx
+++ b/web/src/components/tasks/TaxTask.tsx
@@ -25,7 +25,7 @@ export const TaxTask = (props: Props): ReactElement => {
       <TaskHeader task={props.task} />
       <UnlockedBy task={props.task} />
       <Content>{preInputContent}</Content>
-      <div className="margin-left-4 margin-top-1">
+      <div className="margin-left-3ch margin-top-1">
         <Content>{Config.tax.descriptionText}</Content>
         <TaxDisclaimer legalStructureId={business?.profileData.legalStructureId} />
         <TaxInput task={props.task} />

--- a/web/src/styles/components/input-alignment.scss
+++ b/web/src/styles/components/input-alignment.scss
@@ -1,0 +1,3 @@
+.margin-left-3ch {
+  margin-left: 1.9rem;
+}

--- a/web/src/styles/main.scss
+++ b/web/src/styles/main.scss
@@ -19,6 +19,7 @@
 @import "components/calendar.scss";
 @import "components/prompts.scss";
 @import "components/textfield.scss";
+@import "components/input-alignment.scss";
 
 @import "sections/innov-footer.scss";
 @import "sections/landing.scss";


### PR DESCRIPTION
…ed lists ein

<!-- Please complete the following sections as necessary. -->

## Description

We wanted our fields below numbered lists to align with the same indentation

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

So this is kinda of a weird little quirk but the number column system is using 3ch for its padding which comes from the usa-prose class, I'm just matching that for this indentation to be correct here which unforunatley results in a 1.9rem but that is what it is I suppose. 

<img width="1166" alt="image" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22485301/d4504dc4-9503-4893-b3e0-48cadc0fb567">
<img width="283" alt="image" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22485301/3882b0c8-9e85-4d44-b771-20ea0692b211">


Reulsts

<img width="733" alt="image" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22485301/823daaaf-7323-4a2a-b1cc-77089b4f5ac2">
<img width="771" alt="image" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22485301/e278b37e-f945-4585-a4d4-f3d23bc80aca">



<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
