### PR TITLE
refactor: correct testId for industry dropdown and dropdown list

### DIFF
--- a/web/cypress/support/page_objects/onboardingPage.ts
+++ b/web/cypress/support/page_objects/onboardingPage.ts
@@ -67,7 +67,7 @@ export class OnboardingPage {
   }
 
   getIndustryDropdown() {
-    return cy.get('[data-testid="industryid"]');
+    return cy.get('[data-testid="industryId"]');
   }
 
   getBusinessFormationDatePicker() {
@@ -173,7 +173,7 @@ export class OnboardingPage {
   selectIndustry(industry: string) {
     const industryValue = LookupIndustryById(industry).name;
     this.getIndustryDropdown().click();
-    cy.get('[data-testid="industry-name"]').contains(industryValue).click();
+    cy.get('[data-testid="option"]').contains(industryValue).click();
   }
 
   selectIndustrySector(sectorId: string) {

--- a/web/src/components/MenuOptionSelected.tsx
+++ b/web/src/components/MenuOptionSelected.tsx
@@ -13,7 +13,7 @@ export const MenuOptionSelected = (props: Props): ReactElement => {
         <div className="padding-right-05">
           <Icon>check</Icon>
         </div>
-        <div className="text-bold" data-testid="industry-name">
+        <div className="text-bold" data-testid="option">
           {props.children}
         </div>
       </div>

--- a/web/src/components/MenuOptionUnselected.tsx
+++ b/web/src/components/MenuOptionUnselected.tsx
@@ -8,7 +8,7 @@ interface Props {
 export const MenuOptionUnselected = (props: Props): ReactElement => {
   return (
     <>
-      <div className="padding-left-205 text-wrap" data-testid="industry-name">
+      <div className="padding-left-205 text-wrap" data-testid="option">
         {props.children}
       </div>
 

--- a/web/src/components/onboarding/IndustryDropdown.tsx
+++ b/web/src/components/onboarding/IndustryDropdown.tsx
@@ -164,7 +164,7 @@ export const IndustryDropdown = (props: Props): ReactElement => {
               id="industryId"
               inputProps={{
                 "aria-label": "Industry",
-                "data-testid": "industryid",
+                "data-testid": "industryId",
                 ...params.inputProps,
               }}
               value={searchText}

--- a/web/test/pages/onboarding/helpers-onboarding.tsx
+++ b/web/test/pages/onboarding/helpers-onboarding.tsx
@@ -140,7 +140,7 @@ export const createPageHelpers = (): PageHelpers => {
   };
 
   const getIndustryValue = (): string => {
-    return (screen.queryByTestId("industryid") as HTMLInputElement)?.value;
+    return (screen.queryByTestId("industryId") as HTMLInputElement)?.value;
   };
 
   const getRadioGroup = (sectionAriaLabel: string): HTMLElement => {

--- a/web/test/pages/profile/profile-starting.test.tsx
+++ b/web/test/pages/profile/profile-starting.test.tsx
@@ -1330,6 +1330,6 @@ describe("profile - starting business", () => {
   });
 
   const getIndustryValue = (): string => {
-    return (screen.queryByTestId("industryid") as HTMLInputElement)?.value;
+    return (screen.queryByTestId("industryId") as HTMLInputElement)?.value;
   };
 });


### PR DESCRIPTION
## Description
Updated data test id in `MenuOptionSelected` and `MenuOptionUnselected` to a generic id because it's used in other places other than industry. And updated data test id of industryId using camel case format.

### Ticket

https://www.pivotaltracker.com/story/show/185894552

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
