### PR TITLE
When adding the business in the start section bug

### DIFF
--- a/content/src/fieldConfig/config.json
+++ b/content/src/fieldConfig/config.json
@@ -50,6 +50,7 @@
   "navigationDefaults": {
     "navBarUnnamedOwnedBusinessText": "Unnamed Business",
     "navBarUnnamedForeignRemoteSellerWorkerText": "Unnamed Out-of-State Business",
+    "navBarUnnamedDbaBusinessText": "Unnamed DBA",
     "guestModalTitle": "## Link with myNewJersey to Save Your Progress",
     "guestAlertBody": "Now that you've filled out your business information, you can save your progress and come back later to [link your Navigator account with myNewJersey](/account-setup?source=guest_snackbar). ",
     "guestSuccessTitle": "### Welcome to your Business.NJ.gov account!",

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -3371,6 +3371,11 @@ collections:
                   name: navBarUnnamedForeignRemoteSellerWorkerText,
                   widget: string,
                 }
+              - {
+                  label: Navbar Unnamed Business FOREIGN DBA unnamed text,
+                  name: navBarUnnamedDbaBusinessText,
+                  widget: string,
+                }
               - { label: Guest Alert Title, name: guestAlertTitle, widget: string }
               - { label: Guest Alert Body, name: guestAlertBody, widget: text }
               - { label: Guest Success Snackbar Title, name: guestSuccessTitle, widget: string }

--- a/web/src/components/tasks/business-formation/name/NexusUnavailable.tsx
+++ b/web/src/components/tasks/business-formation/name/NexusUnavailable.tsx
@@ -30,7 +30,7 @@ export const NexusUnavailable = (props: UnavailableProps): ReactElement => {
   return (
     <>
       <div data-testid="unavailable-text">
-        <Alert variant="error">
+        <Alert variant="info">
           <PureMarkdownContent components={inlineParagraphComponent}>{textBeforeButton}</PureMarkdownContent>{" "}
           <UnStyledButton
             style="default"

--- a/web/src/lib/domain-logic/getNavBarBusinessTitle.test.ts
+++ b/web/src/lib/domain-logic/getNavBarBusinessTitle.test.ts
@@ -141,6 +141,38 @@ describe("getNavBarBusinessTitle", () => {
         });
       });
     });
+
+    describe("Nexus DBA", () => {
+      it("shows unnamed dba when the nexusDbaName is empty and needsNexusDbaName is true", () => {
+        const business = generateBusiness({
+          profileData: generateProfileData({
+            businessPersona: "FOREIGN",
+            foreignBusinessType: "NEXUS",
+            businessName: "test business Name",
+            needsNexusDbaName: true,
+            nexusDbaName: "",
+          }),
+        });
+        const navBarBusinessTitle = getNavBarBusinessTitle(business, IsAuthenticated.TRUE);
+        expect(navBarBusinessTitle).toEqual(Config.navigationDefaults.navBarUnnamedDbaBusinessText);
+      });
+
+      it("shows the dba name when the user has entered a DBA name", () => {
+        const dbaName = "dbaName";
+
+        const business = generateBusiness({
+          profileData: generateProfileData({
+            businessPersona: "FOREIGN",
+            foreignBusinessType: "NEXUS",
+            businessName: "test business Name",
+            needsNexusDbaName: true,
+            nexusDbaName: dbaName,
+          }),
+        });
+        const navBarBusinessTitle = getNavBarBusinessTitle(business, IsAuthenticated.TRUE);
+        expect(navBarBusinessTitle).toEqual(dbaName);
+      });
+    });
   });
 
   describe("when name undefined, legal structure defined, and industry defined", () => {

--- a/web/src/lib/domain-logic/getNavBarBusinessTitle.ts
+++ b/web/src/lib/domain-logic/getNavBarBusinessTitle.ts
@@ -11,19 +11,36 @@ export const getNavBarBusinessTitle = (
     return Config.navigationDefaults.navBarGuestText;
   }
 
-  const { businessName, tradeName, legalStructureId, industryId, businessPersona, foreignBusinessType } =
-    business.profileData;
+  const {
+    businessName,
+    tradeName,
+    legalStructureId,
+    industryId,
+    businessPersona,
+    foreignBusinessType,
+    needsNexusDbaName,
+    nexusDbaName,
+  } = business.profileData;
 
   const isRemoteWorkerOrSeller = (): boolean => {
     return foreignBusinessType === "REMOTE_SELLER" || foreignBusinessType === "REMOTE_WORKER";
   };
 
   const determineName = (): string => {
+    if (needsNexusDbaName) {
+      if (nexusDbaName === "") {
+        return Config.navigationDefaults.navBarUnnamedDbaBusinessText;
+      }
+      if (nexusDbaName !== "") {
+        return nexusDbaName;
+      }
+    }
+
     if (legalStructureId) {
       return LookupLegalStructureById(legalStructureId).hasTradeName ? tradeName : businessName;
-    } else {
-      return businessName || tradeName || "";
     }
+
+    return businessName || tradeName || "";
   };
 
   const name = determineName();


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

So for this bug we found 3 things
1. The Nexus DBA we found that the error alert when you have an invalid name and have to create a DBA is confusing -> change to info alert
2. Even if the name was unavailable and we put you into the DBA flow we still update the nave dropdown with the business name -> should be "unamed DBA"
3. After a DBA name is chosen the nav bar drop down still displays normal business name rather than DBA name -> dropdown shows DBA name

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/185698190)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
