### PR TITLE
chore(release): 5.31.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [5.31.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v5.30.0...v5.31.0) (2023-09-29)
+
+
+### Features
+
+* [[#186136868](https://github.com/newjersey/navigator.business.nj.gov/issues/186136868)] remove esq from top banner ([2338b95](https://github.com/newjersey/navigator.business.nj.gov/commit/2338b9511ceaac2ac351d26f0df7ce40e1cc54c1))
+
 # [5.30.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v5.29.0...v5.30.0) (2023-09-26)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businessnjgovnavigator/root",
-  "version": "5.30.0",
+  "version": "5.31.0",
   "description": "This is the development repository for the work-in-progress business navigator from the New Jersey Office of Innovation. For info on the existing [Business.NJ.gov](https://business.nj.gov) site, please see the [bottom of this document](https://github.com/newjersey/navigator.business.nj.gov#businessnjgov)",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
# [5.31.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v5.30.0...v5.31.0) (2023-09-29)

### Features

* [[#186136868](https://github.com/newjersey/navigator.business.nj.gov/issues/186136868)] remove esq from top banner ([2338b95](https://github.com/newjersey/navigator.business.nj.gov/commit/2338b9511ceaac2ac351d26f0df7ce40e1cc54c1))
