### PR TITLE
Add analytics event to 'Skip to main content'

### DIFF
--- a/content/src/fieldConfig/config.json
+++ b/content/src/fieldConfig/config.json
@@ -21,6 +21,9 @@
     "requiredTasksSingular": "${numTasks} required task",
     "requiredTasksPlural": "${numTasks} required tasks"
   },
+  "skipToMainContent": {
+    "buttonText": "Skip to main content"
+  },
   "betaBar": {
     "betaModalButtonText": "Share your feedback!",
     "betaMainText": "This site is in beta."

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -3059,6 +3059,10 @@ collections:
         name: "config"
         file: "content/src/fieldConfig/config.json"
         fields:
+          - label: Skip to main content
+            name: skipToMainContent
+            collapsed: true
+            widget: string
           - label: Beta Bar
             name: betaBar
             collapsed: true

--- a/web/src/components/PageSkeleton.tsx
+++ b/web/src/components/PageSkeleton.tsx
@@ -4,6 +4,7 @@ import { LegalMessage } from "@/components/LegalMessage";
 import { Banner } from "@/components/njwds/Banner";
 import { OutageAlertBar } from "@/components/OutageAlertBar";
 import { ReportAnIssueBar } from "@/components/ReportAnIssueBar";
+import { SkipToMainContent } from "@/components/SkipToMainContent";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import React, { ReactElement } from "react";
 
@@ -18,13 +19,7 @@ export const PageSkeleton = (props: Props): ReactElement => {
   return (
     <>
       <section aria-label="Official government website">
-        {!props.landingPage && (
-          <div>
-            <a className="skip-link" href="#main">
-              Skip to main content
-            </a>
-          </div>
-        )}
+        {!props.landingPage && <SkipToMainContent />}
         <Banner />
         <OutageAlertBar />
         <BetaBar />

--- a/web/src/components/SkipToMainContent.test.tsx
+++ b/web/src/components/SkipToMainContent.test.tsx
@@ -1,0 +1,31 @@
+import { SkipToMainContent } from "@/components/SkipToMainContent";
+import { getMergedConfig } from "@/contexts/configContext";
+import analytics from "@/lib/utils/analytics";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const Config = getMergedConfig();
+
+jest.mock("@/lib/utils/analytics", () => setupMockAnalytics());
+
+const mockAnalytics = analytics as jest.Mocked<typeof analytics>;
+function setupMockAnalytics(): typeof analytics {
+  return {
+    ...jest.requireActual("@/lib/utils/analytics").default,
+    event: {
+      ...jest.requireActual("@/lib/utils/analytics").default.event,
+      skip_to_main_content: {
+        click: {
+          skip_to_main_content: jest.fn(),
+        },
+      },
+    },
+  };
+}
+
+describe("<SkipToMainContent>", () => {
+  it("fires skip_to_main_content analytics event when link is clicked", () => {
+    render(<SkipToMainContent />);
+    fireEvent.click(screen.getByText(Config.skipToMainContent.buttonText));
+    expect(mockAnalytics.event.skip_to_main_content.click.skip_to_main_content).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/SkipToMainContent.tsx
+++ b/web/src/components/SkipToMainContent.tsx
@@ -1,0 +1,19 @@
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import analytics from "@/lib/utils/analytics";
+import { ReactElement } from "react";
+
+export const SkipToMainContent = (): ReactElement => {
+  const { Config } = useConfig();
+
+  return (
+    <div>
+      <a
+        className="skip-link"
+        href="#main"
+        onClick={analytics.event.skip_to_main_content.click.skip_to_main_content}
+      >
+        {Config.skipToMainContent.buttonText}
+      </a>
+    </div>
+  );
+};

--- a/web/src/lib/utils/analytics-legacy.ts
+++ b/web/src/lib/utils/analytics-legacy.ts
@@ -112,7 +112,8 @@ export type LegacyEventCategory =
   | "finish_setup_on_myNewJersey_button"
   | "landing_page"
   | "for_you_card_hide_button"
-  | "for_you_card_unhide_button";
+  | "for_you_card_unhide_button"
+  | "skip_to_main_content_button";
 
 export type LegacyEventAction =
   | "click"
@@ -230,4 +231,5 @@ export type LegacyEventLabel =
   | "go_to_myNJ_registration"
   | "hide_card"
   | "unhide_card"
-  | "unhide_cards";
+  | "unhide_cards"
+  | "skip_to_main_content";

--- a/web/src/lib/utils/analytics.ts
+++ b/web/src/lib/utils/analytics.ts
@@ -218,7 +218,8 @@ type Item =
   | "opportunity_card"
   | "hidden_opportunities_section"
   | "link_with_myNJ"
-  | "landing_page";
+  | "landing_page"
+  | "skip_to_main_content";
 
 type BooleanResponseOption = "yes" | "no";
 
@@ -1921,6 +1922,20 @@ export default {
             legacy_event_label: "open_live_chat",
             click_text: "share_feedback",
             clicked_to: "live_chat",
+          });
+        },
+      },
+    },
+    skip_to_main_content: {
+      click: {
+        skip_to_main_content: () => {
+          eventRunner.track({
+            event: "link_clicks",
+            legacy_event_action: "click",
+            legacy_event_category: "skip_to_main_content_button",
+            legacy_event_label: "skip_to_main_content",
+            click_text: "skip to main content",
+            item: "skip_to_main_content",
           });
         },
       },


### PR DESCRIPTION
## Description

Create a new analytics event to fire `onClick` for "Skip to main content" button.

### Ticket

[184226156](https://www.pivotaltracker.com/story/show/184226156)

### Approach

- Created an independent component
- Moved copy to config
- Added analytics event
- Added test to confirm event fires

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
