### PR TITLE
fix: [#185940232] differentiate foreign and domestic legal type labels for formation

### DIFF
--- a/content/src/fieldConfig/business-formation.json
+++ b/content/src/fieldConfig/business-formation.json
@@ -454,16 +454,25 @@
     },
     "legalStructure": {
       "warningModalContinueButton": "Continue",
-      "limited-liability-company": "LLC",
-      "s-corporation": "Domestic Corporation",
-      "limited-liability-partnership": "LLP",
-      "limited-partnership": "LP",
+      "foreignLabels": {
+        "limited-liability-company": "Foreign LLC",
+        "s-corporation": "Foreign Corporation",
+        "limited-liability-partnership": "Foreign LLP",
+        "limited-partnership": "Foreign LP",
+        "c-corporation": "Foreign Corporation",
+        "nonprofit": "Non-Profit Foreign Corporation"
+      },
+      "domesticLabels": {
+        "limited-liability-company": "LLC",
+        "s-corporation": "Domestic Corporation",
+        "limited-liability-partnership": "LLP",
+        "limited-partnership": "LP",
+        "c-corporation": "Domestic Corporation",
+        "nonprofit": "Non-Profit Domestic Corporation"
+      },
       "warningModalBody": "If you change your proposed business structure in your business profile, you might need to complete a different form. Don't worry, once you update your profile we'll tell you which form you need and where to complete it.",
       "label": "Business Structure",
-      "foreignPrefaceText": "Foreign",
       "warningModalCancelButton": "Cancel",
-      "c-corporation": "Domestic Corporation",
-      "nonprofit": "Non-Profit Domestic Corporation",
       "warningModalHeader": "You Might Need a Different Form",
       "contextualInfo": "business-structure-learn-more"
     },

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -901,12 +901,28 @@ collections:
                 collapsed: true
                 widget: object
                 fields:
-                  - { label: "LLC", name: "limited-liability-company", widget: "string" }
-                  - { label: "LP", name: "limited-partnership", widget: "string" }
-                  - { label: "LLP", name: "limited-liability-partnership", widget: "string" }
-                  - { label: "C-Corp", name: "c-corporation", widget: "string" }
-                  - { label: "S-Corp", name: "s-corporation", widget: "string" }
-                  - { label: "Foreign preface", name: "foreignPrefaceText", widget: "string" }
+                  - label: Domestic Labels
+                    name: domesticLabels
+                    collapsed: false
+                    widget: object
+                    fields:
+                      - { label: "LLC", name: "limited-liability-company", widget: "string" }
+                      - { label: "LP", name: "limited-partnership", widget: "string" }
+                      - { label: "LLP", name: "limited-liability-partnership", widget: "string" }
+                      - { label: "C-Corp", name: "c-corporation", widget: "string" }
+                      - { label: "S-Corp", name: "s-corporation", widget: "string" }
+                      - { label: "Nonprofit", name: "nonprofit", widget: "string" }
+                  - label: Foreign Labels
+                    name: foreignLabels
+                    collapsed: false
+                    widget: object
+                    fields:
+                      - { label: "LLC", name: "limited-liability-company", widget: "string" }
+                      - { label: "LP", name: "limited-partnership", widget: "string" }
+                      - { label: "LLP", name: "limited-liability-partnership", widget: "string" }
+                      - { label: "C-Corp", name: "c-corporation", widget: "string" }
+                      - { label: "S-Corp", name: "s-corporation", widget: "string" }
+                      - { label: "Nonprofit", name: "nonprofit", widget: "string" }
                   - { label: "Business structure", name: "label", widget: "markdown" }
                   - {
                       label: "Review step contextual info",

--- a/web/src/components/tasks/business-formation/business/BusinessNameAndLegalStructure.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessNameAndLegalStructure.tsx
@@ -45,14 +45,14 @@ export const BusinessNameAndLegalStructure = ({ isReviewStep = false }: Props): 
 
   const legalStructureName = (): string => {
     if (!business || !business.profileData.legalStructureId) return "";
-    const preface =
-      business?.profileData.businessPersona === "FOREIGN"
-        ? `${Config.formation.legalStructure.foreignPrefaceText} `
-        : "";
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const legalStructure = (Config.formation.legalStructure as any)[business.profileData.legalStructureId];
-    return `${preface} ${legalStructure}`;
+    if (business.profileData.businessPersona === "FOREIGN") {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (Config.formation.legalStructure.foreignLabels as any)[business.profileData.legalStructureId];
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (Config.formation.legalStructure.domesticLabels as any)[business.profileData.legalStructureId];
+    }
   };
 
   if (!business) {

--- a/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
@@ -812,44 +812,62 @@ describe("Formation - BusinessStep", () => {
       const legalStructureId = "limited-liability-company";
       await getPageHelper({ legalStructureId }, {});
       const displayLegalStructure = screen.getByTestId("legal-structure");
-      expect(displayLegalStructure).toHaveTextContent(Config.formation.legalStructure[legalStructureId]);
+      expect(displayLegalStructure).toHaveTextContent(
+        Config.formation.legalStructure.domesticLabels[legalStructureId]
+      );
     });
 
     it("displays llp legal structure from profile data", async () => {
       const legalStructureId = "limited-liability-partnership";
       await getPageHelper({ legalStructureId }, {});
       const displayLegalStructure = screen.getByTestId("legal-structure");
-      expect(displayLegalStructure).toHaveTextContent(Config.formation.legalStructure[legalStructureId]);
+      expect(displayLegalStructure).toHaveTextContent(
+        Config.formation.legalStructure.domesticLabels[legalStructureId]
+      );
     });
 
     it("displays lp legal structure from profile data", async () => {
       const legalStructureId = "limited-partnership";
       await getPageHelper({ legalStructureId }, {});
       const displayLegalStructure = screen.getByTestId("legal-structure");
-      expect(displayLegalStructure).toHaveTextContent(Config.formation.legalStructure[legalStructureId]);
+      expect(displayLegalStructure).toHaveTextContent(
+        Config.formation.legalStructure.domesticLabels[legalStructureId]
+      );
     });
 
     it("displays sCorp legal structure from profile data", async () => {
       const legalStructureId = "s-corporation";
       await getPageHelper({ legalStructureId }, {});
       const displayLegalStructure = screen.getByTestId("legal-structure");
-      expect(displayLegalStructure).toHaveTextContent(Config.formation.legalStructure[legalStructureId]);
+      expect(displayLegalStructure).toHaveTextContent(
+        Config.formation.legalStructure.domesticLabels[legalStructureId]
+      );
     });
 
     it("displays cCorp legal structure from profile data", async () => {
       const legalStructureId = "c-corporation";
       await getPageHelper({ legalStructureId }, {});
       const displayLegalStructure = screen.getByTestId("legal-structure");
-      expect(displayLegalStructure).toHaveTextContent(Config.formation.legalStructure[legalStructureId]);
+      expect(displayLegalStructure).toHaveTextContent(
+        Config.formation.legalStructure.domesticLabels[legalStructureId]
+      );
     });
 
-    it("displays foreign label ahead of legal structure from profile data", async () => {
+    it("displays foreign label for legal structure for FOREIGN persona", async () => {
       const legalStructureId = randomPublicFilingLegalType();
       await getPageHelper({ legalStructureId, businessPersona: "FOREIGN" }, {});
       const displayLegalStructure = screen.getByTestId("legal-structure");
-      const name = Config.formation.legalStructure[legalStructureId];
       expect(displayLegalStructure).toHaveTextContent(
-        `${Config.formation.legalStructure.foreignPrefaceText} ${name}`
+        Config.formation.legalStructure.foreignLabels[legalStructureId]
+      );
+    });
+
+    it("displays domestic label ahead of legal structure for STARTING persona", async () => {
+      const legalStructureId = randomPublicFilingLegalType();
+      await getPageHelper({ legalStructureId, businessPersona: "STARTING" }, {});
+      const displayLegalStructure = screen.getByTestId("legal-structure");
+      expect(displayLegalStructure).toHaveTextContent(
+        Config.formation.legalStructure.domesticLabels[legalStructureId]
       );
     });
 


### PR DESCRIPTION

<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[185940232](https://www.pivotaltracker.com/story/show/#185940232)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have performed a self-review of my code
- [ ] I have created and/or updated relevant documentation, if necessary
- [ ] I have not used any relative imports
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
