### PR TITLE
Fix misaligned locked icons on profile

### DIFF
--- a/web/src/components/onboarding/FieldLabelProfile.tsx
+++ b/web/src/components/onboarding/FieldLabelProfile.tsx
@@ -39,9 +39,9 @@ export const FieldLabelProfile = (props: Props): ReactElement => {
 
   return (
     <>
-      <div className="flex flex-row fac">
+      <div className="flex flex-row fac margin-bottom-05">
         {isHeaderInConfig && showHeader && (
-          <div role="heading" aria-level={3} className="text-bold margin-bottom-05">
+          <div role="heading" aria-level={3} className="text-bold">
             {contentFromConfig.headerContextualInfo ? (
               <ContextualInfoButton
                 text={contentFromConfig.header}
@@ -59,12 +59,12 @@ export const FieldLabelProfile = (props: Props): ReactElement => {
           </div>
         )}
         {showLockedTooltip && (
-          <div className="margin-left-1 margin-bottom-2">
+          <div className="margin-left-1">
             <ArrowTooltip
               title={Config.profileDefaults.default.lockedFieldTooltipText}
               data-testid={`${props.fieldName}-locked-tooltip`}
             >
-              <div className="fdr fac  font-body-lg">
+              <div className="fdr fac font-body-lg">
                 <Icon>help_outline</Icon>
               </div>
             </ArrowTooltip>


### PR DESCRIPTION
## Description

Fix alignment issue between locked labels and tool tip icon on profile.

### Ticket

[#185885539](https://www.pivotaltracker.com/story/show/185885539)

### Approach

Moved margin-bottom to wrapper div.

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
