### PR TITLE
feat: [#184415884] analytics added to cert and funding cards

### DIFF
--- a/web/src/components/dashboard/OpportunityCard.test.tsx
+++ b/web/src/components/dashboard/OpportunityCard.test.tsx
@@ -1,8 +1,41 @@
 import { OpportunityCard } from "@/components/dashboard/OpportunityCard";
+import { getMergedConfig } from "@/contexts/configContext";
+import analytics from "@/lib/utils/analytics";
 import { generateOpportunity } from "@/test/factories";
-import { render, screen } from "@testing-library/react";
+import { useMockBusiness } from "@/test/mock/mockUseUserData";
+import { generatePreferences } from "@businessnjgovnavigator/shared/";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+jest.mock("@/lib/utils/analytics", () => setupMockAnalytics());
+jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
+
+const Config = getMergedConfig();
+const mockAnalytics = analytics as jest.Mocked<typeof analytics>;
+function setupMockAnalytics(): typeof analytics {
+  return {
+    ...jest.requireActual("@/lib/utils/analytics").default,
+    event: {
+      ...jest.requireActual("@/lib/utils/analytics").default.event,
+      for_you_card_hide_button: {
+        click: {
+          hide_card: jest.fn(),
+        },
+      },
+      for_you_card_unhide_button: {
+        click: {
+          unhide_card: jest.fn(),
+        },
+      },
+    },
+  };
+}
 
 describe("OpportunityCard", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    useMockBusiness({});
+  });
+
   it("renders the name", () => {
     const opportunity = generateOpportunity({ name: "Test Name for Card" });
     render(<OpportunityCard opportunity={opportunity} urlPath="funding" />);
@@ -69,5 +102,20 @@ describe("OpportunityCard", () => {
     const opportunity = generateOpportunity({ descriptionMd: linkContent });
     render(<OpportunityCard opportunity={opportunity} urlPath="funding" />);
     expect(screen.getByText("a li")).toBeInTheDocument();
+  });
+
+  it("fires hide_card analytics when hide button is clicked", () => {
+    render(<OpportunityCard opportunity={generateOpportunity({ id: "123" })} urlPath="funding" />);
+    fireEvent.click(screen.getByText(Config.dashboardDefaults.hideOpportunityText));
+    expect(mockAnalytics.event.for_you_card_hide_button.click.hide_card).toHaveBeenCalledTimes(1);
+    expect(mockAnalytics.event.for_you_card_unhide_button.click.unhide_card).not.toHaveBeenCalled();
+  });
+
+  it("fires unhide_card analytics when unhide button is clicked", () => {
+    useMockBusiness({ preferences: generatePreferences({ hiddenFundingIds: ["123"] }) });
+    render(<OpportunityCard opportunity={generateOpportunity({ id: "123" })} urlPath="funding" />);
+    fireEvent.click(screen.getByText(Config.dashboardDefaults.unHideOpportunityText));
+    expect(mockAnalytics.event.for_you_card_hide_button.click.hide_card).not.toHaveBeenCalled();
+    expect(mockAnalytics.event.for_you_card_unhide_button.click.unhide_card).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/components/dashboard/OpportunityCard.tsx
+++ b/web/src/components/dashboard/OpportunityCard.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@/components/njwds/Icon";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { Opportunity } from "@/lib/types/types";
+import analytics from "@/lib/utils/analytics";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import truncateMarkdown from "markdown-truncate";
@@ -48,6 +49,7 @@ export const OpportunityCard = (props: Props): ReactElement => {
       return;
     }
     const propertyToUpdate = props.urlPath === "funding" ? "hiddenFundingIds" : "hiddenCertificationIds";
+    analytics.event.for_you_card_hide_button.click.hide_card();
     await updateQueue
       .queuePreferences({
         [propertyToUpdate]: [...business.preferences[propertyToUpdate], props.opportunity.id],
@@ -60,6 +62,7 @@ export const OpportunityCard = (props: Props): ReactElement => {
       return;
     }
     const propertyToUpdate = props.urlPath === "funding" ? "hiddenFundingIds" : "hiddenCertificationIds";
+    analytics.event.for_you_card_unhide_button.click.unhide_card();
     await updateQueue
       .queuePreferences({
         [propertyToUpdate]: business.preferences[propertyToUpdate].filter((it: string) => {

--- a/web/src/components/dashboard/SidebarCardsList.test.tsx
+++ b/web/src/components/dashboard/SidebarCardsList.test.tsx
@@ -1,0 +1,65 @@
+import { SidebarCardsList } from "@/components/dashboard/SidebarCardsList";
+import analytics from "@/lib/utils/analytics";
+import { useMockBusiness } from "@/test/mock/mockUseUserData";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+jest.mock("@/lib/utils/analytics", () => setupMockAnalytics());
+jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
+
+const mockAnalytics = analytics as jest.Mocked<typeof analytics>;
+function setupMockAnalytics(): typeof analytics {
+  return {
+    ...jest.requireActual("@/lib/utils/analytics").default,
+    event: {
+      ...jest.requireActual("@/lib/utils/analytics").default.event,
+      for_you_card_unhide_button: {
+        click: {
+          unhide_cards: jest.fn(),
+        },
+      },
+    },
+  };
+}
+
+describe("<SidebarCardsList />", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    useMockBusiness({});
+  });
+
+  it("fire unhide_cards analytics when accordion is opened when displayFundings is true", () => {
+    render(
+      <SidebarCardsList
+        topCards={[]}
+        bottomCards={[]}
+        fundings={[]}
+        hiddenFundings={[]}
+        certifications={[]}
+        hiddenCertifications={[]}
+        displayFundings={true}
+        displayCertifications={false}
+      />
+    );
+    fireEvent.click(screen.getByTestId("hidden-opportunity-header"));
+    fireEvent.click(screen.getByTestId("hidden-opportunity-header"));
+    expect(mockAnalytics.event.for_you_card_unhide_button.click.unhide_cards).toHaveBeenCalledTimes(1);
+  });
+
+  it("fire unhide_cards analytics when accordion is opened when displayCertifications is true", () => {
+    render(
+      <SidebarCardsList
+        topCards={[]}
+        bottomCards={[]}
+        fundings={[]}
+        hiddenFundings={[]}
+        certifications={[]}
+        hiddenCertifications={[]}
+        displayFundings={false}
+        displayCertifications={true}
+      />
+    );
+    fireEvent.click(screen.getByTestId("hidden-opportunity-header"));
+    fireEvent.click(screen.getByTestId("hidden-opportunity-header"));
+    expect(mockAnalytics.event.for_you_card_unhide_button.click.unhide_cards).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/dashboard/SidebarCardsList.tsx
+++ b/web/src/components/dashboard/SidebarCardsList.tsx
@@ -4,6 +4,7 @@ import { SidebarCard } from "@/components/dashboard/SidebarCard";
 import { Icon } from "@/components/njwds/Icon";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { Certification, Funding, SidebarCardContent } from "@/lib/types/types";
+import analytics from "@/lib/utils/analytics";
 import { templateEval } from "@/lib/utils/helpers";
 import { Accordion, AccordionDetails, AccordionSummary } from "@mui/material";
 import { ReactElement, ReactNode, useState } from "react";
@@ -44,7 +45,7 @@ export const SidebarCardsList = (props: Props): ReactElement => {
   };
 
   const hiddenCardsAccordion = (): ReactNode => {
-    if (props.displayCertifications) {
+    if (props.displayCertifications || props.displayFundings) {
       return (
         <>
           <hr className="margin-top-3 bg-cool-lighter" aria-hidden={true} />
@@ -52,6 +53,9 @@ export const SidebarCardsList = (props: Props): ReactElement => {
             <Accordion
               expanded={hiddenAccordionIsOpen}
               onChange={(): void => {
+                if (!hiddenAccordionIsOpen) {
+                  analytics.event.for_you_card_unhide_button.click.unhide_cards();
+                }
                 setHiddenAccordionIsOpen((prevAccordionStatus) => {
                   return !prevAccordionStatus;
                 });

--- a/web/src/lib/utils/analytics-legacy.ts
+++ b/web/src/lib/utils/analytics-legacy.ts
@@ -109,7 +109,9 @@ export type LegacyEventCategory =
   | "roadmap_logout_button"
   | "landing_page_hero_log_in"
   | "finish_setup_on_myNewJersey_button"
-  | "landing_page";
+  | "landing_page"
+  | "for_you_card_hide_button"
+  | "for_you_card_unhide_button";
 
 export type LegacyEventAction =
   | "click"
@@ -223,4 +225,7 @@ export type LegacyEventLabel =
   | "social_equity_business"
   | "business_exists_but_not_in_Gov2Go"
   | "get_unlinked_myNJ_account"
-  | "go_to_myNJ_registration";
+  | "go_to_myNJ_registration"
+  | "hide_card"
+  | "unhide_card"
+  | "unhide_cards";

--- a/web/src/lib/utils/analytics.ts
+++ b/web/src/lib/utils/analytics.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { LegacyEventAction, LegacyEventCategory, LegacyEventLabel } from "@/lib/utils/analytics-legacy";
 import analytics from "./analytics-base";
+
 export const GTM_ID = process.env.GOOGLE_TAG_MANAGER_ID;
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -214,6 +215,8 @@ type Item =
   | "roadmap_logout_button"
   | "landing_page_hero_log_in"
   | "go_to_profile_nudge_button"
+  | "opportunity_card"
+  | "hidden_opportunities_section"
   | "link_with_myNJ"
   | "landing_page";
 
@@ -1932,6 +1935,44 @@ export default {
             legacy_event_label: "open_live_chat",
             click_text: "report_something_that_is_broken",
             clicked_to: "live_chat",
+          });
+        },
+      },
+    },
+    for_you_card_hide_button: {
+      click: {
+        hide_card: () => {
+          eventRunner.track({
+            legacy_event_category: "for_you_card_hide_button",
+            legacy_event_action: "click",
+            legacy_event_label: "hide_card",
+            event: "link_clicks",
+            click_text: "hide",
+            item: "opportunity_card",
+          });
+        },
+      },
+    },
+    for_you_card_unhide_button: {
+      click: {
+        unhide_card: () => {
+          eventRunner.track({
+            legacy_event_category: "for_you_card_unhide_button",
+            legacy_event_action: "click",
+            legacy_event_label: "unhide_card",
+            event: "link_clicks",
+            click_text: "unhide",
+            item: "opportunity_card",
+          });
+        },
+        unhide_cards: () => {
+          eventRunner.track({
+            legacy_event_category: "for_you_card_unhide_button",
+            legacy_event_action: "click",
+            legacy_event_label: "unhide_cards",
+            event: "navigation_clicks",
+            clicked: "expand_contract",
+            item: "hidden_opportunities_section",
           });
         },
       },


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
Added analytics to funding and certification opportunity cards. The analytics fire when the show or hide button within the card is clicked and when the accordion of the hidden card is opened.

I also updated the logic around when the hidden card accordion is rendered. Previously, it only relied on the displayCertifications prop, the conditional was updated. It should rely on both since it contains both opportunity cards.


### Ticket
https://www.pivotaltracker.com/story/show/184415884

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
