### PR TITLE
fix: [#185834867] make sector required for Oscar personas

### DIFF
--- a/web/src/components/onboarding/OnboardingBusinessPersona.tsx
+++ b/web/src/components/onboarding/OnboardingBusinessPersona.tsx
@@ -25,6 +25,8 @@ export const OnboardingBusinessPersona = <T,>(props: FormContextFieldProps<T>): 
     Validate(false);
     setProfileData({
       ...state.profileData,
+      operatingPhase:
+        (event.target.value as BusinessPersona) === "OWNING" ? "GUEST_MODE_OWNING" : "GUEST_MODE",
       businessPersona: event.target.value as BusinessPersona,
     });
   };

--- a/web/test/pages/onboarding/onboarding-owning.test.tsx
+++ b/web/test/pages/onboarding/onboarding-owning.test.tsx
@@ -17,7 +17,7 @@ import {
   generateUserDataForBusiness,
 } from "@businessnjgovnavigator/shared/test";
 import { UserData } from "@businessnjgovnavigator/shared/userData";
-import { screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 
 jest.mock("next/router", () => ({ useRouter: jest.fn() }));
 jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
@@ -68,18 +68,17 @@ describe("onboarding - owning a business", () => {
       expect(screen.getByLabelText("Sector")).toBeInTheDocument();
     });
 
-    it("prevents user from moving after Step 1 if you have not entered a sector", async () => {
-      const userData = generateTestUserData({ sectorId: undefined });
-      useMockRouter({ isReady: true, query: { page: "1" } });
-      const { page } = renderPage({ userData });
-      page.clickNext();
+    it("does not allow OWNING user persona to move past Step 1 if user has not entered a sector", async () => {
+      const { page } = renderPage({ userData: undefined });
+      page.chooseRadio("business-persona-owning");
+      fireEvent.click(screen.getByTestId("next"));
       await waitFor(() => {
-        expect(screen.getByTestId("step-1")).toBeInTheDocument();
+        expect(
+          screen.getByText(Config.profileDefaults.fields.sectorId.default.errorTextRequired)
+        ).toBeInTheDocument();
       });
-      expect(
-        screen.getByText(Config.profileDefaults.fields.sectorId.default.errorTextRequired)
-      ).toBeInTheDocument();
       expect(screen.getByTestId("banner-alert-REQUIRED_REVIEW_INFO_BELOW")).toBeInTheDocument();
+      expect(screen.getByTestId("step-1")).toBeInTheDocument();
     });
 
     it("allows user to move past Step 1 if you have entered a sector", async () => {

--- a/web/test/pages/onboarding/onboarding-shared.test.tsx
+++ b/web/test/pages/onboarding/onboarding-shared.test.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/test/pages/onboarding/helpers-onboarding";
 import { createEmptyProfileData, generateProfileData } from "@businessnjgovnavigator/shared/";
 import { generateBusiness, generateUserDataForBusiness } from "@businessnjgovnavigator/shared/test";
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 
 jest.mock("next/router", () => ({ useRouter: jest.fn() }));
 jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
@@ -42,6 +42,19 @@ describe("onboarding - shared", () => {
     renderPage({});
     expect(screen.getByTestId("step-1")).toBeInTheDocument();
   });
+
+  it.each(["business-persona-starting", "business-persona-foreign"])(
+    "allows %s to move past Step 1",
+    async (radioOption: string) => {
+      const { page } = renderPage({ userData: undefined });
+
+      page.chooseRadio(radioOption);
+      fireEvent.click(screen.getByTestId("next"));
+      await waitFor(() => {
+        expect(screen.getByTestId("step-2")).toBeInTheDocument();
+      });
+    }
+  );
 
   it("routes to the second onboarding page when they have answered the first question and we route them to page 2", async () => {
     useMockRouter({ isReady: true, query: { page: "2" } });


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->


## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
Make sector selection required for Oscar personas.
### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[185834867](https://www.pivotaltracker.com/story/show/185834867)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
Users start out in GUEST_MODE, when sector selection is not a requirement. I updated the code such that when a user is an OWNING persona, then they will be in GUEST_MODE_OWNING: the point at which sector selection is a requirement.

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
