### PR TITLE
Fix onboarding page title string interpolation

### DIFF
--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -370,16 +370,16 @@ const OnboardingPage = (props: Props): ReactElement => {
     }
   };
 
-  const header = (): ReactElement => {
-    const pageTitle = modifyContent({
-      content: Config.onboardingDefaults.pageTitle,
-      condition: () => isAdditionalBusiness,
-      modificationMap: {
-        Additional: "Additional",
-        additional: "additional",
-      },
-    });
+  const pageTitle = modifyContent({
+    content: Config.onboardingDefaults.pageTitle,
+    condition: () => isAdditionalBusiness,
+    modificationMap: {
+      Additional: "Additional",
+      additional: "additional",
+    },
+  });
 
+  const header = (): ReactElement => {
     return (
       <div className="margin-y-2 desktop:margin-y-0 desktop:padding-bottom-1">
         <h1 ref={headerRef}>
@@ -391,7 +391,6 @@ const OnboardingPage = (props: Props): ReactElement => {
       </div>
     );
   };
-
   return (
     <MunicipalitiesContext.Provider value={{ municipalities: props.municipalities }}>
       <profileFormContext.Provider value={formContextState}>
@@ -406,11 +405,7 @@ const OnboardingPage = (props: Props): ReactElement => {
             onBack,
           }}
         >
-          <NextSeo
-            title={`Business.NJ.gov Navigator - ${
-              Config.onboardingDefaults.pageTitle
-            } ${evalHeaderStepsTemplate(page)}`}
-          />
+          <NextSeo title={`Business.NJ.gov Navigator - ${pageTitle} ${evalHeaderStepsTemplate(page)}`} />
           <PageSkeleton>
             <NavBar />
             <ReturnToPreviousBusinessBar previousBusiness={previousBusiness} />


### PR DESCRIPTION
## Description

JS variables used to build the page title were not getting processed correctly. This is an item that was noticed during an accessibility review meeting. 

### Ticket

[#185789032](https://www.pivotaltracker.com/story/show/185789032)

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
