### PR TITLE
Disable renovate bot automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,10 @@
       "automergeStrategy": "rebase"
     },
     {
+      "matchPackageNames": ["@aws-amplify/core", "@aws-amplify/auth"],
+      "automerge": false
+    },
+    {
       "matchPackagePrefixes": ["cypress"],
       "groupName": "cypress"
     },


### PR DESCRIPTION
## Description

Disable Renovate bot auto merging.

## Code author checklist

- [ ] I have performed a self-review of my code
- [ ] I have created and/or updated relevant documentation, if necessary
- [ ] I have not used any relative imports
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
