### PR TITLE
refactor: [#184779281] prefactor to update auth context user

### DIFF
--- a/web/src/components/navbar/NavBar.test.tsx
+++ b/web/src/components/navbar/NavBar.test.tsx
@@ -390,7 +390,7 @@ describe("<NavBar />", () => {
           <WithStatefulUserData initialUserData={userData}>
             <NavBar landingPage={false} showSidebar={false} />
           </WithStatefulUserData>,
-          { user, isAuthenticated: IsAuthenticated.FALSE }
+          { isAuthenticated: IsAuthenticated.FALSE }
         )
       );
       fireEvent.click(screen.getByText(Config.navigationDefaults.navBarGuestText));
@@ -529,7 +529,7 @@ describe("<NavBar />", () => {
             <WithStatefulUserData initialUserData={userData}>
               <NavBar landingPage={false} task={undefined} showSidebar={false} />
             </WithStatefulUserData>,
-            { user, isAuthenticated: IsAuthenticated.FALSE }
+            { isAuthenticated: IsAuthenticated.FALSE }
           )
         );
         fireEvent.click(screen.getByTestId("nav-menu-open"));

--- a/web/src/components/navbar/NavBarPopupMenu.test.tsx
+++ b/web/src/components/navbar/NavBarPopupMenu.test.tsx
@@ -12,7 +12,6 @@ import { useMockBusiness, useMockUserData } from "@/test/mock/mockUseUserData";
 import { WithStatefulUserData } from "@/test/mock/withStatefulUserData";
 import {
   Business,
-  BusinessUser,
   generateBusiness,
   generateProfileData,
   generateUserData,
@@ -58,7 +57,6 @@ describe("<NavBarPopupMenu />", () => {
   const renderNavBarPopupMenu = (params: {
     props: Partial<NavBarPopupMenuProps>;
     userData?: UserData;
-    user?: BusinessUser;
     isAuthenticated?: IsAuthenticated;
   }): void => {
     render(
@@ -72,7 +70,7 @@ describe("<NavBarPopupMenu />", () => {
             {...params.props}
           />
         </WithStatefulUserData>,
-        { user: params.user, isAuthenticated: params.isAuthenticated ?? IsAuthenticated.TRUE }
+        { isAuthenticated: params.isAuthenticated ?? IsAuthenticated.TRUE }
       )
     );
   };

--- a/web/src/components/profile/DevOnlyResetUserDataButton.tsx
+++ b/web/src/components/profile/DevOnlyResetUserDataButton.tsx
@@ -2,6 +2,7 @@ import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
 import { AuthContext } from "@/contexts/authContext";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { ROUTES } from "@/lib/domain-logic/routes";
+import { createEmptyUser } from "@businessnjgovnavigator/shared/businessUser";
 import { createEmptyUserData } from "@businessnjgovnavigator/shared/userData";
 import { useRouter } from "next/router";
 import { ReactElement, useContext } from "react";
@@ -12,8 +13,13 @@ export const DevOnlyResetUserDataButton = (): ReactElement => {
   const router = useRouter();
 
   const resetUserData = async (): Promise<void> => {
-    if (state.user) {
-      const emptyUserData = createEmptyUserData(state.user);
+    if (state.activeUser) {
+      const emptyUser = {
+        ...createEmptyUser(),
+        email: state.activeUser.email,
+        id: state.activeUser.id,
+      };
+      const emptyUserData = createEmptyUserData(emptyUser);
       await updateQueue?.queue(emptyUserData).update();
       router.push(ROUTES.landing);
     }

--- a/web/src/contexts/authContext.ts
+++ b/web/src/contexts/authContext.ts
@@ -2,7 +2,7 @@ import { AuthContextType, IsAuthenticated } from "@/lib/auth/AuthContext";
 import { createContext } from "react";
 
 export const initialState = {
-  user: undefined,
+  activeUser: undefined,
   isAuthenticated: IsAuthenticated.UNKNOWN,
 };
 

--- a/web/src/lib/auth/AuthContext.ts
+++ b/web/src/lib/auth/AuthContext.ts
@@ -1,7 +1,6 @@
-import { BusinessUser } from "@businessnjgovnavigator/shared/";
 import { Dispatch, Reducer } from "react";
 
-export type UserActionType = "LOGIN" | "LOGOUT" | "UPDATE_USER" | "LOGIN_GUEST" | "UPDATE_GUEST";
+export type UserActionType = "LOGIN" | "LOGOUT" | "LOGIN_GUEST";
 
 export enum IsAuthenticated {
   TRUE = "TRUE",
@@ -9,14 +8,19 @@ export enum IsAuthenticated {
   UNKNOWN = "UNKNOWN",
 }
 
+export interface ActiveUser {
+  id: string;
+  email: string;
+}
+
 export interface AuthState {
-  user: BusinessUser | undefined;
+  activeUser: ActiveUser | undefined;
   isAuthenticated: IsAuthenticated;
 }
 
 export interface AuthAction {
   type: UserActionType;
-  user: BusinessUser | undefined;
+  activeUser: ActiveUser | undefined;
 }
 
 export interface AuthContextType {
@@ -30,28 +34,18 @@ export const authReducer: AuthReducer = (state: AuthState, action: AuthAction): 
   switch (action.type) {
     case "LOGIN":
       return {
-        user: action.user,
+        activeUser: action.activeUser,
         isAuthenticated: IsAuthenticated.TRUE,
       };
     case "LOGIN_GUEST":
       return {
-        user: action.user,
-        isAuthenticated: IsAuthenticated.FALSE,
-      };
-    case "UPDATE_GUEST":
-      return {
-        user: action.user,
+        activeUser: action.activeUser,
         isAuthenticated: IsAuthenticated.FALSE,
       };
     case "LOGOUT":
       return {
-        user: undefined,
+        activeUser: undefined,
         isAuthenticated: IsAuthenticated.FALSE,
-      };
-    case "UPDATE_USER":
-      return {
-        user: action.user,
-        isAuthenticated: IsAuthenticated.TRUE,
       };
   }
 };

--- a/web/src/lib/auth/signinHelper.test.ts
+++ b/web/src/lib/auth/signinHelper.test.ts
@@ -2,6 +2,7 @@ import * as api from "@/lib/api-client/apiClient";
 import { onGuestSignIn, onSelfRegister, onSignIn, onSignOut, SelfRegRouter } from "@/lib/auth/signinHelper";
 import { ROUTES } from "@/lib/domain-logic/routes";
 import * as UserDataStorage from "@/lib/storage/UserDataStorage";
+import { generateActiveUser } from "@/test/factories";
 import { generateUser, generateUserData } from "@businessnjgovnavigator/shared/";
 import {
   generateBusiness,
@@ -21,7 +22,7 @@ const mockUserDataStorage = UserDataStorage as jest.Mocked<typeof UserDataStorag
 const originalModule = jest.requireActual("@/lib/storage/UserDataStorage");
 
 jest.mock("./sessionHelper", () => ({
-  getCurrentUser: jest.fn(),
+  getActiveUser: jest.fn(),
   triggerSignOut: jest.fn().mockResolvedValue({}),
 }));
 
@@ -53,13 +54,13 @@ describe("SigninHelper", () => {
     it("dispatches current user login", async () => {
       mockApi.getUserData.mockResolvedValue(generateUserData({}));
 
-      const user = generateUser({});
-      mockSession.getCurrentUser.mockResolvedValue(user);
+      const activeUser = generateActiveUser({});
+      mockSession.getActiveUser.mockResolvedValue(activeUser);
       await onSignIn(mockDispatch);
 
       expect(mockDispatch).toHaveBeenCalledWith({
         type: "LOGIN",
-        user: user,
+        activeUser: activeUser,
       });
     });
   });
@@ -201,7 +202,10 @@ describe("SigninHelper", () => {
       expect(userStorageMock).toHaveBeenCalled();
       expect(mockDispatch).toHaveBeenCalledWith({
         type: "LOGIN_GUEST",
-        user: user,
+        activeUser: {
+          email: user.email,
+          id: user.id,
+        },
       });
     });
 
@@ -210,7 +214,7 @@ describe("SigninHelper", () => {
       mockGetCurrentUserData.mockImplementation(() => {
         return userData;
       });
-      mockSession.getCurrentUser.mockImplementation(() => {
+      mockSession.getActiveUser.mockImplementation(() => {
         throw new Error("New");
       });
       await onGuestSignIn(mockPush, ROUTES.landing, mockDispatch);
@@ -221,7 +225,7 @@ describe("SigninHelper", () => {
       mockGetCurrentUserData.mockImplementation(() => {
         return undefined;
       });
-      mockSession.getCurrentUser.mockImplementation(() => {
+      mockSession.getActiveUser.mockImplementation(() => {
         throw new Error("New");
       });
       await onGuestSignIn(mockPush, ROUTES.dashboard, mockDispatch);
@@ -232,7 +236,7 @@ describe("SigninHelper", () => {
       mockGetCurrentUserData.mockImplementation(() => {
         return undefined;
       });
-      mockSession.getCurrentUser.mockImplementation(() => {
+      mockSession.getActiveUser.mockImplementation(() => {
         throw new Error("New");
       });
       await onGuestSignIn(mockPush, ROUTES.onboarding, mockDispatch);
@@ -243,7 +247,7 @@ describe("SigninHelper", () => {
       mockGetCurrentUserData.mockImplementation(() => {
         return undefined;
       });
-      mockSession.getCurrentUser.mockImplementation(() => {
+      mockSession.getActiveUser.mockImplementation(() => {
         throw new Error("New");
       });
       await onGuestSignIn(mockPush, ROUTES.welcome, mockDispatch);
@@ -254,7 +258,7 @@ describe("SigninHelper", () => {
   describe("onSignOut", () => {
     it("dispatches a logout with undefined user", async () => {
       const user = generateUser({});
-      mockSession.getCurrentUser.mockResolvedValue(user);
+      mockSession.getActiveUser.mockResolvedValue(user);
       const userStorageMock = mockDelete.mockImplementation(() => {});
       await onSignOut(mockPush, mockDispatch);
       expect(mockSession.triggerSignOut).toHaveBeenCalled();

--- a/web/src/lib/data-hooks/useUserData.test.tsx
+++ b/web/src/lib/data-hooks/useUserData.test.tsx
@@ -67,7 +67,7 @@ describe("useUserData", () => {
               <TestComponent />
             </SWRConfig>
           </RoadmapContext.Provider>,
-          { user: currentUser, dispatch: mockDispatch, isAuthenticated }
+          { activeUser: currentUser, dispatch: mockDispatch, isAuthenticated }
         ),
         undefined,
         mockSetError
@@ -168,23 +168,6 @@ describe("useUserData", () => {
       });
 
       expect(mockApi.getUserData).toHaveBeenCalled();
-    });
-
-    it("update auth state when data is initially loaded", async () => {
-      const currentUser = generateUser({});
-      const currentUserData = generateUserData({ user: { ...currentUser, myNJUserKey: "1234" } });
-      mockApi.getUserData.mockResolvedValue(currentUserData);
-      const { refresh } = await setupHook(currentUser, IsAuthenticated.TRUE);
-      await act(() => {
-        return refresh();
-      });
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: "UPDATE_USER",
-        user: {
-          ...currentUser,
-          myNJUserKey: currentUserData.user.myNJUserKey,
-        },
-      });
     });
 
     it("sets error to NO_DATA when api call fails with no cache", async () => {

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import "@newjersey/njwds/dist/css/styles.css";
 import "../styles/main.scss";
 import { ContextualInfoPanel } from "@/components/ContextualInfoPanel";
 import { AuthReducer, authReducer } from "@/lib/auth/AuthContext";
-import { getCurrentUser } from "@/lib/auth/sessionHelper";
+import { getActiveUser } from "@/lib/auth/sessionHelper";
 import { onGuestSignIn, onSignIn } from "@/lib/auth/signinHelper";
 import { Roadmap, UpdateQueue, UserDataError } from "@/lib/types/types";
 import analytics from "@/lib/utils/analytics";
@@ -107,11 +107,11 @@ const App = ({ Component, pageProps }: AppProps): ReactElement => {
 
   useMountEffect(() => {
     if (!pageProps.noAuth) {
-      getCurrentUser()
-        .then((currentUser) => {
+      getActiveUser()
+        .then((activeUser) => {
           dispatch({
             type: "LOGIN",
-            user: currentUser,
+            activeUser: activeUser,
           });
         })
         .catch(() => {
@@ -141,7 +141,7 @@ const App = ({ Component, pageProps }: AppProps): ReactElement => {
       <Script src="/intercom/settings.js" />
       <Script src="/intercom/init.js" />
       <IntercomScript
-        user={state.user}
+        user={updateQueue?.current().user}
         operatingPhaseId={operatingPhaseId}
         legalStructureId={legalStructureId}
         industryId={industryId}

--- a/web/src/pages/loading.tsx
+++ b/web/src/pages/loading.tsx
@@ -5,7 +5,7 @@ import { NavBar } from "@/components/navbar/NavBar";
 import { SingleColumnContainer } from "@/components/njwds/SingleColumnContainer";
 import { PageSkeleton } from "@/components/PageSkeleton";
 import { AuthContext } from "@/contexts/authContext";
-import { getCurrentUser, triggerSignIn } from "@/lib/auth/sessionHelper";
+import { getActiveUser, triggerSignIn } from "@/lib/auth/sessionHelper";
 import { onGuestSignIn } from "@/lib/auth/signinHelper";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
@@ -32,8 +32,8 @@ const LoadingPage = (): ReactElement => {
       return;
     }
     if (router.query[QUERIES.code]) {
-      getCurrentUser().then((currentUser) => {
-        dispatch({ type: "LOGIN", user: currentUser });
+      getActiveUser().then((currentUser) => {
+        dispatch({ type: "LOGIN", activeUser: currentUser });
       });
     } else if (router.asPath.includes(signInSamlError)) {
       setShowLoginErrorModal(true);

--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -54,6 +54,7 @@ import {
   TaskProgress,
   UserData,
 } from "@businessnjgovnavigator/shared/";
+import { createEmptyUser } from "@businessnjgovnavigator/shared/businessUser";
 import { getCurrentBusiness } from "@businessnjgovnavigator/shared/domain-logic/getCurrentBusiness";
 import { businessStructureTaskId } from "@businessnjgovnavigator/shared/domain-logic/taskIds";
 import { emptyProfileData } from "@businessnjgovnavigator/shared/profileData";
@@ -145,7 +146,7 @@ const OnboardingPage = (props: Props): ReactElement => {
       if (
         !router.isReady ||
         hasHandledRouting.current ||
-        !state.user ||
+        !state.activeUser ||
         state.isAuthenticated === IsAuthenticated.UNKNOWN ||
         !hasCompletedFetch
       ) {
@@ -168,7 +169,12 @@ const OnboardingPage = (props: Props): ReactElement => {
         setProfileData(currentUserData.businesses[currentUserData.currentBusinessId].profileData);
         setCurrentFlow(getFlow(currentUserData));
       } else {
-        currentUserData = createEmptyUserData(state.user);
+        const emptyUser = {
+          ...createEmptyUser(),
+          email: state.activeUser.email,
+          id: state.activeUser.id,
+        };
+        currentUserData = createEmptyUserData(emptyUser);
         setRegistrationDimension("Began Onboarding");
         await createUpdateQueue(currentUserData);
         setProfileData(currentUserData.businesses[currentUserData.currentBusinessId].profileData);
@@ -196,7 +202,7 @@ const OnboardingPage = (props: Props): ReactElement => {
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.isReady, state.user, state.isAuthenticated, hasCompletedFetch]);
+  }, [router.isReady, state.activeUser, state.isAuthenticated, hasCompletedFetch]);
 
   const setIndustryAndRouteToPage = async (
     business: Business,

--- a/web/test/factories.ts
+++ b/web/test/factories.ts
@@ -1,3 +1,4 @@
+import { ActiveUser } from "@/lib/auth/AuthContext";
 import {
   AllCounties,
   Certification,
@@ -339,6 +340,14 @@ export const generateOutageConfig = (overrides: Partial<OutageConfig>): OutageCo
     FEATURE_ENABLE_OUTAGE_ALERT_BAR: randomInt() % 2 === 0,
     OUTAGE_ALERT_MESSAGE: `some-message-${randomInt()}`,
     OUTAGE_ALERT_TYPE: randomElementFromArray(["ALL", "LOGGED_IN_ONLY", "UNREGISTERED_ONLY"]),
+    ...overrides,
+  };
+};
+
+export const generateActiveUser = (overrides: Partial<ActiveUser>): ActiveUser => {
+  return {
+    email: `some-email-${randomInt()}@example.com`,
+    id: `some-id-${randomInt()}`,
     ...overrides,
   };
 };

--- a/web/test/helpers/helpers-renderers.tsx
+++ b/web/test/helpers/helpers-renderers.tsx
@@ -3,23 +3,23 @@ import { AuthContext } from "@/contexts/authContext";
 import { ContextualInfo, ContextualInfoContext } from "@/contexts/contextualInfoContext";
 import { RoadmapContext } from "@/contexts/roadmapContext";
 import { UserDataErrorContext } from "@/contexts/userDataErrorContext";
-import { AuthAction, AuthState, IsAuthenticated } from "@/lib/auth/AuthContext";
+import { ActiveUser, AuthAction, AuthState, IsAuthenticated } from "@/lib/auth/AuthContext";
 import { Roadmap, UserDataError } from "@/lib/types/types";
-import { BusinessUser, RegistrationStatus } from "@businessnjgovnavigator/shared/";
+import { RegistrationStatus } from "@businessnjgovnavigator/shared/";
 import { Dispatch, ReactElement, SetStateAction } from "react";
 
 export const withAuth = (
   subject: ReactElement,
   context: {
-    user?: BusinessUser;
+    activeUser?: ActiveUser;
     dispatch?: Dispatch<AuthAction>;
     isAuthenticated?: IsAuthenticated;
   }
 ): ReactElement => {
   const isAuthenticated =
-    context.isAuthenticated || (context.user ? IsAuthenticated.TRUE : IsAuthenticated.FALSE);
+    context.isAuthenticated || (context.activeUser ? IsAuthenticated.TRUE : IsAuthenticated.FALSE);
   const dispatch = context.dispatch || jest.fn();
-  const state: AuthState = { isAuthenticated, user: context.user };
+  const state: AuthState = { isAuthenticated, activeUser: context.activeUser };
   return <AuthContext.Provider value={{ state, dispatch }}>{subject}</AuthContext.Provider>;
 };
 

--- a/web/test/pages/account-setup.test.tsx
+++ b/web/test/pages/account-setup.test.tsx
@@ -100,7 +100,7 @@ describe("Account Setup page", () => {
         <WithStatefulUserData initialUserData={initialUserData}>
           <AccountSetupPage />
         </WithStatefulUserData>,
-        { user: emptyUser, isAuthenticated }
+        { isAuthenticated }
       )
     );
     const page = createPageHelpers();

--- a/web/test/pages/index.test.tsx
+++ b/web/test/pages/index.test.tsx
@@ -4,7 +4,7 @@ import Home from "@/pages/index";
 import { withAuth } from "@/test/helpers/helpers-renderers";
 import { mockPush, useMockRouter } from "@/test/mock/mockRouter";
 import { setMockUserDataResponse, useMockBusiness } from "@/test/mock/mockUseUserData";
-import { generateProfileData, generateUser } from "@businessnjgovnavigator/shared";
+import { generateProfileData } from "@businessnjgovnavigator/shared";
 import { render } from "@testing-library/react";
 
 jest.mock("next/router", () => ({ useRouter: jest.fn() }));
@@ -23,19 +23,19 @@ describe("HomePage", () => {
       onboardingFormProgress: "COMPLETED",
       profileData: generateProfileData({ businessPersona: "STARTING" }),
     });
-    render(withAuth(<Home />, { user: generateUser({}) }));
+    render(withAuth(<Home />, { isAuthenticated: IsAuthenticated.TRUE }));
     expect(mockPush).toHaveBeenCalledWith(ROUTES.dashboard);
   });
 
   it("redirects to onboarding page when user has not completed onboarding flow", () => {
     useMockBusiness({ onboardingFormProgress: "UNSTARTED" });
-    render(withAuth(<Home />, { user: generateUser({}) }));
+    render(withAuth(<Home />, { isAuthenticated: IsAuthenticated.TRUE }));
     expect(mockPush).toHaveBeenCalledWith(ROUTES.onboarding);
   });
 
   it("redirects to dashboard page when it is unknown if user has completed onboarding flow or not", () => {
     setMockUserDataResponse({ error: "NO_DATA", userData: undefined });
-    render(withAuth(<Home />, { user: generateUser({}) }));
+    render(withAuth(<Home />, { isAuthenticated: IsAuthenticated.TRUE }));
     expect(mockPush).toHaveBeenCalledWith(`${ROUTES.dashboard}?error=true`);
   });
 

--- a/web/test/pages/onboarding/helpers-onboarding.tsx
+++ b/web/test/pages/onboarding/helpers-onboarding.tsx
@@ -14,7 +14,6 @@ import { currentBusiness, WithStatefulUserData } from "@/test/mock/withStatefulU
 import {
   BusinessPersona,
   businessStructureTaskId,
-  BusinessUser,
   createEmptyUser,
   createEmptyUserData,
   DateObject,
@@ -45,15 +44,13 @@ const Config = getMergedConfig();
 export const renderPage = ({
   municipalities,
   userData,
-  user,
   isAuthenticated,
 }: {
   municipalities?: Municipality[];
   userData?: UserData | null;
-  user?: BusinessUser;
   isAuthenticated?: IsAuthenticated;
 }): { page: PageHelpers } => {
-  const currentUser = user ?? userData?.user ?? generateUser({});
+  const currentUser = userData?.user ?? generateUser({});
   render(
     withAuth(
       <WithStatefulUserData
@@ -65,7 +62,7 @@ export const renderPage = ({
           <Onboarding municipalities={municipalities || []} />
         </ThemeProvider>
       </WithStatefulUserData>,
-      { user: currentUser, isAuthenticated }
+      { activeUser: currentUser, isAuthenticated }
     )
   );
   const page = createPageHelpers();


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

We were previously tracking `user` inside the AuthState, which represented the user that was signed in to Cognito, but as a full `BusinessUser` with all the BusinessUser things on it, like tracking if that user was signed up for the newsletter and so on. This was inaccurate because none of that information was correct. 

Before this refactor, there would be a `state.user` from the Auth Context, and a `userData.user` from the userData context, and they would both be of type `BusinessUser` and have the same ID, but half the fields were just wildly incorrect and did not actually have matching values between the two "identical" objects.

This refactor removes that issue by making the `user` inside the Auth state represent the values that we get from Cognito and nothing more.

This will make it easier to finish the myNJ existing user story because that story will add a new value to `ActiveUser` in AuthState that does NOT belong on `BusinessUser`, so separating these types is an important pre-factor.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
