### PR TITLE
Add formation task error alert link

### DIFF
--- a/web/src/components/FieldEntryAlert.test.tsx
+++ b/web/src/components/FieldEntryAlert.test.tsx
@@ -1,0 +1,68 @@
+import { FieldEntryAlert } from "@/components/FieldEntryAlert";
+import { AlertVariants } from "@/components/njwds-extended/Alert";
+import { randomInt } from "@businessnjgovnavigator/shared/intHelpers";
+import { render, screen, within } from "@testing-library/react";
+
+describe("<FieldEntryAlert/>", () => {
+  const alertMessage = `This is my alert message ${randomInt()}`;
+
+  it("renders when fields are provided", () => {
+    render(
+      <FieldEntryAlert
+        alertMessage={alertMessage}
+        fields={[{ name: "field-name", label: "Field Name" }]}
+        variant="error"
+      />
+    );
+    expect(screen.getByText(alertMessage)).toBeInTheDocument();
+  });
+
+  it("does not render when fields is an empty array", () => {
+    render(<FieldEntryAlert alertMessage={alertMessage} fields={[]} variant="error" />);
+    expect(screen.queryByText(alertMessage)).not.toBeInTheDocument();
+  });
+
+  it.each(AlertVariants)("sets Alert variant accordingly when provided variant is %s", (variant) => {
+    render(
+      <FieldEntryAlert
+        alertMessage={alertMessage}
+        fields={[{ name: "field-name", label: "Field Name" }]}
+        variant={variant}
+        testId="field-entry-alert"
+      />
+    );
+    expect(screen.getByTestId("field-entry-alert")).toHaveClass(`usa-alert--${variant}`);
+  });
+
+  it("displays each provided field in alert body", () => {
+    const fields = [
+      {
+        name: `random-field-name-${randomInt()}`,
+        label: `random-field-label-${randomInt()}`,
+      },
+      {
+        name: `random-field-name-${randomInt()}`,
+        label: `random-field-label-${randomInt()}`,
+      },
+      {
+        name: `random-field-name-${randomInt()}`,
+        label: `random-field-label-${randomInt()}`,
+      },
+    ];
+
+    render(
+      <FieldEntryAlert
+        alertMessage={alertMessage}
+        fields={fields}
+        variant="info"
+        testId="field-entry-alert"
+      />
+    );
+
+    for (const field of fields) {
+      const item = screen.getByTestId(`question-${field.name}-alert-text`);
+      expect(within(item).getByText(field.label)).toBeInTheDocument();
+      expect(within(item).getByRole("link")).toHaveAttribute("href", `#question-${field.name}`);
+    }
+  });
+});

--- a/web/src/components/FieldEntryAlert.test.tsx
+++ b/web/src/components/FieldEntryAlert.test.tsx
@@ -10,15 +10,25 @@ describe("<FieldEntryAlert/>", () => {
     render(
       <FieldEntryAlert
         alertMessage={alertMessage}
+        alertProps={{
+          variant: "error",
+        }}
         fields={[{ name: "field-name", label: "Field Name" }]}
-        variant="error"
       />
     );
     expect(screen.getByText(alertMessage)).toBeInTheDocument();
   });
 
   it("does not render when fields is an empty array", () => {
-    render(<FieldEntryAlert alertMessage={alertMessage} fields={[]} variant="error" />);
+    render(
+      <FieldEntryAlert
+        alertMessage={alertMessage}
+        alertProps={{
+          variant: "error",
+        }}
+        fields={[]}
+      />
+    );
     expect(screen.queryByText(alertMessage)).not.toBeInTheDocument();
   });
 
@@ -26,9 +36,11 @@ describe("<FieldEntryAlert/>", () => {
     render(
       <FieldEntryAlert
         alertMessage={alertMessage}
+        alertProps={{
+          dataTestid: "field-entry-alert",
+          variant,
+        }}
         fields={[{ name: "field-name", label: "Field Name" }]}
-        variant={variant}
-        testId="field-entry-alert"
       />
     );
     expect(screen.getByTestId("field-entry-alert")).toHaveClass(`usa-alert--${variant}`);
@@ -53,9 +65,11 @@ describe("<FieldEntryAlert/>", () => {
     render(
       <FieldEntryAlert
         alertMessage={alertMessage}
+        alertProps={{
+          dataTestid: "field-entry-alert",
+          variant: "info",
+        }}
         fields={fields}
-        variant="info"
-        testId="field-entry-alert"
       />
     );
 

--- a/web/src/components/FieldEntryAlert.tsx
+++ b/web/src/components/FieldEntryAlert.tsx
@@ -1,0 +1,30 @@
+import { Content } from "@/components/Content";
+import { Alert, AlertVariant } from "@/components/njwds-extended/Alert";
+import { ReactElement } from "react";
+
+interface Props {
+  alertMessage: string;
+  fields: {
+    name: string;
+    label: string;
+  }[];
+  testId?: string;
+  variant: AlertVariant;
+}
+
+export const FieldEntryAlert = (props: Props): ReactElement => {
+  if (props.fields.length === 0) return <></>;
+
+  return (
+    <Alert variant={props.variant} dataTestid={props.testId}>
+      <Content>{props.alertMessage}</Content>
+      <ul>
+        {props.fields.map((field) => (
+          <li key={field.name} data-testid={`question-${field.name}-alert-text`}>
+            <a href={`#question-${field.name}`}>{field.label}</a>
+          </li>
+        ))}
+      </ul>
+    </Alert>
+  );
+};

--- a/web/src/components/FieldEntryAlert.tsx
+++ b/web/src/components/FieldEntryAlert.tsx
@@ -1,12 +1,13 @@
 import { Content } from "@/components/Content";
 import { Alert, AlertVariant } from "@/components/njwds-extended/Alert";
-import { ReactElement } from "react";
+import { ReactElement, ReactNode } from "react";
 
 interface Props {
   alertMessage: string;
   fields: {
     name: string;
     label: string;
+    children?: ReactNode;
   }[];
   testId?: string;
   variant: AlertVariant;
@@ -22,6 +23,7 @@ export const FieldEntryAlert = (props: Props): ReactElement => {
         {props.fields.map((field) => (
           <li key={field.name} data-testid={`question-${field.name}-alert-text`}>
             <a href={`#question-${field.name}`}>{field.label}</a>
+            {field.children}
           </li>
         ))}
       </ul>

--- a/web/src/components/FieldEntryAlert.tsx
+++ b/web/src/components/FieldEntryAlert.tsx
@@ -1,23 +1,22 @@
 import { Content } from "@/components/Content";
-import { Alert, AlertVariant } from "@/components/njwds-extended/Alert";
+import { Alert, AlertProps } from "@/components/njwds-extended/Alert";
 import { ReactElement, ReactNode } from "react";
 
 interface Props {
   alertMessage: string;
+  alertProps: AlertProps;
   fields: {
     name: string;
     label: string;
     children?: ReactNode;
   }[];
-  testId?: string;
-  variant: AlertVariant;
 }
 
 export const FieldEntryAlert = (props: Props): ReactElement => {
   if (props.fields.length === 0) return <></>;
 
   return (
-    <Alert variant={props.variant} dataTestid={props.testId}>
+    <Alert {...props.alertProps}>
       <Content>{props.alertMessage}</Content>
       <ul>
         {props.fields.map((field) => (

--- a/web/src/components/njwds-extended/Alert.tsx
+++ b/web/src/components/njwds-extended/Alert.tsx
@@ -1,8 +1,7 @@
 import { ReactElement, ReactNode } from "react";
 
-interface Props {
+export interface AlertProps {
   variant: AlertVariant;
-  children: ReactNode;
   noIcon?: boolean;
   heading?: string;
   rounded?: boolean;
@@ -10,6 +9,10 @@ interface Props {
   className?: string;
   borderRight?: boolean;
   borderSmall?: boolean;
+}
+
+interface Props extends AlertProps {
+  children: ReactNode;
 }
 
 export const AlertVariants = ["info", "success", "warning", "error", "note"] as const;

--- a/web/src/components/njwds-extended/Alert.tsx
+++ b/web/src/components/njwds-extended/Alert.tsx
@@ -12,7 +12,9 @@ interface Props {
   borderSmall?: boolean;
 }
 
-export type AlertVariant = "info" | "success" | "warning" | "error" | "note";
+export const AlertVariants = ["info", "success", "warning", "error", "note"] as const;
+
+export type AlertVariant = (typeof AlertVariants)[number];
 
 export const Alert = (props: Props): ReactElement => {
   const { variant, children, noIcon, heading, rounded, dataTestid } = props;

--- a/web/src/components/profile/ProfileOpportunitiesAlert.tsx
+++ b/web/src/components/profile/ProfileOpportunitiesAlert.tsx
@@ -1,5 +1,4 @@
-import { Content } from "@/components/Content";
-import { Alert } from "@/components/njwds-extended/Alert";
+import { FieldEntryAlert } from "@/components/FieldEntryAlert";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { getProfileConfig } from "@/lib/domain-logic/getProfileConfig";
@@ -23,20 +22,17 @@ export const ProfileOpportunitiesAlert = (): ReactElement => {
     return contentFromConfig.header;
   };
 
-  if (unansweredOpportunityFields.length === 0) {
-    return <></>;
-  }
+  const unansweredFields = unansweredOpportunityFields.map((field) => ({
+    name: field,
+    label: getLabel(field as ProfileContentField),
+  }));
 
   return (
-    <Alert variant="info" dataTestid="opp-alert">
-      <Content>{Config.profileDefaults.default.profileCompletionAlert}</Content>
-      <ul>
-        {unansweredOpportunityFields.map((field) => (
-          <li key={field} data-testid={`question-${field}-alert-text`}>
-            <a href={`#question-${field}`}>{getLabel(field as ProfileContentField)}</a>
-          </li>
-        ))}
-      </ul>
-    </Alert>
+    <FieldEntryAlert
+      alertMessage={Config.profileDefaults.default.profileCompletionAlert}
+      fields={unansweredFields}
+      testId="opp-alert"
+      variant="info"
+    />
   );
 };

--- a/web/src/components/profile/ProfileOpportunitiesAlert.tsx
+++ b/web/src/components/profile/ProfileOpportunitiesAlert.tsx
@@ -30,9 +30,11 @@ export const ProfileOpportunitiesAlert = (): ReactElement => {
   return (
     <FieldEntryAlert
       alertMessage={Config.profileDefaults.default.profileCompletionAlert}
+      alertProps={{
+        dataTestid: "opp-alert",
+        variant: "info",
+      }}
       fields={unansweredFields}
-      testId="opp-alert"
-      variant="info"
     />
   );
 };

--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.tsx
@@ -1,4 +1,5 @@
 import { AutosaveSpinner } from "@/components/AutosaveSpinner";
+import { FieldEntryAlert } from "@/components/FieldEntryAlert";
 import { Alert } from "@/components/njwds-extended/Alert";
 import { HelpButton } from "@/components/njwds-extended/HelpButton";
 import { HorizontalStepper } from "@/components/njwds-extended/HorizontalStepper";
@@ -458,32 +459,32 @@ export const BusinessFormationPaginator = (props: Props): ReactElement => {
         );
       });
 
+      const fieldsWithErrors = dedupedFieldErrors.map((fieldError) => {
+        let configFieldName = fieldError.field as ConfigFormationFields;
+
+        if (fieldError.field === "members") {
+          configFieldName = getConfigFieldByLegalStructure(state.formationFormData.legalType);
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const label = (Config.formation.fields as any)[configFieldName].label;
+        return {
+          name: configFieldName,
+          label,
+          children: getApiErrorMessage(fieldError.field) && (
+            <ul>
+              <li>{getApiErrorMessage(fieldError.field)}</li>
+            </ul>
+          ),
+        };
+      });
+
       return (
-        <Alert variant="error">
-          <div>{Config.formation.errorBanner.errorOnStep}</div>
-          <ul>
-            {dedupedFieldErrors.map((fieldError) => {
-              let configFieldName = fieldError.field as ConfigFormationFields;
-
-              if (fieldError.field === "members") {
-                configFieldName = getConfigFieldByLegalStructure(state.formationFormData.legalType);
-              }
-
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const label = (Config.formation.fields as any)[configFieldName].label;
-              return (
-                <li key={label}>
-                  {label}
-                  {getApiErrorMessage(fieldError.field) && (
-                    <ul>
-                      <li>{getApiErrorMessage(fieldError.field)}</li>
-                    </ul>
-                  )}
-                </li>
-              );
-            })}
-          </ul>
-        </Alert>
+        <FieldEntryAlert
+          alertMessage={Config.formation.errorBanner.errorOnStep}
+          fields={fieldsWithErrors}
+          variant="error"
+        />
       );
     }
 

--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.tsx
@@ -482,8 +482,10 @@ export const BusinessFormationPaginator = (props: Props): ReactElement => {
       return (
         <FieldEntryAlert
           alertMessage={Config.formation.errorBanner.errorOnStep}
+          alertProps={{
+            variant: "error",
+          }}
           fields={fieldsWithErrors}
-          variant="error"
         />
       );
     }

--- a/web/src/components/tasks/business-formation/FormationField.tsx
+++ b/web/src/components/tasks/business-formation/FormationField.tsx
@@ -1,0 +1,9 @@
+import { ReactElement } from "rehype-react/lib";
+
+interface Props {
+  fieldName: string;
+}
+
+export const FormationField = (props: React.PropsWithChildren<Props>): ReactElement => {
+  return <div id={`question-${props.fieldName}`}>{props.children}</div>;
+};

--- a/web/src/components/tasks/business-formation/billing/BillingStep.tsx
+++ b/web/src/components/tasks/business-formation/billing/BillingStep.tsx
@@ -3,6 +3,7 @@ import { FormationChooseDocuments } from "@/components/tasks/business-formation/
 import { FormationChooseNotifications } from "@/components/tasks/business-formation/billing/FormationChooseNotifications";
 import { PaymentTypeTable } from "@/components/tasks/business-formation/billing/PaymentTypeTable";
 import { BusinessFormationTextField } from "@/components/tasks/business-formation/BusinessFormationTextField";
+import { FormationField } from "@/components/tasks/business-formation/FormationField";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormationErrors } from "@/lib/data-hooks/useFormationErrors";
@@ -23,37 +24,43 @@ export const BillingStep = (): ReactElement => {
       >
         <div className="grid-row grid-gap-1">
           <div className="margin-top-2 tablet:grid-col-6">
-            <BusinessFormationTextField
-              label={Config.formation.fields.contactFirstName.label}
-              fieldName="contactFirstName"
-              errorBarType="MOBILE-ONLY"
-              required={true}
-              validationText={getFieldErrorLabel("contactFirstName")}
-            />
+            <FormationField fieldName="contactFirstName">
+              <BusinessFormationTextField
+                label={Config.formation.fields.contactFirstName.label}
+                fieldName="contactFirstName"
+                errorBarType="MOBILE-ONLY"
+                required={true}
+                validationText={getFieldErrorLabel("contactFirstName")}
+              />
+            </FormationField>
           </div>
           <div className="margin-top-2 tablet:grid-col-6">
-            <BusinessFormationTextField
-              label={Config.formation.fields.contactLastName.label}
-              fieldName="contactLastName"
-              errorBarType="MOBILE-ONLY"
-              required={true}
-              validationText={getFieldErrorLabel("contactLastName")}
-            />
+            <FormationField fieldName="contactLastName">
+              <BusinessFormationTextField
+                label={Config.formation.fields.contactLastName.label}
+                fieldName="contactLastName"
+                errorBarType="MOBILE-ONLY"
+                required={true}
+                validationText={getFieldErrorLabel("contactLastName")}
+              />
+            </FormationField>
           </div>
         </div>
       </WithErrorBar>
       <div className="grid-row grid-gap-1">
         <div className="margin-top-2 tablet:grid-col-6">
-          <BusinessFormationTextField
-            validationText={Config.formation.fields.contactPhoneNumber.error}
-            label={Config.formation.fields.contactPhoneNumber.label}
-            errorBarType="ALWAYS"
-            fieldName={"contactPhoneNumber"}
-            numericProps={{
-              maxLength: 10,
-            }}
-            visualFilter={getPhoneNumberFormat}
-          />
+          <FormationField fieldName="contactPhoneNumber">
+            <BusinessFormationTextField
+              validationText={Config.formation.fields.contactPhoneNumber.error}
+              label={Config.formation.fields.contactPhoneNumber.label}
+              errorBarType="ALWAYS"
+              fieldName="contactPhoneNumber"
+              numericProps={{
+                maxLength: 10,
+              }}
+              visualFilter={getPhoneNumberFormat}
+            />
+          </FormationField>
         </div>
       </div>
       <hr className="margin-y-4" />

--- a/web/src/components/tasks/business-formation/billing/PaymentTypeTable.tsx
+++ b/web/src/components/tasks/business-formation/billing/PaymentTypeTable.tsx
@@ -1,4 +1,5 @@
 import { getCost } from "@/components/tasks/business-formation/billing/getCost";
+import { FormationField } from "@/components/tasks/business-formation/FormationField";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -9,7 +10,7 @@ import { FormHelperText, Radio } from "@mui/material";
 import React, { ReactElement, useContext, useEffect, useState } from "react";
 
 export const PaymentTypeTable = (): ReactElement => {
-  const FIELD = "paymentType";
+  const fieldName = "paymentType";
   const { Config } = useConfig();
   const { state, setFormationFormData, setFieldsInteracted } = useContext(BusinessFormationContext);
 
@@ -63,112 +64,118 @@ export const PaymentTypeTable = (): ReactElement => {
         paymentType: event.target.value as PaymentType,
       };
     });
-    setFieldsInteracted([FIELD]);
+    setFieldsInteracted([fieldName]);
   };
 
-  const hasError = doesFieldHaveError(FIELD);
+  const hasError = doesFieldHaveError(fieldName);
 
   return (
-    <WithErrorBar hasError={hasError} type="ALWAYS">
-      <table className="business-formation-table business-formation-payment">
-        <thead>
-          <tr>
-            <th className="text-bold">{Config.formation.fields.paymentType.label}</th>
-            <th></th>
-            <th></th>
-          </tr>
-          <tr>
-            <th colSpan={3}>
-              {hasError ? (
-                <FormHelperText className={"text-error-dark"}>
-                  {Config.formation.fields.paymentType.error}
-                </FormHelperText>
-              ) : (
-                " "
-              )}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td className={"padding-1"}>
-              <Radio
-                id="paymentTypeCreditCardRadio"
-                color={hasError ? "error" : "primary"}
-                checked={state.formationFormData.paymentType === "CC"}
-                onChange={handleChange}
-                value="CC"
-                name="radio-buttons"
-              />
-            </td>
-            <td>
-              <label
-                htmlFor="paymentTypeCreditCardRadio"
-                className={
-                  hasError
-                    ? "text-error-dark"
-                    : state.formationFormData.paymentType === "CC"
-                    ? "text-primary-dark text-bold"
-                    : ""
-                }
+    <FormationField fieldName={fieldName}>
+      <WithErrorBar hasError={hasError} type="ALWAYS">
+        <table className="business-formation-table business-formation-payment">
+          <thead>
+            <tr>
+              <th className="text-bold">{Config.formation.fields.paymentType.label}</th>
+              <th></th>
+              <th></th>
+            </tr>
+            <tr>
+              <th colSpan={3}>
+                {hasError ? (
+                  <FormHelperText className={"text-error-dark"}>
+                    {Config.formation.fields.paymentType.error}
+                  </FormHelperText>
+                ) : (
+                  " "
+                )}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className={"padding-1"}>
+                <Radio
+                  id="paymentTypeCreditCardRadio"
+                  color={hasError ? "error" : "primary"}
+                  checked={state.formationFormData.paymentType === "CC"}
+                  onChange={handleChange}
+                  value="CC"
+                  name="radio-buttons"
+                />
+              </td>
+              <td>
+                <label
+                  htmlFor="paymentTypeCreditCardRadio"
+                  className={
+                    hasError
+                      ? "text-error-dark"
+                      : state.formationFormData.paymentType === "CC"
+                      ? "text-primary-dark text-bold"
+                      : ""
+                  }
+                >
+                  <div data-testid={"paymentTypeCreditCardLabel"}>
+                    {Config.formation.fields.paymentType.creditCardLabel}
+                  </div>
+                </label>
+              </td>
+              <td
+                className={state.formationFormData.paymentType === "CC" ? "text-primary-dark text-bold" : ""}
               >
-                <div data-testid={"paymentTypeCreditCardLabel"}>
-                  {Config.formation.fields.paymentType.creditCardLabel}
+                {getDollarValue(creditCardCost)}
+              </td>
+            </tr>
+            <tr>
+              <td className={"padding-1"}>
+                <Radio
+                  id="paymentTypeACHRadio"
+                  color={hasError ? "error" : "primary"}
+                  checked={state.formationFormData.paymentType === "ACH"}
+                  onChange={handleChange}
+                  value="ACH"
+                  name="radio-buttons"
+                />
+              </td>
+              <td>
+                <label
+                  htmlFor="paymentTypeACHRadio"
+                  className={
+                    doesFieldHaveError(fieldName)
+                      ? "text-error-dark"
+                      : state.formationFormData.paymentType === "ACH"
+                      ? "text-primary-dark text-bold"
+                      : ""
+                  }
+                >
+                  <div data-testid={"paymentTypeACHLabel"}>
+                    {Config.formation.fields.paymentType.achLabel}
+                  </div>
+                </label>
+              </td>
+              <td
+                className={state.formationFormData.paymentType === "ACH" ? "text-primary-dark text-bold" : ""}
+              >
+                {getDollarValue(achCost)}
+              </td>
+            </tr>
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colSpan={1}>
+                <div className="text-align-left">
+                  <span className="text-bold r">{Config.formation.fields.paymentType.costTotalLabel}</span>{" "}
                 </div>
-              </label>
-            </td>
-            <td className={state.formationFormData.paymentType === "CC" ? "text-primary-dark text-bold" : ""}>
-              {getDollarValue(creditCardCost)}
-            </td>
-          </tr>
-          <tr>
-            <td className={"padding-1"}>
-              <Radio
-                id="paymentTypeACHRadio"
-                color={hasError ? "error" : "primary"}
-                checked={state.formationFormData.paymentType === "ACH"}
-                onChange={handleChange}
-                value="ACH"
-                name="radio-buttons"
-              />
-            </td>
-            <td>
-              <label
-                htmlFor="paymentTypeACHRadio"
-                className={
-                  doesFieldHaveError(FIELD)
-                    ? "text-error-dark"
-                    : state.formationFormData.paymentType === "ACH"
-                    ? "text-primary-dark text-bold"
-                    : ""
-                }
-              >
-                <div data-testid={"paymentTypeACHLabel"}>{Config.formation.fields.paymentType.achLabel}</div>
-              </label>
-            </td>
-            <td
-              className={state.formationFormData.paymentType === "ACH" ? "text-primary-dark text-bold" : ""}
-            >
-              {getDollarValue(achCost)}
-            </td>
-          </tr>
-        </tbody>
-        <tfoot>
-          <tr>
-            <td colSpan={1}>
-              <div className="text-align-left">
-                <span className="text-bold r">{Config.formation.fields.paymentType.costTotalLabel}</span>{" "}
-              </div>
-            </td>
-            <td colSpan={1}></td>
-            <td colSpan={1}>
-              <div className="text-align-right text-bold" aria-label={"Total"}>
-                {getDollarValue(totalCost)}
-              </div>
-            </td>
-          </tr>
-        </tfoot>
-      </table>
-    </WithErrorBar>
+              </td>
+              <td colSpan={1}></td>
+              <td colSpan={1}>
+                <div className="text-align-right text-bold" aria-label={"Total"}>
+                  {getDollarValue(totalCost)}
+                </div>
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </WithErrorBar>
+    </FormationField>
   );
 };

--- a/web/src/components/tasks/business-formation/business/BusinessStep.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessStep.tsx
@@ -4,6 +4,7 @@ import { MainBusinessForeignAddressFlow } from "@/components/tasks/business-form
 import { PartnershipRights } from "@/components/tasks/business-formation/business/PartnershipRights";
 import { Provisions } from "@/components/tasks/business-formation/business/Provisions";
 import { BusinessFormationTextBox } from "@/components/tasks/business-formation/BusinessFormationTextBox";
+import { FormationField } from "@/components/tasks/business-formation/FormationField";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { Fragment, ReactElement, useContext, useMemo } from "react";
@@ -27,31 +28,37 @@ export const BusinessStep = (): ReactElement => {
     return (
       <>
         <hr className="margin-y-2" aria-hidden={true} />
-        <BusinessFormationTextBox
-          maxChars={400}
-          fieldName={"combinedInvestment"}
-          required={true}
-          title={Config.formation.fields.combinedInvestment.label}
-          contentMd={Config.formation.fields.combinedInvestment.body}
-        />
+        <FormationField fieldName="combinedInvestment">
+          <BusinessFormationTextBox
+            maxChars={400}
+            fieldName="combinedInvestment"
+            required={true}
+            title={Config.formation.fields.combinedInvestment.label}
+            contentMd={Config.formation.fields.combinedInvestment.body}
+          />
+        </FormationField>
         <hr className="margin-bottom-2 margin-top-0" aria-hidden={true} />
-        <BusinessFormationTextBox
-          maxChars={400}
-          fieldName={"withdrawals"}
-          required={true}
-          title={Config.formation.fields.withdrawals.label}
-          contentMd={Config.formation.fields.withdrawals.body}
-        />
+        <FormationField fieldName="withdrawals">
+          <BusinessFormationTextBox
+            maxChars={400}
+            fieldName="withdrawals"
+            required={true}
+            title={Config.formation.fields.withdrawals.label}
+            contentMd={Config.formation.fields.withdrawals.body}
+          />
+        </FormationField>
         <hr className="margin-bottom-2 margin-top-0" aria-hidden={true} />
         <PartnershipRights />
         <hr className="margin-bottom-2 margin-top-2" aria-hidden={true} />
-        <BusinessFormationTextBox
-          maxChars={400}
-          fieldName={"dissolution"}
-          required={true}
-          title={Config.formation.fields.dissolution.label}
-          contentMd={Config.formation.fields.dissolution.body}
-        />
+        <FormationField fieldName="dissolution">
+          <BusinessFormationTextBox
+            maxChars={400}
+            fieldName="dissolution"
+            required={true}
+            title={Config.formation.fields.dissolution.label}
+            contentMd={Config.formation.fields.dissolution.body}
+          />
+        </FormationField>
       </>
     );
   };
@@ -59,15 +66,17 @@ export const BusinessStep = (): ReactElement => {
   const businessPurposeSection = (): ReactElement => (
     <>
       <hr className="margin-y-2" aria-hidden={true} key={"business-line-2"} />
-      <BusinessFormationTextBox
-        maxChars={300}
-        fieldName={"businessPurpose"}
-        required={false}
-        inputLabel={Config.formation.fields.businessPurpose.label}
-        addButtonText={Config.formation.fields.businessPurpose.addButtonText}
-        title={Config.formation.fields.businessPurpose.label}
-        contentMd={Config.formation.fields.businessPurpose.body}
-      />
+      <FormationField fieldName="businessPurpose">
+        <BusinessFormationTextBox
+          maxChars={300}
+          fieldName="businessPurpose"
+          required={false}
+          inputLabel={Config.formation.fields.businessPurpose.label}
+          addButtonText={Config.formation.fields.businessPurpose.addButtonText}
+          title={Config.formation.fields.businessPurpose.label}
+          contentMd={Config.formation.fields.businessPurpose.body}
+        />
+      </FormationField>
       <hr className="margin-y-2" aria-hidden={true} key={"business-line-3"} />
     </>
   );

--- a/web/src/components/tasks/business-formation/business/IsVeteranNonprofit.tsx
+++ b/web/src/components/tasks/business-formation/business/IsVeteranNonprofit.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { FormationField } from "@/components/tasks/business-formation/FormationField";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -16,54 +17,56 @@ export const IsVeteranNonprofit = (): ReactElement => {
 
   return (
     <WithErrorBar hasError={hasError} type="ALWAYS" className="margin-top-2">
-      <FormControl variant="outlined" fullWidth>
-        <label className="margin-right-3 text-bold">
-          <Content>{Config.formation.fields.isVeteranNonprofit.description}</Content>
-        </label>
-        <RadioGroup
-          aria-label={camelCaseToSentence(fieldName)}
-          className="fac"
-          value={state.formationFormData.isVeteranNonprofit ?? ""}
-          onChange={(e): void =>
-            setFormationFormData((previousState) => {
-              return {
-                ...previousState,
-                isVeteranNonprofit: JSON.parse(e.target.value),
-              };
-            })
-          }
-          row
-        >
-          <FormControlLabel
-            className="margin-right-0"
-            labelPlacement="end"
-            data-testid={"is-veteran-nonprofit-yes"}
-            value={true}
-            control={<Radio color="primary" />}
-            label={
-              <div className="padding-y-1 margin-right-2">
-                {Config.formation.fields.isVeteranNonprofit.radioYesText}
-              </div>
+      <FormationField fieldName={fieldName}>
+        <FormControl variant="outlined" fullWidth>
+          <label className="margin-right-3 text-bold">
+            <Content>{Config.formation.fields.isVeteranNonprofit.description}</Content>
+          </label>
+          <RadioGroup
+            aria-label={camelCaseToSentence(fieldName)}
+            className="fac"
+            value={state.formationFormData.isVeteranNonprofit ?? ""}
+            onChange={(e): void =>
+              setFormationFormData((previousState) => {
+                return {
+                  ...previousState,
+                  isVeteranNonprofit: JSON.parse(e.target.value),
+                };
+              })
             }
-          />
-          <FormControlLabel
-            labelPlacement="end"
-            data-testid={"is-veteran-nonprofit-no"}
-            value={false}
-            control={<Radio color="primary" />}
-            label={
-              <div className="padding-y-1 margin-right-2">
-                {Config.formation.fields.isVeteranNonprofit.radioNoText}
-              </div>
-            }
-          />
-        </RadioGroup>
-        {hasError && (
-          <FormHelperText className={"text-error-dark"}>
-            {Config.formation.fields.isVeteranNonprofit.error}
-          </FormHelperText>
-        )}
-      </FormControl>
+            row
+          >
+            <FormControlLabel
+              className="margin-right-0"
+              labelPlacement="end"
+              data-testid={"is-veteran-nonprofit-yes"}
+              value={true}
+              control={<Radio color="primary" />}
+              label={
+                <div className="padding-y-1 margin-right-2">
+                  {Config.formation.fields.isVeteranNonprofit.radioYesText}
+                </div>
+              }
+            />
+            <FormControlLabel
+              labelPlacement="end"
+              data-testid={"is-veteran-nonprofit-no"}
+              value={false}
+              control={<Radio color="primary" />}
+              label={
+                <div className="padding-y-1 margin-right-2">
+                  {Config.formation.fields.isVeteranNonprofit.radioNoText}
+                </div>
+              }
+            />
+          </RadioGroup>
+          {hasError && (
+            <FormHelperText className={"text-error-dark"}>
+              {Config.formation.fields.isVeteranNonprofit.error}
+            </FormHelperText>
+          )}
+        </FormControl>
+      </FormationField>
     </WithErrorBar>
   );
 };

--- a/web/src/components/tasks/business-formation/business/MainBusiness.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusiness.tsx
@@ -1,10 +1,13 @@
+import { PracticesLaw } from "@/components/tasks/business-formation/business//PracticesLaw";
 import { BusinessNameAndLegalStructure } from "@/components/tasks/business-formation/business/BusinessNameAndLegalStructure";
+import { ForeignCertificate } from "@/components/tasks/business-formation/business/ForeignCertificate";
 import { ForeignStateOfFormation } from "@/components/tasks/business-formation/business/ForeignStateOfFormation";
 import { FormationDate } from "@/components/tasks/business-formation/business/FormationDate";
 import { IsVeteranNonprofit } from "@/components/tasks/business-formation/business/IsVeteranNonprofit";
 import { NonprofitProvisions } from "@/components/tasks/business-formation/business/NonprofitProvisions";
 import { SuffixDropdown } from "@/components/tasks/business-formation/business/SuffixDropdown";
 import { BusinessFormationTextField } from "@/components/tasks/business-formation/BusinessFormationTextField";
+import { FormationField } from "@/components/tasks/business-formation/FormationField";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -12,8 +15,6 @@ import { useFormationErrors } from "@/lib/data-hooks/useFormationErrors";
 import { isForeignCorporation } from "@/lib/utils/helpers";
 import { corpLegalStructures } from "@businessnjgovnavigator/shared/";
 import { ReactElement, useContext, useMemo } from "react";
-import { ForeignCertificate } from "./ForeignCertificate";
-import { PracticesLaw } from "./PracticesLaw";
 
 export const MainBusiness = (): ReactElement => {
   const { Config } = useConfig();
@@ -34,12 +35,16 @@ export const MainBusiness = (): ReactElement => {
         <div className="grid-row grid-gap-1">
           <div className="margin-top-2 tablet:grid-col-6">
             <WithErrorBar hasError={doesFieldHaveError("businessSuffix")} type="MOBILE-ONLY">
-              <SuffixDropdown />
+              <FormationField fieldName="businessSuffix">
+                <SuffixDropdown />
+              </FormationField>
             </WithErrorBar>
           </div>
           <div className="margin-top-2 tablet:grid-col-6">
             <WithErrorBar hasError={doesFieldHaveError("businessStartDate")} type="MOBILE-ONLY">
-              <FormationDate fieldName="businessStartDate" />
+              <FormationField fieldName="businessStartDate">
+                <FormationDate fieldName="businessStartDate" />
+              </FormationField>
             </WithErrorBar>
           </div>
         </div>
@@ -53,12 +58,16 @@ export const MainBusiness = (): ReactElement => {
             <div className="grid-row grid-gap-1">
               <div className="margin-top-2 tablet:grid-col-6">
                 <WithErrorBar hasError={doesFieldHaveError("foreignStateOfFormation")} type="MOBILE-ONLY">
-                  <ForeignStateOfFormation />
+                  <FormationField fieldName="foreignStateOfFormation">
+                    <ForeignStateOfFormation />
+                  </FormationField>
                 </WithErrorBar>
               </div>
               <div className="margin-top-2 tablet:grid-col-6">
                 <WithErrorBar hasError={doesFieldHaveError("foreignDateOfFormation")} type="MOBILE-ONLY">
-                  <FormationDate fieldName="foreignDateOfFormation" />
+                  <FormationField fieldName="foreignDateOfFormation">
+                    <FormationDate fieldName="foreignDateOfFormation" />
+                  </FormationField>
                 </WithErrorBar>
               </div>
             </div>
@@ -67,9 +76,13 @@ export const MainBusiness = (): ReactElement => {
           {isForeignCorporation(state.formationFormData.legalType) && (
             <>
               <WithErrorBar hasError={doesFieldHaveError("willPracticeLaw")} type="ALWAYS">
-                <PracticesLaw hasError={doesFieldHaveError("willPracticeLaw")} />
+                <FormationField fieldName="willPracticeLaw">
+                  <PracticesLaw hasError={doesFieldHaveError("willPracticeLaw")} />
+                </FormationField>
               </WithErrorBar>
-              <ForeignCertificate hasError={doesFieldHaveError("foreignGoodStandingFile")} />
+              <FormationField fieldName="foreignGoodStandingFile">
+                <ForeignCertificate hasError={doesFieldHaveError("foreignGoodStandingFile")} />
+              </FormationField>
             </>
           )}
         </>
@@ -86,18 +99,20 @@ export const MainBusiness = (): ReactElement => {
       {corpLegalStructures.includes(state.formationFormData.legalType) && (
         <div className="grid-row grid-gap-1">
           <div className="margin-top-2 tablet:grid-col-6">
-            <BusinessFormationTextField
-              errorBarType="ALWAYS"
-              label={Config.formation.fields.businessTotalStock.label}
-              numericProps={{
-                minLength: 1,
-                trimLeadingZeroes: true,
-                maxLength: 11,
-              }}
-              required={true}
-              fieldName={"businessTotalStock"}
-              validationText={Config.formation.fields.businessTotalStock.error}
-            />
+            <FormationField fieldName="businessTotalStock">
+              <BusinessFormationTextField
+                errorBarType="ALWAYS"
+                label={Config.formation.fields.businessTotalStock.label}
+                numericProps={{
+                  minLength: 1,
+                  trimLeadingZeroes: true,
+                  maxLength: 11,
+                }}
+                required={true}
+                fieldName={"businessTotalStock"}
+                validationText={Config.formation.fields.businessTotalStock.error}
+              />
+            </FormationField>
           </div>
         </div>
       )}

--- a/web/src/components/tasks/business-formation/business/MainBusinessAddressIntl.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusinessAddressIntl.tsx
@@ -1,6 +1,7 @@
 import { CountryDropdown } from "@/components/CountryDropdown";
 import { ModifiedContent } from "@/components/ModifiedContent";
 import { BusinessFormationTextField } from "@/components/tasks/business-formation/BusinessFormationTextField";
+import { FormationField } from "@/components/tasks/business-formation/FormationField";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -15,22 +16,26 @@ export const MainBusinessIntl = (): ReactElement => {
 
   return (
     <>
-      <BusinessFormationTextField
-        label={Config.formation.fields.addressLine1.label}
-        fieldName="addressLine1"
-        required={true}
-        className={"margin-bottom-2"}
-        errorBarType="ALWAYS"
-        validationText={getFieldErrorLabel("addressLine1")}
-      />
-      <BusinessFormationTextField
-        label={Config.formation.fields.addressLine2.label}
-        secondaryLabel={Config.formation.general.optionalLabel}
-        errorBarType="ALWAYS"
-        fieldName="addressLine2"
-        validationText={getFieldErrorLabel("addressLine2")}
-        className="margin-bottom-2"
-      />
+      <FormationField fieldName="addressLine1">
+        <BusinessFormationTextField
+          label={Config.formation.fields.addressLine1.label}
+          fieldName="addressLine1"
+          required={true}
+          className={"margin-bottom-2"}
+          errorBarType="ALWAYS"
+          validationText={getFieldErrorLabel("addressLine1")}
+        />
+      </FormationField>
+      <FormationField fieldName="addressLine2">
+        <BusinessFormationTextField
+          label={Config.formation.fields.addressLine2.label}
+          secondaryLabel={Config.formation.general.optionalLabel}
+          errorBarType="ALWAYS"
+          fieldName="addressLine2"
+          validationText={getFieldErrorLabel("addressLine2")}
+          className="margin-bottom-2"
+        />
+      </FormationField>
       <WithErrorBar
         hasError={doSomeFieldsHaveError(["addressCity", "addressProvince"])}
         type="DESKTOP-ONLY"
@@ -38,22 +43,26 @@ export const MainBusinessIntl = (): ReactElement => {
       >
         <div className="grid-row grid-gap-1">
           <div className="tablet:grid-col-6 margin-bottom-2 tablet:margin-bottom-0">
-            <BusinessFormationTextField
-              label={Config.formation.fields.addressCity.label}
-              fieldName="addressCity"
-              required={true}
-              errorBarType="MOBILE-ONLY"
-              validationText={getFieldErrorLabel("addressCity")}
-            />
+            <FormationField fieldName="addressCity">
+              <BusinessFormationTextField
+                label={Config.formation.fields.addressCity.label}
+                fieldName="addressCity"
+                required={true}
+                errorBarType="MOBILE-ONLY"
+                validationText={getFieldErrorLabel("addressCity")}
+              />
+            </FormationField>
           </div>
           <div className="tablet:grid-col-6">
-            <BusinessFormationTextField
-              errorBarType="MOBILE-ONLY"
-              label={Config.formation.fields.addressProvince.label}
-              fieldName="addressProvince"
-              required={true}
-              validationText={getFieldErrorLabel("addressProvince")}
-            />
+            <FormationField fieldName="addressProvince">
+              <BusinessFormationTextField
+                errorBarType="MOBILE-ONLY"
+                label={Config.formation.fields.addressProvince.label}
+                fieldName="addressProvince"
+                required={true}
+                validationText={getFieldErrorLabel("addressProvince")}
+              />
+            </FormationField>
           </div>
         </div>
       </WithErrorBar>
@@ -61,37 +70,41 @@ export const MainBusinessIntl = (): ReactElement => {
         <strong>
           <ModifiedContent>{Config.formation.fields.addressCountry.label}</ModifiedContent>
         </strong>
-        <CountryDropdown
-          useFullName
-          excludeUS
-          fieldName="addressCountry"
-          value={state.formationFormData.addressCountry}
-          error={doesFieldHaveError("addressCountry")}
-          validationText={Config.formation.fields.addressCountry.error}
-          required
-          onValidation={(): void => setFieldsInteracted(["addressCountry"])}
-          onSelect={(country): void => {
-            setFormationFormData((previousFormationData) => {
-              return {
-                ...previousFormationData,
-                addressCountry: country?.shortCode,
-              };
-            });
-            setFieldsInteracted(["addressCountry"]);
-          }}
-        />
+        <FormationField fieldName="addressCountry">
+          <CountryDropdown
+            useFullName
+            excludeUS
+            fieldName="addressCountry"
+            value={state.formationFormData.addressCountry}
+            error={doesFieldHaveError("addressCountry")}
+            validationText={Config.formation.fields.addressCountry.error}
+            required
+            onValidation={(): void => setFieldsInteracted(["addressCountry"])}
+            onSelect={(country): void => {
+              setFormationFormData((previousFormationData) => {
+                return {
+                  ...previousFormationData,
+                  addressCountry: country?.shortCode,
+                };
+              });
+              setFieldsInteracted(["addressCountry"]);
+            }}
+          />
+        </FormationField>
       </WithErrorBar>
 
       <div className="grid-row grid-gap-1 margin-top-2">
         <div className="tablet:grid-col-6">
-          <BusinessFormationTextField
-            label={Config.formation.fields.addressZipCode.foreign.label}
-            valueFilter={formatIntlPostalCode}
-            errorBarType="ALWAYS"
-            required={true}
-            fieldName={"addressZipCode"}
-            validationText={Config.formation.fields.addressZipCode.foreign.errorIntl}
-          />
+          <FormationField fieldName="addressZipCode">
+            <BusinessFormationTextField
+              label={Config.formation.fields.addressZipCode.foreign.label}
+              valueFilter={formatIntlPostalCode}
+              errorBarType="ALWAYS"
+              required={true}
+              fieldName="addressZipCode"
+              validationText={Config.formation.fields.addressZipCode.foreign.errorIntl}
+            />
+          </FormationField>
         </div>
       </div>
     </>

--- a/web/src/components/tasks/business-formation/business/MainBusinessAddressNj.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusinessAddressNj.tsx
@@ -6,6 +6,7 @@ import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { StateDropdown } from "@/components/StateDropdown";
 import { FormationMunicipality } from "@/components/tasks/business-formation/business/FormationMunicipality";
 import { BusinessFormationTextField } from "@/components/tasks/business-formation/BusinessFormationTextField";
+import { FormationField } from "@/components/tasks/business-formation/FormationField";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -65,22 +66,26 @@ export const MainBusinessAddressNj = (): ReactElement => {
       {isExpanded && (
         <>
           <CannabisLocationAlert industryId={business?.profileData.industryId} />
-          <BusinessFormationTextField
-            label={Config.formation.fields.addressLine1.label}
-            fieldName="addressLine1"
-            required={true}
-            className={"margin-bottom-2"}
-            errorBarType="ALWAYS"
-            validationText={getFieldErrorLabel("addressLine1")}
-          />
-          <BusinessFormationTextField
-            label={Config.formation.fields.addressLine2.label}
-            secondaryLabel={Config.formation.general.optionalLabel}
-            errorBarType="ALWAYS"
-            fieldName="addressLine2"
-            validationText={getFieldErrorLabel("addressLine2")}
-            className="margin-bottom-2"
-          />
+          <FormationField fieldName="addressLine1">
+            <BusinessFormationTextField
+              label={Config.formation.fields.addressLine1.label}
+              fieldName="addressLine1"
+              required={true}
+              className={"margin-bottom-2"}
+              errorBarType="ALWAYS"
+              validationText={getFieldErrorLabel("addressLine1")}
+            />
+          </FormationField>
+          <FormationField fieldName="addressLine2">
+            <BusinessFormationTextField
+              label={Config.formation.fields.addressLine2.label}
+              secondaryLabel={Config.formation.general.optionalLabel}
+              errorBarType="ALWAYS"
+              fieldName="addressLine2"
+              validationText={getFieldErrorLabel("addressLine2")}
+              className="margin-bottom-2"
+            />
+          </FormationField>
           <WithErrorBar
             hasError={doSomeFieldsHaveError(["addressState", "addressZipCode", "addressMunicipality"])}
             type="DESKTOP-ONLY"
@@ -102,23 +107,27 @@ export const MainBusinessAddressNj = (): ReactElement => {
                       <strong>
                         <ModifiedContent>{Config.formation.fields.addressState.label}</ModifiedContent>
                       </strong>
-                      <StateDropdown
-                        fieldName="addressState"
-                        value={"New Jersey"}
-                        validationText={Config.formation.fields.addressState.error}
-                        disabled={true}
-                        onSelect={(): void => {}}
-                      />
+                      <FormationField fieldName="addressState">
+                        <StateDropdown
+                          fieldName="addressState"
+                          value={"New Jersey"}
+                          validationText={Config.formation.fields.addressState.error}
+                          disabled={true}
+                          onSelect={(): void => {}}
+                        />
+                      </FormationField>
                     </div>
                     <div className="grid-col-7">
-                      <BusinessFormationTextField
-                        label={Config.formation.fields.addressZipCode.label}
-                        numericProps={{ maxLength: 5 }}
-                        required={true}
-                        errorBarType="NEVER"
-                        fieldName={"addressZipCode"}
-                        validationText={getFieldErrorLabel("addressZipCode")}
-                      />
+                      <FormationField fieldName="addressZipCode">
+                        <BusinessFormationTextField
+                          label={Config.formation.fields.addressZipCode.label}
+                          numericProps={{ maxLength: 5 }}
+                          required={true}
+                          errorBarType="NEVER"
+                          fieldName={"addressZipCode"}
+                          validationText={getFieldErrorLabel("addressZipCode")}
+                        />
+                      </FormationField>
                     </div>
                   </div>
                 </WithErrorBar>

--- a/web/src/components/tasks/business-formation/business/MainBusinessAddressUs.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusinessAddressUs.tsx
@@ -1,6 +1,7 @@
 import { ModifiedContent } from "@/components/ModifiedContent";
 import { StateDropdown } from "@/components/StateDropdown";
 import { BusinessFormationTextField } from "@/components/tasks/business-formation/BusinessFormationTextField";
+import { FormationField } from "@/components/tasks/business-formation/FormationField";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -14,35 +15,41 @@ export const MainBusinessUs = (): ReactElement => {
 
   return (
     <>
-      <BusinessFormationTextField
-        label={Config.formation.fields.addressLine1.label}
-        fieldName="addressLine1"
-        required={true}
-        className={"margin-bottom-2"}
-        errorBarType="ALWAYS"
-        validationText={getFieldErrorLabel("addressLine1")}
-      />
-      <BusinessFormationTextField
-        label={Config.formation.fields.addressLine2.label}
-        secondaryLabel={Config.formation.general.optionalLabel}
-        errorBarType="ALWAYS"
-        fieldName="addressLine2"
-        validationText={getFieldErrorLabel("addressLine2")}
-        className="margin-bottom-2"
-      />
+      <FormationField fieldName="addressLine1">
+        <BusinessFormationTextField
+          label={Config.formation.fields.addressLine1.label}
+          fieldName="addressLine1"
+          required={true}
+          className={"margin-bottom-2"}
+          errorBarType="ALWAYS"
+          validationText={getFieldErrorLabel("addressLine1")}
+        />
+      </FormationField>
+      <FormationField fieldName="addressLine2">
+        <BusinessFormationTextField
+          label={Config.formation.fields.addressLine2.label}
+          secondaryLabel={Config.formation.general.optionalLabel}
+          errorBarType="ALWAYS"
+          fieldName="addressLine2"
+          validationText={getFieldErrorLabel("addressLine2")}
+          className="margin-bottom-2"
+        />
+      </FormationField>
       <WithErrorBar
         hasError={doSomeFieldsHaveError(["addressState", "addressZipCode", "addressCity"])}
         type="DESKTOP-ONLY"
       >
         <div className="grid-row grid-gap-1">
           <div className="grid-col-12 tablet:grid-col-6">
-            <BusinessFormationTextField
-              errorBarType="MOBILE-ONLY"
-              label={Config.formation.fields.addressCity.label}
-              fieldName="addressCity"
-              required={true}
-              validationText={getFieldErrorLabel("addressCity")}
-            />
+            <FormationField fieldName="addressCity">
+              <BusinessFormationTextField
+                errorBarType="MOBILE-ONLY"
+                label={Config.formation.fields.addressCity.label}
+                fieldName="addressCity"
+                required={true}
+                validationText={getFieldErrorLabel("addressCity")}
+              />
+            </FormationField>
           </div>
           <div className="grid-col-12 tablet:grid-col-6 margin-top-2 tablet:margin-top-0">
             <WithErrorBar
@@ -54,33 +61,37 @@ export const MainBusinessUs = (): ReactElement => {
                   <strong>
                     <ModifiedContent>{Config.formation.fields.addressState.label}</ModifiedContent>
                   </strong>
-                  <StateDropdown
-                    fieldName="addressState"
-                    value={state.formationFormData.addressState?.name}
-                    error={doesFieldHaveError("addressState")}
-                    validationText={Config.formation.fields.addressState.error}
-                    required
-                    onValidation={(): void => setFieldsInteracted(["addressState"])}
-                    onSelect={(stateObject): void => {
-                      setFormationFormData((previousFormationData) => {
-                        return {
-                          ...previousFormationData,
-                          addressState: stateObject,
-                        };
-                      });
-                      setFieldsInteracted(["addressState"]);
-                    }}
-                  />
+                  <FormationField fieldName="addressState">
+                    <StateDropdown
+                      fieldName="addressState"
+                      value={state.formationFormData.addressState?.name}
+                      error={doesFieldHaveError("addressState")}
+                      validationText={Config.formation.fields.addressState.error}
+                      required
+                      onValidation={(): void => setFieldsInteracted(["addressState"])}
+                      onSelect={(stateObject): void => {
+                        setFormationFormData((previousFormationData) => {
+                          return {
+                            ...previousFormationData,
+                            addressState: stateObject,
+                          };
+                        });
+                        setFieldsInteracted(["addressState"]);
+                      }}
+                    />
+                  </FormationField>
                 </div>
                 <div className="grid-col-7">
-                  <BusinessFormationTextField
-                    label={Config.formation.fields.addressZipCode.label}
-                    numericProps={{ maxLength: 5 }}
-                    required={true}
-                    errorBarType="NEVER"
-                    fieldName={"addressZipCode"}
-                    validationText={Config.formation.fields.addressZipCode.foreign.errorUS}
-                  />
+                  <FormationField fieldName="addressZipCode">
+                    <BusinessFormationTextField
+                      label={Config.formation.fields.addressZipCode.label}
+                      numericProps={{ maxLength: 5 }}
+                      required={true}
+                      errorBarType="NEVER"
+                      fieldName="addressZipCode"
+                      validationText={Config.formation.fields.addressZipCode.foreign.errorUS}
+                    />
+                  </FormationField>
                 </div>
               </div>
             </WithErrorBar>

--- a/web/src/components/tasks/business-formation/business/NonprofitProvisions.tsx
+++ b/web/src/components/tasks/business-formation/business/NonprofitProvisions.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@/components/Content";
 import { BusinessFormationTextField } from "@/components/tasks/business-formation/BusinessFormationTextField";
+import { FormationField } from "@/components/tasks/business-formation/FormationField";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -28,24 +29,26 @@ export const NonprofitProvisions = (): ReactElement => {
       <div className="margin-top-1">
         <div className="grid-row">
           <div className="grid-col">
-            <BusinessFormationTextField
-              fieldName={fieldName}
-              required={true}
-              errorBarType="ALWAYS"
-              validationText={Config.formation.general.genericErrorText}
-              label={Config.formation.nonprofitProvisions.description}
-              fieldOptions={{
-                multiline: true,
-                rows: 3,
-                className: "override-padding",
-                inputProps: {
-                  maxLength: 400,
-                  sx: {
-                    padding: "1rem",
+            <FormationField fieldName={fieldName}>
+              <BusinessFormationTextField
+                fieldName={fieldName}
+                required={true}
+                errorBarType="ALWAYS"
+                validationText={Config.formation.general.genericErrorText}
+                label={Config.formation.nonprofitProvisions.description}
+                fieldOptions={{
+                  multiline: true,
+                  rows: 3,
+                  className: "override-padding",
+                  inputProps: {
+                    maxLength: 400,
+                    sx: {
+                      padding: "1rem",
+                    },
                   },
-                },
-              }}
-            />
+                }}
+              />
+            </FormationField>
           </div>
         </div>
         <div className="text-base-dark margin-top-1 margin-bottom-2">
@@ -84,28 +87,30 @@ export const NonprofitProvisions = (): ReactElement => {
         <strong>
           <Content>{title}</Content>
         </strong>
-        <FormControl error={hasError}>
-          <RadioGroup
-            aria-label={camelCaseToSentence(fieldName)}
-            name={camelCaseToSentence(fieldName)}
-            value={state.formationFormData[fieldName]?.toString() ?? ""}
-            onChange={onChange}
-            row
-          >
-            {values.map((value) => (
-              <FormControlLabel
-                key={`${fieldName}-${value}`}
-                style={{ alignItems: "center" }}
-                value={value}
-                control={
-                  <Radio data-testid={`${fieldName}-${value}`} color={hasError ? "error" : "primary"} />
-                }
-                label={getRadioLabel(value)}
-              />
-            ))}
-          </RadioGroup>
-          <FormHelperText>{hasError ? Config.formation.general.genericErrorText : ""}</FormHelperText>
-        </FormControl>
+        <FormationField fieldName={fieldName}>
+          <FormControl error={hasError}>
+            <RadioGroup
+              aria-label={camelCaseToSentence(fieldName)}
+              name={camelCaseToSentence(fieldName)}
+              value={state.formationFormData[fieldName]?.toString() ?? ""}
+              onChange={onChange}
+              row
+            >
+              {values.map((value) => (
+                <FormControlLabel
+                  key={`${fieldName}-${value}`}
+                  style={{ alignItems: "center" }}
+                  value={value}
+                  control={
+                    <Radio data-testid={`${fieldName}-${value}`} color={hasError ? "error" : "primary"} />
+                  }
+                  label={getRadioLabel(value)}
+                />
+              ))}
+            </RadioGroup>
+            <FormHelperText>{hasError ? Config.formation.general.genericErrorText : ""}</FormHelperText>
+          </FormControl>
+        </FormationField>
       </WithErrorBar>
     );
   };

--- a/web/src/components/tasks/business-formation/business/PartnershipRights.tsx
+++ b/web/src/components/tasks/business-formation/business/PartnershipRights.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@/components/Content";
 import { BusinessFormationTextField } from "@/components/tasks/business-formation/BusinessFormationTextField";
+import { FormationField } from "@/components/tasks/business-formation/FormationField";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -17,24 +18,26 @@ export const PartnershipRights = (): ReactElement => {
   const getTextField = (fieldName: FormationTextField): ReactNode => {
     return (
       <div className="margin-top-1">
-        <BusinessFormationTextField
-          fieldName={fieldName}
-          required={true}
-          errorBarType="ALWAYS"
-          validationText={Config.formation.general.genericErrorText}
-          label={Config.formation.partnershipRights.description}
-          fieldOptions={{
-            multiline: true,
-            rows: 3,
-            className: "override-padding",
-            inputProps: {
-              maxLength: 400,
-              sx: {
-                padding: "1rem",
+        <FormationField fieldName={fieldName}>
+          <BusinessFormationTextField
+            fieldName={fieldName}
+            required={true}
+            errorBarType="ALWAYS"
+            validationText={Config.formation.general.genericErrorText}
+            label={Config.formation.partnershipRights.description}
+            fieldOptions={{
+              multiline: true,
+              rows: 3,
+              className: "override-padding",
+              inputProps: {
+                maxLength: 400,
+                sx: {
+                  padding: "1rem",
+                },
               },
-            },
-          }}
-        />
+            }}
+          />
+        </FormationField>
         <div className="text-base-dark margin-top-1 margin-bottom-2">
           {(state.formationFormData[fieldName] as string)?.length ?? 0} / {400}{" "}
           {Config.formation.general.charactersLabel}
@@ -48,35 +51,37 @@ export const PartnershipRights = (): ReactElement => {
     return (
       <WithErrorBar className="margin-top-2" hasError={hasError} type="ALWAYS">
         <Content>{title}</Content>
-        <FormControl error={hasError}>
-          <RadioGroup
-            aria-label={camelCaseToSentence(fieldName)}
-            name={camelCaseToSentence(fieldName)}
-            value={state.formationFormData[fieldName]?.toString() ?? ""}
-            onChange={(e): void => {
-              setFormationFormData({
-                ...state.formationFormData,
-                [fieldName]: JSON.parse(e.target.value),
-              });
-              setFieldsInteracted([fieldName]);
-            }}
-            row
-          >
-            <FormControlLabel
-              style={{ alignItems: "center" }}
-              value={"true"}
-              control={<Radio data-testid={`${fieldName}-true`} color={hasError ? "error" : "primary"} />}
-              label={Config.formation.partnershipRights.radioYesText}
-            />
-            <FormControlLabel
-              style={{ alignItems: "center" }}
-              value={"false"}
-              control={<Radio color={hasError ? "error" : "primary"} data-testid={`${fieldName}-false`} />}
-              label={Config.formation.partnershipRights.radioNoText}
-            />
-          </RadioGroup>
-          <FormHelperText>{hasError ? Config.formation.general.genericErrorText : ""}</FormHelperText>
-        </FormControl>
+        <FormationField fieldName={fieldName}>
+          <FormControl error={hasError}>
+            <RadioGroup
+              aria-label={camelCaseToSentence(fieldName)}
+              name={camelCaseToSentence(fieldName)}
+              value={state.formationFormData[fieldName]?.toString() ?? ""}
+              onChange={(e): void => {
+                setFormationFormData({
+                  ...state.formationFormData,
+                  [fieldName]: JSON.parse(e.target.value),
+                });
+                setFieldsInteracted([fieldName]);
+              }}
+              row
+            >
+              <FormControlLabel
+                style={{ alignItems: "center" }}
+                value={"true"}
+                control={<Radio data-testid={`${fieldName}-true`} color={hasError ? "error" : "primary"} />}
+                label={Config.formation.partnershipRights.radioYesText}
+              />
+              <FormControlLabel
+                style={{ alignItems: "center" }}
+                value={"false"}
+                control={<Radio color={hasError ? "error" : "primary"} data-testid={`${fieldName}-false`} />}
+                label={Config.formation.partnershipRights.radioNoText}
+              />
+            </RadioGroup>
+            <FormHelperText>{hasError ? Config.formation.general.genericErrorText : ""}</FormHelperText>
+          </FormControl>
+        </FormationField>
       </WithErrorBar>
     );
   };

--- a/web/src/components/tasks/business-formation/contacts/ContactsStep.tsx
+++ b/web/src/components/tasks/business-formation/contacts/ContactsStep.tsx
@@ -4,6 +4,7 @@ import { createSignedEmptyFormationObject } from "@/components/tasks/business-fo
 import { Members } from "@/components/tasks/business-formation/contacts/Members";
 import { RegisteredAgent } from "@/components/tasks/business-formation/contacts/RegisteredAgent";
 import { Signatures } from "@/components/tasks/business-formation/contacts/Signatures";
+import { FormationField } from "@/components/tasks/business-formation/FormationField";
 import { getErrorStateForField } from "@/components/tasks/business-formation/getErrorStateForField";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -46,7 +47,9 @@ export const ContactsStep = (): ReactElement => {
         {shouldShowMembers() && (
           <>
             <hr className="margin-top-0 margin-bottom-3" />
-            <Members hasError={doesFieldHaveError("members")} />
+            <FormationField fieldName="members">
+              <Members hasError={doesFieldHaveError("members")} />
+            </FormationField>
           </>
         )}
         <hr className="margin-top-0 margin-bottom-3" />
@@ -56,51 +59,53 @@ export const ContactsStep = (): ReactElement => {
           </Alert>
         )}
         {incorporationLegalStructures.includes(state.formationFormData.legalType) ? (
-          <Addresses<FormationIncorporator>
-            createEmptyAddress={(): FormationIncorporator => {
-              return createSignedEmptyFormationObject(
-                state.formationFormData.legalType,
-                createEmptyFormationIncorporator
-              );
-            }}
-            fieldName={"incorporators"}
-            addressData={state.formationFormData.incorporators ?? []}
-            setData={(incorporators): void => {
-              setFormationFormData((previousFormationData) => {
-                return {
-                  ...previousFormationData,
-                  incorporators: incorporators,
-                };
-              });
-            }}
-            defaultAddress={
-              "limited-partnership" === state.formationFormData.legalType
-                ? {
-                    addressCity:
-                      state.formationFormData.addressMunicipality?.name ??
-                      state.formationFormData.addressCity,
-                    addressLine1: state.formationFormData.addressLine1,
-                    addressLine2: state.formationFormData.addressLine2,
-                    addressState: state.formationFormData.addressState,
-                    addressZipCode: state.formationFormData.addressZipCode,
-                  }
-                : undefined
-            }
-            needSignature={true}
-            displayContent={{
-              description: getDescription("incorporators"),
-              header: Config.formation.fields.incorporators.label,
-              placeholder: Config.formation.fields.incorporators.placeholder ?? "",
-              newButtonText: Config.formation.fields.incorporators.addButtonText,
-              snackbarHeader: Config.formation.fields.incorporators.successSnackbarHeader,
-              snackbarBody: Config.formation.fields.incorporators.successSnackbarBody,
-              modalTitle: Config.formation.fields.incorporators.modalTitle,
-              modalSaveButton: Config.formation.fields.incorporators.addButtonText,
-              error: Config.formation.fields.incorporators.error,
-            }}
-            legalType={state.formationFormData.legalType}
-            hasError={doesFieldHaveError("signers") || doesFieldHaveError("incorporators")}
-          />
+          <FormationField fieldName="incorporators">
+            <Addresses<FormationIncorporator>
+              createEmptyAddress={(): FormationIncorporator => {
+                return createSignedEmptyFormationObject(
+                  state.formationFormData.legalType,
+                  createEmptyFormationIncorporator
+                );
+              }}
+              fieldName="incorporators"
+              addressData={state.formationFormData.incorporators ?? []}
+              setData={(incorporators): void => {
+                setFormationFormData((previousFormationData) => {
+                  return {
+                    ...previousFormationData,
+                    incorporators: incorporators,
+                  };
+                });
+              }}
+              defaultAddress={
+                "limited-partnership" === state.formationFormData.legalType
+                  ? {
+                      addressCity:
+                        state.formationFormData.addressMunicipality?.name ??
+                        state.formationFormData.addressCity,
+                      addressLine1: state.formationFormData.addressLine1,
+                      addressLine2: state.formationFormData.addressLine2,
+                      addressState: state.formationFormData.addressState,
+                      addressZipCode: state.formationFormData.addressZipCode,
+                    }
+                  : undefined
+              }
+              needSignature={true}
+              displayContent={{
+                description: getDescription("incorporators"),
+                header: Config.formation.fields.incorporators.label,
+                placeholder: Config.formation.fields.incorporators.placeholder ?? "",
+                newButtonText: Config.formation.fields.incorporators.addButtonText,
+                snackbarHeader: Config.formation.fields.incorporators.successSnackbarHeader,
+                snackbarBody: Config.formation.fields.incorporators.successSnackbarBody,
+                modalTitle: Config.formation.fields.incorporators.modalTitle,
+                modalSaveButton: Config.formation.fields.incorporators.addButtonText,
+                error: Config.formation.fields.incorporators.error,
+              }}
+              legalType={state.formationFormData.legalType}
+              hasError={doesFieldHaveError("signers") || doesFieldHaveError("incorporators")}
+            />
+          </FormationField>
         ) : (
           <Signatures />
         )}

--- a/web/src/components/tasks/business-formation/contacts/RegisteredAgent.tsx
+++ b/web/src/components/tasks/business-formation/contacts/RegisteredAgent.tsx
@@ -3,6 +3,7 @@ import { ModifiedContent } from "@/components/ModifiedContent";
 import { MunicipalityDropdown } from "@/components/profile/MunicipalityDropdown";
 import { StateDropdown } from "@/components/StateDropdown";
 import { BusinessFormationTextField } from "@/components/tasks/business-formation/BusinessFormationTextField";
+import { FormationField } from "@/components/tasks/business-formation/FormationField";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { MunicipalitiesContext } from "@/contexts/municipalitiesContext";
@@ -162,14 +163,16 @@ export const RegisteredAgent = (): ReactElement => {
         <div className="margin-top-2">
           {state.formationFormData.agentNumberOrManual === "NUMBER" && (
             <div data-testid="agent-number">
-              <BusinessFormationTextField
-                label={Config.formation.fields.agentNumber.label}
-                numericProps={{ minLength: 4, maxLength: 7 }}
-                fieldName="agentNumber"
-                required={true}
-                validationText={Config.formation.fields.agentNumber.error}
-                errorBarType="ALWAYS"
-              />
+              <FormationField fieldName="agentNumber">
+                <BusinessFormationTextField
+                  label={Config.formation.fields.agentNumber.label}
+                  numericProps={{ minLength: 4, maxLength: 7 }}
+                  fieldName="agentNumber"
+                  required={true}
+                  validationText={Config.formation.fields.agentNumber.error}
+                  errorBarType="ALWAYS"
+                />
+              </FormationField>
             </div>
           )}
 
@@ -190,24 +193,28 @@ export const RegisteredAgent = (): ReactElement => {
               <WithErrorBar hasError={doSomeFieldsHaveError(["agentName", "agentEmail"])} type="DESKTOP-ONLY">
                 <div className="grid-row grid-gap-1 margin-bottom-2">
                   <div className="grid-col-12 tablet:grid-col-6">
-                    <BusinessFormationTextField
-                      label={Config.formation.fields.agentName.label}
-                      required={true}
-                      validationText={getFieldErrorLabel("agentName")}
-                      errorBarType="MOBILE-ONLY"
-                      fieldName="agentName"
-                      disabled={shouldBeDisabled("agentName", "ACCOUNT")}
-                    />
+                    <FormationField fieldName="agentName">
+                      <BusinessFormationTextField
+                        label={Config.formation.fields.agentName.label}
+                        required={true}
+                        validationText={getFieldErrorLabel("agentName")}
+                        errorBarType="MOBILE-ONLY"
+                        fieldName="agentName"
+                        disabled={shouldBeDisabled("agentName", "ACCOUNT")}
+                      />
+                    </FormationField>
                   </div>
                   <div className="grid-col-12 tablet:grid-col-6 margin-top-2 tablet:margin-top-0">
-                    <BusinessFormationTextField
-                      label={Config.formation.fields.agentEmail.label}
-                      fieldName="agentEmail"
-                      errorBarType="MOBILE-ONLY"
-                      required={true}
-                      validationText={getFieldErrorLabel("agentEmail")}
-                      disabled={shouldBeDisabled("agentEmail", "ACCOUNT")}
-                    />
+                    <FormationField fieldName="agentEmail">
+                      <BusinessFormationTextField
+                        label={Config.formation.fields.agentEmail.label}
+                        fieldName="agentEmail"
+                        errorBarType="MOBILE-ONLY"
+                        required={true}
+                        validationText={getFieldErrorLabel("agentEmail")}
+                        disabled={shouldBeDisabled("agentEmail", "ACCOUNT")}
+                      />
+                    </FormationField>
                   </div>
                 </div>
               </WithErrorBar>
@@ -225,22 +232,26 @@ export const RegisteredAgent = (): ReactElement => {
                   />
                 </div>
               )}
-              <BusinessFormationTextField
-                label={Config.formation.fields.agentOfficeAddressLine1.label}
-                fieldName="agentOfficeAddressLine1"
-                required={true}
-                validationText={getFieldErrorLabel("agentOfficeAddressLine1")}
-                disabled={shouldBeDisabled("agentOfficeAddressLine1", "ADDRESS")}
-                errorBarType="ALWAYS"
-              />
-              <BusinessFormationTextField
-                label={Config.formation.fields.agentOfficeAddressLine2.label}
-                fieldName="agentOfficeAddressLine2"
-                validationText={getFieldErrorLabel("agentOfficeAddressLine2")}
-                disabled={state.formationFormData.agentUseBusinessAddress}
-                errorBarType="ALWAYS"
-                className={"margin-top-2"}
-              />
+              <FormationField fieldName="agentOfficeAddressLine1">
+                <BusinessFormationTextField
+                  label={Config.formation.fields.agentOfficeAddressLine1.label}
+                  fieldName="agentOfficeAddressLine1"
+                  required={true}
+                  validationText={getFieldErrorLabel("agentOfficeAddressLine1")}
+                  disabled={shouldBeDisabled("agentOfficeAddressLine1", "ADDRESS")}
+                  errorBarType="ALWAYS"
+                />
+              </FormationField>
+              <FormationField fieldName="agentOfficeAddressLine2">
+                <BusinessFormationTextField
+                  label={Config.formation.fields.agentOfficeAddressLine2.label}
+                  fieldName="agentOfficeAddressLine2"
+                  validationText={getFieldErrorLabel("agentOfficeAddressLine2")}
+                  disabled={state.formationFormData.agentUseBusinessAddress}
+                  errorBarType="ALWAYS"
+                  className={"margin-top-2"}
+                />
+              </FormationField>
               <WithErrorBar
                 type="DESKTOP-ONLY"
                 hasError={doSomeFieldsHaveError([
@@ -259,22 +270,24 @@ export const RegisteredAgent = (): ReactElement => {
                           {Config.formation.fields.agentOfficeAddressMunicipality.label}
                         </ModifiedContent>
                       </strong>
-                      <MunicipalityDropdown
-                        municipalities={municipalities}
-                        fieldName={"agentOfficeAddressMunicipality"}
-                        error={doesFieldHaveError("agentOfficeAddressMunicipality")}
-                        disabled={shouldBeDisabled("agentOfficeAddressMunicipality", "ADDRESS")}
-                        validationLabel="Error"
-                        value={state.formationFormData.agentOfficeAddressMunicipality}
-                        onSelect={(value: Municipality | undefined): void => {
-                          setFormationFormData({
-                            ...state.formationFormData,
-                            agentOfficeAddressMunicipality: value,
-                          });
-                        }}
-                        onValidation={(): void => setFieldsInteracted(["agentOfficeAddressMunicipality"])}
-                        helperText={Config.formation.fields.agentOfficeAddressMunicipality.error}
-                      />
+                      <FormationField fieldName="agentOfficeAddressMunicipality">
+                        <MunicipalityDropdown
+                          municipalities={municipalities}
+                          fieldName="agentOfficeAddressMunicipality"
+                          error={doesFieldHaveError("agentOfficeAddressMunicipality")}
+                          disabled={shouldBeDisabled("agentOfficeAddressMunicipality", "ADDRESS")}
+                          validationLabel="Error"
+                          value={state.formationFormData.agentOfficeAddressMunicipality}
+                          onSelect={(value: Municipality | undefined): void => {
+                            setFormationFormData({
+                              ...state.formationFormData,
+                              agentOfficeAddressMunicipality: value,
+                            });
+                          }}
+                          onValidation={(): void => setFieldsInteracted(["agentOfficeAddressMunicipality"])}
+                          helperText={Config.formation.fields.agentOfficeAddressMunicipality.error}
+                        />
+                      </FormationField>
                     </WithErrorBar>
                   </div>
                   <div className="grid-col-12 tablet:grid-col-6 margin-top-2 tablet:margin-top-0">
@@ -289,24 +302,28 @@ export const RegisteredAgent = (): ReactElement => {
                               {Config.formation.fields.agentOfficeAddressState.label}
                             </ModifiedContent>
                           </strong>
-                          <StateDropdown
-                            fieldName="agentOfficeAddressState"
-                            value={"New Jersey"}
-                            validationText={Config.formation.fields.agentOfficeAddressState.error}
-                            disabled={true}
-                            onSelect={(): void => {}}
-                          />
+                          <FormationField fieldName="agentOfficeAddressState">
+                            <StateDropdown
+                              fieldName="agentOfficeAddressState"
+                              value="New Jersey"
+                              validationText={Config.formation.fields.agentOfficeAddressState.error}
+                              disabled={true}
+                              onSelect={(): void => {}}
+                            />
+                          </FormationField>
                         </div>
                         <div className="grid-col-7">
-                          <BusinessFormationTextField
-                            errorBarType="NEVER"
-                            numericProps={{ maxLength: 5 }}
-                            fieldName="agentOfficeAddressZipCode"
-                            label={Config.formation.fields.agentOfficeAddressZipCode.label}
-                            validationText={Config.formation.fields.agentOfficeAddressZipCode.error}
-                            required={true}
-                            disabled={shouldBeDisabled("agentOfficeAddressZipCode", "ADDRESS")}
-                          />
+                          <FormationField fieldName="agentOfficeAddressZipCode">
+                            <BusinessFormationTextField
+                              errorBarType="NEVER"
+                              numericProps={{ maxLength: 5 }}
+                              fieldName="agentOfficeAddressZipCode"
+                              label={Config.formation.fields.agentOfficeAddressZipCode.label}
+                              validationText={Config.formation.fields.agentOfficeAddressZipCode.error}
+                              required={true}
+                              disabled={shouldBeDisabled("agentOfficeAddressZipCode", "ADDRESS")}
+                            />
+                          </FormationField>
                         </div>
                       </div>
                     </WithErrorBar>

--- a/web/src/components/tasks/business-formation/contacts/Signatures.tsx
+++ b/web/src/components/tasks/business-formation/contacts/Signatures.tsx
@@ -8,6 +8,7 @@ import {
   createSignedEmptyFormationObject,
   needsSignerTypeFunc,
 } from "@/components/tasks/business-formation/contacts/helpers";
+import { FormationField } from "@/components/tasks/business-formation/FormationField";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -262,20 +263,22 @@ export const Signatures = (): ReactElement => {
             </strong>
           </div>
         )}
-        <GenericTextField
-          inputWidth="full"
-          value={state.formationFormData.signers[index].name}
-          handleChange={(value: string): void => handleSignerChange(value, index)}
-          error={hasError && doesRowHaveError(index)}
-          onValidation={(): void => {
-            setFieldsInteracted([FIELD_NAME]);
-          }}
-          validationText={getInlineValidationText()}
-          fieldName="signer"
-          className={`margin-top-0`}
-          ariaLabel={`Signer ${index}`}
-          required={true}
-        />
+        <FormationField fieldName="signer">
+          <GenericTextField
+            inputWidth="full"
+            value={state.formationFormData.signers[index].name}
+            handleChange={(value: string): void => handleSignerChange(value, index)}
+            error={hasError && doesRowHaveError(index)}
+            onValidation={(): void => {
+              setFieldsInteracted([FIELD_NAME]);
+            }}
+            validationText={getInlineValidationText()}
+            fieldName="signer"
+            className={`margin-top-0`}
+            ariaLabel={`Signer ${index}`}
+            required={true}
+          />
+        </FormationField>
       </>
     );
   };

--- a/web/src/styles/base/global.scss
+++ b/web/src/styles/base/global.scss
@@ -87,7 +87,7 @@ ol {
 
 .usa-link:visited,
 .usa-prose > a:visited {
-  color: $primary-darker !important;
+  color: $accent-cool-darkest !important;
 }
 
 .fit-screen-content {
@@ -211,7 +211,7 @@ ol {
 .usa-alert__text a,
 .usa-link,
 .usa-prose > a {
-  color: $primary !important;
+  color: $accent-cool-darkest !important;
 
   @media all and (max-width: $sm) {
     word-wrap: anywhere !important;
@@ -232,22 +232,23 @@ ol {
 
 .usa-link:visited,
 .usa-prose > a:visited {
-  color: $primary !important;
+  color: $accent-cool-darkest !important;
 }
 
 .usa-link:focus,
-.usa-prose > a:focus {
-  outline: 0.25rem solid $primary !important;
+.usa-prose > a:focus,
+.usa-prose a:focus {
+  outline: 0.25rem solid $accent-cool-darkest !important;
 }
 
 .usa-link:hover,
 .usa-prose > a:hover {
-  color: $primary-dark !important;
+  color: $accent-cool-more-dark !important;
 }
 
 .usa-link:active,
 .usa-prose > a:active {
-  color: $primary-darker !important;
+  color: $accent-cool-darkest !important;
 }
 
 @media all and (min-width: $xs) {


### PR DESCRIPTION
## Description

- Adds links to the error alert in business formation driving to the fields lower on the page.
- Makes all `usa-links` blue

### Ticket

[#184432488](https://www.pivotaltracker.com/story/show/184432488)
[#184432499](https://www.pivotaltracker.com/story/show/184432499)

### Approach

Componentize the alert used on profile to highlight opportunity fields, and implement in both the profile and in formation task.

### Steps to Test

Testing this in the UI requires triggering errors in formation and then clicking the generated links.

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
