### PR TITLE
fix: [#186165401] correctly show API error for state dropdown in formation

### DIFF
--- a/web/src/components/tasks/business-formation/business/ForeignStateOfFormation.tsx
+++ b/web/src/components/tasks/business-formation/business/ForeignStateOfFormation.tsx
@@ -13,7 +13,6 @@ export const ForeignStateOfFormation = (): ReactElement => {
   const { doesFieldHaveError } = useFormationErrors();
 
   const handleChange = (stateObject: StateObject | undefined): void => {
-    setFieldsInteracted([FIELD]);
     setFormationFormData((previousFormationData) => {
       return {
         ...previousFormationData,

--- a/web/src/components/tasks/business-formation/business/MainBusinessAddressUs.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusinessAddressUs.tsx
@@ -76,7 +76,6 @@ export const MainBusinessUs = (): ReactElement => {
                             addressState: stateObject,
                           };
                         });
-                        setFieldsInteracted(["addressState"]);
                       }}
                     />
                   </FormationField>


### PR DESCRIPTION

<!-- Please complete the following sections as necessary. -->

It was happening because of an erroneous extra call to `setFieldsInteracted` which was basically setting the field to interacted on mount and causing the API error to consider itself "resolved"

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#186165401](https://www.pivotaltracker.com/story/show/#186165401)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
