### PR TITLE
chore: [#185992659] replace all imports of config.json with useConfig

### DIFF
--- a/web/src/components/AuthButton.tsx
+++ b/web/src/components/AuthButton.tsx
@@ -3,8 +3,8 @@ import { AuthContext } from "@/contexts/authContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { triggerSignIn } from "@/lib/auth/sessionHelper";
 import { onSignOut } from "@/lib/auth/signinHelper";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import analytics from "@/lib/utils/analytics";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { useRouter } from "next/router";
 import { ReactElement, useContext } from "react";
 
@@ -15,6 +15,7 @@ interface Props {
 export const AuthButton = (props?: Props): ReactElement => {
   const { state, dispatch } = useContext(AuthContext);
   const router = useRouter();
+  const { Config } = useConfig();
 
   const loginButton = (): ReactElement => {
     return (

--- a/web/src/components/BetaBar.tsx
+++ b/web/src/components/BetaBar.tsx
@@ -1,10 +1,12 @@
 import { ButtonIcon } from "@/components/ButtonIcon";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import analytics from "@/lib/utils/analytics";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { ReactElement } from "react";
 
 export const BetaBar = (): ReactElement => {
+  const { Config } = useConfig();
+
   return (
     <div
       className="display-flex flex-justify-center flex-align-center bg-accent-warm-extra-light font-sans-xs minh-3 margin-auto width-full padding-y-1"

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -1,10 +1,10 @@
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { AuthContext } from "@/contexts/authContext";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { ROUTES } from "@/lib/domain-logic/routes";
 import analytics from "@/lib/utils/analytics";
 import { templateEval } from "@/lib/utils/helpers";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { getCurrentDateInNewJersey } from "@businessnjgovnavigator/shared/";
 import { LookupLegalStructureById } from "@businessnjgovnavigator/shared/legalStructure";
 import { useRouter } from "next/router";
@@ -12,7 +12,7 @@ import { ReactElement, useContext } from "react";
 
 export const Header = (): ReactElement => {
   const { state } = useContext(AuthContext);
-
+  const { Config } = useConfig();
   const { business, userData } = useUserData();
   const router = useRouter();
 

--- a/web/src/components/InnovFooter.tsx
+++ b/web/src/components/InnovFooter.tsx
@@ -1,11 +1,12 @@
 import { Icon } from "@/components/njwds/Icon";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { MediaQueries } from "@/lib/PageSizes";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { useMediaQuery } from "@mui/material";
 import { ReactElement } from "react";
 
 export const InnovFooter = (): ReactElement => {
   const isLargeScreen = useMediaQuery(MediaQueries.desktopAndUp);
+  const { Config } = useConfig();
 
   return (
     <div className="usa-identifier">

--- a/web/src/components/LegalMessage.tsx
+++ b/web/src/components/LegalMessage.tsx
@@ -1,9 +1,11 @@
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import analytics from "@/lib/utils/analytics";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { ReactElement } from "react";
 
 export const LegalMessage = (): ReactElement => {
+  const { Config } = useConfig();
+
   return (
     <div className="bg-base-lightest">
       <div className="grid-container-widescreen desktop:padding-x-7">

--- a/web/src/components/TaskCTA.tsx
+++ b/web/src/components/TaskCTA.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable unicorn/filename-case */
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import analytics from "@/lib/utils/analytics";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { ReactElement, ReactNode } from "react";
 
 interface Props {
@@ -12,6 +12,8 @@ interface Props {
 }
 
 export const TaskCTA = (props: Props): ReactElement => {
+  const { Config } = useConfig();
+
   if (props.onClick) {
     return (
       <div className="flex flex-justify-end flex-column-reverse mobile-lg:flex-row bg-base-lightest margin-x-neg-4 padding-3 margin-top-3 margin-bottom-neg-4 radius-bottom-lg">

--- a/web/src/components/TaskElement.tsx
+++ b/web/src/components/TaskElement.tsx
@@ -4,9 +4,9 @@ import { HorizontalLine } from "@/components/HorizontalLine";
 import { PostOnboardingRadioQuestion } from "@/components/post-onboarding/PostOnboardingRadioQuestion";
 import { TaskCTA } from "@/components/TaskCTA";
 import { TaskHeader } from "@/components/TaskHeader";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { Task } from "@/lib/types/types";
 import { rswitch } from "@/lib/utils/helpers";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { LookupTaskAgencyById } from "@businessnjgovnavigator/shared/taskAgency";
 import { Business } from "@businessnjgovnavigator/shared/userData";
 import { ReactElement, ReactNode } from "react";
@@ -18,6 +18,7 @@ interface Props {
 }
 
 export const TaskElement = (props: Props): ReactElement => {
+  const { Config } = useConfig();
   const hasPostOnboardingQuestion = !!props.task.postOnboardingQuestion;
   const shouldShowDeferredQuestion = props.task.requiresLocation;
   let hasDeferredLocationQuestion = false;

--- a/web/src/components/TaskProgressTagLookup.tsx
+++ b/web/src/components/TaskProgressTagLookup.tsx
@@ -1,7 +1,9 @@
 import { Tag } from "@/components/njwds-extended/Tag";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
+import { getMergedConfig } from "@/contexts/configContext";
 import { TaskProgress } from "@businessnjgovnavigator/shared";
 import { ReactElement } from "react";
+
+const Config = getMergedConfig();
 
 export const TaskProgressTagLookup: Record<TaskProgress, ReactElement> = {
   NOT_STARTED: (

--- a/web/src/components/TaskSidebarPageLayout.test.tsx
+++ b/web/src/components/TaskSidebarPageLayout.test.tsx
@@ -1,9 +1,9 @@
 import { TaskSidebarPageLayout } from "@/components/TaskSidebarPageLayout";
+import { getMergedConfig } from "@/contexts/configContext";
 import { generateStep } from "@/test/factories";
 import { useMockRouter } from "@/test/mock/mockRouter";
 import { useMockRoadmap } from "@/test/mock/mockUseRoadmap";
 import { useMockBusiness } from "@/test/mock/mockUseUserData";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { generateBusiness } from "@businessnjgovnavigator/shared";
 import * as materialUi from "@mui/material";
 import { useMediaQuery } from "@mui/material";
@@ -20,6 +20,8 @@ jest.mock("@mui/material", () => mockMaterialUI());
 jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
 jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
 jest.mock("next/router", () => ({ useRouter: jest.fn() }));
+
+const Config = getMergedConfig();
 
 describe("<TaskSidebarPageLayout />", () => {
   beforeEach(() => {

--- a/web/src/components/UserDataErrorAlert.tsx
+++ b/web/src/components/UserDataErrorAlert.tsx
@@ -1,9 +1,10 @@
 import { Alert } from "@/components/njwds-extended/Alert";
+import { getMergedConfig } from "@/contexts/configContext";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { UserDataError } from "@/lib/types/types";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { ReactElement } from "react";
 
+const Config = getMergedConfig();
 const UserDataErrorLookup: Record<UserDataError, string> = {
   NO_DATA: Config.siteWideErrorMessages.errorTextNoData,
   CACHED_ONLY: Config.siteWideErrorMessages.errorTextCachedOnly,

--- a/web/src/components/auth/NeedsAccountModal.tsx
+++ b/web/src/components/auth/NeedsAccountModal.tsx
@@ -4,11 +4,11 @@ import { Icon } from "@/components/njwds/Icon";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { triggerSignIn } from "@/lib/auth/sessionHelper";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { QUERIES, ROUTES } from "@/lib/domain-logic/routes";
 import analytics from "@/lib/utils/analytics";
 import { useMountEffectWhenDefined } from "@/lib/utils/helpers";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { Box, Dialog, DialogContent, DialogTitle, IconButton } from "@mui/material";
 import { useRouter } from "next/router";
 import { ReactElement, useContext } from "react";
@@ -18,6 +18,7 @@ export const NeedsAccountModal = (): ReactElement => {
   const router = useRouter();
   const { isAuthenticated, showNeedsAccountModal, setShowNeedsAccountModal } =
     useContext(NeedsAccountContext);
+  const { Config } = useConfig();
 
   useMountEffectWhenDefined(() => {
     if (isAuthenticated === IsAuthenticated.TRUE) {

--- a/web/src/components/auth/NeedsAccountSnackbar.tsx
+++ b/web/src/components/auth/NeedsAccountSnackbar.tsx
@@ -3,14 +3,15 @@ import { SnackbarAlert } from "@/components/njwds-extended/SnackbarAlert";
 import { Icon } from "@/components/njwds/Icon";
 import { AuthContext } from "@/contexts/authContext";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useSidebarCards } from "@/lib/data-hooks/useSidebarCards";
 import { MediaQueries } from "@/lib/PageSizes";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { SIDEBAR_CARDS } from "@businessnjgovnavigator/shared/domain-logic/sidebarCards";
 import { IconButton, useMediaQuery } from "@mui/material";
 import { ReactElement, useContext } from "react";
 
 export const NeedsAccountSnackbar = (): ReactElement => {
+  const { Config } = useConfig();
   const { showCard } = useSidebarCards();
   const { showNeedsAccountSnackbar, setShowNeedsAccountSnackbar } = useContext(NeedsAccountContext);
   const { state } = useContext(AuthContext);

--- a/web/src/components/dashboard/SectionAccordion.tsx
+++ b/web/src/components/dashboard/SectionAccordion.tsx
@@ -1,9 +1,9 @@
 import { Icon } from "@/components/njwds/Icon";
 import { SectionAccordionContext } from "@/contexts/sectionAccordionContext";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useRoadmap } from "@/lib/data-hooks/useRoadmap";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import analytics from "@/lib/utils/analytics";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { SectionType } from "@businessnjgovnavigator/shared";
 import { Accordion, AccordionDetails, AccordionSummary } from "@mui/material";
 import { ReactElement, ReactNode } from "react";
@@ -27,6 +27,7 @@ export const SectionAccordion = (props: Props): ReactElement => {
   const sectionName = props.sectionType.toLowerCase();
   const isOpen = business?.preferences.roadmapOpenSections.includes(props.sectionType) ?? false;
   const isCompleted = isSectionCompleted(props.sectionType);
+  const { Config } = useConfig();
 
   const handleAccordionStateChange = async (): Promise<void> => {
     const roadmapOpenSections = business?.preferences.roadmapOpenSections;

--- a/web/src/components/navbar/NavBarDesktop.tsx
+++ b/web/src/components/navbar/NavBarDesktop.tsx
@@ -5,13 +5,13 @@ import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { Icon } from "@/components/njwds/Icon";
 import { AuthContext } from "@/contexts/authContext";
 import { triggerSignIn } from "@/lib/auth/sessionHelper";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { getBusinessIconColor } from "@/lib/domain-logic/getBusinessIconColor";
 import { getNavBarBusinessTitle } from "@/lib/domain-logic/getNavBarBusinessTitle";
 import { orderBusinessIdsByDateCreated } from "@/lib/domain-logic/orderBusinessIdsByDateCreated";
 import { ROUTES } from "@/lib/domain-logic/routes";
 import analytics from "@/lib/utils/analytics";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { ClickAwayListener, Grow, Paper, Popper } from "@mui/material";
 import { useRouter } from "next/router";
 import React, { ReactElement, useContext, useEffect, useMemo, useRef, useState } from "react";
@@ -20,6 +20,7 @@ export const NavBarDesktop = (): ReactElement => {
   const { business, userData } = useUserData();
   const { state } = useContext(AuthContext);
   const router = useRouter();
+  const { Config } = useConfig();
 
   const [open, setOpen] = useState(false);
   const anchorRef = useRef<HTMLButtonElement | null>(null);

--- a/web/src/components/navbar/NavBarLandingDesktop.tsx
+++ b/web/src/components/navbar/NavBarLandingDesktop.tsx
@@ -1,13 +1,14 @@
 import { AuthButton } from "@/components/AuthButton";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { ROUTES } from "@/lib/domain-logic/routes";
 import analytics from "@/lib/utils/analytics";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { useRouter } from "next/router";
 import { ReactElement } from "react";
 
 export const NavBarLandingDesktop = (): ReactElement => {
   const router = useRouter();
+  const { Config } = useConfig();
 
   return (
     <div className="position-sticky top-0 z-500 bg-white">

--- a/web/src/components/navbar/NavBarPopupMenu.tsx
+++ b/web/src/components/navbar/NavBarPopupMenu.tsx
@@ -5,6 +5,7 @@ import { AuthContext } from "@/contexts/authContext";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { triggerSignIn } from "@/lib/auth/sessionHelper";
 import { onSelfRegister, onSignOut } from "@/lib/auth/signinHelper";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { getBusinessIconColor } from "@/lib/domain-logic/getBusinessIconColor";
 import { getNavBarBusinessTitle } from "@/lib/domain-logic/getNavBarBusinessTitle";
@@ -13,7 +14,6 @@ import { QUERIES, ROUTES, routeWithQuery } from "@/lib/domain-logic/routes";
 import { switchCurrentBusiness } from "@/lib/domain-logic/switchCurrentBusiness";
 import analytics from "@/lib/utils/analytics";
 import { getUserNameOrEmail } from "@/lib/utils/helpers";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { MenuItem, MenuList } from "@mui/material";
 import { useRouter } from "next/router";
 import { ReactElement, useContext } from "react";
@@ -35,6 +35,7 @@ export interface Props {
 export const NavBarPopupMenu = (props: Props): ReactElement => {
   const { userData, updateQueue } = useUserData();
   const { state, dispatch } = useContext(AuthContext);
+  const { Config } = useConfig();
   const { setRegistrationStatus } = useContext(NeedsAccountContext);
 
   const router = useRouter();

--- a/web/src/components/njwds-extended/SidebarPageLayout.tsx
+++ b/web/src/components/njwds-extended/SidebarPageLayout.tsx
@@ -1,8 +1,8 @@
 import { Icon } from "@/components/njwds/Icon";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { ROUTES } from "@/lib/domain-logic/routes";
 import { MediaQueries } from "@/lib/PageSizes";
 import analytics from "@/lib/utils/analytics";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { useMediaQuery } from "@mui/material";
 import Link from "next/link";
 import React, { ReactElement } from "react";
@@ -25,6 +25,7 @@ export const SidebarPageLayout = ({
   belowBoxComponent,
 }: SidebarPageLayoutProps): ReactElement => {
   const isLargeScreen = useMediaQuery(MediaQueries.desktopAndUp);
+  const { Config } = useConfig();
 
   const backButton = (
     <Link href={ROUTES.dashboard} passHref>

--- a/web/src/components/onboarding/OnboardingButtonGroup.tsx
+++ b/web/src/components/onboarding/OnboardingButtonGroup.tsx
@@ -1,8 +1,8 @@
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { scrollToTop } from "@/lib/utils/helpers";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import React, { ReactElement, useContext } from "react";
 
 interface Props {
@@ -12,6 +12,7 @@ interface Props {
 
 export const OnboardingButtonGroup = (props: Props): ReactElement => {
   const { state, onBack } = useContext(ProfileDataContext);
+  const { Config } = useConfig();
 
   const back = (event: React.MouseEvent): void => {
     event.preventDefault();

--- a/web/src/components/onboarding/ReturnToPreviousBusinessBar.tsx
+++ b/web/src/components/onboarding/ReturnToPreviousBusinessBar.tsx
@@ -1,12 +1,12 @@
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { Icon } from "@/components/njwds/Icon";
 import { AuthContext } from "@/contexts/authContext";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { getNavBarBusinessTitle } from "@/lib/domain-logic/getNavBarBusinessTitle";
 import { removeBusiness } from "@/lib/domain-logic/removeBusiness";
 import { ROUTES } from "@/lib/domain-logic/routes";
 import { templateEval } from "@/lib/utils/helpers";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { Business } from "@businessnjgovnavigator/shared/userData";
 import { useRouter } from "next/router";
 import { ReactElement, useContext } from "react";
@@ -16,6 +16,7 @@ interface Props {
 }
 
 export const ReturnToPreviousBusinessBar = (props: Props): ReactElement | null => {
+  const { Config } = useConfig();
   const { updateQueue, userData } = useUserData();
   const { state } = useContext(AuthContext);
   const router = useRouter();

--- a/web/src/components/profile/ProfileNumericField.tsx
+++ b/web/src/components/profile/ProfileNumericField.tsx
@@ -1,6 +1,6 @@
 import { OnboardingField, OnboardingProps } from "@/components/onboarding/OnboardingField";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { templateEval } from "@/lib/utils/helpers";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { ReactElement } from "react";
 
 interface NumericFieldProps {
@@ -11,6 +11,8 @@ interface NumericFieldProps {
 interface Props<T> extends Omit<OnboardingProps<T>, "numericProps">, NumericFieldProps {}
 
 export const ProfileNumericField = <T,>({ minLength, maxLength, ...props }: Props<T>): ReactElement => {
+  const { Config } = useConfig();
+
   const validationText =
     minLength === undefined
       ? templateEval(Config.onboardingDefaults.errorTextMinimumNumericField, {

--- a/web/src/components/tasks/CheckStatus.tsx
+++ b/web/src/components/tasks/CheckStatus.tsx
@@ -1,10 +1,10 @@
 import { Alert } from "@/components/njwds-extended/Alert";
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
+import { getMergedConfig } from "@/contexts/configContext";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { LicenseSearchError } from "@/lib/types/types";
 import analytics from "@/lib/utils/analytics";
 import { useMountEffectWhenDefined } from "@/lib/utils/helpers";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { createEmptyNameAndAddress, NameAndAddress } from "@businessnjgovnavigator/shared/";
 import { TextField } from "@mui/material";
 import createStyles from "@mui/styles/createStyles";
@@ -28,6 +28,7 @@ interface Props {
   isLoading: boolean;
 }
 
+const Config = getMergedConfig();
 const LicenseSearchErrorLookup: Record<LicenseSearchError, string> = {
   NOT_FOUND: Config.licenseSearchTask.errorTextNotFound,
   FIELDS_REQUIRED: Config.licenseSearchTask.errorTextFieldsRequired,

--- a/web/src/components/tasks/LicenseStatusReceipt.tsx
+++ b/web/src/components/tasks/LicenseStatusReceipt.tsx
@@ -1,7 +1,7 @@
 import { Icon } from "@/components/njwds/Icon";
+import { getMergedConfig } from "@/contexts/configContext";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import analytics from "@/lib/utils/analytics";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { LicenseStatus, LicenseStatusItem } from "@businessnjgovnavigator/shared/";
 import { ReactElement, useEffect, useState } from "react";
 
@@ -20,6 +20,7 @@ type PermitTheme = {
   headerIconColor: string;
 };
 
+const Config = getMergedConfig();
 const pendingPermitTheme: PermitTheme = {
   gradient: "gradient-blue",
   bgColor: "bg-info-extra-light",

--- a/web/src/components/tasks/LicenseTask.tsx
+++ b/web/src/components/tasks/LicenseTask.tsx
@@ -5,13 +5,13 @@ import { CheckStatus } from "@/components/tasks/CheckStatus";
 import { LicenseStatusReceipt } from "@/components/tasks/LicenseStatusReceipt";
 import { UnlockedBy } from "@/components/tasks/UnlockedBy";
 import * as api from "@/lib/api-client/apiClient";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useRoadmap } from "@/lib/data-hooks/useRoadmap";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { LicenseSearchError, Task } from "@/lib/types/types";
 import analytics from "@/lib/utils/analytics";
 import { useMountEffectWhenDefined } from "@/lib/utils/helpers";
 import { getModifiedTaskContent } from "@/lib/utils/roadmap-helpers";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { LicenseStatusResult, NameAndAddress, UserData } from "@businessnjgovnavigator/shared/";
 import { TabContext, TabList, TabPanel } from "@mui/lab/";
 import { Box, Tab } from "@mui/material";
@@ -32,6 +32,7 @@ export const LicenseTask = (props: Props): ReactElement => {
   const [licenseStatusResult, setLicenseStatusResult] = useState<LicenseStatusResult | undefined>(undefined);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const { business, refresh } = useUserData();
+  const { Config } = useConfig();
 
   const allFieldsHaveValues = (nameAndAddress: NameAndAddress): boolean => {
     return !!(nameAndAddress.name && nameAndAddress.addressLine1 && nameAndAddress.zipCode);

--- a/web/src/components/tasks/UnlockedBy.tsx
+++ b/web/src/components/tasks/UnlockedBy.tsx
@@ -1,8 +1,8 @@
 import { UnlockingAlert } from "@/components/tasks/UnlockingAlert";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useTaskFromRoadmap } from "@/lib/data-hooks/useTaskFromRoadmap";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { Task } from "@/lib/types/types";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { ReactElement } from "react";
 
 interface Props {
@@ -12,6 +12,7 @@ interface Props {
 
 export const UnlockedBy = (props: Props): ReactElement => {
   const { business } = useUserData();
+  const { Config } = useConfig();
 
   const taskFromRoadmap = useTaskFromRoadmap(props.task.id);
 

--- a/web/src/components/tasks/UnlockingAlert.tsx
+++ b/web/src/components/tasks/UnlockingAlert.tsx
@@ -1,6 +1,6 @@
 import { Alert, AlertVariant } from "@/components/njwds-extended/Alert";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { TaskLink } from "@/lib/types/types";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { ReactElement } from "react";
 
 interface Props {
@@ -14,6 +14,8 @@ interface Props {
 }
 
 export const UnlockingAlert = (props: Props): ReactElement => {
+  const { Config } = useConfig();
+
   if (props.taskLinks.length === 0 && !props.isLoading) {
     return <></>;
   }

--- a/web/src/components/tasks/cannabis/CannabisApplyForLicenseTask.tsx
+++ b/web/src/components/tasks/cannabis/CannabisApplyForLicenseTask.tsx
@@ -4,12 +4,12 @@ import { TaskHeader } from "@/components/TaskHeader";
 import { CannabisApplicationQuestionsTab } from "@/components/tasks/cannabis/CannabisApplicationQuestionsTab";
 import { CannabisApplicationRequirementsTab } from "@/components/tasks/cannabis/CannabisApplicationRequirementsTab";
 import { UnlockedBy } from "@/components/tasks/UnlockedBy";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { PriorityApplicationType, priorityTypesObj } from "@/lib/domain-logic/cannabisPriorityTypes";
 import { Task } from "@/lib/types/types";
 import analytics from "@/lib/utils/analytics";
 import { scrollToTop, useMountEffectWhenDefined } from "@/lib/utils/helpers";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { Business } from "@businessnjgovnavigator/shared/userData";
 import { ReactElement, useState } from "react";
 
@@ -25,6 +25,7 @@ export const CannabisApplyForLicenseTask = (props: Props): ReactElement => {
   const userDataFromHook = useUserData();
   const updateQueue = userDataFromHook.updateQueue;
   const business = props.CMS_ONLY_fakeBusiness ?? userDataFromHook.business;
+  const { Config } = useConfig();
 
   const [displayFirstTab, setDisplayFirstTab] = useState<boolean>(true);
   const [successSnackbarIsOpen, setSuccessSnackbarIsOpen] = useState(false);

--- a/web/src/lib/utils/onboardingPageHelpers.ts
+++ b/web/src/lib/utils/onboardingPageHelpers.ts
@@ -1,10 +1,12 @@
 import { OnboardingFlow } from "@/components/onboarding/OnboardingFlows";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
+import { getMergedConfig } from "@/contexts/configContext";
 import { LookupIndustryById } from "@businessnjgovnavigator/shared/industry";
 import { Business } from "@businessnjgovnavigator/shared/userData";
 import { QUERY_PARAMS_VALUES } from "../domain-logic/routes";
 import { FlowType, Page } from "../types/types";
 import { getFlow, templateEval } from "./helpers";
+
+const Config = getMergedConfig();
 
 export const mapFlowQueryToPersona: Record<QUERY_PARAMS_VALUES["flow"], FlowType> = {
   starting: "STARTING",

--- a/web/src/pages/filings/[filingUrlSlug].tsx
+++ b/web/src/pages/filings/[filingUrlSlug].tsx
@@ -7,11 +7,11 @@ import { Icon } from "@/components/njwds/Icon";
 import { PageSkeleton } from "@/components/PageSkeleton";
 import { TaskCTA } from "@/components/TaskCTA";
 import { TaskSidebarPageLayout } from "@/components/TaskSidebarPageLayout";
+import { getMergedConfig } from "@/contexts/configContext";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { sortCalendarEventsEarliestToLatest } from "@/lib/domain-logic/filterCalendarEvents";
 import { FilingUrlSlugParam, loadAllFilingUrlSlugs, loadFilingByUrlSlug } from "@/lib/static/loadFilings";
 import { Filing, TaxFilingMethod } from "@/lib/types/types";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import {
   defaultDateFormat,
   parseDateWithFormat,
@@ -26,6 +26,7 @@ interface Props {
   filing: Filing;
 }
 
+const Config = getMergedConfig();
 export const taxFilingMethodMap: Record<TaxFilingMethod, string> = {
   online: Config.filingDefaults.onlineTaxFilingMethod,
   "paper-or-by-mail-only": Config.filingDefaults.paperOrMailOnlyTaxFilingMethod,

--- a/web/src/pages/funding/[fundingUrlSlug].tsx
+++ b/web/src/pages/funding/[fundingUrlSlug].tsx
@@ -4,13 +4,13 @@ import { NavBar } from "@/components/navbar/NavBar";
 import { PageSkeleton } from "@/components/PageSkeleton";
 import { TaskCTA } from "@/components/TaskCTA";
 import { TaskSidebarPageLayout } from "@/components/TaskSidebarPageLayout";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { getNaicsDisplayMd } from "@/lib/domain-logic/getNaicsDisplayMd";
 import { MediaQueries } from "@/lib/PageSizes";
 import { FundingUrlSlugParam, loadAllFundingUrlSlugs, loadFundingByUrlSlug } from "@/lib/static/loadFundings";
 import { Funding } from "@/lib/types/types";
 import { templateEval } from "@/lib/utils/helpers";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import { LookupFundingAgencyById } from "@businessnjgovnavigator/shared/fundingAgency";
 import { useMediaQuery } from "@mui/material";
 import { GetStaticPathsResult, GetStaticPropsResult } from "next";
@@ -23,6 +23,7 @@ interface Props {
 
 export const FundingElement = (props: { funding: Funding }): ReactElement => {
   const isLargeScreen = useMediaQuery(MediaQueries.desktopAndUp);
+  const { Config } = useConfig();
 
   const { business } = useUserData();
 

--- a/web/src/pages/licenses/[licenseUrlSlug].tsx
+++ b/web/src/pages/licenses/[licenseUrlSlug].tsx
@@ -4,10 +4,10 @@ import { NavBar } from "@/components/navbar/NavBar";
 import { PageSkeleton } from "@/components/PageSkeleton";
 import { TaskCTA } from "@/components/TaskCTA";
 import { TaskSidebarPageLayout } from "@/components/TaskSidebarPageLayout";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { LicenseUrlSlugParam, loadAllLicenseUrlSlugs, loadLicenseByUrlSlug } from "@/lib/static/loadLicenses";
 import { LicenseEvent } from "@/lib/types/types";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import {
   defaultDateFormat,
   LicenseEventSubtype,
@@ -28,6 +28,8 @@ interface LicenseElementProps {
 }
 
 export const LicenseElement = (props: LicenseElementProps): ReactElement => {
+  const { Config } = useConfig();
+
   const titles: Record<LicenseEventSubtype, string> = {
     expiration: Config.licenseEventDefaults.expirationTitleLabel,
     renewal: Config.licenseEventDefaults.renewalTitleLabel,

--- a/web/src/pages/tasks/[taskUrlSlug].tsx
+++ b/web/src/pages/tasks/[taskUrlSlug].tsx
@@ -13,6 +13,7 @@ import { NaicsCodeTask } from "@/components/tasks/NaicsCodeTask";
 import { TaxTask } from "@/components/tasks/TaxTask";
 import { TaskSidebarPageLayout } from "@/components/TaskSidebarPageLayout";
 import { MunicipalitiesContext } from "@/contexts/municipalitiesContext";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useRoadmap } from "@/lib/data-hooks/useRoadmap";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { allowFormation } from "@/lib/domain-logic/allowFormation";
@@ -22,7 +23,6 @@ import { loadAllTaskUrlSlugs, loadTaskByUrlSlug, TaskUrlSlugParam } from "@/lib/
 import { Task, TasksDisplayContent } from "@/lib/types/types";
 import { rswitch } from "@/lib/utils/helpers";
 import { getTaskFromRoadmap, getUrlSlugs } from "@/lib/utils/roadmap-helpers";
-import Config from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import {
   businessStructureTaskId,
   formationTaskId,
@@ -52,6 +52,7 @@ const TaskPage = (props: Props): ReactElement => {
       nextUrlSlug: arrayOfTasks[currentUrlSlugIndex + 1],
     };
   }, [props.task.urlSlug, roadmap]);
+  const { Config } = useConfig();
 
   const renderNextAndPreviousButtons = (): ReactElement | undefined => {
     const isValidLegalStructure = allowFormation(


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
They are instances in the application where we are importing the config.json file. The intent of this re-factoring ticket is to replace that import with the use config data hook, so that that config variable gets all of the merged content.
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->
https://www.pivotaltracker.com/story/show/185992659



## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
