### PR TITLE
fix: [#185940288] allow Outside of the USA selection for foreign state of formation

### DIFF
--- a/shared/src/states.ts
+++ b/shared/src/states.ts
@@ -54,6 +54,7 @@ export const arrayOfStateNames = [
   "Wisconsin",
   "West Virginia",
   "Wyoming",
+  "Outside of the USA",
 ] as const;
 
 export const arrayOfStateShortCodes = [
@@ -112,6 +113,7 @@ export const arrayOfStateShortCodes = [
   "WI",
   "WV",
   "WY",
+  "Outside of the USA",
 ] as const;
 
 export type StateNames = (typeof arrayOfStateNames)[number];
@@ -178,4 +180,5 @@ export const arrayOfStateObjects: StateObject[] = [
   { shortCode: "WI", name: "Wisconsin" },
   { shortCode: "WV", name: "West Virginia" },
   { shortCode: "WY", name: "Wyoming" },
+  { shortCode: "Outside of the USA", name: "Outside of the USA" },
 ];

--- a/web/src/components/StateDropdown.test.tsx
+++ b/web/src/components/StateDropdown.test.tsx
@@ -35,4 +35,30 @@ describe("<StateDropdown />", () => {
     expect(screen.queryByText("VI")).not.toBeInTheDocument();
     expect(screen.queryByText("GU")).not.toBeInTheDocument();
   });
+
+  it("renders list including 'Outside of the USA' option", () => {
+    render(
+      <StateDropdown
+        value={undefined}
+        fieldName={"test"}
+        onSelect={(): void => {}}
+        includeOutsideUSA={true}
+      />
+    );
+    fireEvent.click(screen.getByTestId("test"));
+    expect(screen.getByText("Outside of the USA")).toBeInTheDocument();
+  });
+
+  it("does not include 'Outside of the USA' option when prop is false", () => {
+    render(
+      <StateDropdown
+        value={undefined}
+        fieldName={"test"}
+        onSelect={(): void => {}}
+        includeOutsideUSA={false}
+      />
+    );
+    fireEvent.click(screen.getByTestId("test"));
+    expect(screen.queryByText("Outside of the USA")).not.toBeInTheDocument();
+  });
 });

--- a/web/src/components/StateDropdown.tsx
+++ b/web/src/components/StateDropdown.tsx
@@ -14,6 +14,7 @@ interface Props {
   validationText?: string;
   excludeNJ?: boolean;
   excludeTerritories?: boolean;
+  includeOutsideUSA?: boolean;
   useFullName?: boolean;
   validationLabel?: string;
   autoComplete?: boolean;
@@ -58,6 +59,12 @@ export const StateDropdown = (props: Props): ReactElement => {
 
   const filteredStates = (): StateObject[] => {
     let result = states;
+    if (!props.includeOutsideUSA) {
+      result = result.filter((stateObject) => {
+        return stateObject.shortCode !== "Outside of the USA";
+      });
+    }
+
     if (props.excludeNJ) {
       result = result.filter((stateObject) => {
         return stateObject.shortCode !== "NJ";

--- a/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
@@ -407,6 +407,17 @@ describe("Formation - BusinessStep", () => {
       expect(within(listBox).getByText("Ohio")).toBeInTheDocument();
     });
 
+    it("includes 'Outside of the USA' in the foreign state of formation dropdown", async () => {
+      const page = await getPageHelper(
+        { businessPersona: "FOREIGN", legalStructureId: "limited-liability-company" },
+        { foreignStateOfFormation: undefined }
+      );
+
+      const listBox = await page.getListBoxForInputElementByTestId("foreignStateOfFormation");
+
+      expect(within(listBox).getByText("Outside of the USA")).toBeInTheDocument();
+    });
+
     it("displays error on field validation", async () => {
       const page = await getPageHelper(
         { businessPersona: "FOREIGN", legalStructureId: "limited-liability-company" },

--- a/web/src/components/tasks/business-formation/business/ForeignStateOfFormation.tsx
+++ b/web/src/components/tasks/business-formation/business/ForeignStateOfFormation.tsx
@@ -37,6 +37,7 @@ export const ForeignStateOfFormation = (): ReactElement => {
         required
         error={doesFieldHaveError(FIELD)}
         onSelect={handleChange}
+        includeOutsideUSA={true}
       />
     </>
   );


### PR DESCRIPTION

<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[185940288](https://www.pivotaltracker.com/story/show/#185940288)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have performed a self-review of my code
- [ ] I have created and/or updated relevant documentation, if necessary
- [ ] I have not used any relative imports
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
