### PR TITLE
feat: [#184376697] Remove Header Text Field from Info Alert Block

### DIFF
--- a/content/src/roadmaps/license-tasks/notary-register.md
+++ b/content/src/roadmaps/license-tasks/notary-register.md
@@ -41,5 +41,6 @@ webflowId: 5f77296c2edc674c7cb4a708
 > **After Receiving Your Notary Public Commission Certificate:**
 > Within three months, take your notary public commission certificate and oath qualification certificate to the office of the county clerk where you reside (for non‐residents, where you are employed in New Jersey) to swear to the Oath of Office.
 
-:::infoAlert{ header="Required for Advertisements" }
+:::infoAlert
 A notary public who is not licensed as an attorney-at-law must provide a statement in any advertisements stating that they're not an attorney licensed to practice law and cannot offer legal advice.
+:::

--- a/web/src/components/Content.test.tsx
+++ b/web/src/components/Content.test.tsx
@@ -37,10 +37,9 @@ describe("<Content />", () => {
 
   describe("infoAlert", () => {
     it("renders info alert with header", () => {
-      const mdString = ":::infoAlert{header='Header Text'}\n" + "body text\n" + ":::";
+      const mdString = ":::infoAlert\n body text\n :::";
 
       render(<Content>{mdString}</Content>);
-      expect(screen.getByText("Header Text")).toBeInTheDocument();
       expect(screen.getByText("body text")).toBeInTheDocument();
     });
   });

--- a/web/src/components/Content.tsx
+++ b/web/src/components/Content.tsx
@@ -57,11 +57,7 @@ export const Content = (props: ContentProps): ReactElement => {
       );
     },
     infoAlert: (props: any): ReactElement => {
-      return (
-        <Alert variant="info" heading={props.header}>
-          {props.children}
-        </Alert>
-      );
+      return <Alert variant="info">{props.children}</Alert>;
     },
     cannabisLocationAlert: (): ReactElement => (
       <CannabisLocationAlert industryId={business?.profileData.industryId} />

--- a/web/src/components/PureMarkdownContent.tsx
+++ b/web/src/components/PureMarkdownContent.tsx
@@ -40,7 +40,6 @@ function customRemarkPlugin():
         switch (node.name) {
           case "cannabisLocationAlert":
           case "greenBox":
-          case "infoAlert":
           case "note":
             data.hProperties = { header: node.attributes.header };
             break;

--- a/web/src/lib/cms/editors/infoAlert.tsx
+++ b/web/src/lib/cms/editors/infoAlert.tsx
@@ -3,12 +3,6 @@ export default {
   label: "Info Alert Block",
   fields: [
     {
-      name: "header",
-      label: "Header Text",
-      required: false,
-      widget: "string",
-    },
-    {
       name: "body",
       label: "Body Text",
       required: true,
@@ -20,44 +14,23 @@ export default {
   collapsed: false,
   summary: "{{fields.title}}",
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fromBlock: (match: any): { header: string; body: string } => {
+  fromBlock: (match: any): { body: string } => {
     const string = match[0];
-    const openCurlyIndex = string.indexOf("{");
-    const closedCurlyIndex = string.indexOf("}");
 
-    const headerValue =
-      openCurlyIndex < 0
-        ? undefined
-        : string
-            .slice(openCurlyIndex + 1, closedCurlyIndex)
-            .trim()
-            .split("=")[1]
-            .slice(1, -1);
-
-    const hasHeader = openCurlyIndex >= 0;
     const startLength = ":::infoAlert".length;
     const endLength = ":::".length;
-    const body = hasHeader
-      ? string.slice(closedCurlyIndex + 1, -1 * endLength).trim()
-      : string.slice(startLength, -1 * endLength);
+    const body = string.slice(startLength, -1 * endLength);
 
     return {
-      header: headerValue,
       body: body,
     };
   },
   // Function to create a text block from an instance of this component
-  toBlock: (obj: { header?: string; body: string }): string => {
-    if (obj.header) {
-      return `:::infoAlert{ header="${obj.header}" } \n ${obj.body ? obj.body.trim() : ""}\n:::`;
-    }
+  toBlock: (obj: { body: string }): string => {
     return `:::infoAlert \n ${obj.body ? obj.body.trim() : ""}\n:::`;
   },
 
-  toPreview: (obj: { header?: string; body: string }): string => {
-    if (obj.header) {
-      return `:::infoAlert{ header="${obj.header}" } \n ${obj.body ? obj.body.trim() : ""}\n:::`;
-    }
+  toPreview: (obj: { body: string }): string => {
     return `:::infoAlert \n ${obj.body ? obj.body.trim() : ""}\n:::`;
   },
 };


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
The info alert block has 2 fields: Header and Body
Per our style guide, we'll only use the Body section

The ask:

A quick audit to ensure there is no content in any alert block header
To have the Header field removed to prevent errors in the future
ADO User Story
https://dev.azure.com/dillonsullivan/BFS/_workitems/edit/721
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[184376697](https://www.pivotaltracker.com/story/show/)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
1) Tested locally by trying to add a infoAlert and made sure the header wasnt there.
<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
