### PR TITLE
chore: [#186184213] consolidated instances of window.open

### DIFF
--- a/web/src/components/navbar/NavBarPopupMenu.test.tsx
+++ b/web/src/components/navbar/NavBarPopupMenu.test.tsx
@@ -254,7 +254,7 @@ describe("<NavBarPopupMenu />", () => {
         process.env.MYNJ_PROFILE_LINK = profileLink;
 
         fireEvent.click(screen.getByText(Config.navigationDefaults.myNJAccountText));
-        expect(openMock).toHaveBeenCalledWith(profileLink, "_ blank");
+        expect(openMock).toHaveBeenCalledWith(profileLink, "_blank", "noopener noreferrer");
       });
 
       it("sends user to landing when logout button is clicked", async () => {

--- a/web/src/components/navbar/NavBarPopupMenu.tsx
+++ b/web/src/components/navbar/NavBarPopupMenu.tsx
@@ -13,7 +13,7 @@ import { orderBusinessIdsByDateCreated } from "@/lib/domain-logic/orderBusinessI
 import { QUERIES, ROUTES, routeWithQuery } from "@/lib/domain-logic/routes";
 import { switchCurrentBusiness } from "@/lib/domain-logic/switchCurrentBusiness";
 import analytics from "@/lib/utils/analytics";
-import { getUserNameOrEmail } from "@/lib/utils/helpers";
+import { getUserNameOrEmail, openInNewTab } from "@/lib/utils/helpers";
 import { MenuItem, MenuList } from "@mui/material";
 import { useRouter } from "next/router";
 import { ReactElement, useContext } from "react";
@@ -81,7 +81,7 @@ export const NavBarPopupMenu = (props: Props): ReactElement => {
     return NavMenuItem({
       onClick: (): void => {
         analytics.event.account_menu_myNJ_account.click.go_to_myNJ_home();
-        window.open(process.env.MYNJ_PROFILE_LINK || "", "_ blank");
+        openInNewTab(process.env.MYNJ_PROFILE_LINK || "");
         props.handleClose();
       },
       icon: <ButtonIcon svgFilename="profile" sizePx="25px" />,

--- a/web/src/components/tasks/business-formation/DbaFormationPaginator.tsx
+++ b/web/src/components/tasks/business-formation/DbaFormationPaginator.tsx
@@ -15,7 +15,7 @@ import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { MediaQueries } from "@/lib/PageSizes";
 import analytics from "@/lib/utils/analytics";
-import { scrollToTopOfElement, useMountEffect } from "@/lib/utils/helpers";
+import { openInNewTab, scrollToTopOfElement, useMountEffect } from "@/lib/utils/helpers";
 import { FormationFormData } from "@businessnjgovnavigator/shared/formationData";
 import { useMediaQuery } from "@mui/material";
 import { ReactElement, ReactNode, useContext, useEffect, useRef, useState } from "react";
@@ -203,7 +203,7 @@ export const DbaFormationPaginator = (): ReactElement => {
           title={Config.DbaFormationTask.dbaCtaModalHeader}
           primaryButtonText={Config.DbaFormationTask.dbaCtaModalContinueButtonText}
           primaryButtonOnClick={(): void => {
-            window.open(state.dbaContent.Authorize.callToActionLink, "_ blank");
+            openInNewTab(state.dbaContent.Authorize.callToActionLink);
           }}
           secondaryButtonText={Config.DbaFormationTask.dbaCtaModalCancelButtonText}
         >

--- a/web/src/components/tasks/cannabis/CannabisPriorityRequirements.tsx
+++ b/web/src/components/tasks/cannabis/CannabisPriorityRequirements.tsx
@@ -6,7 +6,7 @@ import { Icon } from "@/components/njwds/Icon";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { noneOfTheAbovePriorityId, priorityTypesObj } from "@/lib/domain-logic/cannabisPriorityTypes";
-import { useMountEffect, useMountEffectWhenDefined } from "@/lib/utils/helpers";
+import { openInNewTab, useMountEffect, useMountEffectWhenDefined } from "@/lib/utils/helpers";
 import { Accordion, AccordionDetails, AccordionSummary } from "@mui/material";
 import { ReactElement, ReactNode, useState } from "react";
 
@@ -69,10 +69,6 @@ export const CannabisPriorityRequirements = (props: Props): ReactElement => {
       !displaySocialEquityPriorityType &&
       !displayNoPriorityType
     );
-  };
-
-  const openInNewTab = (link: string): void => {
-    window.open(link, "_ blank");
   };
 
   const renderCTAButtons = (): ReactNode => {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

A prior story revealed that this new helper function for window.open for a new tab could / shoudl be consolidated across the code base

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/186184213)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
