### PR TITLE
feat: [#185801983] register for taxes task should not allow edits or …

### DIFF
--- a/web/src/components/data-fields/tax-id/SingleTaxId.tsx
+++ b/web/src/components/data-fields/tax-id/SingleTaxId.tsx
@@ -2,9 +2,7 @@
 
 import { DataField, DataFieldProps } from "@/components/data-fields/DataField";
 import { TaxIdDisplayStatus } from "@/components/data-fields/tax-id/TaxIdHelpers";
-import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { formatTaxId } from "@/lib/domain-logic/formatTaxId";
 import { MediaQueries } from "@/lib/PageSizes";
 import { InputAdornment, useMediaQuery } from "@mui/material";
@@ -20,12 +18,8 @@ export const SingleTaxId = ({ handleChangeOverride, validationText, ...props }: 
 
   const isTabletAndUp = useMediaQuery(MediaQueries.tabletAndUp);
   const { state, setProfileData } = useContext(ProfileDataContext);
-  const { isAuthenticated, setShowNeedsAccountModal } = useContext(NeedsAccountContext);
 
   const handleChange = (value: string): void => {
-    if (isAuthenticated === IsAuthenticated.FALSE) {
-      setShowNeedsAccountModal(true);
-    }
     if (handleChangeOverride) {
       handleChangeOverride(value);
       return;

--- a/web/src/components/tasks/TaxInput.tsx
+++ b/web/src/components/tasks/TaxInput.tsx
@@ -24,7 +24,7 @@ interface Props {
 
 export const TaxInput = (props: Props): ReactElement => {
   const { business, updateQueue } = useUserData();
-  const { isAuthenticated } = useContext(NeedsAccountContext);
+  const { isAuthenticated, setShowNeedsAccountModal } = useContext(NeedsAccountContext);
   const { Config } = useConfig();
   const [profileData, setProfileData] = useState<ProfileData>(
     business?.profileData ?? createEmptyProfileData()
@@ -106,6 +106,23 @@ export const TaxInput = (props: Props): ReactElement => {
     </div>
   );
 
+  const getNeedsAccountModalFunction = (): (() => void) | undefined => {
+    if (isAuthenticated === IsAuthenticated.FALSE) {
+      return () => {
+        return setShowNeedsAccountModal(true);
+      };
+    }
+    return undefined;
+  };
+
+  const onSave = (): void => {
+    if (isAuthenticated === IsAuthenticated.FALSE) {
+      setShowNeedsAccountModal(true);
+    } else {
+      onSubmit();
+    }
+  };
+
   return (
     <profileFormContext.Provider value={formContextState}>
       <ProfileDataContext.Provider
@@ -126,11 +143,14 @@ export const TaxInput = (props: Props): ReactElement => {
               </Alert>
             ) : (
               <>
-                <TaxId required />
+                <TaxId
+                  required={isAuthenticated === IsAuthenticated.TRUE}
+                  handleChangeOverride={getNeedsAccountModalFunction()}
+                />
                 <div className="tablet:margin-top-05 tablet:margin-left-2">
                   <SecondaryButton
                     isColor="primary"
-                    onClick={onSubmit}
+                    onClick={onSave}
                     isLoading={isLoading}
                     isSubmitButton={true}
                     isRightMarginRemoved={true}

--- a/web/src/components/tasks/TaxTask.test.tsx
+++ b/web/src/components/tasks/TaxTask.test.tsx
@@ -239,11 +239,28 @@ describe("<TaxTask />", () => {
 
     it("opens Needs Account modal on save button click", async () => {
       renderPage();
-      fireEvent.change(screen.getByLabelText("Tax id"), { target: { value: "123456789123" } });
       fireEvent.click(screen.getByText(`Register & ${Config.tax.saveButtonText}`));
       await waitFor(() => {
         return expect(setShowNeedsAccountModal).toHaveBeenCalledWith(true);
       });
+      expect(userDataWasNotUpdated()).toBe(true);
+      expect(
+        screen.queryByText(Config.profileDefaults.fields.taxId.default.errorTextRequired)
+      ).not.toBeInTheDocument();
+    });
+
+    it("opens Needs Account modal when trying to enter tax input data, and does not show inline errors or update userData", async () => {
+      renderPage();
+      fireEvent.change(screen.getByLabelText("Tax id"), { target: { value: "1" } });
+      fireEvent.blur(screen.getByLabelText("Tax id"));
+      await waitFor(() => {
+        return expect(setShowNeedsAccountModal).toHaveBeenCalledWith(true);
+      });
+      expect(userDataWasNotUpdated()).toBe(true);
+      expect(
+        screen.queryByText(Config.profileDefaults.fields.taxId.default.errorTextRequired)
+      ).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Tax id")).toHaveValue("");
     });
   });
 


### PR DESCRIPTION
…submition in guest mode

<!-- Please complete the following sections as necessary. -->

## Description

The register state taxes task was allowing modifications and saving in guest mode in some cases (and copy paste into it)



<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/185801983)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

Go to the task tax-register page after signing in as any persona and choosing a business structure. ,

try to type, paste into the input and try to hit the register and save button, see that you cannot and get a popup telling you to link to my NJ to save. 

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
