### PR TITLE
feat: [#184606443] storybook button revisions

### DIFF
--- a/web/src/components/TaskProgressTagLookup.tsx
+++ b/web/src/components/TaskProgressTagLookup.tsx
@@ -7,17 +7,17 @@ const Config = getMergedConfig();
 
 export const TaskProgressTagLookup: Record<TaskProgress, ReactElement> = {
   NOT_STARTED: (
-    <Tag backgroundColor="base-lighter" dataTestid="NOT_STARTED" isFixedWidth>
+    <Tag backgroundColor="base-lighter" dataTestid="NOT_STARTED" isFixedWidth isSmallerVerticalPadding>
       {Config.taskProgress.NOT_STARTED}
     </Tag>
   ),
   IN_PROGRESS: (
-    <Tag backgroundColor="accent-cool-lighter" dataTestid="IN_PROGRESS" isFixedWidth>
+    <Tag backgroundColor="accent-cool-lighter" dataTestid="IN_PROGRESS" isFixedWidth isSmallerVerticalPadding>
       {Config.taskProgress.IN_PROGRESS}
     </Tag>
   ),
   COMPLETED: (
-    <Tag backgroundColor="primary-lightest" dataTestid="COMPLETED" isFixedWidth>
+    <Tag backgroundColor="primary-lightest" dataTestid="COMPLETED" isFixedWidth isSmallerVerticalPadding>
       {Config.taskProgress.COMPLETED}
     </Tag>
   ),

--- a/web/src/components/njwds-extended/GenericButton.tsx
+++ b/web/src/components/njwds-extended/GenericButton.tsx
@@ -19,6 +19,7 @@ export interface GenericButtonProps {
   isNotFullWidthOnMobile?: boolean;
   isFullWidthOnDesktop?: boolean;
   isVerticalPaddingRemoved?: boolean;
+  isReducedPaddingRight?: boolean;
 }
 
 export const GenericButton = forwardRef(function GenericButton(
@@ -32,6 +33,7 @@ export const GenericButton = forwardRef(function GenericButton(
   const isNotFullWidthOnMobile = props.isNotFullWidthOnMobile ? "width-auto" : "";
   const isVerticalPaddingRemoved = props.isVerticalPaddingRemoved ? "padding-y-0" : "padding-y-11px";
   const intercomButton = props.isIntercomEnabled ? "intercom-button" : "";
+  const isReducedPaddingRight = props.isReducedPaddingRight ? "padding-right-1" : "";
 
   const widthRef = useRef<HTMLInputElement | null>(null);
   const [width, setWidth] = useState<number>();
@@ -51,6 +53,7 @@ export const GenericButton = forwardRef(function GenericButton(
     showDisabledClass,
     fullWidth,
     isVerticalPaddingRemoved,
+    isReducedPaddingRight,
   ]
     .map((i) => {
       return i?.trim();

--- a/web/src/components/njwds-extended/Tag.tsx
+++ b/web/src/components/njwds-extended/Tag.tsx
@@ -21,6 +21,7 @@ interface Props {
   isLowerCase?: boolean;
   isRadiusMd?: boolean;
   isWrappingText?: boolean;
+  isSmallerVerticalPadding?: boolean;
 }
 
 export const Tag = (props: Props): ReactElement => {
@@ -64,11 +65,12 @@ export const Tag = (props: Props): ReactElement => {
   }
 
   const defaultStyle =
-    "flex flex-align-center flex-justify usa-tag font-sans-2xs width-full width-auto line-height-sans-2 padding-y-2px";
+    "flex flex-align-center flex-justify usa-tag font-sans-2xs width-full width-auto line-height-sans-2";
   const textWrap = props.isWrappingText ? "text-wrap display-block" : "text-no-wrap";
   const fixedWidth = props.isFixedWidth ? "tag-fixed-width" : "";
   const disableUppercase = props.isLowerCase ? "text-no-uppercase" : "";
   const radius = props.isRadiusMd ? "radius-md" : "";
+  const verticalPadding = props.isSmallerVerticalPadding ? "padding-y-2px" : "padding-y-05";
 
   const className = [
     defaultStyle,
@@ -78,6 +80,7 @@ export const Tag = (props: Props): ReactElement => {
     fixedWidth,
     disableUppercase,
     radius,
+    verticalPadding,
     props.className,
   ]
     .map((i) => {

--- a/web/src/pages/filings/[filingUrlSlug].tsx
+++ b/web/src/pages/filings/[filingUrlSlug].tsx
@@ -65,9 +65,14 @@ export const FilingElement = (props: {
                 ) : (
                   <></>
                 )}
-                {props.filing.extension && (
+                {true && (
                   <div className="margin-left-4">
-                    <Tag backgroundColor="accent-cooler-lightest" data-testid="extension" isLowerCase>
+                    <Tag
+                      backgroundColor="accent-cooler-lightest"
+                      data-testid="extension"
+                      isLowerCase
+                      isSmallerVerticalPadding
+                    >
                       {Config.filingDefaults.extensionTagText}
                     </Tag>
                   </div>

--- a/web/stories/Molecules/Button/PrimaryRegular.stories.tsx
+++ b/web/stories/Molecules/Button/PrimaryRegular.stories.tsx
@@ -28,6 +28,7 @@ export const IconRight = Template.bind({});
 
 IconRight.args = {
   isColor: "primary",
+  isReducedPaddingRight: true,
   children: (
     <>
       <>Button</>


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

In response to these comments by Cary

<img width="433" alt="image" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22485301/8f0ef55d-8053-425a-b7f9-504bd27fcffb">


<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/184606443)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

SO we have this weird situation in which was want special right padding for when we have icons to make them look right, I elected to do a prop for this. 

We also have a weird situation where the tags sometimes want a 2px vertical padding or a 4px vertical padding in some situations. 


<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation, if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
