### PR TITLE
feat: [#184749103] remove US Territories from formation state dropdown

### DIFF
--- a/shared/src/test/formationFactories.ts
+++ b/shared/src/test/formationFactories.ts
@@ -41,7 +41,12 @@ export const generateFormationUSAddress = (overrides: Partial<FormationAddress>)
     addressCity: `some-address-city-${randomInt()}`,
     addressState: randomElementFromArray(
       states.filter((state) => {
-        return state.shortCode !== "NJ";
+        return (
+          state.shortCode !== "NJ" &&
+          state.shortCode !== "AS" &&
+          state.shortCode !== "VI" &&
+          state.shortCode !== "GU"
+        );
       })
     ),
     addressCountry: "US",

--- a/web/cypress/support/helpers/factories.ts
+++ b/web/cypress/support/helpers/factories.ts
@@ -31,7 +31,12 @@ export const generateFormationUSAddress = (overrides: Partial<FormationAddress>)
     addressCity: `some-address-city-${randomInt()}`,
     addressState: randomElementFromArray(
       states.filter((state) => {
-        return state.shortCode !== "NJ";
+        return (
+          state.shortCode !== "NJ" &&
+          state.shortCode !== "AS" &&
+          state.shortCode !== "VI" &&
+          state.shortCode !== "GU"
+        );
       })
     ),
     addressCountry: "US",

--- a/web/src/components/StateDropdown.test.tsx
+++ b/web/src/components/StateDropdown.test.tsx
@@ -15,6 +15,12 @@ describe("<StateDropdown />", () => {
     expect(screen.getByText("GU")).toBeInTheDocument();
   });
 
+  it("renders list without NJ", () => {
+    render(<StateDropdown value={undefined} fieldName={"test"} onSelect={(): void => {}} excludeNJ={true} />);
+    fireEvent.click(screen.getByTestId("test"));
+    expect(screen.queryByText("NJ")).not.toBeInTheDocument();
+  });
+
   it("renders list without US Territories", () => {
     render(
       <StateDropdown

--- a/web/src/components/StateDropdown.test.tsx
+++ b/web/src/components/StateDropdown.test.tsx
@@ -1,0 +1,32 @@
+import { StateDropdown } from "@/components/StateDropdown";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+describe("<StateDropdown />", () => {
+  beforeEach(() => {});
+
+  it("renders list with NJ and US Territories", () => {
+    render(
+      <StateDropdown value={undefined} fieldName={"test"} onSelect={(): void => {}} excludeNJ={false} />
+    );
+    fireEvent.click(screen.getByTestId("test"));
+    expect(screen.getByText("NJ")).toBeInTheDocument();
+    expect(screen.getByText("AS")).toBeInTheDocument();
+    expect(screen.getByText("VI")).toBeInTheDocument();
+    expect(screen.getByText("GU")).toBeInTheDocument();
+  });
+
+  it("renders list without US Territories", () => {
+    render(
+      <StateDropdown
+        value={undefined}
+        fieldName={"test"}
+        onSelect={(): void => {}}
+        excludeTerritories={true}
+      />
+    );
+    fireEvent.click(screen.getByTestId("test"));
+    expect(screen.queryByText("AS")).not.toBeInTheDocument();
+    expect(screen.queryByText("VI")).not.toBeInTheDocument();
+    expect(screen.queryByText("GU")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/StateDropdown.tsx
+++ b/web/src/components/StateDropdown.tsx
@@ -13,6 +13,7 @@ interface Props {
   error?: boolean;
   validationText?: string;
   excludeNJ?: boolean;
+  excludeTerritories?: boolean;
   useFullName?: boolean;
   validationLabel?: string;
   autoComplete?: boolean;
@@ -55,12 +56,23 @@ export const StateDropdown = (props: Props): ReactElement => {
     },
   });
 
-  const filteredStates = (): StateObject[] =>
-    props.excludeNJ
-      ? states.filter((stateObject) => {
-          return stateObject.shortCode !== "NJ";
-        })
-      : states;
+  const filteredStates = (): StateObject[] => {
+    let result = states;
+    if (props.excludeNJ) {
+      result = result.filter((stateObject) => {
+        return stateObject.shortCode !== "NJ";
+      });
+    }
+
+    if (props.excludeTerritories) {
+      result = result.filter((stateObject) => {
+        return (
+          stateObject.shortCode !== "AS" && stateObject.shortCode !== "VI" && stateObject.shortCode !== "GU"
+        );
+      });
+    }
+    return result;
+  };
 
   const getState = (value: string | undefined): StateObject | undefined => {
     return filteredStates().find((state: StateObject) => {

--- a/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
@@ -395,6 +395,18 @@ describe("Formation - BusinessStep", () => {
       );
     });
 
+    it("does not include New Jersey in the foreign state of formation dropdown", async () => {
+      const page = await getPageHelper(
+        { businessPersona: "FOREIGN", legalStructureId: "limited-liability-company" },
+        { foreignStateOfFormation: undefined }
+      );
+
+      const listBox = await page.getListBoxForInputElementByTestId("foreignStateOfFormation");
+
+      expect(within(listBox).queryByText("New Jersey")).not.toBeInTheDocument();
+      expect(within(listBox).getByText("Ohio")).toBeInTheDocument();
+    });
+
     it("displays error on field validation", async () => {
       const page = await getPageHelper(
         { businessPersona: "FOREIGN", legalStructureId: "limited-liability-company" },

--- a/web/src/components/tasks/business-formation/contacts/AddressModal.tsx
+++ b/web/src/components/tasks/business-formation/contacts/AddressModal.tsx
@@ -6,6 +6,7 @@ import { ModifiedContent } from "@/components/ModifiedContent";
 import { StateDropdown } from "@/components/StateDropdown";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { useConfig } from "@/lib/data-hooks/useConfig";
+import { useUserData } from "@/lib/data-hooks/useUserData";
 import { templateEval } from "@/lib/utils/helpers";
 import { FormationIncorporator, FormationMember, StateObject } from "@businessnjgovnavigator/shared";
 import { Checkbox, FormControlLabel, FormGroup } from "@mui/material";
@@ -33,6 +34,8 @@ interface Props<T extends FormationMember | FormationIncorporator> {
 export const AddressModal = <T extends FormationMember | FormationIncorporator>(
   props: Props<T>
 ): ReactElement => {
+  const { business } = useUserData();
+  const isStarting = business?.profileData.businessPersona === "STARTING";
   const { Config } = useConfig();
   const [useDefaultAddress, setUseDefaultAddress] = useState<boolean>(false);
   const [addressData, setAddressData] = useState<T>(props.createEmptyAddress());
@@ -378,6 +381,7 @@ export const AddressModal = <T extends FormationMember | FormationIncorporator>(
                         disabled={shouldBeDisabled("addressState")}
                         onValidation={onValidation}
                         required={true}
+                        excludeTerritories={isStarting}
                       />
                     </div>
                     <div className="grid-col-7">

--- a/web/src/components/tasks/business-formation/contacts/Addresses.test.tsx
+++ b/web/src/components/tasks/business-formation/contacts/Addresses.test.tsx
@@ -10,7 +10,7 @@ import {
   generateMunicipality,
 } from "@businessnjgovnavigator/shared";
 import * as materialUi from "@mui/material";
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 
 function mockMaterialUI(): typeof materialUi {
   return {
@@ -231,6 +231,18 @@ describe("Formation - Addresses", () => {
         page.fillText("Address name", "The Dude");
       });
     });
+  });
+
+  it("does not include US Territories in state dropdown for users starting a new business", async () => {
+    const page = await getPageHelper({ legalStructureId: "limited-partnership" }, { incorporators: [] });
+    page.clickAddNewIncorporator();
+
+    const listBox = await page.getListBoxForInputElementByTestId("addressState");
+
+    expect(within(listBox).getByText("NJ")).toBeInTheDocument();
+    expect(within(listBox).queryByText("AS")).not.toBeInTheDocument();
+    expect(within(listBox).queryByText("VI")).not.toBeInTheDocument();
+    expect(within(listBox).queryByText("GU")).not.toBeInTheDocument();
   });
 
   const attemptApiSubmission = async (page: FormationPageHelpers): Promise<void> => {

--- a/web/test/helpers/helpers-formation.tsx
+++ b/web/test/helpers/helpers-formation.tsx
@@ -196,6 +196,7 @@ export type FormationPageHelpers = {
   getInputElementByLabel: (label: string) => HTMLInputElement;
   getInputElementByTestId: (testId: string) => HTMLInputElement;
   getInputElementByParentTestId: (testId: string, params: { type: string }) => HTMLInputElement;
+  getListBoxForInputElementByTestId: (testId: string) => Promise<HTMLInputElement>;
   selectByText: (label: string, value: string) => void;
   selectCheckbox: (label: string) => void;
   selectCheckboxByTestId: (testId: string) => void;
@@ -494,6 +495,14 @@ export const createFormationPageHelpers = (): FormationPageHelpers => {
     }
   };
 
+  const getListBoxForInputElementByTestId = async (testId: string): Promise<HTMLInputElement> => {
+    fireEvent.click(screen.getByTestId(testId));
+    await waitFor(() => {
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+    return screen.getByRole("listbox") as HTMLInputElement;
+  };
+
   return {
     fillText,
     fillAndSubmitBusinessNameStep,
@@ -503,6 +512,7 @@ export const createFormationPageHelpers = (): FormationPageHelpers => {
     submitContactsStep,
     submitNexusBusinessNameStep,
     fillAndSubmitNexusBusinessNameStep,
+    getListBoxForInputElementByTestId,
     submitBillingStep,
     submitReviewStep,
     searchBusinessName,


### PR DESCRIPTION
## Description
Removed US Terrorities from state dropdown in address modal; US Terrorities are only removed for Poppy.
Added test for foreign state of formation dropdown: dropdown list does not include New Jersey. It was missing.

### Ticket
https://www.pivotaltracker.com/story/show/184749103
https://www.pivotaltracker.com/story/show/185894567

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
