### PR TITLE
Fix imports to get ReactElement from react library

### DIFF
--- a/web/src/components/tasks/business-formation/FormationField.tsx
+++ b/web/src/components/tasks/business-formation/FormationField.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from "rehype-react/lib";
+import { ReactElement } from "react";
 
 interface Props {
   fieldName: string;

--- a/web/src/components/tasks/business-formation/review/ReviewForeignCertificate.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewForeignCertificate.tsx
@@ -2,7 +2,7 @@ import { ReviewNotEntered } from "@/components/tasks/business-formation/review/s
 import { ReviewSubSection } from "@/components/tasks/business-formation/review/section/ReviewSubSection";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { InputFile } from "@businessnjgovnavigator/shared/formationData";
-import { ReactElement } from "rehype-react/lib";
+import { ReactElement } from "react";
 
 interface Props {
   foreignGoodStandingFile: InputFile | undefined;

--- a/web/src/components/tasks/business-formation/review/ReviewIsVeteranNonprofit.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewIsVeteranNonprofit.tsx
@@ -1,7 +1,7 @@
 import { Content } from "@/components/Content";
 import { ReviewLineItem } from "@/components/tasks/business-formation/review/section/ReviewLineItem";
 import { useConfig } from "@/lib/data-hooks/useConfig";
-import { ReactElement } from "rehype-react/lib";
+import { ReactElement } from "react";
 
 interface Props {
   value: boolean | undefined;

--- a/web/src/components/tasks/business-formation/review/ReviewWillPracticeLaw.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewWillPracticeLaw.tsx
@@ -1,7 +1,7 @@
 import { ReviewNotEntered } from "@/components/tasks/business-formation/review/section/ReviewNotEntered";
 import { ReviewSubSection } from "@/components/tasks/business-formation/review/section/ReviewSubSection";
 import { useConfig } from "@/lib/data-hooks/useConfig";
-import { ReactElement } from "rehype-react/lib";
+import { ReactElement } from "react";
 
 interface Props {
   willPracticeLaw: boolean | undefined;


### PR DESCRIPTION
## Description

There were a couple instances where `ReactElement` was being incorrectly imported from the `rehype-react/lib` package. Nothing seems to have been broken, infact this was probably perfectly fine from a functional perspective.

Updated these 4 instances to import from the `react` library we use throughout our application.

Checked all other imports of `ReactElement` to verify they were coming from the correct library as well.

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
