### PR TITLE
feat: [#185424624] add quick actions to cms

### DIFF
--- a/content/src/quick-actions/template.md
+++ b/content/src/quick-actions/template.md
@@ -1,0 +1,12 @@
+---
+notesMd: Example notes
+filename: template
+urlSlug: example-url-slug
+name: template example
+id: template id
+form: template form
+callToActionText: template action text
+callToActionLink: http://www.example.com
+---
+
+template example content

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -2867,8 +2867,36 @@ collections:
           options: ["above-opportunities", "below-opportunities"],
         }
 
+  - name: "quick-actions-label"
+    label: "🟧 QUICK ACTIONS"
+    folder: "content/src"
+    fields:
+      - { name: "" }
+
+  - name: "quick-actions"
+    label: "Quick Actions"
+    folder: "content/src/quick-actions"
+    summary: "{{filename}} - {{name}}"
+    identifier_field: "{{filename}}"
+    slug: "{{fields.filename}}"
+    delete: true
+    sortable_fields: ["name", "filename"]
+    create: true
+    editor:
+      preview: true
+    fields:
+      - { label: "Internal Notes", name: "notesMd", widget: "markdown", required: false }
+      - { label: "Filename", name: "filename", widget: "nospace", required: false }
+      - { label: "Url Slug", name: "urlSlug", widget: "nospace" }
+      - { label: "Name/Title", name: "name", widget: "string" }
+      - { label: "ID", name: "id", widget: "string" }
+      - { label: "Content", name: "body", widget: "markdown" }
+      - { label: "Form", name: "form", widget: "string", required: false }
+      - { label: "Call To Action Text", name: "callToActionText", widget: "string", required: false }
+      - { label: "Call To Action Link", name: "callToActionLink", widget: "string", required: false }
+
   - name: "misc-label"
-    label: "🟧 MISC"
+    label: "🟨 MISC"
     folder: "content/src"
     fields:
       - { name: "" }

--- a/web/src/lib/search/cmsCollections.ts
+++ b/web/src/lib/search/cmsCollections.ts
@@ -44,7 +44,11 @@ export const cmsCollections = [
     children: ["Dashboard - Config", "Sidebar Cards Content"],
   },
   {
-    label: "🟧 MISC",
+    label: "🟧 QUICK ACTIONS",
+    children: ["Quick Actions"],
+  },
+  {
+    label: "🟨 MISC",
     children: [
       "Export Pdf Config",
       "Dropdown Mappings",

--- a/web/src/lib/search/searchQuickActions.ts
+++ b/web/src/lib/search/searchQuickActions.ts
@@ -1,0 +1,41 @@
+import { findMatchInBlock, findMatchInLabelledText } from "@/lib/search/helpers";
+import { Match } from "@/lib/search/typesForSearch";
+import { QuickAction } from "@/lib/types/types";
+
+export const searchQuickActions = (quickActions: QuickAction[], term: string): Match[] => {
+  const matches: Match[] = [];
+
+  for (const quickAction of quickActions) {
+    let match: Match = {
+      filename: quickAction.filename,
+      snippets: [],
+    };
+
+    const content = quickAction.contentMd.toLowerCase();
+    const name = quickAction.name.toLowerCase();
+    const cta = quickAction.callToActionText?.toLowerCase();
+    const ctaLink = quickAction.callToActionLink?.toLowerCase();
+    const filename = quickAction.filename?.toLowerCase();
+    const urlSlug = quickAction.urlSlug.toLowerCase();
+    const form = quickAction.form?.toLowerCase();
+
+    const blockTexts = [content];
+    const labelledTexts = [
+      { content: cta, label: "CTA Text" },
+      { content: ctaLink, label: "CTA Link" },
+      { content: name, label: "Name/Title" },
+      { content: filename, label: "Filename" },
+      { content: urlSlug, label: "Url Slug" },
+      { content: form, label: "Form" },
+    ];
+
+    match = findMatchInBlock(blockTexts, term, match);
+    match = findMatchInLabelledText(labelledTexts, term, match);
+
+    if (match.snippets.length > 0) {
+      matches.push(match);
+    }
+  }
+
+  return matches;
+};

--- a/web/src/lib/static/loadQuickActions.ts
+++ b/web/src/lib/static/loadQuickActions.ts
@@ -1,0 +1,21 @@
+import { QuickAction } from "@/lib/types/types";
+import fs from "fs";
+import path from "path";
+import { convertQuickActionMd } from "../utils/markdownReader";
+
+const quickActionsDir = path.join(process.cwd(), "..", "content", "src", "quick-actions");
+
+export const loadAllQuickActions = (): QuickAction[] => {
+  const fileNames = fs.readdirSync(quickActionsDir);
+  return fileNames.map((fileName) => {
+    return loadQuickActionsByFileName(fileName);
+  });
+};
+
+export const loadQuickActionsByFileName = (fileName: string): QuickAction => {
+  const fullPath = path.join(quickActionsDir, `${fileName}`);
+  const fileContents = fs.readFileSync(fullPath, "utf8");
+
+  const fileNameWithoutMd = fileName.split(".md")[0];
+  return convertQuickActionMd(fileContents, fileNameWithoutMd);
+};

--- a/web/src/lib/types/types.ts
+++ b/web/src/lib/types/types.ts
@@ -197,6 +197,17 @@ export interface Opportunity {
   status?: string;
 }
 
+export interface QuickAction {
+  id: string;
+  name: string;
+  urlSlug: string;
+  filename: string;
+  contentMd: string;
+  callToActionLink: string | undefined;
+  callToActionText: string | undefined;
+  form: string | undefined;
+}
+
 export type FundingType =
   | "tax credit"
   | "loan"

--- a/web/src/lib/utils/markdownReader.ts
+++ b/web/src/lib/utils/markdownReader.ts
@@ -15,6 +15,7 @@ import {
   LicenseEvent,
   MarkdownResult,
   PostOnboardingFile,
+  QuickAction,
   TaskWithoutLinks,
   TaxAgency,
   TaxFilingMethod,
@@ -63,6 +64,16 @@ export const convertLicenseMd = (taskMdContents: string, filename: string): Lice
     contentMd: matterResult.content,
     filename,
     ...taskGrayMatter,
+  };
+};
+
+export const convertQuickActionMd = (quickActionMdContents: string, filename: string): QuickAction => {
+  const matterResult = matter(quickActionMdContents);
+  const quickActionGrayMatter = matterResult.data as QuickActionGrayMatter;
+  return {
+    contentMd: matterResult.content,
+    filename,
+    ...quickActionGrayMatter,
   };
 };
 
@@ -145,6 +156,15 @@ type LicenseGrayMatter = {
   urlSlug: string;
   callToActionLink: string;
   callToActionText: string;
+};
+
+type QuickActionGrayMatter = {
+  id: string;
+  name: string;
+  urlSlug: string;
+  callToActionLink: string;
+  callToActionText: string;
+  form: string;
 };
 
 type TaskGrayMatter = {

--- a/web/src/pages/mgmt/search.tsx
+++ b/web/src/pages/mgmt/search.tsx
@@ -13,6 +13,7 @@ import { searchIndustries } from "@/lib/search/searchIndustries";
 import { searchLicenseEvents } from "@/lib/search/searchLicenseEvents";
 import { searchNonEssentialQuestions } from "@/lib/search/searchNonEssentialQuestions";
 import { searchPostOnboarding } from "@/lib/search/searchPostOnboarding";
+import { searchQuickActions } from "@/lib/search/searchQuickActions";
 import { searchSidebarCards } from "@/lib/search/searchSidebarCards";
 import { searchSteps } from "@/lib/search/searchSteps";
 import { searchTasks } from "@/lib/search/searchTasks";
@@ -28,6 +29,7 @@ import { loadAllFilings } from "@/lib/static/loadFilings";
 import { loadAllFundings } from "@/lib/static/loadFundings";
 import { loadAllLicenses } from "@/lib/static/loadLicenses";
 import { loadAllPostOnboarding } from "@/lib/static/loadPostOnboarding";
+import { loadAllQuickActions } from "@/lib/static/loadQuickActions";
 import { loadAllLicenseTasks, loadAllTasksOnly } from "@/lib/static/loadTasks";
 import { loadAllWebflowLicenses } from "@/lib/static/loadWebflowLicenses";
 import {
@@ -38,6 +40,7 @@ import {
   LicenseEvent,
   NonEssentialQuestion,
   PostOnboardingFile,
+  QuickAction,
   RoadmapDisplayContent,
   SidebarCardContent,
   Step,
@@ -68,6 +71,7 @@ interface Props {
   archivedContextualInfo: ContextualInfoFile[];
   postOnboarding: PostOnboardingFile[];
   licenseEvents: LicenseEvent[];
+  quickActions: QuickAction[];
   cmsConfig: any;
 }
 
@@ -86,6 +90,7 @@ const SearchContentPage = (props: Props): ReactElement => {
   const [nonEssentialQuestionsMatches, setNonEssentialQuestionsMatches] = useState<Match[]>([]);
   const [webflowLicenseMatches, setWebflowLicenseMatches] = useState<Match[]>([]);
   const [filingMatches, setFilingMatches] = useState<Match[]>([]);
+  const [quickActionMatches, setQuickActionMatches] = useState<Match[]>([]);
   const [sidebarCardMatches, setSidebarCardMatches] = useState<Match[]>([]);
   const [contextualInfoMatches, setContextualInfoMatches] = useState<Match[]>([]);
   const [archivedContextualInfoMatches, setArchivedContextualInfoMatches] = useState<Match[]>([]);
@@ -118,6 +123,7 @@ const SearchContentPage = (props: Props): ReactElement => {
     setCertArchiveMatches(searchCertifications(props.archivedCertifications, lowercaseTerm));
     setFundingMatches(searchFundings(props.fundings, lowercaseTerm));
     setIndustryMatches(searchIndustries(Industries, lowercaseTerm));
+    setQuickActionMatches(searchQuickActions(props.quickActions, lowercaseTerm));
 
     const defaultStepsMatches = searchSteps(Steps.steps as Step[], lowercaseTerm, { filename: "Steps" });
     const foreignStepsMatches = searchSteps(ForeignSteps.steps as Step[], lowercaseTerm, {
@@ -161,6 +167,7 @@ const SearchContentPage = (props: Props): ReactElement => {
         ...archivedContextualInfoMatches,
         ...contextualInfoMatches,
         ...groupedConfigMatches,
+        ...quickActionMatches,
       ].length === 0
     );
   };
@@ -199,6 +206,10 @@ const SearchContentPage = (props: Props): ReactElement => {
     "Post Onboarding Content": postOnboardingMatches,
   };
 
+  const quickActionCollection = {
+    "Quick Actions": quickActionMatches,
+  };
+
   const authedView = (
     <div>
       <h1>Search in CMS</h1>
@@ -227,6 +238,10 @@ const SearchContentPage = (props: Props): ReactElement => {
       <MatchCollection matchedCollections={calendarCollection} groupedConfigMatches={groupedConfigMatches} />
       <MatchCollection matchedCollections={dashboardCollection} groupedConfigMatches={groupedConfigMatches} />
       <MatchCollection matchedCollections={miscCollection} groupedConfigMatches={groupedConfigMatches} />
+      <MatchCollection
+        matchedCollections={quickActionCollection}
+        groupedConfigMatches={groupedConfigMatches}
+      />
     </div>
   );
 
@@ -265,6 +280,7 @@ export const getStaticProps = async (): Promise<GetStaticPropsResult<Props>> => 
       archivedContextualInfo: loadAllArchivedContextualInfo(),
       postOnboarding: loadAllPostOnboarding(),
       licenseEvents: loadAllLicenses(),
+      quickActions: loadAllQuickActions(),
       cmsConfig: loadCmsConfig(),
     },
   };


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
Add quick actions to cms.
<!-- Summary of the changes, related issue, relevant motivation, and context -->
From a content perspective, I use the template to generate content for quick actions.

Acceptance Criteria
Given than I am a Content team member
When accessing Netlify then I see a detail screen as described in this google doc
and it will be in a new collection

Template is built using this guide: https://docs.google.com/document/d/1qtbb3E6k7ZTx3H-4Lvvm_mkQxE3wAGQ6B9QJ_k-1khQ/edit
Template is added Netlify.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#185424624](https://www.pivotaltracker.com/story/show/)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
Update config.yml for cms to add quick actions
### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
