### PR TITLE
feat: 184643298 - Add go to profile nudge for Dakota Nexus and poppy …

### DIFF
--- a/api/src/domain/updateSidebarCards.test.ts
+++ b/api/src/domain/updateSidebarCards.test.ts
@@ -1,5 +1,4 @@
 import { formationTaskId } from "@shared/domain-logic/taskIds";
-import { OperatingPhaseId } from "@shared/operatingPhase";
 import {
   generateBusiness,
   generateMunicipality,
@@ -10,6 +9,7 @@ import {
 import { updateSidebarCards } from "./updateSidebarCards";
 
 import { getCurrentBusiness } from "@shared/domain-logic/getCurrentBusiness";
+import { OperatingPhases } from "@shared/index";
 
 describe("updateRoadmapSidebarCards", () => {
   describe("successful registration", () => {
@@ -173,17 +173,14 @@ describe("updateRoadmapSidebarCards", () => {
   });
 
   describe("go-to-profile nudge", () => {
-    const poppyPhases: OperatingPhaseId[] = [
-      "GUEST_MODE",
-      "NEEDS_TO_FORM",
-      "NEEDS_TO_REGISTER_FOR_TAXES",
-      "FORMED_AND_REGISTERED",
-      "UP_AND_RUNNING",
-    ];
+    const phasesWhereGoToProfileNudgeTrue = OperatingPhases.filter((it) => it.displayGoToProfileNudge).map(
+      (it) => it.id
+    );
+    const phasesWhereGoToProfileNudgeFalse = OperatingPhases.filter((it) => !it.displayGoToProfileNudge).map(
+      (it) => it.id
+    );
 
-    const oscarPhases: OperatingPhaseId[] = ["GUEST_MODE_OWNING", "UP_AND_RUNNING_OWNING"];
-
-    it.each(poppyPhases)("does not add go-to-profile nudge for %s", (operatingPhase) => {
+    it.each(phasesWhereGoToProfileNudgeFalse)("does not add go-to-profile nudge for %s", (operatingPhase) => {
       const userData = generateUserDataForBusiness(
         generateBusiness({
           profileData: generateProfileData({
@@ -199,7 +196,7 @@ describe("updateRoadmapSidebarCards", () => {
       );
     });
 
-    it.each(oscarPhases)(
+    it.each(phasesWhereGoToProfileNudgeTrue)(
       "adds go-to-profile nudge for %s when at least one opportunity question unanswered",
       (operatingPhase) => {
         const userData = generateUserDataForBusiness(
@@ -218,7 +215,7 @@ describe("updateRoadmapSidebarCards", () => {
       }
     );
 
-    it.each(oscarPhases)(
+    it.each(phasesWhereGoToProfileNudgeTrue)(
       "removes go-to-profile nudge for %s when all opportunity questions answered",
       (operatingPhase) => {
         const userData = generateUserDataForBusiness(

--- a/api/src/domain/updateSidebarCards.ts
+++ b/api/src/domain/updateSidebarCards.ts
@@ -1,5 +1,6 @@
 import { getCurrentBusiness } from "@shared/domain-logic/getCurrentBusiness";
 import { isFieldAnswered, OPPORTUNITY_FIELDS } from "@shared/domain-logic/opportunityFields";
+import { LookupOperatingPhaseById } from "@shared/operatingPhase";
 import { modifyCurrentBusiness } from "@shared/test";
 import { UserData } from "@shared/userData";
 import { UpdateSidebarCards } from "./types";
@@ -51,10 +52,11 @@ export const updateSidebarCards: UpdateSidebarCards = (userData: UserData): User
     hideCard("task-progress");
   }
 
-  if (operatingPhase === "UP_AND_RUNNING_OWNING" || operatingPhase === "GUEST_MODE_OWNING") {
+  if (LookupOperatingPhaseById(operatingPhase).displayGoToProfileNudge) {
     const isEveryOpportunityFieldAnswered = OPPORTUNITY_FIELDS.every((field) => {
       return isFieldAnswered(field, currentBusiness.profileData);
     });
+
     if (isEveryOpportunityFieldAnswered) {
       hideCard("go-to-profile");
     } else {

--- a/shared/src/operatingPhase.ts
+++ b/shared/src/operatingPhase.ts
@@ -16,6 +16,7 @@ export interface OperatingPhase {
   readonly sectorRequired: boolean;
   readonly displayBusinessStructurePrompt: boolean;
   readonly displayHomeBasedPrompt: boolean;
+  readonly displayGoToProfileNudge: boolean;
 }
 
 export type OperatingPhaseId =
@@ -52,6 +53,7 @@ export const LookupOperatingPhaseById = (id: OperatingPhaseId | undefined): Oper
       sectorRequired: false,
       displayBusinessStructurePrompt: false,
       displayHomeBasedPrompt: false,
+      displayGoToProfileNudge: false,
     }
   );
 };
@@ -75,6 +77,7 @@ export const OperatingPhases: OperatingPhase[] = [
     displayBusinessStructurePrompt: true,
     displayHomeBasedPrompt: false,
     sectorRequired: false,
+    displayGoToProfileNudge: false,
   },
   {
     id: "GUEST_MODE_WITH_BUSINESS_STRUCTURE",
@@ -94,6 +97,7 @@ export const OperatingPhases: OperatingPhase[] = [
     displayBusinessStructurePrompt: false,
     displayHomeBasedPrompt: true,
     sectorRequired: false,
+    displayGoToProfileNudge: false,
   },
   {
     id: "GUEST_MODE_OWNING",
@@ -113,6 +117,7 @@ export const OperatingPhases: OperatingPhase[] = [
     sectorRequired: true,
     displayBusinessStructurePrompt: false,
     displayHomeBasedPrompt: false,
+    displayGoToProfileNudge: true,
   },
   {
     id: "FORMED_AND_REGISTERED",
@@ -132,6 +137,7 @@ export const OperatingPhases: OperatingPhase[] = [
     displayBusinessStructurePrompt: false,
     displayHomeBasedPrompt: true,
     sectorRequired: false,
+    displayGoToProfileNudge: false,
   },
   {
     id: "NEEDS_TO_FORM",
@@ -151,6 +157,7 @@ export const OperatingPhases: OperatingPhase[] = [
     sectorRequired: false,
     displayBusinessStructurePrompt: false,
     displayHomeBasedPrompt: true,
+    displayGoToProfileNudge: false,
   },
   {
     id: "NEEDS_BUSINESS_STRUCTURE",
@@ -170,6 +177,7 @@ export const OperatingPhases: OperatingPhase[] = [
     displayBusinessStructurePrompt: true,
     displayHomeBasedPrompt: false,
     sectorRequired: false,
+    displayGoToProfileNudge: false,
   },
   {
     id: "NEEDS_TO_REGISTER_FOR_TAXES",
@@ -189,6 +197,7 @@ export const OperatingPhases: OperatingPhase[] = [
     sectorRequired: false,
     displayBusinessStructurePrompt: false,
     displayHomeBasedPrompt: true,
+    displayGoToProfileNudge: false,
   },
   {
     id: "UP_AND_RUNNING",
@@ -208,6 +217,7 @@ export const OperatingPhases: OperatingPhase[] = [
     displayBusinessStructurePrompt: false,
     displayHomeBasedPrompt: false,
     sectorRequired: true,
+    displayGoToProfileNudge: true,
   },
   {
     id: "UP_AND_RUNNING_OWNING",
@@ -227,5 +237,6 @@ export const OperatingPhases: OperatingPhase[] = [
     sectorRequired: true,
     displayBusinessStructurePrompt: false,
     displayHomeBasedPrompt: false,
+    displayGoToProfileNudge: true,
   },
 ];


### PR DESCRIPTION

<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
 Add go to profile nudge for Dakota Nexus and popp

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#184643298](https://www.pivotaltracker.com/story/show/)

### Approach
Add "Go to Profile" Nudge for Poppy & Dakota Nexus Up-and-running Phase after clicking the show the funding button.
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes
Add "Go to Profile" Nudge for Poppy & Dakota Nexus Up-and-running Phase
<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
