### PR TITLE
feat: [#186025115] skip onboarding for industry query strings without essential questions

### DIFF
--- a/web/test/pages/onboarding/onboarding-shared.test.tsx
+++ b/web/test/pages/onboarding/onboarding-shared.test.tsx
@@ -1,5 +1,6 @@
 import { onboardingFlows } from "@/components/onboarding/OnboardingFlows";
 import { getMergedConfig } from "@/contexts/configContext";
+import { QUERIES, ROUTES } from "@/lib/domain-logic/routes";
 import { templateEval } from "@/lib/utils/helpers";
 import { randomElementFromArray } from "@/test/helpers/helpers-utilities";
 import * as mockRouter from "@/test/mock/mockRouter";
@@ -88,19 +89,22 @@ describe("onboarding - shared", () => {
     expect(screen.getByTestId("step-1")).toBeInTheDocument();
   });
 
-  it("routes to industry page when industry without essential question is set by using industry query string", async () => {
+  it("routes to dashboard page when industry WITHOUT essential question is set by using industry query string", async () => {
     const industry = randomElementFromArray(industriesWithOutEssentialQuestion).id;
     useMockRouter({ isReady: true, query: { industry } });
-    const { page } = renderPage({});
-    expect(screen.getByTestId("step-2")).toBeInTheDocument();
-    page.clickNext();
+    renderPage({});
     await waitFor(() => {
-      expect(currentBusiness().profileData.businessPersona).toEqual("STARTING");
+      expect(mockPush).toHaveBeenCalledWith({
+        pathname: ROUTES.dashboard,
+        query: { [QUERIES.fromOnboarding]: "true" },
+      });
     });
+    expect(currentBusiness().profileData.businessPersona).toEqual("STARTING");
     expect(currentBusiness().profileData.industryId).toEqual(industry);
+    expect(currentBusiness().onboardingFormProgress).toEqual("COMPLETED");
   });
 
-  it("routes to the industry page when industry with essential question is set by using industry query string", async () => {
+  it("routes to the onboarding industry page when industry WITH essential question is set by using industry query string", async () => {
     const industry = randomElementFromArray(industriesWithEssentialQuestion).id;
     useMockRouter({ isReady: true, query: { industry } });
     const { page } = renderPage({});


### PR DESCRIPTION

<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

The switch to using `localUpdateQueue` and passing it around is because for the query string users, the updateQueue gets created earlier in the routing useEffect, and gets set to the global context state, but since React state updates are async, it was still undefined in state when we got down to the `completeOnboarding` function, which needs it to be defined in order to finish everything up. So we instead use the return value to reference the queue everywhere as the onboarding routing completes.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#186025115](https://www.pivotaltracker.com/story/show/#186025115)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
