### PR TITLE
refactor: define sidebarCard IDs in object type

### DIFF
--- a/api/src/domain/updateSidebarCards.test.ts
+++ b/api/src/domain/updateSidebarCards.test.ts
@@ -9,7 +9,17 @@ import {
 import { updateSidebarCards } from "./updateSidebarCards";
 
 import { getCurrentBusiness } from "@shared/domain-logic/getCurrentBusiness";
+import { SIDEBAR_CARDS } from "@shared/domain-logic/sidebarCards";
 import { OperatingPhases } from "@shared/index";
+
+const {
+  formationNudge,
+  fundingNudge,
+  goToProfile,
+  notRegistered,
+  notRegisteredExistingAccount,
+  registeredForTaxes,
+} = SIDEBAR_CARDS;
 
 describe("updateRoadmapSidebarCards", () => {
   describe("not registered card", () => {
@@ -20,18 +30,16 @@ describe("updateRoadmapSidebarCards", () => {
             operatingPhase: "NEEDS_TO_FORM",
           }),
           preferences: generatePreferences({
-            visibleSidebarCards: ["not-registered"],
+            visibleSidebarCards: [notRegistered],
           }),
         })
       );
 
       const updatedUserData = updateSidebarCards(userData);
       expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).not.toContain(
-        "not-registered"
+        notRegistered
       );
-      expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain(
-        "formation-nudge"
-      );
+      expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain(formationNudge);
     });
 
     it("removes not-registered-existing-account card and adds formation nudge card", async () => {
@@ -41,18 +49,16 @@ describe("updateRoadmapSidebarCards", () => {
             operatingPhase: "NEEDS_TO_FORM",
           }),
           preferences: generatePreferences({
-            visibleSidebarCards: ["not-registered-existing-account"],
+            visibleSidebarCards: [notRegisteredExistingAccount],
           }),
         })
       );
 
       const updatedUserData = updateSidebarCards(userData);
       expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).not.toContain(
-        "not-registered-existing-account"
+        notRegisteredExistingAccount
       );
-      expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain(
-        "formation-nudge"
-      );
+      expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain(formationNudge);
     });
 
     it("leaves existing cards except for not registered when adding formation nudge card", async () => {
@@ -62,18 +68,16 @@ describe("updateRoadmapSidebarCards", () => {
             operatingPhase: "NEEDS_TO_FORM",
           }),
           preferences: generatePreferences({
-            visibleSidebarCards: ["other-card", "not-registered"],
+            visibleSidebarCards: ["other-card", notRegistered],
           }),
         })
       );
 
       const updatedUserData = updateSidebarCards(userData);
       expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).not.toContain(
-        "not-registered"
+        notRegistered
       );
-      expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain(
-        "formation-nudge"
-      );
+      expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain(formationNudge);
       expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain("other-card");
     });
 
@@ -84,18 +88,16 @@ describe("updateRoadmapSidebarCards", () => {
             operatingPhase: "NEEDS_TO_FORM",
           }),
           preferences: generatePreferences({
-            visibleSidebarCards: ["other-card", "not-registered-existing-account"],
+            visibleSidebarCards: ["other-card", notRegisteredExistingAccount],
           }),
         })
       );
 
       const updatedUserData = updateSidebarCards(userData);
       expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).not.toContain(
-        "not-registered-existing-account"
+        notRegisteredExistingAccount
       );
-      expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain(
-        "formation-nudge"
-      );
+      expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain(formationNudge);
       expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain("other-card");
     });
   });
@@ -115,9 +117,7 @@ describe("updateRoadmapSidebarCards", () => {
       );
 
       const updatedUserData = updateSidebarCards(userData);
-      expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain(
-        "formation-nudge"
-      );
+      expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain(formationNudge);
     });
 
     it("removes formation-nudge if  operatingPhase is NEEDS_TO_REGISTER_FOR_TAXES", () => {
@@ -126,13 +126,13 @@ describe("updateRoadmapSidebarCards", () => {
           profileData: generateProfileData({
             operatingPhase: "NEEDS_TO_REGISTER_FOR_TAXES",
           }),
-          preferences: generatePreferences({ visibleSidebarCards: ["formation-nudge"] }),
+          preferences: generatePreferences({ visibleSidebarCards: [formationNudge] }),
         })
       );
 
       const updatedUserData = updateSidebarCards(userData);
       expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).not.toContain(
-        "formation-nudge"
+        formationNudge
       );
     });
   });
@@ -149,7 +149,7 @@ describe("updateRoadmapSidebarCards", () => {
       );
       const updatedUserData = updateSidebarCards(userData);
       expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain(
-        "registered-for-taxes-nudge"
+        registeredForTaxes
       );
     });
 
@@ -159,12 +159,12 @@ describe("updateRoadmapSidebarCards", () => {
           profileData: generateProfileData({
             operatingPhase: "FORMED_AND_REGISTERED",
           }),
-          preferences: generatePreferences({ visibleSidebarCards: ["registered-for-taxes-nudge"] }),
+          preferences: generatePreferences({ visibleSidebarCards: [registeredForTaxes] }),
         })
       );
       const updatedUserData = updateSidebarCards(userData);
       expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).not.toContain(
-        "registered-for-taxes-nudge"
+        registeredForTaxes
       );
     });
   });
@@ -181,9 +181,9 @@ describe("updateRoadmapSidebarCards", () => {
       );
       const updatedUserData = updateSidebarCards(userData);
       expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).not.toContain(
-        "formation-nudge"
+        formationNudge
       );
-      expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain("funding-nudge");
+      expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain(fundingNudge);
     });
 
     it("removes funding-nudge when operatingPhase is NEEDS_TO_REGISTER_FOR_TAXES", () => {
@@ -192,13 +192,11 @@ describe("updateRoadmapSidebarCards", () => {
           profileData: generateProfileData({
             operatingPhase: "NEEDS_TO_REGISTER_FOR_TAXES",
           }),
-          preferences: generatePreferences({ visibleSidebarCards: ["funding-nudge"] }),
+          preferences: generatePreferences({ visibleSidebarCards: [fundingNudge] }),
         })
       );
       const updatedUserData = updateSidebarCards(userData);
-      expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).not.toContain(
-        "funding-nudge"
-      );
+      expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).not.toContain(fundingNudge);
     });
   });
 
@@ -221,9 +219,7 @@ describe("updateRoadmapSidebarCards", () => {
         })
       );
       const updatedUserData = updateSidebarCards(userData);
-      expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).not.toContain(
-        "go-to-profile"
-      );
+      expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).not.toContain(goToProfile);
     });
 
     it.each(phasesWhereGoToProfileNudgeTrue)(
@@ -239,9 +235,7 @@ describe("updateRoadmapSidebarCards", () => {
           })
         );
         const updatedUserData = updateSidebarCards(userData);
-        expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain(
-          "go-to-profile"
-        );
+        expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain(goToProfile);
       }
     );
 
@@ -263,7 +257,7 @@ describe("updateRoadmapSidebarCards", () => {
         );
         const updatedUserData = updateSidebarCards(userData);
         expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).not.toContain(
-          "go-to-profile"
+          goToProfile
         );
       }
     );

--- a/api/src/domain/updateSidebarCards.ts
+++ b/api/src/domain/updateSidebarCards.ts
@@ -1,5 +1,6 @@
 import { getCurrentBusiness } from "@shared/domain-logic/getCurrentBusiness";
 import { getFieldsForProfile, isFieldAnswered } from "@shared/domain-logic/opportunityFields";
+import { SIDEBAR_CARDS } from "@shared/domain-logic/sidebarCards";
 import { LookupOperatingPhaseById } from "@shared/operatingPhase";
 import { modifyCurrentBusiness } from "@shared/test";
 import { UserData } from "@shared/userData";
@@ -24,31 +25,31 @@ export const updateSidebarCards: UpdateSidebarCards = (userData: UserData): User
     cards = [...allCardsExceptIdToHide];
   };
 
-  if (operatingPhase !== "GUEST_MODE" && cards.includes("not-registered")) {
-    hideCard("not-registered");
+  if (operatingPhase !== "GUEST_MODE" && cards.includes(SIDEBAR_CARDS.notRegistered)) {
+    hideCard(SIDEBAR_CARDS.notRegistered);
   }
 
-  if (operatingPhase !== "GUEST_MODE" && cards.includes("not-registered-existing-account")) {
-    hideCard("not-registered-existing-account");
+  if (operatingPhase !== "GUEST_MODE" && cards.includes(SIDEBAR_CARDS.notRegisteredExistingAccount)) {
+    hideCard(SIDEBAR_CARDS.notRegisteredExistingAccount);
   }
 
   if (operatingPhase === "NEEDS_TO_FORM") {
-    showCard("formation-nudge");
+    showCard(SIDEBAR_CARDS.formationNudge);
   } else {
-    hideCard("formation-nudge");
+    hideCard(SIDEBAR_CARDS.formationNudge);
   }
 
   if (operatingPhase === "NEEDS_TO_REGISTER_FOR_TAXES") {
-    showCard("registered-for-taxes-nudge");
+    showCard(SIDEBAR_CARDS.registeredForTaxes);
   } else {
-    hideCard("registered-for-taxes-nudge");
-    hideCard("registered-for-taxes-nudge");
+    hideCard(SIDEBAR_CARDS.registeredForTaxes);
+    hideCard(SIDEBAR_CARDS.registeredForTaxes);
   }
 
   if (operatingPhase === "FORMED_AND_REGISTERED") {
-    showCard("funding-nudge");
+    showCard(SIDEBAR_CARDS.fundingNudge);
   } else {
-    hideCard("funding-nudge");
+    hideCard(SIDEBAR_CARDS.fundingNudge);
   }
 
   if (LookupOperatingPhaseById(operatingPhase).displayGoToProfileNudge) {
@@ -59,9 +60,9 @@ export const updateSidebarCards: UpdateSidebarCards = (userData: UserData): User
     );
 
     if (isEveryOpportunityFieldAnswered) {
-      hideCard("go-to-profile");
+      hideCard(SIDEBAR_CARDS.goToProfile);
     } else {
-      showCard("go-to-profile");
+      showCard(SIDEBAR_CARDS.goToProfile);
     }
   }
 

--- a/shared/src/domain-logic/sidebarCards.ts
+++ b/shared/src/domain-logic/sidebarCards.ts
@@ -1,0 +1,8 @@
+export const SIDEBAR_CARDS = {
+  formationNudge: "formation-nudge",
+  fundingNudge: "funding-nudge",
+  goToProfile: "go-to-profile",
+  notRegistered: "not-registered",
+  notRegisteredExistingAccount: "not-registered-existing-account",
+  registeredForTaxes: "registered-for-taxes-nudge",
+};

--- a/web/src/components/auth/NeedsAccountSnackbar.test.tsx
+++ b/web/src/components/auth/NeedsAccountSnackbar.test.tsx
@@ -12,6 +12,7 @@ import {
   setupStatefulUserDataContext,
   WithStatefulUserData,
 } from "@/test/mock/withStatefulUserData";
+import { SIDEBAR_CARDS } from "@businessnjgovnavigator/shared/domain-logic/sidebarCards";
 import { generateBusiness, generateUserData } from "@businessnjgovnavigator/shared/test";
 import * as materialUi from "@mui/material";
 import { useMediaQuery } from "@mui/material";
@@ -120,9 +121,9 @@ describe("<NeedsAccountSnackbar />", () => {
       isAuthenticated: IsAuthenticated.FALSE,
     });
     fireEvent.click(screen.getByLabelText("close"));
-    expect(currentBusiness().preferences.visibleSidebarCards).toContain("not-registered");
+    expect(currentBusiness().preferences.visibleSidebarCards).toContain(SIDEBAR_CARDS.notRegistered);
     expect(currentBusiness().preferences.visibleSidebarCards).not.toContain(
-      "not-registered-existing-account"
+      SIDEBAR_CARDS.notRegisteredExistingAccount
     );
   });
 
@@ -132,8 +133,10 @@ describe("<NeedsAccountSnackbar />", () => {
       isAuthenticated: IsAuthenticated.FALSE,
     });
     fireEvent.click(screen.getByLabelText("close"));
-    expect(currentBusiness().preferences.visibleSidebarCards).toContain("not-registered-existing-account");
-    expect(currentBusiness().preferences.visibleSidebarCards).not.toContain("not-registered");
+    expect(currentBusiness().preferences.visibleSidebarCards).toContain(
+      SIDEBAR_CARDS.notRegisteredExistingAccount
+    );
+    expect(currentBusiness().preferences.visibleSidebarCards).not.toContain(SIDEBAR_CARDS.notRegistered);
   });
 
   it("icon logo on mobile", async () => {

--- a/web/src/components/auth/NeedsAccountSnackbar.tsx
+++ b/web/src/components/auth/NeedsAccountSnackbar.tsx
@@ -6,6 +6,7 @@ import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { useSidebarCards } from "@/lib/data-hooks/useSidebarCards";
 import { MediaQueries } from "@/lib/PageSizes";
 import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
+import { SIDEBAR_CARDS } from "@businessnjgovnavigator/shared/domain-logic/sidebarCards";
 import { IconButton, useMediaQuery } from "@mui/material";
 import { ReactElement, useContext } from "react";
 
@@ -22,9 +23,9 @@ export const NeedsAccountSnackbar = (): ReactElement => {
   const handleClose = async (): Promise<void> => {
     setShowNeedsAccountSnackbar(false);
     if (state.activeUser?.encounteredMyNjLinkingError) {
-      await showCard("not-registered-existing-account");
+      await showCard(SIDEBAR_CARDS.notRegisteredExistingAccount);
     } else {
-      await showCard("not-registered");
+      await showCard(SIDEBAR_CARDS.notRegistered);
     }
   };
 

--- a/web/src/components/dashboard/SidebarCard.test.tsx
+++ b/web/src/components/dashboard/SidebarCard.test.tsx
@@ -3,6 +3,7 @@ import { generateSidebarCardContent } from "@/test/factories";
 import { useMockRouter } from "@/test/mock/mockRouter";
 import { useMockRoadmap } from "@/test/mock/mockUseRoadmap";
 import { useMockBusiness } from "@/test/mock/mockUseUserData";
+import { SIDEBAR_CARDS } from "@businessnjgovnavigator/shared/domain-logic/sidebarCards";
 import { render, screen } from "@testing-library/react";
 
 jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
@@ -18,7 +19,7 @@ describe("<SidebarCard />", () => {
   });
 
   it("renders SidebarCardFundingNudge for id funding-nudge", () => {
-    const card = generateSidebarCardContent({ id: "funding-nudge", ctaText: "Click me" });
+    const card = generateSidebarCardContent({ id: SIDEBAR_CARDS.fundingNudge, ctaText: "Click me" });
     render(<SidebarCard card={card} />);
     expect(screen.getByTestId("cta-funding-nudge")).toBeInTheDocument();
   });

--- a/web/src/components/dashboard/SidebarCard.tsx
+++ b/web/src/components/dashboard/SidebarCard.tsx
@@ -5,6 +5,7 @@ import { SidebarCardGoToProfileNudge } from "@/components/dashboard/SidebarCardG
 import { SidebarCardRegisteredForTaxesNudge } from "@/components/dashboard/SidebarCardRegisteredForTaxesNudge";
 import { SidebarCardContent } from "@/lib/types/types";
 import { rswitch } from "@/lib/utils/helpers";
+import { SIDEBAR_CARDS } from "@businessnjgovnavigator/shared/domain-logic/sidebarCards";
 import { ReactElement } from "react";
 
 type Props = {
@@ -15,10 +16,10 @@ export const SidebarCard = (props: Props): ReactElement => {
   return (
     <>
       {rswitch(props.card.id, {
-        "funding-nudge": <SidebarCardFundingNudge card={props.card} />,
-        "formation-nudge": <SidebarCardFormationNudge card={props.card} />,
-        "registered-for-taxes-nudge": <SidebarCardRegisteredForTaxesNudge card={props.card} />,
-        "go-to-profile": <SidebarCardGoToProfileNudge card={props.card} />,
+        [SIDEBAR_CARDS.fundingNudge]: <SidebarCardFundingNudge card={props.card} />,
+        [SIDEBAR_CARDS.formationNudge]: <SidebarCardFormationNudge card={props.card} />,
+        [SIDEBAR_CARDS.registeredForTaxes]: <SidebarCardRegisteredForTaxesNudge card={props.card} />,
+        [SIDEBAR_CARDS.goToProfile]: <SidebarCardGoToProfileNudge card={props.card} />,
         default: (
           <SidebarCardGeneric
             card={props.card}

--- a/web/src/components/dashboard/SidebarCardFormationNudge.test.tsx
+++ b/web/src/components/dashboard/SidebarCardFormationNudge.test.tsx
@@ -11,6 +11,7 @@ import {
   WithStatefulUserData,
 } from "@/test/mock/withStatefulUserData";
 import { formationTaskId, generateProfileData } from "@businessnjgovnavigator/shared/";
+import { SIDEBAR_CARDS } from "@businessnjgovnavigator/shared/domain-logic/sidebarCards";
 import { generatePreferences, generateUserData } from "@businessnjgovnavigator/shared/test";
 import { Business } from "@businessnjgovnavigator/shared/userData";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -39,7 +40,7 @@ describe("<SidebarCardFormationNudge />", () => {
       jest.resetAllMocks();
       useMockRouter({});
       setupStatefulUserDataContext();
-      card = generateSidebarCardContent({ id: "formation-nudge" });
+      card = generateSidebarCardContent({ id: SIDEBAR_CARDS.formationNudge });
       mockBuildUserRoadmap.buildUserRoadmap.mockResolvedValue(generateRoadmap({}));
     });
 
@@ -48,7 +49,7 @@ describe("<SidebarCardFormationNudge />", () => {
         profileData: generateProfileData({
           businessPersona: "STARTING",
         }),
-        preferences: generatePreferences({ visibleSidebarCards: ["formation-nudge"] }),
+        preferences: generatePreferences({ visibleSidebarCards: [SIDEBAR_CARDS.formationNudge] }),
       });
 
       fireEvent.click(screen.getByTestId("cta-formation-nudge"));

--- a/web/src/components/dashboard/SidebarCardFundingNudge.test.tsx
+++ b/web/src/components/dashboard/SidebarCardFundingNudge.test.tsx
@@ -10,6 +10,7 @@ import {
   userDataWasNotUpdated,
   WithStatefulUserData,
 } from "@/test/mock/withStatefulUserData";
+import { SIDEBAR_CARDS } from "@businessnjgovnavigator/shared/domain-logic/sidebarCards";
 import {
   generateBusiness,
   generatePreferences,
@@ -27,6 +28,7 @@ const Config = getMergedConfig();
 
 describe("<SidebarCardFundingNudge />", () => {
   let card: SidebarCardContent;
+  const { fundingNudge } = SIDEBAR_CARDS;
 
   const renderWithBusiness = (business: Partial<Business>): void => {
     render(
@@ -40,7 +42,7 @@ describe("<SidebarCardFundingNudge />", () => {
     jest.resetAllMocks();
     useMockRouter({});
     setupStatefulUserDataContext();
-    card = generateSidebarCardContent({ id: "funding-nudge" });
+    card = generateSidebarCardContent({ id: fundingNudge });
   });
 
   describe("when clicking funding button for non-generic industry", () => {
@@ -50,7 +52,7 @@ describe("<SidebarCardFundingNudge />", () => {
           businessPersona: "STARTING",
           industryId: "cannabis",
         }),
-        preferences: generatePreferences({ visibleSidebarCards: ["funding-nudge"] }),
+        preferences: generatePreferences({ visibleSidebarCards: [fundingNudge] }),
       });
 
       fireEvent.click(screen.getByTestId("cta-funding-nudge"));
@@ -65,7 +67,7 @@ describe("<SidebarCardFundingNudge />", () => {
           businessPersona: "STARTING",
           industryId: "generic",
         }),
-        preferences: generatePreferences({ visibleSidebarCards: ["funding-nudge"] }),
+        preferences: generatePreferences({ visibleSidebarCards: [fundingNudge] }),
       });
 
       fireEvent.click(screen.getByTestId("cta-funding-nudge"));
@@ -83,7 +85,7 @@ describe("<SidebarCardFundingNudge />", () => {
           businessPersona: "STARTING",
           industryId: "generic",
         }),
-        preferences: generatePreferences({ visibleSidebarCards: ["funding-nudge"] }),
+        preferences: generatePreferences({ visibleSidebarCards: [fundingNudge] }),
       });
 
       fireEvent.click(screen.getByTestId("cta-funding-nudge"));

--- a/web/src/components/dashboard/SidebarCardRegisteredForTaxesNudge.test.tsx
+++ b/web/src/components/dashboard/SidebarCardRegisteredForTaxesNudge.test.tsx
@@ -9,6 +9,7 @@ import {
   WithStatefulUserData,
 } from "@/test/mock/withStatefulUserData";
 import { getCurrentDateISOString } from "@businessnjgovnavigator/shared/dateHelpers";
+import { SIDEBAR_CARDS } from "@businessnjgovnavigator/shared/domain-logic/sidebarCards";
 import {
   Business,
   generateTaxFilingCalendarEvent,
@@ -44,7 +45,7 @@ describe("<SidebarCardRegisteredForTaxesNudge />", () => {
       jest.resetAllMocks();
       useMockRouter({});
       setupStatefulUserDataContext();
-      card = generateSidebarCardContent({ id: "registered-for-taxes-nudge" });
+      card = generateSidebarCardContent({ id: SIDEBAR_CARDS.registeredForTaxes });
       mockBuildUserRoadmap.buildUserRoadmap.mockResolvedValue(generateRoadmap({}));
     });
 

--- a/web/src/components/dashboard/TwoTabDashboardLayout.test.tsx
+++ b/web/src/components/dashboard/TwoTabDashboardLayout.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/test/factories";
 import { randomElementFromArray } from "@/test/helpers/helpers-utilities";
 import { useMockBusiness } from "@/test/mock/mockUseUserData";
+import { SIDEBAR_CARDS } from "@businessnjgovnavigator/shared/domain-logic/sidebarCards";
 import { OperatingPhases } from "@businessnjgovnavigator/shared/operatingPhase";
 import { generatePreferences } from "@businessnjgovnavigator/shared/test";
 import { fireEvent, render, screen } from "@testing-library/react";
@@ -68,7 +69,7 @@ describe("<TwoTabDashboardLayout />", () => {
       });
 
       useMockBusiness({
-        preferences: generatePreferences({ visibleSidebarCards: ["not-registered"] }),
+        preferences: generatePreferences({ visibleSidebarCards: [SIDEBAR_CARDS.notRegistered] }),
         profileData: {
           ...getProfileDataForUnfilteredOpportunities(),
           operatingPhase: randomElementFromArray(operatingPhases).id,
@@ -92,7 +93,7 @@ describe("<TwoTabDashboardLayout />", () => {
       });
 
       useMockBusiness({
-        preferences: generatePreferences({ visibleSidebarCards: ["not-registered"] }),
+        preferences: generatePreferences({ visibleSidebarCards: [SIDEBAR_CARDS.notRegistered] }),
         profileData: {
           ...getProfileDataForUnfilteredOpportunities(),
           operatingPhase: randomElementFromArray(operatingPhases).id,
@@ -117,7 +118,7 @@ describe("<TwoTabDashboardLayout />", () => {
       });
 
       useMockBusiness({
-        preferences: generatePreferences({ visibleSidebarCards: ["not-registered"] }),
+        preferences: generatePreferences({ visibleSidebarCards: [SIDEBAR_CARDS.notRegistered] }),
         profileData: {
           ...getProfileDataForUnfilteredOpportunities(),
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
Replace usages of raw strings when referencing Sidebar Card IDs with using a key from a defined object instead. Similar to our `ROUTES` pattern

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have performed a self-review of my code
- [ ] I have created and/or updated relevant documentation, if necessary
- [ ] I have not used any relative imports
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
