### PR TITLE
feat: [#185893614] license status check migration - public movers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,6 +201,11 @@ commands:
             echo 'export USE_BASIC_AUTH=$USE_BASIC_AUTH_DEV' >> $BASH_ENV
             echo 'export BASIC_AUTH_USERNAME=$BASIC_AUTH_USERNAME' >> $BASH_ENV
             echo 'export BASIC_AUTH_PASSWORD=$BASIC_AUTH_PASSWORD' >> $BASH_ENV
+            echo 'export DCA_DYNAMICS_ORG_URL_DEV=$DCA_DYNAMICS_ORG_URL' >> $BASH_ENV
+            echo 'export DCA_DYNAMICS_CLIENT_ID_DEV=$DCA_DYNAMICS_CLIENT_ID' >> $BASH_ENV
+            echo 'export DCA_DYNAMICS_SECRET_DEV=$DCA_DYNAMICS_SECRET' >> $BASH_ENV
+            echo 'export DCA_DYNAMICS_TENANT_ID_DEV=$DCA_DYNAMICS_TENANT_ID' >> $BASH_ENV
+            echo 'export FEATURE_DYNAMICS_PUBLIC_MOVERS_DEV=$FEATURE_DYNAMICS_PUBLIC_MOVERS' >> $BASH_ENV
 
   set-cypress-env-vars:
     steps:
@@ -226,6 +231,11 @@ commands:
             echo 'export AWS_CRYPTO_CONTEXT_PURPOSE=$AWS_CRYPTO_CONTEXT_PURPOSE' >> $BASH_ENV
             echo 'export AWS_CRYPTO_CONTEXT_ORIGIN=$AWS_CRYPTO_CONTEXT_ORIGIN' >> $BASH_ENV
             echo 'export DISABLE_GTM=true' >> $BASH_ENV
+            echo 'export DCA_DYNAMICS_ORG_URL_DEV=$DCA_DYNAMICS_ORG_URL' >> $BASH_ENV
+            echo 'export DCA_DYNAMICS_CLIENT_ID_DEV=$DCA_DYNAMICS_CLIENT_ID' >> $BASH_ENV
+            echo 'export DCA_DYNAMICS_SECRET_DEV=$DCA_DYNAMICS_SECRET' >> $BASH_ENV
+            echo 'export DCA_DYNAMICS_TENANT_ID_DEV=$DCA_DYNAMICS_TENANT_ID' >> $BASH_ENV
+            echo 'export FEATURE_DYNAMICS_PUBLIC_MOVERS_DEV=$FEATURE_DYNAMICS_PUBLIC_MOVERS' >> $BASH_ENV
 
   set-staging-env-vars:
     steps:
@@ -262,6 +272,11 @@ commands:
             echo 'export USE_BASIC_AUTH=$USE_BASIC_AUTH_STAGING' >> $BASH_ENV
             echo 'export BASIC_AUTH_USERNAME=$BASIC_AUTH_USERNAME' >> $BASH_ENV
             echo 'export BASIC_AUTH_PASSWORD=$BASIC_AUTH_PASSWORD' >> $BASH_ENV
+            echo 'export DCA_DYNAMICS_ORG_URL_STAGING=$DCA_DYNAMICS_ORG_URL' >> $BASH_ENV
+            echo 'export DCA_DYNAMICS_CLIENT_ID_STAGING=$DCA_DYNAMICS_CLIENT_ID' >> $BASH_ENV
+            echo 'export DCA_DYNAMICS_SECRET_STAGING=$DCA_DYNAMICS_SECRET' >> $BASH_ENV
+            echo 'export DCA_DYNAMICS_TENANT_ID_STAGING=$DCA_DYNAMICS_TENANT_ID' >> $BASH_ENV
+            echo 'export FEATURE_DYNAMICS_PUBLIC_MOVERS_STAGING=$FEATURE_DYNAMICS_PUBLIC_MOVERS' >> $BASH_ENV
 
   set-prod-env-vars:
     steps:
@@ -296,6 +311,11 @@ commands:
             echo 'export AWS_CRYPTO_CONTEXT_PURPOSE=$AWS_CRYPTO_CONTEXT_PURPOSE' >> $BASH_ENV
             echo 'export AWS_CRYPTO_CONTEXT_ORIGIN=$AWS_CRYPTO_CONTEXT_ORIGIN' >> $BASH_ENV
             echo 'export OUTAGE_ALERT_CONFIG_URL=$OUTAGE_ALERT_CONFIG_URL' >> $BASH_ENV
+            echo 'export DCA_DYNAMICS_ORG_URL_PROD=$DCA_DYNAMICS_ORG_URL' >> $BASH_ENV
+            echo 'export DCA_DYNAMICS_CLIENT_ID_PROD=$DCA_DYNAMICS_CLIENT_ID' >> $BASH_ENV
+            echo 'export DCA_DYNAMICS_SECRET_PROD=$DCA_DYNAMICS_SECRET' >> $BASH_ENV
+            echo 'export DCA_DYNAMICS_TENANT_ID_PROD=$DCA_DYNAMICS_TENANT_ID' >> $BASH_ENV
+            echo 'export FEATURE_DYNAMICS_PUBLIC_MOVERS_PROD=$FEATURE_DYNAMICS_PUBLIC_MOVERS' >> $BASH_ENV
 
   set-content-env-vars:
     steps:

--- a/api/.eslintrc.json
+++ b/api/.eslintrc.json
@@ -47,7 +47,7 @@
       }
     },
     {
-      "files": ["src/client/*", "src/db/*"],
+      "files": ["src/client/*", "src/db/*", "src/client/dynamics/*"],
       "extends": ["plugin:unicorn/recommended"],
       "rules": {
         "unicorn/filename-case": [

--- a/api/serverless.ts
+++ b/api/serverless.ts
@@ -52,6 +52,12 @@ const awsCryptoContextStage = process.env.AWS_CRYPTO_CONTEXT_STAGE || "";
 const awsCryptoContextPurpose = process.env.AWS_CRYPTO_CONTEXT_PURPOSE || "";
 const awsCryptoContextOrigin = process.env.AWS_CRYPTO_CONTEXT_ORIGIN || "";
 
+const dcaDynamicsTenantId = process.env.DCA_DYNAMICS_TENANT_ID || "";
+const dcaDynamicsUrl = process.env.DCA_DYNAMICS_ORG_URL || "";
+const dcaDynamicsClientId = process.env.DCA_DYNAMICS_CLIENT_ID || "";
+const dcaDynamicsSecret = process.env.DCA_DYNAMICS_SECRET || "";
+const featureDynamicsPublicMovers = process.env.FEATURE_DYNAMICS_PUBLIC_MOVERS || "";
+
 const serverlessConfiguration: AWS = {
   useDotenv: true,
   service: "businessnjgov-api",
@@ -174,6 +180,11 @@ const serverlessConfiguration: AWS = {
       AWS_CRYPTO_CONTEXT_STAGE: awsCryptoContextStage,
       AWS_CRYPTO_CONTEXT_PURPOSE: awsCryptoContextPurpose,
       AWS_CRYPTO_CONTEXT_ORIGIN: awsCryptoContextOrigin,
+      DCA_DYNAMICS_TENANT_ID: dcaDynamicsTenantId,
+      DCA_DYNAMICS_ORG_URL: dcaDynamicsUrl,
+      DCA_DYNAMICS_CLIENT_ID: dcaDynamicsClientId,
+      DCA_DYNAMICS_SECRET: dcaDynamicsSecret,
+      FEATURE_DYNAMICS_PUBLIC_MOVERS: featureDynamicsPublicMovers,
     } as AwsLambdaEnvironment,
     logRetentionInDays: 180,
   },

--- a/api/src/api/licenseStatusRouter.test.ts
+++ b/api/src/api/licenseStatusRouter.test.ts
@@ -5,8 +5,8 @@ import { setupExpress } from "@libs/express";
 import {
   generateBusiness,
   generateLicenseData,
+  generateLicenseSearchNameAndAddress,
   generateLicenseStatusItem,
-  generateNameAndAddress,
   generateUserDataForBusiness,
 } from "@shared/test";
 import { Express } from "express";
@@ -59,7 +59,7 @@ describe("licenseStatusRouter", () => {
     const userData = generateUserDataForBusiness(generateBusiness({ licenseData }));
     stubUpdateLicenseStatus.mockResolvedValue(userData);
 
-    const nameAndAddress = generateNameAndAddress({});
+    const nameAndAddress = generateLicenseSearchNameAndAddress({});
     stubUserDataClient.get.mockResolvedValue(userData);
     const response = await request(app).post(`/license-status`).send(nameAndAddress);
     expect(response.status).toEqual(200);
@@ -77,14 +77,14 @@ describe("licenseStatusRouter", () => {
     const userData = generateUserDataForBusiness(generateBusiness({ licenseData }));
     stubUpdateLicenseStatus.mockResolvedValue(userData);
 
-    const response = await request(app).post(`/license-status`).send(generateNameAndAddress({}));
+    const response = await request(app).post(`/license-status`).send(generateLicenseSearchNameAndAddress({}));
     expect(stubUserDataClient.put).toHaveBeenCalledWith(userData);
     expect(response.status).toEqual(404);
   });
 
   it("returns 500 if license search errors", async () => {
     stubUpdateLicenseStatus.mockRejectedValue({});
-    const response = await request(app).post(`/license-status`).send(generateNameAndAddress({}));
+    const response = await request(app).post(`/license-status`).send(generateLicenseSearchNameAndAddress({}));
     expect(stubUserDataClient.put).not.toHaveBeenCalled();
     expect(response.status).toEqual(500);
   });

--- a/api/src/api/licenseStatusRouter.ts
+++ b/api/src/api/licenseStatusRouter.ts
@@ -1,7 +1,7 @@
 import { getSignedInUserId } from "@api/userRouter";
 import { UpdateLicenseStatus, UserDataClient } from "@domain/types";
 import { getCurrentBusiness } from "@shared/domain-logic/getCurrentBusiness";
-import { NameAndAddress } from "@shared/license";
+import { LicenseSearchNameAndAddress } from "@shared/license";
 import { UserData } from "@shared/userData";
 import { Router } from "express";
 
@@ -13,7 +13,7 @@ export const licenseStatusRouterFactory = (
 
   router.post("/license-status", async (req, res) => {
     const userId = getSignedInUserId(req);
-    const nameAndAddress = req.body as NameAndAddress;
+    const nameAndAddress = req.body as LicenseSearchNameAndAddress;
     const userData = await userDataClient.get(userId);
     updateLicenseStatus(userData, nameAndAddress)
       .then(async (userData: UserData) => {

--- a/api/src/client/WebserviceLicenseStatusProcessorClient.test.ts
+++ b/api/src/client/WebserviceLicenseStatusProcessorClient.test.ts
@@ -1,0 +1,432 @@
+import { parseDateWithFormat } from "@shared/dateHelpers";
+import { LicenseEntity, LicenseStatusResult } from "@shared/license";
+import { generateLicenseSearchNameAndAddress } from "@shared/test";
+import { generateLicenseEntity } from "../../test/factories";
+import { LicenseStatusClient, NO_MATCH_ERROR, SearchLicenseStatus } from "../domain/types";
+import {
+  determineLicenseStatus,
+  WebserviceLicenseStatusProcessorClient,
+} from "./WebserviceLicenseStatusProcessorClient";
+
+const entityWithAddress = (address: string): LicenseEntity => {
+  return generateLicenseEntity({
+    checkoffStatus: "Completed",
+    licenseStatus: "Active",
+    addressLine1: address,
+  });
+};
+
+describe("WebserviceLicenseStatusProcessorClient", () => {
+  let stubLicenseStatusClient: jest.Mocked<LicenseStatusClient>;
+  let searchLicenseStatus: SearchLicenseStatus;
+
+  beforeEach(() => {
+    stubLicenseStatusClient = {
+      search: jest.fn(),
+    };
+
+    searchLicenseStatus = WebserviceLicenseStatusProcessorClient(stubLicenseStatusClient);
+  });
+
+  it("searches for license status on name, zipcode, and license type", async () => {
+    stubLicenseStatusClient.search.mockResolvedValue([]);
+    const nameAndAddress = generateLicenseSearchNameAndAddress({
+      name: "Crystal",
+      zipCode: "12345",
+    });
+    await expect(searchLicenseStatus(nameAndAddress, "Home improvement")).rejects.toEqual(
+      new Error(NO_MATCH_ERROR)
+    );
+    expect(stubLicenseStatusClient.search).toHaveBeenCalledWith("crystal", "12345", "Home improvement");
+  });
+
+  it("removes leading/trailing space and business designators from search name", async () => {
+    stubLicenseStatusClient.search.mockResolvedValue([]);
+    const nameAndAddress = generateLicenseSearchNameAndAddress({
+      name: " Crystal, LLC   ",
+      zipCode: "12345",
+    });
+    await expect(searchLicenseStatus(nameAndAddress, "Home improvement")).rejects.toEqual(
+      new Error(NO_MATCH_ERROR)
+    );
+    expect(stubLicenseStatusClient.search).toHaveBeenCalledWith("crystal", "12345", "Home improvement");
+  });
+
+  it("returns the status license items from most recent application with matching address", async () => {
+    stubLicenseStatusClient.search.mockResolvedValue([
+      generateLicenseEntity({
+        addressLine1: "1234 Main St",
+        applicationNumber: "SOME OLDER APPLICATION NUMBER",
+        checklistItem: "OLDER APPLICATION",
+        issueDate: "20080404 000000.000",
+      }),
+      generateLicenseEntity({
+        addressLine1: "1234 Main St",
+        applicationNumber: "12345",
+        checklistItem: "Item 1",
+        checkoffStatus: "Completed",
+        licenseStatus: "Pending",
+        issueDate: "20210404 000000.000",
+      }),
+      generateLicenseEntity({
+        addressLine1: "SOMETHING ELSE",
+        applicationNumber: "45678",
+      }),
+      generateLicenseEntity({
+        applicationNumber: "12345",
+        checklistItem: "Item 2",
+        checkoffStatus: "Completed",
+        issueDate: "20210404 000000.000",
+      }),
+    ]);
+
+    const nameAndAddress = generateLicenseSearchNameAndAddress({
+      addressLine1: "1234 Main St",
+    });
+
+    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
+    expect(result.status).toEqual("PENDING");
+    expect(result.checklistItems).toEqual(
+      expect.arrayContaining([
+        {
+          title: "Item 1",
+          status: "ACTIVE",
+        },
+        {
+          title: "Item 2",
+          status: "ACTIVE",
+        },
+      ])
+    );
+  });
+
+  it("returns an expired license if that's the most recent application", async () => {
+    stubLicenseStatusClient.search.mockResolvedValue([
+      generateLicenseEntity({
+        addressLine1: "1234 Main St",
+        applicationNumber: "SOME OLDER ACTIVE APPLICATION NUMBER",
+        checklistItem: "OLDER ACTIVE APPLICATION",
+        issueDate: "20080404 000000.000",
+      }),
+      generateLicenseEntity({
+        addressLine1: "1234 Main St",
+        applicationNumber: "12345",
+        checklistItem: "Item 1",
+        checkoffStatus: "Completed",
+        licenseStatus: "Expired",
+        issueDate: "20210404 000000.000",
+      }),
+      generateLicenseEntity({
+        applicationNumber: "12345",
+        checklistItem: "Item 2",
+        checkoffStatus: "Completed",
+        issueDate: "20210404 000000.000",
+      }),
+    ]);
+
+    const nameAndAddress = generateLicenseSearchNameAndAddress({
+      addressLine1: "1234 Main St",
+    });
+
+    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
+    expect(result.status).toEqual("EXPIRED");
+    expect(result.checklistItems).toEqual(
+      expect.arrayContaining([
+        {
+          title: "Item 1",
+          status: "ACTIVE",
+        },
+        {
+          title: "Item 2",
+          status: "ACTIVE",
+        },
+      ])
+    );
+  });
+
+  it("uses dateThisStatus as the date of an entity if issueDate is undefined", async () => {
+    stubLicenseStatusClient.search.mockResolvedValue([
+      generateLicenseEntity({
+        addressLine1: "1234 Main St",
+        applicationNumber: "SOME OLDER APPLICATION NUMBER WITH AN ISSUE DATE",
+        checklistItem: "ACTIVE OLDER APPLICATION WITH AN ISSUE DATE",
+        issueDate: "20180327 000000.000",
+      }),
+      generateLicenseEntity({
+        addressLine1: "1234 Main St",
+        applicationNumber: "12345",
+        checklistItem: "Item 1",
+        checkoffStatus: "Completed",
+        licenseStatus: "Expired",
+        issueDate: undefined,
+        dateThisStatus: "20210405 000000.000",
+        expirationDate: undefined,
+      }),
+    ]);
+
+    const nameAndAddress = generateLicenseSearchNameAndAddress({
+      addressLine1: "1234 Main St",
+    });
+
+    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
+    expect(result.status).toEqual("EXPIRED");
+    expect(result.checklistItems).toEqual(
+      expect.arrayContaining([
+        {
+          title: "Item 1",
+          status: "ACTIVE",
+        },
+      ])
+    );
+  });
+
+  it("saves expirationDate as expirationISO if it exists", async () => {
+    stubLicenseStatusClient.search.mockResolvedValue([
+      generateLicenseEntity({
+        addressLine1: "1234 Main St",
+        applicationNumber: "12345",
+        checklistItem: "Item 1",
+        checkoffStatus: "Completed",
+        licenseStatus: "ACTIVE",
+        issueDate: undefined,
+        dateThisStatus: undefined,
+        expirationDate: "20210505 000000.000",
+      }),
+    ]);
+
+    const nameAndAddress = generateLicenseSearchNameAndAddress({
+      addressLine1: "1234 Main St",
+    });
+
+    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
+    expect(result.expirationISO).toEqual(parseDateWithFormat("20210505", "YYYYMMDD").toISOString());
+  });
+
+  it("does not save the expirationDate if invalid", async () => {
+    stubLicenseStatusClient.search.mockResolvedValue([
+      generateLicenseEntity({
+        addressLine1: "1234 Main St",
+        applicationNumber: "12345",
+        checklistItem: "Item 1",
+        checkoffStatus: "Completed",
+        licenseStatus: "ACTIVE",
+        issueDate: undefined,
+        dateThisStatus: undefined,
+        expirationDate: "20210",
+      }),
+    ]);
+
+    const nameAndAddress = generateLicenseSearchNameAndAddress({
+      addressLine1: "1234 Main St",
+    });
+
+    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
+    expect(result.expirationISO).toBeUndefined();
+  });
+
+  it("does not save the expirationDate if undefined", async () => {
+    stubLicenseStatusClient.search.mockResolvedValue([
+      generateLicenseEntity({
+        addressLine1: "1234 Main St",
+        applicationNumber: "12345",
+        checklistItem: "Item 1",
+        checkoffStatus: "Completed",
+        licenseStatus: "ACTIVE",
+        issueDate: undefined,
+        dateThisStatus: undefined,
+        expirationDate: undefined,
+      }),
+    ]);
+
+    const nameAndAddress = generateLicenseSearchNameAndAddress({
+      addressLine1: "1234 Main St",
+    });
+
+    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
+    expect(result.expirationISO).toBeUndefined();
+  });
+
+  it("uses expirationDate as the date of an entity if issueDate and dateThisStatus are undefined", async () => {
+    stubLicenseStatusClient.search.mockResolvedValue([
+      generateLicenseEntity({
+        addressLine1: "1234 Main St",
+        applicationNumber: "SOME OLDER APPLICATION NUMBER WITH AN ISSUE DATE",
+        checklistItem: "ACTIVE OLDER APPLICATION WITH AN ISSUE DATE",
+        issueDate: "20210327 000000.000",
+      }),
+      generateLicenseEntity({
+        addressLine1: "1234 Main St",
+        applicationNumber: "12345",
+        checklistItem: "Item 1",
+        checkoffStatus: "Completed",
+        licenseStatus: "Expired",
+        issueDate: undefined,
+        dateThisStatus: undefined,
+        expirationDate: "20210505 000000.000",
+      }),
+    ]);
+
+    const nameAndAddress = generateLicenseSearchNameAndAddress({
+      addressLine1: "1234 Main St",
+    });
+
+    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
+    expect(result.status).toEqual("EXPIRED");
+    expect(result.checklistItems).toEqual(
+      expect.arrayContaining([
+        {
+          title: "Item 1",
+          status: "ACTIVE",
+        },
+      ])
+    );
+  });
+
+  const queryWithAddress = async (address: string): Promise<LicenseStatusResult> => {
+    return await searchLicenseStatus(
+      generateLicenseSearchNameAndAddress({
+        addressLine1: address,
+      }),
+      "Home improvement"
+    );
+  };
+
+  describe("detailed address matching logic", () => {
+    it("matches on address ignoring spaces and non-alphanumeric characters", async () => {
+      stubLicenseStatusClient.search.mockResolvedValue([entityWithAddress(" 123    Main St.  ! ")]);
+
+      const result = await queryWithAddress("123 Main St");
+      expect(result.status).toEqual("ACTIVE");
+    });
+
+    it("matches on address ignoring casing", async () => {
+      stubLicenseStatusClient.search.mockResolvedValue([entityWithAddress(" 123 MAIN ST ")]);
+
+      const result = await queryWithAddress("123 main st");
+      expect(result.status).toEqual("ACTIVE");
+    });
+
+    it("matches on address*", async () => {
+      stubLicenseStatusClient.search.mockResolvedValue([entityWithAddress("123 MAIN ST, UNIT C")]);
+
+      const result = await queryWithAddress("123 main st");
+      expect(result.status).toEqual("ACTIVE");
+    });
+  });
+
+  it("maps Completed to ACTIVE and Unchecked to PENDING", async () => {
+    stubLicenseStatusClient.search.mockResolvedValue([
+      generateLicenseEntity({
+        addressLine1: "1234 Main St",
+        applicationNumber: "12345",
+        checklistItem: "Item 1",
+        checkoffStatus: "Completed",
+      }),
+      generateLicenseEntity({
+        addressLine1: "1234 Main St",
+        applicationNumber: "12345",
+        checklistItem: "Item 2",
+        checkoffStatus: "Unchecked",
+      }),
+    ]);
+
+    const nameAndAddress = generateLicenseSearchNameAndAddress({
+      addressLine1: "1234 Main St",
+    });
+
+    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
+    expect(result.checklistItems).toEqual(
+      expect.arrayContaining([
+        {
+          title: "Item 1",
+          status: "ACTIVE",
+        },
+        {
+          title: "Item 2",
+          status: "PENDING",
+        },
+      ])
+    );
+  });
+
+  it("filters out Not Applicable items", async () => {
+    stubLicenseStatusClient.search.mockResolvedValue([
+      generateLicenseEntity({
+        addressLine1: "1234 Main St",
+        applicationNumber: "12345",
+        checklistItem: "Item 1",
+        checkoffStatus: "Completed",
+      }),
+      generateLicenseEntity({
+        addressLine1: "1234 Main St",
+        applicationNumber: "12345",
+        checklistItem: "Item 2",
+        checkoffStatus: "Not Applicable",
+      }),
+    ]);
+
+    const nameAndAddress = generateLicenseSearchNameAndAddress({
+      addressLine1: "1234 Main St",
+    });
+
+    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
+    expect(result.checklistItems).toEqual([
+      {
+        title: "Item 1",
+        status: "ACTIVE",
+      },
+    ]);
+  });
+
+  it("rejects with NO_MATCH when no result matches the address", async () => {
+    stubLicenseStatusClient.search.mockResolvedValue([generateLicenseEntity({}), generateLicenseEntity({})]);
+
+    const nameAndAddress = generateLicenseSearchNameAndAddress({});
+    await expect(searchLicenseStatus(nameAndAddress, "")).rejects.toEqual(new Error(NO_MATCH_ERROR));
+  });
+
+  it("rejects when search fails", async () => {
+    stubLicenseStatusClient.search.mockRejectedValue("some api error");
+
+    const nameAndAddress = generateLicenseSearchNameAndAddress({});
+    await expect(searchLicenseStatus(nameAndAddress, "")).rejects.toEqual("some api error");
+  });
+});
+
+describe("determineLicenseStatus", () => {
+  it("returns BARRED when status is barred", () => {
+    expect(determineLicenseStatus("Barred")).toBe("BARRED");
+  });
+
+  it("returns OUT_OF_BUSINESS when status is out of business", () => {
+    expect(determineLicenseStatus("Out of Business")).toBe("OUT_OF_BUSINESS");
+  });
+
+  it("returns REINSTATEMENT_PENDING when status is Reinstatement Pending", () => {
+    expect(determineLicenseStatus("Reinstatement Pending")).toBe("REINSTATEMENT_PENDING");
+  });
+
+  it("returns CLOSED when status is closed", () => {
+    expect(determineLicenseStatus("Closed")).toBe("CLOSED");
+  });
+
+  it("returns DELETED when status is deleted", () => {
+    expect(determineLicenseStatus("Deleted")).toBe("DELETED");
+  });
+
+  it("returns DENIED when status is denied", () => {
+    expect(determineLicenseStatus("Denied")).toBe("DENIED");
+  });
+
+  it("returns VOLUNTARY_SURRENDER when status is Voluntary Surrender", () => {
+    expect(determineLicenseStatus("Voluntary Surrender")).toBe("VOLUNTARY_SURRENDER");
+  });
+
+  it("returns WITHDRAWN when status is Withdrawn", () => {
+    expect(determineLicenseStatus("Withdrawn")).toBe("WITHDRAWN");
+  });
+
+  it("returns UNKNOWN when status is not valid", () => {
+    expect(determineLicenseStatus("fake status")).toBe("UNKNOWN");
+  });
+});

--- a/api/src/client/WebserviceLicenseStatusProcessorClient.ts
+++ b/api/src/client/WebserviceLicenseStatusProcessorClient.ts
@@ -1,0 +1,94 @@
+import { getLicenseDate, parseDateWithFormat } from "@shared/dateHelpers";
+import {
+  LicenseSearchNameAndAddress,
+  LicenseStatus,
+  LicenseStatusItem,
+  LicenseStatusResult,
+} from "@shared/license";
+import { inputManipulator } from "../domain/inputManipulator";
+import { LicenseStatusClient, NO_MATCH_ERROR, SearchLicenseStatus } from "../domain/types";
+
+export const WebserviceLicenseStatusProcessorClient = (
+  licenseStatusClient: LicenseStatusClient
+): SearchLicenseStatus => {
+  return async (
+    nameAndAddress: LicenseSearchNameAndAddress,
+    licenseType: string
+  ): Promise<LicenseStatusResult> => {
+    const searchName = inputManipulator(nameAndAddress.name)
+      .makeLowerCase()
+      .removeBusinessDesignators()
+      .trimPunctuation().value;
+
+    const entities = await licenseStatusClient.search(searchName, nameAndAddress.zipCode, licenseType);
+
+    const allMatchingAddressesArray = entities.filter((it) => {
+      return cleanAddress(it.addressLine1).startsWith(cleanAddress(nameAndAddress.addressLine1));
+    });
+
+    if (allMatchingAddressesArray.length === 0) {
+      throw new Error(NO_MATCH_ERROR);
+    }
+
+    const match = allMatchingAddressesArray.reduce((a, b) => {
+      return getLicenseDate(a) > getLicenseDate(b) ? a : b;
+    });
+
+    const items: LicenseStatusItem[] = entities
+      .filter((it) => {
+        return it.applicationNumber === match.applicationNumber;
+      })
+      .filter((it) => {
+        return it.checkoffStatus === "Unchecked" || it.checkoffStatus === "Completed";
+      })
+      .map((it) => {
+        return {
+          title: it.checklistItem,
+          status: it.checkoffStatus === "Completed" ? "ACTIVE" : "PENDING",
+        };
+      });
+
+    const expirationDate =
+      match.expirationDate === undefined || match.expirationDate.length < 8
+        ? undefined
+        : parseDateWithFormat(match.expirationDate, "YYYYMMDD X");
+    return {
+      status: determineLicenseStatus(match.licenseStatus),
+      expirationISO: expirationDate?.toISOString(),
+      checklistItems: items,
+    };
+  };
+};
+
+export const determineLicenseStatus = (value: string): LicenseStatus => {
+  switch (value) {
+    case "Active":
+      return "ACTIVE";
+    case "Pending":
+      return "PENDING";
+    case "Expired":
+      return "EXPIRED";
+    case "Barred":
+      return "BARRED";
+    case "Out of Business":
+      return "OUT_OF_BUSINESS";
+    case "Reinstatement Pending":
+      return "REINSTATEMENT_PENDING";
+    case "Closed":
+      return "CLOSED";
+    case "Deleted":
+      return "DELETED";
+    case "Denied":
+      return "DENIED";
+    case "Voluntary Surrender":
+      return "VOLUNTARY_SURRENDER";
+    case "Withdrawn":
+      return "WITHDRAWN";
+    default:
+      return "UNKNOWN";
+  }
+};
+
+export const cleanAddress = (value: string): string => {
+  return inputManipulator(value).makeLowerCase().stripPunctuation().stripWhitespace().value;
+};

--- a/api/src/client/dynamics/DynamicsAccessTokenClient.test.ts
+++ b/api/src/client/dynamics/DynamicsAccessTokenClient.test.ts
@@ -1,0 +1,56 @@
+import { LogWriter, LogWriterType } from "@libs/logWriter";
+import axios from "axios";
+import { DynamicsAccessTokenClient } from "./DynamicsAccessTokenClient";
+import { AccessTokenClient } from "./types";
+
+jest.mock("winston");
+jest.mock("axios");
+const mockAxios = axios as jest.Mocked<typeof axios>;
+
+describe("DynamicsAccessTokenClient", () => {
+  let client: AccessTokenClient;
+  let logger: LogWriterType;
+
+  const ORG_URL = "www.test-org-url.com";
+  const TENANT_ID = "test-tenant-id-123";
+  const CLIENT_ID = "test-client-id-123";
+  const CLIENT_SECRET = "test-client-secret-123";
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    logger = LogWriter("NavigatorWebService", "ApiLogs", "us-test-1");
+
+    client = DynamicsAccessTokenClient(logger, {
+      tenantId: TENANT_ID,
+      orgUrl: ORG_URL,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+  });
+
+  it("postForms to dynamics access token endpoint with a body", async () => {
+    const accessTokenMockResponse = {
+      token_type: "Bearer",
+      expires_in: "3599",
+      ext_expires_in: "3599",
+      expires_on: "1692118180",
+      not_before: "1692114280",
+      resource: ORG_URL,
+      access_token: "test-access-token",
+    };
+
+    mockAxios.postForm.mockResolvedValue({ data: accessTokenMockResponse });
+    expect(await client.getAccessToken()).toEqual(accessTokenMockResponse.access_token);
+    expect(mockAxios.postForm).toHaveBeenCalledWith(`https://login.windows.net/${TENANT_ID}/oauth2/token`, {
+      grant_type: "client_credentials",
+      resource: ORG_URL,
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+    });
+  });
+
+  it("returns empty string if received data is empty", async () => {
+    mockAxios.postForm.mockResolvedValue({ data: {} });
+    expect(await client.getAccessToken()).toEqual("");
+  });
+});

--- a/api/src/client/dynamics/DynamicsAccessTokenClient.ts
+++ b/api/src/client/dynamics/DynamicsAccessTokenClient.ts
@@ -1,0 +1,37 @@
+import { LogWriterType } from "@libs/logWriter";
+import axios, { AxiosError } from "axios";
+import { AccessTokenClient } from "./types";
+
+type Config = {
+  tenantId: string;
+  orgUrl: string;
+  clientId: string;
+  clientSecret: string;
+};
+
+export const DynamicsAccessTokenClient = (logWriter: LogWriterType, config: Config): AccessTokenClient => {
+  const getAccessToken = async (): Promise<string> => {
+    const logId = logWriter.GetId();
+    logWriter.LogInfo(`Dynamics Access Token Client - Id:${logId}`);
+
+    return axios
+      .postForm(`https://login.windows.net/${config.tenantId}/oauth2/token`, {
+        grant_type: "client_credentials",
+        resource: config.orgUrl,
+        client_id: config.clientId,
+        client_secret: config.clientSecret,
+      })
+      .then((response) => {
+        logWriter.LogInfo(`Dynamics Access Token Client - Id:${logId} - Response Status: ${response.status}`);
+        return response.data.access_token || "";
+      })
+      .catch((error: AxiosError) => {
+        logWriter.LogError(`Dynamics Access Token Client - Id:${logId} - Error:`, error);
+        throw error.response?.status;
+      });
+  };
+
+  return {
+    getAccessToken,
+  };
+};

--- a/api/src/client/dynamics/DynamicsBusinessAddressClient.test.ts
+++ b/api/src/client/dynamics/DynamicsBusinessAddressClient.test.ts
@@ -1,0 +1,184 @@
+/* eslint-disable unicorn/no-null */
+import { LogWriter, LogWriterType } from "@libs/logWriter";
+import { generateLicenseSearchAddress } from "@shared/test";
+import axios from "axios";
+import { DynamicsBusinessAddressClient } from "./DynamicsBusinessAddressClient";
+import { BusinessAddressClient } from "./types";
+
+jest.mock("axios");
+jest.mock("winston");
+const mockAxios = axios as jest.Mocked<typeof axios>;
+
+describe("DynamicsBusinessAddressClient", () => {
+  let client: BusinessAddressClient;
+  let logger: LogWriterType;
+
+  const ORG_URL = "www.test-org-url.com";
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    logger = LogWriter("NavigatorWebService", "ApiLogs", "us-test-1");
+
+    client = DynamicsBusinessAddressClient(logger, ORG_URL);
+  });
+
+  const mockAccessToken = "access-granted";
+  const mockBusinessIds = ["id2", "id3"];
+
+  it("makes a get request to dynamics api with business address query and auth token in header", async () => {
+    const businessAddressMockResponse = {
+      value: [
+        {
+          createdon: "2023-05-31T10:31:51Z",
+          rgb_city: "Washington",
+          rgb_county: null,
+          rgb_name: "Apt GFG 3900A Watson Pl NW",
+          rgb_state: "DC",
+          rgb_street1: "3900A Watson Pl NW",
+          rgb_street2: "Apt GFG",
+          rgb_typecode: 100000000,
+          rgb_zip: "20016-6739",
+          statecode: 0,
+          rgb_addressid: "ff166755-9eff-ed11-a81b-001dd80703e0",
+        },
+        {
+          createdon: "2023-05-31T10:32:04Z",
+          rgb_city: "Chesapeake",
+          rgb_county: null,
+          rgb_name: "Trlr T 322 Ballahack Rd",
+          rgb_state: "VA",
+          rgb_street1: "Trlr T 322 Ballahack Rd",
+          rgb_street2: null,
+          rgb_typecode: 100000001,
+          rgb_zip: "23322-2479",
+          statecode: 0,
+          rgb_addressid: "4da7455c-9eff-ed11-a81b-001dd80703e0",
+        },
+      ],
+    };
+
+    mockAxios.get.mockResolvedValue({ data: businessAddressMockResponse });
+    expect(await client.getBusinessIdsAndLicenseSearchAddresses(mockAccessToken, mockBusinessIds)).toEqual([
+      {
+        businessId: "id2",
+        addresses: [
+          generateLicenseSearchAddress({
+            addressLine1: "3900A Watson Pl NW",
+            addressLine2: "Apt GFG",
+            zipCode: "20016",
+          }),
+          generateLicenseSearchAddress({
+            addressLine1: "Trlr T 322 Ballahack Rd",
+            addressLine2: "",
+            zipCode: "23322",
+          }),
+        ],
+      },
+      {
+        businessId: "id3",
+        addresses: [
+          generateLicenseSearchAddress({
+            addressLine1: "3900A Watson Pl NW",
+            addressLine2: "Apt GFG",
+            zipCode: "20016",
+          }),
+          generateLicenseSearchAddress({
+            addressLine1: "Trlr T 322 Ballahack Rd",
+            addressLine2: "",
+            zipCode: "23322",
+          }),
+        ],
+      },
+    ]);
+    expect(mockAxios.get).toHaveBeenNthCalledWith(
+      1,
+      `${ORG_URL}/api/data/v9.2/rgb_addresses?$select=createdon,rgb_city,rgb_county,rgb_name,rgb_state,rgb_street1,rgb_street2,rgb_typecode,rgb_zip,statecode&$filter=(_rgb_businessid_value eq ${mockBusinessIds[0]})&$top=50`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+
+    expect(mockAxios.get).toHaveBeenNthCalledWith(
+      2,
+      `${ORG_URL}/api/data/v9.2/rgb_addresses?$select=createdon,rgb_city,rgb_county,rgb_name,rgb_state,rgb_street1,rgb_street2,rgb_typecode,rgb_zip,statecode&$filter=(_rgb_businessid_value eq ${mockBusinessIds[1]})&$top=50`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+  });
+
+  it("filters out addresses whose statecode is not 0", async () => {
+    const businessAddressMockResponse = {
+      value: [
+        {
+          createdon: "2023-05-31T10:31:51Z",
+          rgb_city: "Washington",
+          rgb_county: null,
+          rgb_name: "Apt GFG 3900A Watson Pl NW",
+          rgb_state: "DC",
+          rgb_street1: "Apt GFG 3900A Watson Pl NW",
+          rgb_street2: null,
+          rgb_typecode: 100000000,
+          rgb_zip: "20016-6739",
+          statecode: 0,
+          rgb_addressid: "ff166755-9eff-ed11-a81b-001dd80703e0",
+        },
+        {
+          createdon: "2023-05-31T10:32:04Z",
+          rgb_city: "Chesapeake",
+          rgb_county: null,
+          rgb_name: "Trlr T 322 Ballahack Rd",
+          rgb_state: "VA",
+          rgb_street1: "Trlr T 322 Ballahack Rd",
+          rgb_street2: null,
+          rgb_typecode: 100000001,
+          rgb_zip: "23322-2479",
+          statecode: 1,
+          rgb_addressid: "4da7455c-9eff-ed11-a81b-001dd80703e0",
+        },
+      ],
+    };
+
+    mockAxios.get.mockResolvedValue({ data: businessAddressMockResponse });
+    expect(await client.getBusinessIdsAndLicenseSearchAddresses(mockAccessToken, mockBusinessIds)).toEqual([
+      {
+        businessId: "id2",
+        addresses: [
+          generateLicenseSearchAddress({
+            addressLine1: "Apt GFG 3900A Watson Pl NW",
+            addressLine2: "",
+            zipCode: "20016",
+          }),
+        ],
+      },
+      {
+        businessId: "id3",
+        addresses: [
+          generateLicenseSearchAddress({
+            addressLine1: "Apt GFG 3900A Watson Pl NW",
+            addressLine2: "",
+            zipCode: "20016",
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it("returns empty array if received data value is empty", async () => {
+    mockAxios.get.mockResolvedValue({ data: { value: [] } });
+    expect(await client.getBusinessIdsAndLicenseSearchAddresses(mockAccessToken, mockBusinessIds)).toEqual([
+      {
+        businessId: "id2",
+        addresses: [],
+      },
+      {
+        businessId: "id3",
+        addresses: [],
+      },
+    ]);
+  });
+});

--- a/api/src/client/dynamics/DynamicsBusinessAddressClient.ts
+++ b/api/src/client/dynamics/DynamicsBusinessAddressClient.ts
@@ -1,0 +1,80 @@
+import { LogWriterType } from "@libs/logWriter";
+import { LicenseSearchAddress } from "@shared/license";
+import axios, { AxiosError } from "axios";
+import { ACTIVE_STATECODE, BusinessAddressClient, BusinessIdAndLicenseSearchAddresses } from "./types";
+
+export const DynamicsBusinessAddressClient = (
+  logWriter: LogWriterType,
+  orgUrl: string
+): BusinessAddressClient => {
+  const getBusinessAddresses = async (
+    accessToken: string,
+    businessId: string
+  ): Promise<LicenseSearchAddress[]> => {
+    const logId = logWriter.GetId();
+    logWriter.LogInfo(`Dynamics Business Address Client - Id:${logId}`);
+
+    return axios
+      .get(
+        `${orgUrl}/api/data/v9.2/rgb_addresses?$select=createdon,rgb_city,rgb_county,rgb_name,rgb_state,rgb_street1,rgb_street2,rgb_typecode,rgb_zip,statecode&$filter=(_rgb_businessid_value eq ${businessId})&$top=50`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      )
+      .then((response) => {
+        logWriter.LogInfo(
+          `Dynamics Business Address Client - Id:${logId} - Response: ${JSON.stringify(response.data)}`
+        );
+        const activeAddresses = response.data.value.filter(
+          (address: DynamicsApiAddressResponse) => address.statecode === ACTIVE_STATECODE
+        );
+        return activeAddresses.map((address: DynamicsApiAddressResponse) => processAddress(address));
+      })
+      .catch((error: AxiosError) => {
+        logWriter.LogError(`Dynamics Business Address Client - Id:${logId} - Error:`, error);
+        throw error.response?.status;
+      });
+  };
+
+  const getBusinessIdsAndLicenseSearchAddresses = async (
+    accessToken: string,
+    businessIds: string[]
+  ): Promise<BusinessIdAndLicenseSearchAddresses[]> => {
+    const getBusinessAddressesById = async (id: string): Promise<BusinessIdAndLicenseSearchAddresses> => {
+      return {
+        businessId: id,
+        addresses: await getBusinessAddresses(accessToken, id),
+      };
+    };
+
+    return await Promise.all(businessIds.map((id) => getBusinessAddressesById(id)));
+  };
+
+  return {
+    getBusinessIdsAndLicenseSearchAddresses,
+  };
+};
+
+type DynamicsApiAddressResponse = {
+  createdon: string;
+  rgb_city: string;
+  rgb_county: string;
+  rgb_name: string;
+  rgb_state: string;
+  rgb_street1: string;
+  rgb_street2: string;
+  rgb_typecode: number;
+  rgb_zip: string;
+  statecode: number;
+  rgb_addressid: string;
+};
+
+const processAddress = (address: DynamicsApiAddressResponse): LicenseSearchAddress => {
+  return {
+    addressLine1: address.rgb_street1 || "",
+    addressLine2: address.rgb_street2 || "",
+    zipCode: address.rgb_zip.slice(0, 5) || "",
+  };
+};

--- a/api/src/client/dynamics/DynamicsBusinessIdsClient.test.ts
+++ b/api/src/client/dynamics/DynamicsBusinessIdsClient.test.ts
@@ -1,0 +1,67 @@
+import { NO_MATCH_ERROR } from "@domain/types";
+import { LogWriter, LogWriterType } from "@libs/logWriter";
+import axios from "axios";
+import { DynamicsBusinessIdsClient } from "./DynamicsBusinessIdsClient";
+import { BusinessIdClient } from "./types";
+
+jest.mock("axios");
+jest.mock("winston");
+const mockAxios = axios as jest.Mocked<typeof axios>;
+
+describe("DynamicsBusinessIdsClient", () => {
+  let client: BusinessIdClient;
+  let logger: LogWriterType;
+
+  const ORG_URL = "www.test-org-url.com";
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    logger = LogWriter("NavigatorWebService", "ApiLogs", "us-test-1");
+
+    client = DynamicsBusinessIdsClient(logger, ORG_URL);
+  });
+
+  const mockAccessToken = "access-granted";
+  const mockNametoSearch = "Barcade";
+
+  const mockBusinessName1 = "Barcade123456";
+  const mockBusinessId1 = "123456";
+
+  const mockBusinessName2 = "Barcade789102";
+  const mockBusinessId2 = "789102";
+
+  it("makes a get request to dynamics api with the business ids query and auth token in header", async () => {
+    const businessIdMockResponse = {
+      value: [
+        {
+          name: mockBusinessName1,
+          accountid: mockBusinessId1,
+        },
+        {
+          name: mockBusinessName2,
+          accountid: mockBusinessId2,
+        },
+      ],
+    };
+
+    mockAxios.get.mockResolvedValue({ data: businessIdMockResponse });
+    expect(await client.getMatchedBusinessIds(mockAccessToken, mockNametoSearch)).toEqual([
+      mockBusinessId1,
+      mockBusinessId2,
+    ]);
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/accounts?$select=name,accountid&$filter=(contains(name, '${mockNametoSearch}'))&$top=50`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+  });
+
+  it("rejects with NO_MATCH error when received data value is an empty array", async () => {
+    mockAxios.get.mockResolvedValue({ data: { value: [] } });
+    const expectedThrownError = client.getMatchedBusinessIds(mockAccessToken, mockNametoSearch);
+    await expect(expectedThrownError).rejects.toEqual(new Error(NO_MATCH_ERROR));
+  });
+});

--- a/api/src/client/dynamics/DynamicsBusinessIdsClient.ts
+++ b/api/src/client/dynamics/DynamicsBusinessIdsClient.ts
@@ -1,0 +1,42 @@
+import { NO_MATCH_ERROR } from "@domain/types";
+import { LogWriterType } from "@libs/logWriter";
+import axios, { AxiosError } from "axios";
+import { BusinessIdClient } from "./types";
+
+export const DynamicsBusinessIdsClient = (logWriter: LogWriterType, orgUrl: string): BusinessIdClient => {
+  const getMatchedBusinessIds = async (accessToken: string, nameToSearch: string): Promise<string[]> => {
+    const logId = logWriter.GetId();
+    logWriter.LogInfo(`Dynamics Business Id Client - Id:${logId}`);
+    return axios
+      .get(
+        `${orgUrl}/api/data/v9.2/accounts?$select=name,accountid&$filter=(contains(name, '${nameToSearch}'))&$top=50`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      )
+      .then((response) => {
+        logWriter.LogInfo(
+          `Dynamics Business Id Client - Id:${logId} - Response: ${JSON.stringify(response.data)}`
+        );
+
+        if (response.data.value.length === 0) throw new Error(NO_MATCH_ERROR);
+        return response.data.value.map((idObj: BusinessIdResponse) => idObj.accountid);
+      })
+      .catch((error: AxiosError) => {
+        if (error.message === NO_MATCH_ERROR) throw error;
+        logWriter.LogError(`Dynamics Business Id Client - Id:${logId} - Error:`, error);
+        throw error.response?.status;
+      });
+  };
+
+  return {
+    getMatchedBusinessIds,
+  };
+};
+
+type BusinessIdResponse = {
+  name: string;
+  accountid: string;
+};

--- a/api/src/client/dynamics/DynamicsChecklistItemsClient.test.ts
+++ b/api/src/client/dynamics/DynamicsChecklistItemsClient.test.ts
@@ -1,0 +1,74 @@
+/* eslint-disable unicorn/no-null */
+import axios from "axios";
+import { LogWriter, LogWriterType } from "../../libs/logWriter";
+import { DynamicsChecklistItemsClient } from "./DynamicsChecklistItemsClient";
+import { ChecklistItemsClient } from "./types";
+
+jest.mock("axios");
+jest.mock("winston");
+const mockAxios = axios as jest.Mocked<typeof axios>;
+
+describe("DynamicsChecklistItemsClient", () => {
+  let client: ChecklistItemsClient;
+  let logger: LogWriterType;
+
+  const ORG_URL = "www.test-org-url.com";
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    logger = LogWriter("NavigatorWebService", "ApiLogs", "us-test-1");
+
+    client = DynamicsChecklistItemsClient(logger, ORG_URL);
+  });
+
+  const mocklicenseApplicationId = "123456";
+  const mockAccessToken = "access-granted";
+
+  it("makes a get request to dynamics api with the checklist items query and auth token in the header", async () => {
+    const mockChecklistItemsResponse = {
+      value: [
+        {
+          activitytypecode: "rgb_checklistitem",
+          rgb_categorycode: 100000000,
+          statecode: 0,
+          subject: "Business Forms - Cert of Inc, Formation, Trade Names",
+          statuscode: 1,
+          activityid: "69aead2d-9fff-ed11-8847-001dd803435d",
+        },
+        {
+          activitytypecode: "rgb_checklistitem",
+          rgb_categorycode: 100000000,
+          statecode: 0,
+          subject: "Registration Fee",
+          statuscode: 2,
+          activityid: "fec7d939-9fff-ed11-8847-001dd803435d",
+        },
+      ],
+    };
+
+    mockAxios.get.mockResolvedValue({ data: mockChecklistItemsResponse });
+    expect(await client.getChecklistItems(mockAccessToken, mocklicenseApplicationId)).toEqual([
+      {
+        title: "Business Forms - Cert of Inc, Formation, Trade Names",
+        status: "PENDING",
+      },
+      {
+        title: "Registration Fee",
+        status: "ACTIVE",
+      },
+    ]);
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/rgb_checklistitems?$select=activitytypecode,rgb_categorycode,statecode,subject,statuscode&$filter=(_regardingobjectid_value eq ${mocklicenseApplicationId})&$top=50`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+  });
+
+  it("returns empty array if received data value is empty", async () => {
+    mockAxios.get.mockResolvedValue({ data: { value: [] } });
+    expect(await client.getChecklistItems(mockAccessToken, mocklicenseApplicationId)).toEqual([]);
+  });
+});

--- a/api/src/client/dynamics/DynamicsChecklistItemsClient.ts
+++ b/api/src/client/dynamics/DynamicsChecklistItemsClient.ts
@@ -1,0 +1,66 @@
+import { LogWriterType } from "@libs/logWriter";
+import { CheckoffStatus, LicenseStatusItem } from "@shared/license";
+import axios, { AxiosError } from "axios";
+import { ChecklistItemsClient } from "./types";
+
+export const DynamicsChecklistItemsClient = (
+  logWriter: LogWriterType,
+  orgUrl: string
+): ChecklistItemsClient => {
+  const getChecklistItems = async (
+    accessToken: string,
+    licenseApplicationId: string
+  ): Promise<LicenseStatusItem[]> => {
+    const logId = logWriter.GetId();
+    logWriter.LogInfo(`Dynamics Checklist Items Client - Id:${logId}`);
+    return axios
+      .get(
+        `${orgUrl}/api/data/v9.2/rgb_checklistitems?$select=activitytypecode,rgb_categorycode,statecode,subject,statuscode&$filter=(_regardingobjectid_value eq ${licenseApplicationId})&$top=50`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      )
+      .then((response) => {
+        logWriter.LogInfo(
+          `Dynamics Checklist Items Client - Id:${logId} - Response: ${JSON.stringify(response.data)}`
+        );
+
+        return response.data.value.map((checklistItem: DynamicsApiChecklistItemsResponse) =>
+          processChecklistItems(checklistItem)
+        );
+      })
+      .catch((error: AxiosError) => {
+        logWriter.LogError(`Dynamics Checklist Items Client - Id:${logId} - Error:`, error);
+        throw error.response?.status;
+      });
+  };
+
+  return {
+    getChecklistItems,
+  };
+};
+
+type DynamicsApiChecklistItemsResponse = {
+  activitytypecode: string;
+  rgb_categorycode: number;
+  statecode: number;
+  subject: string;
+  statuscode: number;
+  activityid: string;
+};
+
+const statusCodeToChecklistItemStatus: Record<number, CheckoffStatus> = {
+  1: "PENDING",
+  2: "ACTIVE",
+  3: "PENDING",
+  4: "PENDING",
+};
+
+const processChecklistItems = (checklistItem: DynamicsApiChecklistItemsResponse): LicenseStatusItem => {
+  return {
+    title: checklistItem.subject,
+    status: statusCodeToChecklistItemStatus[checklistItem.statuscode],
+  };
+};

--- a/api/src/client/dynamics/DynamicsLicenseApplicationIdClient.test.ts
+++ b/api/src/client/dynamics/DynamicsLicenseApplicationIdClient.test.ts
@@ -1,0 +1,236 @@
+/* eslint-disable unicorn/no-null */
+import { MULTIPLE_MAIN_APPS_ERROR, NO_MAIN_APPS_ERROR } from "@domain/types";
+import { LogWriter, LogWriterType } from "@libs/logWriter";
+import axios from "axios";
+import { DynamicsLicenseApplicationIdClient } from "./DynamicsLicenseApplicationIdClient";
+import { LicenseApplicationIdClient } from "./types";
+
+jest.mock("axios");
+jest.mock("winston");
+const mockAxios = axios as jest.Mocked<typeof axios>;
+
+describe("DynamicsLicenseApplicationIdClient", () => {
+  let client: LicenseApplicationIdClient;
+  let logger: LogWriterType;
+
+  const ORG_URL = "www.test-org-url.com";
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    logger = LogWriter("NavigatorWebService", "ApiLogs", "us-test-1");
+    client = DynamicsLicenseApplicationIdClient(logger, ORG_URL);
+  });
+
+  const mockBusinessId = "123456";
+  const mockAccessToken = "access-granted";
+  const publicMoversAndWarehousemenLicenseTypeId = "19391a3f-53df-eb11-bacb-001dd8028561";
+
+  it("makes a get request to dynamics api with the license application id query and auth token in header", async () => {
+    const mockLicenseApplicationIdResponse = {
+      value: [
+        {
+          rgb_appnumber: "MLI00030602",
+          rgb_number: "39PM00105300",
+          rgb_startdate: "2023-06-07T11:49:24Z",
+          rgb_versioncode: 100000000,
+          rgb_expirationdate: "2023-09-30T00:00:00Z",
+          statecode: 0,
+          statuscode: 100000006,
+          rgb_applicationid: "7b5c178c-2805-ee11-a81c-001dd805ef6c",
+          _rgb_businessid_value: "6182f96b-2105-ee11-a81c-001dd805ef6c",
+        },
+        {
+          rgb_appnumber: "WLI00030610",
+          rgb_number: "39PW00105401",
+          rgb_startdate: "2023-06-08T04:44:34Z",
+          rgb_versioncode: 100000000,
+          rgb_expirationdate: "2023-09-30T00:00:00Z",
+          statecode: 0,
+          statuscode: 100000006,
+          rgb_applicationid: "8b7bbfb9-b605-ee11-a81c-001dd80648b3",
+          _rgb_businessid_value: "6182f96b-2105-ee11-a81c-001dd805ef6c",
+        },
+        {
+          rgb_appnumber: "MLI00030615",
+          rgb_number: "39PM00105502",
+          rgb_startdate: "2023-06-08T04:52:25Z",
+          rgb_versioncode: 100000000,
+          rgb_expirationdate: "2023-09-30T00:00:00Z",
+          statecode: 0,
+          statuscode: 100000006,
+          rgb_applicationid: "1abb2efc-b705-ee11-a81c-001dd80648b3",
+          _rgb_businessid_value: "6182f96b-2105-ee11-a81c-001dd805ef6c",
+        },
+      ],
+    };
+
+    mockAxios.get.mockResolvedValue({ data: mockLicenseApplicationIdResponse });
+    expect(
+      await client.getLicenseApplicationId(mockAccessToken, mockBusinessId, "Public Movers and Warehousemen")
+    ).toEqual({
+      expirationDate: "2023-09-30T00:00:00Z",
+      applicationId: "7b5c178c-2805-ee11-a81c-001dd805ef6c",
+      licenseStatus: "ACTIVE",
+    });
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/rgb_applications?$select=rgb_appnumber,rgb_number,rgb_startdate,rgb_versioncode,rgb_expirationdate,statecode,statuscode,rgb_applicationid&$filter=(_rgb_businessid_value eq ${mockBusinessId} and _rgb_apptypeid_value eq ${publicMoversAndWarehousemenLicenseTypeId})&$top=50`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+  });
+
+  it("filters out applications whose statecode is not 0", async () => {
+    const mockLicenseApplicationIdResponse = {
+      value: [
+        {
+          rgb_appnumber: "INACTIVE1234",
+          rgb_number: "39PW00105401",
+          rgb_startdate: null,
+          rgb_versioncode: 100000000,
+          rgb_expirationdate: null,
+          statecode: 1,
+          statuscode: 100000005,
+          rgb_applicationid: "license-id-1357",
+        },
+        {
+          rgb_appnumber: "TELI00030500",
+          rgb_number: "39PW00105400",
+          rgb_startdate: null,
+          rgb_versioncode: 100000000,
+          rgb_expirationdate: null,
+          statecode: 0,
+          statuscode: 100000005,
+          rgb_applicationid: "license-id-1357",
+        },
+      ],
+    };
+
+    mockAxios.get.mockResolvedValue({ data: mockLicenseApplicationIdResponse });
+    expect(
+      await client.getLicenseApplicationId(mockAccessToken, mockBusinessId, "Public Movers and Warehousemen")
+    ).toEqual({
+      expirationDate: "",
+      applicationId: "license-id-1357",
+      licenseStatus: "APPROVED",
+    });
+  });
+
+  it("filters out applications whose rgb_number doesn't end with 00", async () => {
+    const mockLicenseApplicationIdResponse = {
+      value: [
+        {
+          rgb_appnumber: "WLI00030610",
+          rgb_number: "39PW00105401",
+          rgb_startdate: "2023-06-08T04:44:34Z",
+          rgb_versioncode: 100000000,
+          rgb_expirationdate: "2023-09-30T00:00:00Z",
+          statecode: 0,
+          statuscode: 100000006,
+          rgb_applicationid: "8b7bbfb9-b605-ee11-a81c-001dd80648b3",
+          _rgb_businessid_value: "6182f96b-2105-ee11-a81c-001dd805ef6c",
+        },
+        {
+          rgb_appnumber: "MLI00030615",
+          rgb_number: "39PM00105502",
+          rgb_startdate: "2023-06-08T04:52:25Z",
+          rgb_versioncode: 100000000,
+          rgb_expirationdate: "2023-09-30T00:00:00Z",
+          statecode: 0,
+          statuscode: 100000006,
+          rgb_applicationid: "1abb2efc-b705-ee11-a81c-001dd80648b3",
+          _rgb_businessid_value: "6182f96b-2105-ee11-a81c-001dd805ef6c",
+        },
+        {
+          rgb_appnumber: "MLI00030602",
+          rgb_number: "39PM00105300",
+          rgb_startdate: "2023-06-07T11:49:24Z",
+          rgb_versioncode: 100000000,
+          rgb_expirationdate: "2023-09-30T00:00:00Z",
+          statecode: 0,
+          statuscode: 100000006,
+          rgb_applicationid: "7b5c178c-2805-ee11-a81c-001dd805ef6c",
+          _rgb_businessid_value: "6182f96b-2105-ee11-a81c-001dd805ef6c",
+        },
+      ],
+    };
+
+    mockAxios.get.mockResolvedValue({ data: mockLicenseApplicationIdResponse });
+    expect(
+      await client.getLicenseApplicationId(mockAccessToken, mockBusinessId, "Public Movers and Warehousemen")
+    ).toEqual({
+      expirationDate: "2023-09-30T00:00:00Z",
+      applicationId: "7b5c178c-2805-ee11-a81c-001dd805ef6c",
+      licenseStatus: "ACTIVE",
+    });
+  });
+
+  it("throws NO_MAIN_APPS error when there are no matching apps whose rgb_number ends with 00", async () => {
+    mockAxios.get.mockResolvedValue({
+      data: {
+        value: [
+          {
+            rgb_appnumber: "WLI00030610",
+            rgb_number: "39PW00105401",
+            rgb_startdate: "2023-06-08T04:44:34Z",
+            rgb_versioncode: 100000000,
+            rgb_expirationdate: "2023-09-30T00:00:00Z",
+            statecode: 0,
+            statuscode: 100000006,
+            rgb_applicationid: "8b7bbfb9-b605-ee11-a81c-001dd80648b3",
+            _rgb_businessid_value: "6182f96b-2105-ee11-a81c-001dd805ef6c",
+          },
+        ],
+      },
+    });
+    await expect(
+      client.getLicenseApplicationId(mockAccessToken, mockBusinessId, "Public Movers and Warehousemen")
+    ).rejects.toEqual(new Error(NO_MAIN_APPS_ERROR));
+  });
+
+  it("throws MULTIPLE_MAIN_APPS error when there are multiple matching apps whose rgb_number ends with 00", async () => {
+    const mockResponseWithMultipleMainApplications = {
+      value: [
+        {
+          rgb_appnumber: "WLI00030610",
+          rgb_number: "39PW00105401",
+          rgb_startdate: "2023-06-08T04:44:34Z",
+          rgb_versioncode: 100000000,
+          rgb_expirationdate: "2023-09-30T00:00:00Z",
+          statecode: 0,
+          statuscode: 100000006,
+          rgb_applicationid: "8b7bbfb9-b605-ee11-a81c-001dd80648b3",
+          _rgb_businessid_value: "6182f96b-2105-ee11-a81c-001dd805ef6c",
+        },
+        {
+          rgb_appnumber: "MLI00030615",
+          rgb_number: "39PM00105500",
+          rgb_startdate: "2023-06-08T04:52:25Z",
+          rgb_versioncode: 100000000,
+          rgb_expirationdate: "2023-09-30T00:00:00Z",
+          statecode: 0,
+          statuscode: 100000006,
+          rgb_applicationid: "1abb2efc-b705-ee11-a81c-001dd80648b3",
+          _rgb_businessid_value: "6182f96b-2105-ee11-a81c-001dd805ef6c",
+        },
+        {
+          rgb_appnumber: "MLI00030602",
+          rgb_number: "39PM00105300",
+          rgb_startdate: "2023-06-07T11:49:24Z",
+          rgb_versioncode: 100000000,
+          rgb_expirationdate: "2023-09-30T00:00:00Z",
+          statecode: 0,
+          statuscode: 100000006,
+          rgb_applicationid: "7b5c178c-2805-ee11-a81c-001dd805ef6c",
+          _rgb_businessid_value: "6182f96b-2105-ee11-a81c-001dd805ef6c",
+        },
+      ],
+    };
+    mockAxios.get.mockResolvedValue({ data: mockResponseWithMultipleMainApplications });
+    await expect(
+      client.getLicenseApplicationId(mockAccessToken, mockBusinessId, "Public Movers and Warehousemen")
+    ).rejects.toEqual(new Error(MULTIPLE_MAIN_APPS_ERROR));
+  });
+});

--- a/api/src/client/dynamics/DynamicsLicenseApplicationIdClient.ts
+++ b/api/src/client/dynamics/DynamicsLicenseApplicationIdClient.ts
@@ -1,0 +1,118 @@
+import { MULTIPLE_MAIN_APPS_ERROR, NO_MAIN_APPS_ERROR } from "@domain/types";
+import { LogWriterType } from "@libs/logWriter";
+import { LicenseStatus } from "@shared/license";
+import axios, { AxiosError } from "axios";
+import {
+  ACTIVE_STATECODE,
+  LicenseApplicationIdClient,
+  LicenseApplicationIdResponse,
+  MAIN_APP_END_DIGITS,
+} from "./types";
+
+export const DynamicsLicenseApplicationIdClient = (
+  logWriter: LogWriterType,
+  orgUrl: string
+): LicenseApplicationIdClient => {
+  const getLicenseApplicationId = (
+    accessToken: string,
+    businessId: string,
+    licenseType: string
+  ): Promise<LicenseApplicationIdResponse> => {
+    const logId = logWriter.GetId();
+    logWriter.LogInfo(`Dynamics License Application Id Client - Id:${logId}`);
+
+    return axios
+      .get(
+        `${orgUrl}/api/data/v9.2/rgb_applications?$select=rgb_appnumber,rgb_number,rgb_startdate,rgb_versioncode,rgb_expirationdate,statecode,statuscode,rgb_applicationid&$filter=(_rgb_businessid_value eq ${businessId} and _rgb_apptypeid_value eq ${licenseTypeToLicenseId[licenseType]})&$top=50`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      )
+      .then((response) => {
+        logWriter.LogInfo(
+          `Dynamics License Application Id Client - Id:${logId} - Response: ${JSON.stringify(response.data)}`
+        );
+
+        const mainActiveApplications = response.data.value
+          .filter(
+            (applicationDetails: LicenseApplicationIdApiResponse) =>
+              applicationDetails.statecode === ACTIVE_STATECODE
+          )
+          .filter(
+            (applicationDetails: LicenseApplicationIdApiResponse) =>
+              applicationDetails.rgb_number.slice(-2) === MAIN_APP_END_DIGITS
+          );
+
+        if (mainActiveApplications.length === 0) {
+          throw new Error(NO_MAIN_APPS_ERROR);
+        }
+
+        if (mainActiveApplications.length > 1) {
+          throw new Error(MULTIPLE_MAIN_APPS_ERROR);
+        }
+
+        return processApplicationDetails(mainActiveApplications[0]);
+      })
+      .catch((error: AxiosError) => {
+        logWriter.LogError(`Dynamics License Application Id Client - Id:${logId} - Error:`, error);
+        if (error.message === NO_MAIN_APPS_ERROR || error.message === MULTIPLE_MAIN_APPS_ERROR) throw error;
+        throw error.response?.status;
+      });
+  };
+
+  return {
+    getLicenseApplicationId,
+  };
+};
+
+const licenseTypeToLicenseId: Record<string, string> = {
+  "Public Movers and Warehousemen": "19391a3f-53df-eb11-bacb-001dd8028561",
+  "Home Improvement Contractor": "7a391a3f-53df-eb11-bacb-001dd8028561",
+};
+
+const statusCodeToLicenseStatus: Record<number, LicenseStatus> = {
+  1: "DRAFT",
+  100000000: "SUBMITTED",
+  100000001: "UNDER_INTERNAL_REVIEW",
+  100000017: "SPECIAL_REVIEW",
+  100000002: "PENDING_DEFICIENCIES",
+  100000003: "DEFICIENCIES_SUBMITTED",
+  100000004: "CHECKLIST_COMPLETED",
+  100000005: "APPROVED",
+  100000006: "ACTIVE",
+  100000007: "PENDING_RENEWAL",
+  100000008: "PENDING_REINSTATEMENT",
+  100000018: "EXPIRED",
+  2: "INACTIVE",
+  100000009: "WITHDRAWN",
+  100000010: "ABANDONED",
+  100000011: "DENIED",
+  100000012: "EXPIRED",
+  100000013: "SUSPENDED",
+  100000014: "REVOKED",
+  100000015: "CLOSED",
+  100000016: "BARRED",
+};
+
+type LicenseApplicationIdApiResponse = {
+  rgb_appnumber: string;
+  rgb_number: string;
+  rgb_startdate: string;
+  rgb_versioncode: number;
+  rgb_expirationdate: string;
+  statecode: number;
+  statuscode: number;
+  rgb_applicationid: string;
+};
+
+const processApplicationDetails = (
+  response: LicenseApplicationIdApiResponse
+): LicenseApplicationIdResponse => {
+  return {
+    expirationDate: response.rgb_expirationdate || "",
+    applicationId: response.rgb_applicationid || "",
+    licenseStatus: statusCodeToLicenseStatus[response.statuscode] || "",
+  };
+};

--- a/api/src/client/dynamics/DynamicsLicenseStatusClient.test.ts
+++ b/api/src/client/dynamics/DynamicsLicenseStatusClient.test.ts
@@ -1,0 +1,152 @@
+import {
+  MULTIPLE_MAIN_APPS_ERROR,
+  NO_MAIN_APPS_ERROR,
+  NO_MATCH_ERROR,
+  SearchLicenseStatus,
+} from "@domain/types";
+import { LogWriter, LogWriterType } from "@libs/logWriter";
+import { DynamicsLicenseStatusClient } from "./DynamicsLicenseStatusClient";
+import {
+  AccessTokenClient,
+  BusinessAddressClient,
+  BusinessIdClient,
+  ChecklistItemsClient,
+  LicenseApplicationIdClient,
+} from "./types";
+
+describe("DynamicsLicenseStatusClient", () => {
+  let client: SearchLicenseStatus;
+  let logger: LogWriterType;
+
+  let stubAccessTokenClient: jest.Mocked<AccessTokenClient>;
+  let stubBusinessIdClient: jest.Mocked<BusinessIdClient>;
+  let stubBusinessAddressClient: jest.Mocked<BusinessAddressClient>;
+  let stubChecklistItemsClient: jest.Mocked<ChecklistItemsClient>;
+  let stubLicenseApplicationIdClient: jest.Mocked<LicenseApplicationIdClient>;
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    logger = LogWriter("NavigatorWebService", "ApiLogs", "us-test-1");
+
+    stubAccessTokenClient = {
+      getAccessToken: jest.fn(),
+    };
+
+    stubBusinessIdClient = {
+      getMatchedBusinessIds: jest.fn(),
+    };
+    stubBusinessAddressClient = {
+      getBusinessIdsAndLicenseSearchAddresses: jest.fn(),
+    };
+    stubChecklistItemsClient = {
+      getChecklistItems: jest.fn(),
+    };
+    stubLicenseApplicationIdClient = {
+      getLicenseApplicationId: jest.fn(),
+    };
+
+    client = DynamicsLicenseStatusClient(logger, {
+      accessTokenClient: stubAccessTokenClient,
+      businessIdClient: stubBusinessIdClient,
+      businessAddressClient: stubBusinessAddressClient,
+      licenseApplicationIdClient: stubLicenseApplicationIdClient,
+      checklistItemsClient: stubChecklistItemsClient,
+    });
+  });
+
+  it("returns a license status result", async () => {
+    stubBusinessAddressClient.getBusinessIdsAndLicenseSearchAddresses.mockResolvedValue([
+      {
+        businessId: "mockBusinessId",
+        addresses: [{ addressLine1: "123 Main St", addressLine2: "Apt 101", zipCode: "12345" }],
+      },
+    ]);
+    stubLicenseApplicationIdClient.getLicenseApplicationId.mockResolvedValue({
+      expirationDate: "2023-12-3",
+      applicationId: "app-id-123",
+      licenseStatus: "ACTIVE",
+    });
+    stubChecklistItemsClient.getChecklistItems.mockResolvedValue([
+      {
+        title: "Business Forms - Cert of Inc, Formation, Trade Names",
+        status: "PENDING",
+      },
+      {
+        title: "Registration Fee",
+        status: "ACTIVE",
+      },
+    ]);
+
+    const nameAndAddress = {
+      name: "Public Movers Test Business",
+      addressLine1: "123 Main St",
+      addressLine2: "Apt 101",
+      zipCode: "12345",
+    };
+
+    const result = await client(nameAndAddress, "Public Movers and Warehousemen");
+
+    expect(result).toEqual({
+      status: "ACTIVE",
+      expirationISO: "2023-12-3",
+      checklistItems: [
+        {
+          title: "Business Forms - Cert of Inc, Formation, Trade Names",
+          status: "PENDING",
+        },
+        {
+          title: "Registration Fee",
+          status: "ACTIVE",
+        },
+      ],
+    });
+  });
+
+  it("throws a NO_MATCH error when a sub client client throws a NO_MATCH error", async () => {
+    stubBusinessIdClient.getMatchedBusinessIds.mockRejectedValue(new Error(NO_MATCH_ERROR));
+    const nameAndAddress = {
+      name: "Public Movers Test Business",
+      addressLine1: "123 Main St",
+      addressLine2: "Apt 101",
+      zipCode: "12345",
+    };
+    await expect(client(nameAndAddress, "Public Movers and Warehousemen")).rejects.toThrow(NO_MATCH_ERROR);
+  });
+
+  it.each([{ errorCode: NO_MAIN_APPS_ERROR }, { errorCode: MULTIPLE_MAIN_APPS_ERROR }])(
+    "throws a $errorCode error when a sub client client throws a $errorCode error",
+    async ({ errorCode }) => {
+      stubBusinessAddressClient.getBusinessIdsAndLicenseSearchAddresses.mockResolvedValue([
+        {
+          businessId: "mockBusinessId",
+          addresses: [{ addressLine1: "123 Main St", addressLine2: "Apt 101", zipCode: "12345" }],
+        },
+      ]);
+      stubLicenseApplicationIdClient.getLicenseApplicationId.mockRejectedValue(new Error(errorCode));
+      const nameAndAddress = {
+        name: "Public Movers Test Business",
+        addressLine1: "123 Main St",
+        addressLine2: "Apt 101",
+        zipCode: "12345",
+      };
+      await expect(client(nameAndAddress, "Public Movers and Warehousemen")).rejects.toThrow(errorCode);
+    }
+  );
+
+  it("throws a 400 error when a sub client client throws a 400", async () => {
+    stubBusinessAddressClient.getBusinessIdsAndLicenseSearchAddresses.mockResolvedValue([
+      {
+        businessId: "mockBusinessId",
+        addresses: [{ addressLine1: "123 Main St", addressLine2: "Apt 101", zipCode: "12345" }],
+      },
+    ]);
+    stubLicenseApplicationIdClient.getLicenseApplicationId.mockRejectedValue(new Error("400"));
+    const nameAndAddress = {
+      name: "Public Movers Test Business",
+      addressLine1: "123 Main St",
+      addressLine2: "Apt 101",
+      zipCode: "12345",
+    };
+    await expect(client(nameAndAddress, "Public Movers and Warehousemen")).rejects.toThrow("400");
+  });
+});

--- a/api/src/client/dynamics/DynamicsLicenseStatusClient.ts
+++ b/api/src/client/dynamics/DynamicsLicenseStatusClient.ts
@@ -1,0 +1,71 @@
+import { SearchLicenseStatus } from "@domain/types";
+import { LogWriterType } from "@libs/logWriter";
+import { LicenseSearchNameAndAddress, LicenseStatusResult } from "@shared/license";
+import { searchBusinessAddressesForMatch } from "./searchBusinessAddressesForMatch";
+import {
+  AccessTokenClient,
+  BusinessAddressClient,
+  BusinessIdClient,
+  ChecklistItemsClient,
+  LicenseApplicationIdClient,
+} from "./types";
+
+type Config = {
+  accessTokenClient: AccessTokenClient;
+  businessIdClient: BusinessIdClient;
+  businessAddressClient: BusinessAddressClient;
+  licenseApplicationIdClient: LicenseApplicationIdClient;
+  checklistItemsClient: ChecklistItemsClient;
+};
+
+export const DynamicsLicenseStatusClient = (
+  logWriter: LogWriterType,
+  config: Config
+): SearchLicenseStatus => {
+  return async (
+    nameAndAddress: LicenseSearchNameAndAddress,
+    licenseType: string
+  ): Promise<LicenseStatusResult> => {
+    const accessToken = await config.accessTokenClient.getAccessToken();
+
+    const matchedBusinessIds = await config.businessIdClient.getMatchedBusinessIds(
+      accessToken,
+      nameAndAddress.name
+    );
+
+    const businessIdsAndLicenseSearchAddresses =
+      await config.businessAddressClient.getBusinessIdsAndLicenseSearchAddresses(
+        accessToken,
+        matchedBusinessIds
+      );
+
+    const matchedBusinessIdByAddress = searchBusinessAddressesForMatch(
+      businessIdsAndLicenseSearchAddresses,
+      nameAndAddress
+    );
+
+    const applicationIdResponse = await config.licenseApplicationIdClient.getLicenseApplicationId(
+      accessToken,
+      matchedBusinessIdByAddress,
+      licenseType
+    );
+
+    const checkListItems = await config.checklistItemsClient.getChecklistItems(
+      accessToken,
+      applicationIdResponse.applicationId
+    );
+
+    const response = {
+      status: applicationIdResponse.licenseStatus,
+      expirationISO: applicationIdResponse.expirationDate,
+      checklistItems: checkListItems,
+    };
+
+    const logId = logWriter.GetId();
+    logWriter.LogInfo(
+      `Dynamics License Status Client - Id:${logId} - Response:  ${JSON.stringify(response)}`
+    );
+
+    return response;
+  };
+};

--- a/api/src/client/dynamics/searchBusinessAddressesForMatch.test.ts
+++ b/api/src/client/dynamics/searchBusinessAddressesForMatch.test.ts
@@ -1,0 +1,121 @@
+import { NO_MATCH_ERROR } from "@domain/types";
+import { generateLicenseSearchAddress } from "@shared/test";
+import { searchBusinessAddressesForMatch } from "./searchBusinessAddressesForMatch";
+
+describe("searchBusinessAddressesForMatch", () => {
+  const userInputtedAddress = generateLicenseSearchAddress({
+    addressLine1: "Main St",
+    addressLine2: "Apt 1",
+    zipCode: "12345",
+  });
+  const matchedAddress1 = generateLicenseSearchAddress({
+    addressLine1: "Main St",
+    addressLine2: "Apt 1",
+    zipCode: "12345",
+  });
+  const matchedAddress2 = generateLicenseSearchAddress({
+    addressLine1: "Main St",
+    addressLine2: "Apt 1",
+    zipCode: "12345",
+  });
+  const randomBusinessWithRandomAddresses1 = {
+    businessId: "randomBusiness1",
+    addresses: [generateLicenseSearchAddress({}), generateLicenseSearchAddress({})],
+  };
+  const randomBusinessWithRandomAddresses2 = {
+    businessId: "randomBusiness2",
+    addresses: [generateLicenseSearchAddress({}), generateLicenseSearchAddress({})],
+  };
+  const businessWithNoAddresses = {
+    businessId: "noAddressBusiness",
+    addresses: [],
+  };
+
+  describe("single business ids", () => {
+    it("returns correct business id when it has two matching addresses", () => {
+      const businessIdAndMatchingAddresses = {
+        businessId: "matchingBusinessId-1234",
+        addresses: [matchedAddress1, matchedAddress2],
+      };
+      const result = searchBusinessAddressesForMatch([businessIdAndMatchingAddresses], userInputtedAddress);
+      expect(result).toEqual("matchingBusinessId-1234");
+    });
+
+    it("throws error when there is no match", () => {
+      expect(() =>
+        searchBusinessAddressesForMatch([randomBusinessWithRandomAddresses1], userInputtedAddress)
+      ).toThrow(NO_MATCH_ERROR);
+    });
+
+    it("throws error when there are no addresses", () => {
+      expect(() => searchBusinessAddressesForMatch([businessWithNoAddresses], userInputtedAddress)).toThrow(
+        NO_MATCH_ERROR
+      );
+    });
+  });
+
+  describe("multiple business ids", () => {
+    it("returns correct business id when it has one matching address", () => {
+      const businessIdWithMatchingAddress = {
+        businessId: "matchingBusinessId-1234",
+        addresses: [matchedAddress1, generateLicenseSearchAddress({})],
+      };
+      const result = searchBusinessAddressesForMatch(
+        [businessIdWithMatchingAddress, randomBusinessWithRandomAddresses1],
+        userInputtedAddress
+      );
+      expect(result).toEqual("matchingBusinessId-1234");
+    });
+
+    it("returns correct business id when it has two matching addresses", () => {
+      const businessIdAndMatchingAddresses = {
+        businessId: "matchingBusinessId-1234",
+        addresses: [matchedAddress1, matchedAddress2],
+      };
+      const result = searchBusinessAddressesForMatch(
+        [businessIdAndMatchingAddresses, randomBusinessWithRandomAddresses1],
+        userInputtedAddress
+      );
+      expect(result).toEqual("matchingBusinessId-1234");
+    });
+
+    it("returns correct business id when it has one matching address and other has no address", () => {
+      const businessIdAndMatchingAddresses = {
+        businessId: "matchingBusinessId-1234",
+        addresses: [matchedAddress1, generateLicenseSearchAddress({})],
+      };
+
+      const result = searchBusinessAddressesForMatch(
+        [businessWithNoAddresses, businessIdAndMatchingAddresses],
+        userInputtedAddress
+      );
+      expect(result).toEqual("matchingBusinessId-1234");
+    });
+
+    it("throws error when there is no match", () => {
+      expect(() =>
+        searchBusinessAddressesForMatch(
+          [randomBusinessWithRandomAddresses1, randomBusinessWithRandomAddresses2],
+          userInputtedAddress
+        )
+      ).toThrow(NO_MATCH_ERROR);
+    });
+
+    it("throws error when there is more than one match across two different business ids", () => {
+      const businessIdAndMatchingAddresses1 = {
+        businessId: "businessId1",
+        addresses: [matchedAddress1, generateLicenseSearchAddress({})],
+      };
+      const businessIdAndMatchingAddresses2 = {
+        businessId: "businessId2",
+        addresses: [matchedAddress2, generateLicenseSearchAddress({})],
+      };
+      expect(() =>
+        searchBusinessAddressesForMatch(
+          [businessIdAndMatchingAddresses1, businessIdAndMatchingAddresses2],
+          userInputtedAddress
+        )
+      ).toThrow(NO_MATCH_ERROR);
+    });
+  });
+});

--- a/api/src/client/dynamics/searchBusinessAddressesForMatch.ts
+++ b/api/src/client/dynamics/searchBusinessAddressesForMatch.ts
@@ -1,0 +1,32 @@
+import { NO_MATCH_ERROR } from "@domain/types";
+import { LicenseSearchAddress } from "@shared/license";
+import { BusinessIdAndLicenseSearchAddresses } from "./types";
+
+export const searchBusinessAddressesForMatch = (
+  businessIdsAndLicenseAddresses: BusinessIdAndLicenseSearchAddresses[],
+  nameAndAddress: LicenseSearchAddress
+): string => {
+  const result: string[] = [];
+
+  const isAddressMatch = (
+    address: LicenseSearchAddress,
+    userInputtedAddress: LicenseSearchAddress
+  ): boolean => {
+    return (
+      userInputtedAddress.addressLine1 === address.addressLine1 &&
+      address.zipCode === userInputtedAddress.zipCode
+    );
+  };
+
+  for (const { businessId, addresses } of businessIdsAndLicenseAddresses) {
+    for (const address of addresses) {
+      if (isAddressMatch(address, nameAndAddress)) {
+        result.push(businessId);
+        break;
+      }
+    }
+  }
+
+  if (result.length !== 1) throw new Error(NO_MATCH_ERROR);
+  return result[0];
+};

--- a/api/src/client/dynamics/types.ts
+++ b/api/src/client/dynamics/types.ts
@@ -1,0 +1,42 @@
+import { LicenseSearchAddress, LicenseStatus, LicenseStatusItem } from "@shared/license";
+
+export interface AccessTokenClient {
+  getAccessToken: () => Promise<string>;
+}
+
+export interface BusinessIdClient {
+  getMatchedBusinessIds: (accessToken: string, nameToSearch: string) => Promise<string[]>;
+}
+
+export interface BusinessAddressClient {
+  getBusinessIdsAndLicenseSearchAddresses: (
+    accessToken: string,
+    businessIds: string[]
+  ) => Promise<BusinessIdAndLicenseSearchAddresses[]>;
+}
+
+export interface ChecklistItemsClient {
+  getChecklistItems: (accessToken: string, applicationId: string) => Promise<LicenseStatusItem[]>;
+}
+
+export interface BusinessIdAndLicenseSearchAddresses {
+  businessId: string;
+  addresses: LicenseSearchAddress[];
+}
+
+export interface LicenseApplicationIdClient {
+  getLicenseApplicationId: (
+    accessToken: string,
+    businessId: string,
+    licenseType: string
+  ) => Promise<LicenseApplicationIdResponse>;
+}
+
+export type LicenseApplicationIdResponse = {
+  expirationDate: string;
+  applicationId: string;
+  licenseStatus: LicenseStatus;
+};
+
+export const ACTIVE_STATECODE = 0;
+export const MAIN_APP_END_DIGITS = "00";

--- a/api/src/domain/license-status/searchLicenseStatusFactory.test.ts
+++ b/api/src/domain/license-status/searchLicenseStatusFactory.test.ts
@@ -1,432 +1,55 @@
-import {
-  determineLicenseStatus,
-  searchLicenseStatusFactory,
-} from "@domain/license-status/searchLicenseStatusFactory";
-import { LicenseStatusClient, SearchLicenseStatus } from "@domain/types";
-import { parseDateWithFormat } from "@shared/dateHelpers";
-import { LicenseEntity, LicenseStatusResult } from "@shared/license";
-import { generateNameAndAddress } from "@shared/test";
-import { generateLicenseEntity } from "@test/factories";
+import { searchLicenseStatusFactory } from "@domain/license-status/searchLicenseStatusFactory";
+import { SearchLicenseStatusFactory } from "@domain/types";
+import { generateLicenseSearchNameAndAddress } from "@shared/test";
 
-const entityWithAddress = (address: string): LicenseEntity => {
-  return generateLicenseEntity({
-    checkoffStatus: "Completed",
-    licenseStatus: "Active",
-    addressLine1: address,
-  });
-};
+describe("searchLicenseStatusFactory", () => {
+  let stubLegacySearchLicenseStatus: jest.Mock;
+  let stubNewSearchLicenseStatus: jest.Mock;
+  let searchLicenseStatus: SearchLicenseStatusFactory;
 
-describe("searchLicenseStatus", () => {
-  let stubLicenseStatusClient: jest.Mocked<LicenseStatusClient>;
-  let searchLicenseStatus: SearchLicenseStatus;
+  let ORIGINAL_FEATURE_DYNAMICS_PUBLIC_MOVERS: string | undefined;
 
   beforeEach(() => {
-    stubLicenseStatusClient = {
-      search: jest.fn(),
-    };
-
-    searchLicenseStatus = searchLicenseStatusFactory(stubLicenseStatusClient);
-  });
-
-  it("searches for license status on name, zipcode, and license type", async () => {
-    stubLicenseStatusClient.search.mockResolvedValue([]);
-    const nameAndAddress = generateNameAndAddress({
-      name: "Crystal",
-      zipCode: "12345",
-    });
-    await expect(searchLicenseStatus(nameAndAddress, "Home improvement")).rejects.toEqual(
-      new Error("NO_MATCH")
-    );
-    expect(stubLicenseStatusClient.search).toHaveBeenCalledWith("crystal", "12345", "Home improvement");
-  });
-
-  it("removes leading/trailing space and business designators from search name", async () => {
-    stubLicenseStatusClient.search.mockResolvedValue([]);
-    const nameAndAddress = generateNameAndAddress({
-      name: " Crystal, LLC   ",
-      zipCode: "12345",
-    });
-    await expect(searchLicenseStatus(nameAndAddress, "Home improvement")).rejects.toEqual(
-      new Error("NO_MATCH")
-    );
-    expect(stubLicenseStatusClient.search).toHaveBeenCalledWith("crystal", "12345", "Home improvement");
-  });
-
-  it("returns the status license items from most recent application with matching address", async () => {
-    stubLicenseStatusClient.search.mockResolvedValue([
-      generateLicenseEntity({
-        addressLine1: "1234 Main St",
-        applicationNumber: "SOME OLDER APPLICATION NUMBER",
-        checklistItem: "OLDER APPLICATION",
-        issueDate: "20080404 000000.000",
-      }),
-      generateLicenseEntity({
-        addressLine1: "1234 Main St",
-        applicationNumber: "12345",
-        checklistItem: "Item 1",
-        checkoffStatus: "Completed",
-        licenseStatus: "Pending",
-        issueDate: "20210404 000000.000",
-      }),
-      generateLicenseEntity({
-        addressLine1: "SOMETHING ELSE",
-        applicationNumber: "45678",
-      }),
-      generateLicenseEntity({
-        applicationNumber: "12345",
-        checklistItem: "Item 2",
-        checkoffStatus: "Completed",
-        issueDate: "20210404 000000.000",
-      }),
-    ]);
-
-    const nameAndAddress = generateNameAndAddress({
-      addressLine1: "1234 Main St",
-    });
-
-    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
-    expect(result.status).toEqual("PENDING");
-    expect(result.checklistItems).toEqual(
-      expect.arrayContaining([
-        {
-          title: "Item 1",
-          status: "ACTIVE",
-        },
-        {
-          title: "Item 2",
-          status: "ACTIVE",
-        },
-      ])
+    ORIGINAL_FEATURE_DYNAMICS_PUBLIC_MOVERS = process.env.FEATURE_DYNAMICS_PUBLIC_MOVERS;
+    process.env.FEATURE_DYNAMICS_PUBLIC_MOVERS = "true";
+    stubLegacySearchLicenseStatus = jest.fn();
+    stubNewSearchLicenseStatus = jest.fn();
+    searchLicenseStatus = searchLicenseStatusFactory(
+      stubLegacySearchLicenseStatus,
+      stubNewSearchLicenseStatus
     );
   });
 
-  it("returns an expired license if that's the most recent application", async () => {
-    stubLicenseStatusClient.search.mockResolvedValue([
-      generateLicenseEntity({
-        addressLine1: "1234 Main St",
-        applicationNumber: "SOME OLDER ACTIVE APPLICATION NUMBER",
-        checklistItem: "OLDER ACTIVE APPLICATION",
-        issueDate: "20080404 000000.000",
-      }),
-      generateLicenseEntity({
-        addressLine1: "1234 Main St",
-        applicationNumber: "12345",
-        checklistItem: "Item 1",
-        checkoffStatus: "Completed",
-        licenseStatus: "Expired",
-        issueDate: "20210404 000000.000",
-      }),
-      generateLicenseEntity({
-        applicationNumber: "12345",
-        checklistItem: "Item 2",
-        checkoffStatus: "Completed",
-        issueDate: "20210404 000000.000",
-      }),
-    ]);
-
-    const nameAndAddress = generateNameAndAddress({
-      addressLine1: "1234 Main St",
-    });
-
-    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
-    expect(result.status).toEqual("EXPIRED");
-    expect(result.checklistItems).toEqual(
-      expect.arrayContaining([
-        {
-          title: "Item 1",
-          status: "ACTIVE",
-        },
-        {
-          title: "Item 2",
-          status: "ACTIVE",
-        },
-      ])
-    );
+  afterEach(() => {
+    process.env.FEATURE_DYNAMICS_PUBLIC_MOVERS = ORIGINAL_FEATURE_DYNAMICS_PUBLIC_MOVERS;
   });
 
-  it("uses dateThisStatus as the date of an entity if issueDate is undefined", async () => {
-    stubLicenseStatusClient.search.mockResolvedValue([
-      generateLicenseEntity({
-        addressLine1: "1234 Main St",
-        applicationNumber: "SOME OLDER APPLICATION NUMBER WITH AN ISSUE DATE",
-        checklistItem: "ACTIVE OLDER APPLICATION WITH AN ISSUE DATE",
-        issueDate: "20180327 000000.000",
-      }),
-      generateLicenseEntity({
-        addressLine1: "1234 Main St",
-        applicationNumber: "12345",
-        checklistItem: "Item 1",
-        checkoffStatus: "Completed",
-        licenseStatus: "Expired",
-        issueDate: undefined,
-        dateThisStatus: "20210405 000000.000",
-        expirationDate: undefined,
-      }),
-    ]);
-
-    const nameAndAddress = generateNameAndAddress({
-      addressLine1: "1234 Main St",
+  describe("when license type is public movers and warehouse", () => {
+    it("returns new status client when env var is true", () => {
+      const licenseType = "Public Movers and Warehousemen";
+      const licenseStatus = searchLicenseStatus(licenseType);
+      licenseStatus(generateLicenseSearchNameAndAddress({}), licenseType);
+      expect(stubNewSearchLicenseStatus).toHaveBeenCalled();
+      expect(stubLegacySearchLicenseStatus).not.toHaveBeenCalled();
     });
 
-    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
-    expect(result.status).toEqual("EXPIRED");
-    expect(result.checklistItems).toEqual(
-      expect.arrayContaining([
-        {
-          title: "Item 1",
-          status: "ACTIVE",
-        },
-      ])
-    );
-  });
-
-  it("saves expirationDate as expirationISO if it exists", async () => {
-    stubLicenseStatusClient.search.mockResolvedValue([
-      generateLicenseEntity({
-        addressLine1: "1234 Main St",
-        applicationNumber: "12345",
-        checklistItem: "Item 1",
-        checkoffStatus: "Completed",
-        licenseStatus: "ACTIVE",
-        issueDate: undefined,
-        dateThisStatus: undefined,
-        expirationDate: "20210505 000000.000",
-      }),
-    ]);
-
-    const nameAndAddress = generateNameAndAddress({
-      addressLine1: "1234 Main St",
-    });
-
-    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
-    expect(result.expirationISO).toEqual(parseDateWithFormat("20210505", "YYYYMMDD").toISOString());
-  });
-
-  it("does not save the expirationDate if invalid", async () => {
-    stubLicenseStatusClient.search.mockResolvedValue([
-      generateLicenseEntity({
-        addressLine1: "1234 Main St",
-        applicationNumber: "12345",
-        checklistItem: "Item 1",
-        checkoffStatus: "Completed",
-        licenseStatus: "ACTIVE",
-        issueDate: undefined,
-        dateThisStatus: undefined,
-        expirationDate: "20210",
-      }),
-    ]);
-
-    const nameAndAddress = generateNameAndAddress({
-      addressLine1: "1234 Main St",
-    });
-
-    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
-    expect(result.expirationISO).toBeUndefined();
-  });
-
-  it("does not save the expirationDate if undefined", async () => {
-    stubLicenseStatusClient.search.mockResolvedValue([
-      generateLicenseEntity({
-        addressLine1: "1234 Main St",
-        applicationNumber: "12345",
-        checklistItem: "Item 1",
-        checkoffStatus: "Completed",
-        licenseStatus: "ACTIVE",
-        issueDate: undefined,
-        dateThisStatus: undefined,
-        expirationDate: undefined,
-      }),
-    ]);
-
-    const nameAndAddress = generateNameAndAddress({
-      addressLine1: "1234 Main St",
-    });
-
-    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
-    expect(result.expirationISO).toBeUndefined();
-  });
-
-  it("uses expirationDate as the date of an entity if issueDate and dateThisStatus are undefined", async () => {
-    stubLicenseStatusClient.search.mockResolvedValue([
-      generateLicenseEntity({
-        addressLine1: "1234 Main St",
-        applicationNumber: "SOME OLDER APPLICATION NUMBER WITH AN ISSUE DATE",
-        checklistItem: "ACTIVE OLDER APPLICATION WITH AN ISSUE DATE",
-        issueDate: "20210327 000000.000",
-      }),
-      generateLicenseEntity({
-        addressLine1: "1234 Main St",
-        applicationNumber: "12345",
-        checklistItem: "Item 1",
-        checkoffStatus: "Completed",
-        licenseStatus: "Expired",
-        issueDate: undefined,
-        dateThisStatus: undefined,
-        expirationDate: "20210505 000000.000",
-      }),
-    ]);
-
-    const nameAndAddress = generateNameAndAddress({
-      addressLine1: "1234 Main St",
-    });
-
-    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
-    expect(result.status).toEqual("EXPIRED");
-    expect(result.checklistItems).toEqual(
-      expect.arrayContaining([
-        {
-          title: "Item 1",
-          status: "ACTIVE",
-        },
-      ])
-    );
-  });
-
-  const queryWithAddress = async (address: string): Promise<LicenseStatusResult> => {
-    return await searchLicenseStatus(
-      generateNameAndAddress({
-        addressLine1: address,
-      }),
-      "Home improvement"
-    );
-  };
-
-  describe("detailed address matching logic", () => {
-    it("matches on address ignoring spaces and non-alphanumeric characters", async () => {
-      stubLicenseStatusClient.search.mockResolvedValue([entityWithAddress(" 123    Main St.  ! ")]);
-
-      const result = await queryWithAddress("123 Main St");
-      expect(result.status).toEqual("ACTIVE");
-    });
-
-    it("matches on address ignoring casing", async () => {
-      stubLicenseStatusClient.search.mockResolvedValue([entityWithAddress(" 123 MAIN ST ")]);
-
-      const result = await queryWithAddress("123 main st");
-      expect(result.status).toEqual("ACTIVE");
-    });
-
-    it("matches on address*", async () => {
-      stubLicenseStatusClient.search.mockResolvedValue([entityWithAddress("123 MAIN ST, UNIT C")]);
-
-      const result = await queryWithAddress("123 main st");
-      expect(result.status).toEqual("ACTIVE");
+    it("returns legacy license status client when env var is false", () => {
+      process.env.FEATURE_DYNAMICS_PUBLIC_MOVERS = "false";
+      const licenseType = "Public Movers and Warehousemen";
+      const licenseStatus = searchLicenseStatus(licenseType);
+      licenseStatus(generateLicenseSearchNameAndAddress({}), licenseType);
+      expect(stubNewSearchLicenseStatus).not.toHaveBeenCalled();
+      expect(stubLegacySearchLicenseStatus).toHaveBeenCalled();
     });
   });
 
-  it("maps Completed to ACTIVE and Unchecked to PENDING", async () => {
-    stubLicenseStatusClient.search.mockResolvedValue([
-      generateLicenseEntity({
-        addressLine1: "1234 Main St",
-        applicationNumber: "12345",
-        checklistItem: "Item 1",
-        checkoffStatus: "Completed",
-      }),
-      generateLicenseEntity({
-        addressLine1: "1234 Main St",
-        applicationNumber: "12345",
-        checklistItem: "Item 2",
-        checkoffStatus: "Unchecked",
-      }),
-    ]);
-
-    const nameAndAddress = generateNameAndAddress({
-      addressLine1: "1234 Main St",
+  describe("when license type is not public movers and warehouse", () => {
+    it("always returns legacy license client status", () => {
+      const licenseType = "Architecture";
+      const licenseStatus = searchLicenseStatus(licenseType);
+      licenseStatus(generateLicenseSearchNameAndAddress({}), licenseType);
+      expect(stubNewSearchLicenseStatus).not.toHaveBeenCalled();
+      expect(stubLegacySearchLicenseStatus).toHaveBeenCalled();
     });
-
-    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
-    expect(result.checklistItems).toEqual(
-      expect.arrayContaining([
-        {
-          title: "Item 1",
-          status: "ACTIVE",
-        },
-        {
-          title: "Item 2",
-          status: "PENDING",
-        },
-      ])
-    );
-  });
-
-  it("filters out Not Applicable items", async () => {
-    stubLicenseStatusClient.search.mockResolvedValue([
-      generateLicenseEntity({
-        addressLine1: "1234 Main St",
-        applicationNumber: "12345",
-        checklistItem: "Item 1",
-        checkoffStatus: "Completed",
-      }),
-      generateLicenseEntity({
-        addressLine1: "1234 Main St",
-        applicationNumber: "12345",
-        checklistItem: "Item 2",
-        checkoffStatus: "Not Applicable",
-      }),
-    ]);
-
-    const nameAndAddress = generateNameAndAddress({
-      addressLine1: "1234 Main St",
-    });
-
-    const result = await searchLicenseStatus(nameAndAddress, "Home improvement");
-    expect(result.checklistItems).toEqual([
-      {
-        title: "Item 1",
-        status: "ACTIVE",
-      },
-    ]);
-  });
-
-  it("rejects with NO_MATCH when no result matches the address", async () => {
-    stubLicenseStatusClient.search.mockResolvedValue([generateLicenseEntity({}), generateLicenseEntity({})]);
-
-    const nameAndAddress = generateNameAndAddress({});
-    await expect(searchLicenseStatus(nameAndAddress, "")).rejects.toEqual(new Error("NO_MATCH"));
-  });
-
-  it("rejects when search fails", async () => {
-    stubLicenseStatusClient.search.mockRejectedValue("some api error");
-
-    const nameAndAddress = generateNameAndAddress({});
-    await expect(searchLicenseStatus(nameAndAddress, "")).rejects.toEqual("some api error");
-  });
-});
-
-describe("determineLicenseStatus", () => {
-  it("returns BARRED when status is barred", () => {
-    expect(determineLicenseStatus("Barred")).toBe("BARRED");
-  });
-
-  it("returns OUT_OF_BUSINESS when status is out of business", () => {
-    expect(determineLicenseStatus("Out of Business")).toBe("OUT_OF_BUSINESS");
-  });
-
-  it("returns REINSTATEMENT_PENDING when status is Reinstatement Pending", () => {
-    expect(determineLicenseStatus("Reinstatement Pending")).toBe("REINSTATEMENT_PENDING");
-  });
-
-  it("returns CLOSED when status is closed", () => {
-    expect(determineLicenseStatus("Closed")).toBe("CLOSED");
-  });
-
-  it("returns DELETED when status is deleted", () => {
-    expect(determineLicenseStatus("Deleted")).toBe("DELETED");
-  });
-
-  it("returns DENIED when status is denied", () => {
-    expect(determineLicenseStatus("Denied")).toBe("DENIED");
-  });
-
-  it("returns VOLUNTARY_SURRENDER when status is Voluntary Surrender", () => {
-    expect(determineLicenseStatus("Voluntary Surrender")).toBe("VOLUNTARY_SURRENDER");
-  });
-
-  it("returns WITHDRAWN when status is Withdrawn", () => {
-    expect(determineLicenseStatus("Withdrawn")).toBe("WITHDRAWN");
-  });
-
-  it("returns UNKNOWN when status is not valid", () => {
-    expect(determineLicenseStatus("fake status")).toBe("UNKNOWN");
   });
 });

--- a/api/src/domain/license-status/searchLicenseStatusFactory.ts
+++ b/api/src/domain/license-status/searchLicenseStatusFactory.ts
@@ -1,84 +1,18 @@
-import { inputManipulator } from "@domain/inputManipulator";
-import { LicenseStatusClient, SearchLicenseStatus } from "@domain/types";
-import { getLicenseDate, parseDateWithFormat } from "@shared/dateHelpers";
-import { LicenseStatus, LicenseStatusItem, LicenseStatusResult, NameAndAddress } from "@shared/license";
+import { SearchLicenseStatus } from "@domain/types";
 
-export const searchLicenseStatusFactory = (licenseStatusClient: LicenseStatusClient): SearchLicenseStatus => {
-  return async (nameAndAddress: NameAndAddress, licenseType: string): Promise<LicenseStatusResult> => {
-    const searchName = inputManipulator(nameAndAddress.name)
-      .makeLowerCase()
-      .removeBusinessDesignators()
-      .trimPunctuation().value;
+export const searchLicenseStatusFactory = (
+  legacySearchLicenseStatus: SearchLicenseStatus,
+  newSearchLicenseStatus: SearchLicenseStatus
+) => {
+  return (licenseType: string): SearchLicenseStatus => {
+    const useNewSearchLicenseStatus = (): boolean =>
+      licenseType === "Public Movers and Warehousemen" &&
+      process.env.FEATURE_DYNAMICS_PUBLIC_MOVERS === "true";
 
-    const entities = await licenseStatusClient.search(searchName, nameAndAddress.zipCode, licenseType);
-
-    const allMatchingAddressesArray = entities.filter((it) => {
-      return cleanAddress(it.addressLine1).startsWith(cleanAddress(nameAndAddress.addressLine1));
-    });
-
-    if (allMatchingAddressesArray.length === 0) {
-      throw new Error("NO_MATCH");
+    if (useNewSearchLicenseStatus()) {
+      return newSearchLicenseStatus;
     }
 
-    const match = allMatchingAddressesArray.reduce((a, b) => {
-      return getLicenseDate(a) > getLicenseDate(b) ? a : b;
-    });
-
-    const items: LicenseStatusItem[] = entities
-      .filter((it) => {
-        return it.applicationNumber === match.applicationNumber;
-      })
-      .filter((it) => {
-        return it.checkoffStatus === "Unchecked" || it.checkoffStatus === "Completed";
-      })
-      .map((it) => {
-        return {
-          title: it.checklistItem,
-          status: it.checkoffStatus === "Completed" ? "ACTIVE" : "PENDING",
-        };
-      });
-
-    const expirationDate =
-      match.expirationDate === undefined || match.expirationDate.length < 8
-        ? undefined
-        : parseDateWithFormat(match.expirationDate, "YYYYMMDD X");
-    return {
-      status: determineLicenseStatus(match.licenseStatus),
-      expirationISO: expirationDate?.toISOString(),
-      checklistItems: items,
-    };
+    return legacySearchLicenseStatus;
   };
-};
-
-export const determineLicenseStatus = (value: string): LicenseStatus => {
-  switch (value) {
-    case "Active":
-      return "ACTIVE";
-    case "Pending":
-      return "PENDING";
-    case "Expired":
-      return "EXPIRED";
-    case "Barred":
-      return "BARRED";
-    case "Out of Business":
-      return "OUT_OF_BUSINESS";
-    case "Reinstatement Pending":
-      return "REINSTATEMENT_PENDING";
-    case "Closed":
-      return "CLOSED";
-    case "Deleted":
-      return "DELETED";
-    case "Denied":
-      return "DENIED";
-    case "Voluntary Surrender":
-      return "VOLUNTARY_SURRENDER";
-    case "Withdrawn":
-      return "WITHDRAWN";
-    default:
-      return "UNKNOWN";
-  }
-};
-
-export const cleanAddress = (value: string): string => {
-  return inputManipulator(value).makeLowerCase().stripPunctuation().stripWhitespace().value;
 };

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -1,7 +1,7 @@
 import { NameAvailability, NameAvailabilityResponse } from "@shared/businessNameSearch";
 import { BusinessUser, NewsletterResponse, UserTestingResponse } from "@shared/businessUser";
 import { FormationSubmitResponse, GetFilingResponse, InputFile } from "@shared/formationData";
-import { LicenseEntity, LicenseStatusResult, NameAndAddress } from "@shared/license";
+import { LicenseEntity, LicenseSearchNameAndAddress, LicenseStatusResult } from "@shared/license";
 import { ProfileData } from "@shared/profileData";
 import { TaxFilingCalendarEvent, TaxFilingLookupState, TaxFilingOnboardingState } from "@shared/taxFiling";
 import { UserData } from "@shared/userData";
@@ -94,11 +94,23 @@ export type SelfRegResponse = {
 };
 
 export type SearchBusinessName = (name: string) => Promise<NameAvailability>;
+
+export type SearchLicenseStatusFactory = (licenseType: string) => SearchLicenseStatus;
+
 export type SearchLicenseStatus = (
-  nameAndAddress: NameAndAddress,
+  nameAndAddress: LicenseSearchNameAndAddress,
   licenseType: string
 ) => Promise<LicenseStatusResult>;
-export type UpdateLicenseStatus = (userData: UserData, nameAndAddress: NameAndAddress) => Promise<UserData>;
+
+export type UpdateLicenseStatus = (
+  userData: UserData,
+  nameAndAddress: LicenseSearchNameAndAddress
+) => Promise<UserData>;
+
 export type UpdateOperatingPhase = (userData: UserData) => UserData;
 export type UpdateSidebarCards = (userData: UserData) => UserData;
 export type GetCertHttpsAgent = () => Promise<https.Agent>;
+
+export const NO_MATCH_ERROR = "NO_MATCH";
+export const NO_MAIN_APPS_ERROR = "NO_MAIN_APPS";
+export const MULTIPLE_MAIN_APPS_ERROR = "MULTIPLE_MAIN_APPS";

--- a/api/test/factories.ts
+++ b/api/test/factories.ts
@@ -20,8 +20,8 @@ import {
   generateBusiness,
   generateFormationData,
   generateFormationFormData,
+  generateLicenseSearchNameAndAddress,
   generateLicenseStatusItem,
-  generateNameAndAddress,
   generateProfileData,
   generateUserDataForBusiness,
   randomPublicFilingLegalType,
@@ -112,7 +112,7 @@ export const generateLicenseEntity = (overrides: Partial<LicenseEntity>): Licens
 
 export const generateLicenseData = (overrides: Partial<LicenseData>): LicenseData => {
   return {
-    nameAndAddress: generateNameAndAddress({}),
+    nameAndAddress: generateLicenseSearchNameAndAddress({}),
     completedSearch: true,
     items: [generateLicenseStatusItem({})],
     status: randomElementFromArray(["PENDING", "ACTIVE", "EXPIRED"]),

--- a/content/src/fieldConfig/config.json
+++ b/content/src/fieldConfig/config.json
@@ -205,7 +205,21 @@
     "errorTextSearchFailed": "Sorry, something went wrong. Please try again later.",
     "withdrawnPermitStatusText": "Withdrawn",
     "outOfBusinessPermitStatusText": "Out of Business",
-    "expiredPermitStatusText": "Expired"
+    "expiredPermitStatusText": "Expired",
+    "draftStatusText": "Draft",
+    "submittedStatusText":"Submitted",
+    "underInternalReviewStatusText":"Under Internal Review",
+    "specialReviewStatusText":"Special Review",
+    "pendingDeficienciesStatusText":"Pending Deficiencies",
+    "deficienciesSubmittedStatusText":"Deficiencies Submitted",
+    "checklistCompletedStatusText":"Checklist Completed",
+    "approvedStatusText":"Approved",
+    "pendingRenewalStatusText":"Pending Renewal",
+    "pendingReinstatementStatusText":"Pending Reinstatement",
+    "inactiveStatusText": "Inactive",
+    "abandonedStatusText": "Abandoned",
+    "suspendedStatusText": "Suspended",
+    "revokedStatusText": "Revoked"
   },
   "fundingDefaults": {
     "issuingAgencyText": "Issuing Agency"

--- a/shared/src/license.ts
+++ b/shared/src/license.ts
@@ -23,10 +23,24 @@ export type LicenseStatus =
   | "DELETED"
   | "DENIED"
   | "VOLUNTARY_SURRENDER"
-  | "WITHDRAWN";
+  | "WITHDRAWN"
+  | "DRAFT"
+  | "SUBMITTED"
+  | "UNDER_INTERNAL_REVIEW"
+  | "SPECIAL_REVIEW"
+  | "PENDING_DEFICIENCIES"
+  | "DEFICIENCIES_SUBMITTED"
+  | "CHECKLIST_COMPLETED"
+  | "APPROVED"
+  | "PENDING_RENEWAL"
+  | "PENDING_REINSTATEMENT"
+  | "INACTIVE"
+  | "ABANDONED"
+  | "SUSPENDED"
+  | "REVOKED";
 
 export interface LicenseData {
-  nameAndAddress: NameAndAddress;
+  nameAndAddress: LicenseSearchNameAndAddress;
   completedSearch: boolean;
   expirationISO?: string;
   lastUpdatedISO: string;
@@ -53,18 +67,21 @@ export type LicenseEntity = {
   dateThisStatus: string;
 };
 
-export type NameAndAddress = {
+export interface LicenseSearchNameAndAddress extends LicenseSearchAddress {
   name: string;
-  addressLine1: string;
-  addressLine2: string;
-  zipCode: string;
-};
+}
 
-export const createEmptyNameAndAddress = (): NameAndAddress => {
+export const createEmptyLicenseSearchNameAndAddress = (): LicenseSearchNameAndAddress => {
   return {
     name: "",
     addressLine1: "",
     addressLine2: "",
     zipCode: "",
   };
+};
+
+export type LicenseSearchAddress = {
+  addressLine1: string;
+  addressLine2: string;
+  zipCode: string;
 };

--- a/shared/src/test/factories.ts
+++ b/shared/src/test/factories.ts
@@ -15,7 +15,13 @@ import {
 import { Industries, Industry } from "../industry";
 import { randomInt } from "../intHelpers";
 import { LegalStructure, LegalStructures } from "../legalStructure";
-import { LicenseData, LicenseStatusItem, LicenseStatusResult, NameAndAddress } from "../license";
+import {
+  LicenseData,
+  LicenseSearchAddress,
+  LicenseSearchNameAndAddress,
+  LicenseStatusItem,
+  LicenseStatusResult,
+} from "../license";
 import { MunicipalityDetail } from "../municipality";
 import { IndustrySpecificData, ProfileData } from "../profileData";
 import { arrayOfSectors, SectorType } from "../sector";
@@ -86,9 +92,20 @@ export const generatePreferences = (overrides: Partial<Preferences>): Preference
   };
 };
 
-export const generateNameAndAddress = (overrides: Partial<NameAndAddress>): NameAndAddress => {
+export const generateLicenseSearchNameAndAddress = (
+  overrides: Partial<LicenseSearchNameAndAddress>
+): LicenseSearchNameAndAddress => {
   return {
     name: `some-name-${randomInt()}`,
+    ...generateLicenseSearchAddress({}),
+    ...overrides,
+  };
+};
+
+export const generateLicenseSearchAddress = (
+  overrides: Partial<LicenseSearchAddress>
+): LicenseSearchAddress => {
+  return {
     addressLine1: `some-address-1-${randomInt()}`,
     addressLine2: `some-address-2-${randomInt()}`,
     zipCode: `some-zipcode-${randomInt()}`,
@@ -147,7 +164,7 @@ export const randomLegalStructure = (publicFiling?: {
 
 export const generateLicenseData = (overrides: Partial<LicenseData>): LicenseData => {
   return {
-    nameAndAddress: generateNameAndAddress({}),
+    nameAndAddress: generateLicenseSearchNameAndAddress({}),
     completedSearch: false,
     items: [generateLicenseStatusItem({})],
     status: "PENDING",

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -3708,6 +3708,29 @@ collections:
                   widget: string,
                 }
               - { label: Status - Withdrawn, name: withdrawnPermitStatusText, widget: string }
+              - { label: Status - Draft, name: draftStatusText, widget: string }
+              - { label: Status - Draft, name: draftStatusText, widget: string }
+              - { label: Status - Submitted, name: submittedStatusText, widget: string }
+              - { label: Status - Under Internal Review, name: underInternalReviewStatusText, widget: string }
+              - { label: Status - Special Review, name: specialReviewStatusText, widget: string }
+              - { label: Status - Pending Deficiencies, name: pendingDeficienciesStatusText, widget: string }
+              - {
+                  label: Status - Deficiencies Submitted,
+                  name: deficienciesSubmittedStatusText,
+                  widget: string,
+                }
+              - { label: Status - Checklist Completed, name: checklistCompletedStatusText, widget: string }
+              - { label: Status - Approved, name: approvedStatusText, widget: string }
+              - { label: Status - Pending Renewal, name: pendingRenewalStatusText, widget: string }
+              - {
+                  label: Status - Pending Reinstatement,
+                  name: pendingReinstatementStatusText,
+                  widget: string,
+                }
+              - { label: Status - Inactive, name: inactiveStatusText, widget: string }
+              - { label: Status - Abandoned, name: abandonedStatusText, widget: string }
+              - { label: Status - Suspended, name: suspendedStatusText, widget: string }
+              - { label: Status - Revoked, name: revokedStatusText, widget: string }
               - { label: Tooltip Text, name: tooltipText, widget: text }
           - label: Task Progress
             name: taskProgress

--- a/web/src/components/tasks/CheckStatus.tsx
+++ b/web/src/components/tasks/CheckStatus.tsx
@@ -5,7 +5,10 @@ import { useUserData } from "@/lib/data-hooks/useUserData";
 import { LicenseSearchError } from "@/lib/types/types";
 import analytics from "@/lib/utils/analytics";
 import { useMountEffectWhenDefined } from "@/lib/utils/helpers";
-import { createEmptyNameAndAddress, NameAndAddress } from "@businessnjgovnavigator/shared/";
+import {
+  createEmptyLicenseSearchNameAndAddress,
+  LicenseSearchNameAndAddress,
+} from "@businessnjgovnavigator/shared/";
 import { TextField } from "@mui/material";
 import createStyles from "@mui/styles/createStyles";
 import makeStyles from "@mui/styles/makeStyles";
@@ -23,7 +26,7 @@ const useStyles = makeStyles(() => {
 });
 
 interface Props {
-  onSubmit: (nameAndAddress: NameAndAddress) => void;
+  onSubmit: (nameAndAddress: LicenseSearchNameAndAddress) => void;
   error: LicenseSearchError | undefined;
   isLoading: boolean;
 }
@@ -37,7 +40,9 @@ const LicenseSearchErrorLookup: Record<LicenseSearchError, string> = {
 
 export const CheckStatus = (props: Props): ReactElement => {
   const classes = useStyles();
-  const [formValues, setFormValues] = useState<NameAndAddress>(createEmptyNameAndAddress());
+  const [formValues, setFormValues] = useState<LicenseSearchNameAndAddress>(
+    createEmptyLicenseSearchNameAndAddress()
+  );
   const { business } = useUserData();
 
   useMountEffectWhenDefined(() => {
@@ -62,7 +67,7 @@ export const CheckStatus = (props: Props): ReactElement => {
   };
 
   const handleChangeForKey = (
-    key: keyof NameAndAddress
+    key: keyof LicenseSearchNameAndAddress
   ): ((event: ChangeEvent<HTMLInputElement>) => void) => {
     return (event: ChangeEvent<HTMLInputElement>): void => {
       setFormValues((prevValues) => {

--- a/web/src/components/tasks/LicenseStatusReceipt.tsx
+++ b/web/src/components/tasks/LicenseStatusReceipt.tsx
@@ -61,16 +61,47 @@ const LicenseStatusLookup: Record<LicenseStatus, string> = {
   VOLUNTARY_SURRENDER: Config.licenseSearchTask.voluntarySurrenderPermitStatusText,
   WITHDRAWN: Config.licenseSearchTask.withdrawnPermitStatusText,
   UNKNOWN: "",
+  DRAFT: Config.licenseSearchTask.draftStatusText,
+  SUBMITTED: Config.licenseSearchTask.submittedStatusText,
+  UNDER_INTERNAL_REVIEW: Config.licenseSearchTask.underInternalReviewStatusText,
+  SPECIAL_REVIEW: Config.licenseSearchTask.specialReviewStatusText,
+  PENDING_DEFICIENCIES: Config.licenseSearchTask.pendingDeficienciesStatusText,
+  DEFICIENCIES_SUBMITTED: Config.licenseSearchTask.deficienciesSubmittedStatusText,
+  CHECKLIST_COMPLETED: Config.licenseSearchTask.checklistCompletedStatusText,
+  APPROVED: Config.licenseSearchTask.approvedStatusText,
+  PENDING_RENEWAL: Config.licenseSearchTask.pendingRenewalStatusText,
+  PENDING_REINSTATEMENT: Config.licenseSearchTask.pendingReinstatementStatusText,
+  INACTIVE: Config.licenseSearchTask.inactiveStatusText,
+  ABANDONED: Config.licenseSearchTask.abandonedStatusText,
+  SUSPENDED: Config.licenseSearchTask.suspendedStatusText,
+  REVOKED: Config.licenseSearchTask.revokedStatusText,
 };
 
 export const LicenseStatusReceipt = (props: Props): ReactElement => {
   const [theme, setTheme] = useState<PermitTheme>(pendingPermitTheme);
   const { business } = useUserData();
 
+  const isPending = (licenseStatus: LicenseStatus): boolean => {
+    const pendingStatus: LicenseStatus[] = [
+      "PENDING",
+      "DRAFT",
+      "SUBMITTED",
+      "UNDER_INTERNAL_REVIEW",
+      "SPECIAL_REVIEW",
+      "PENDING_DEFICIENCIES",
+      "DEFICIENCIES_SUBMITTED",
+      "CHECKLIST_COMPLETED",
+      "APPROVED",
+      "PENDING_RENEWAL",
+      "PENDING_REINSTATEMENT",
+    ];
+    return pendingStatus.includes(licenseStatus);
+  };
+
   useEffect(() => {
     if (props.status === "ACTIVE") {
       setTheme(activePermitTheme);
-    } else if (props.status === "PENDING") {
+    } else if (isPending(props.status)) {
       setTheme(pendingPermitTheme);
     } else {
       setTheme(grayPermitTheme);

--- a/web/src/components/tasks/LicenseTask.test.tsx
+++ b/web/src/components/tasks/LicenseTask.test.tsx
@@ -8,14 +8,11 @@ import {
   Business,
   generateBusiness,
   generateLicenseData,
+  generateLicenseSearchNameAndAddress,
   generateProfileData,
   generateUserDataForBusiness,
 } from "@businessnjgovnavigator/shared";
-import {
-  generateLicenseStatusItem,
-  generateNameAndAddress,
-  generateUserData,
-} from "@businessnjgovnavigator/shared/test";
+import { generateLicenseStatusItem, generateUserData } from "@businessnjgovnavigator/shared/test";
 import { createTheme, ThemeProvider } from "@mui/material";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
@@ -107,7 +104,7 @@ describe("<LicenseTask />", () => {
       useMockBusiness({
         licenseData: generateLicenseData({
           completedSearch: false,
-          nameAndAddress: generateNameAndAddress({
+          nameAndAddress: generateLicenseSearchNameAndAddress({
             name: "My Cool Nail Salon",
           }),
         }),
@@ -121,7 +118,7 @@ describe("<LicenseTask />", () => {
       useMockBusiness({
         licenseData: generateLicenseData({
           completedSearch: true,
-          nameAndAddress: generateNameAndAddress({
+          nameAndAddress: generateLicenseSearchNameAndAddress({
             name: "My Cool Nail Salon",
           }),
           status: "ACTIVE",
@@ -139,7 +136,7 @@ describe("<LicenseTask />", () => {
     it("fills form values from user data if applicable", async () => {
       useMockBusiness({
         licenseData: generateLicenseData({
-          nameAndAddress: generateNameAndAddress({
+          nameAndAddress: generateLicenseSearchNameAndAddress({
             name: "Applebees",
             addressLine1: "123 Main St",
             addressLine2: "Apt 1",
@@ -177,7 +174,15 @@ describe("<LicenseTask />", () => {
 
     it("fills and saves form values and submits license status search with industry", async () => {
       act(() => {
-        mockApi.checkLicenseStatus.mockResolvedValue(generateUserData({}));
+        mockApi.checkLicenseStatus.mockResolvedValue(
+          generateUserDataForBusiness(
+            generateBusiness({
+              licenseData: generateLicenseData({
+                status: "DRAFT",
+              }),
+            })
+          )
+        );
       });
       renderTask();
 
@@ -188,7 +193,7 @@ describe("<LicenseTask />", () => {
 
       fireEvent.submit(screen.getByTestId("check-status-submit"));
       await waitFor(() => {
-        expect(screen.getByText("Pending")).toBeInTheDocument();
+        expect(screen.getByText("Draft")).toBeInTheDocument();
       });
       expect(mockApi.checkLicenseStatus).toHaveBeenCalledWith({
         name: "My Cool Nail Salon",
@@ -335,7 +340,7 @@ describe("<LicenseTask />", () => {
       useMockBusiness({
         licenseData: generateLicenseData({
           completedSearch: true,
-          nameAndAddress: generateNameAndAddress({
+          nameAndAddress: generateLicenseSearchNameAndAddress({
             name: "My Cool Nail Salon",
             addressLine1: "123 Main St",
             addressLine2: "Suite 1",

--- a/web/src/components/tasks/LicenseTask.tsx
+++ b/web/src/components/tasks/LicenseTask.tsx
@@ -12,7 +12,7 @@ import { LicenseSearchError, Task } from "@/lib/types/types";
 import analytics from "@/lib/utils/analytics";
 import { useMountEffectWhenDefined } from "@/lib/utils/helpers";
 import { getModifiedTaskContent } from "@/lib/utils/roadmap-helpers";
-import { LicenseStatusResult, NameAndAddress, UserData } from "@businessnjgovnavigator/shared/";
+import { LicenseSearchNameAndAddress, LicenseStatusResult, UserData } from "@businessnjgovnavigator/shared/";
 import { TabContext, TabList, TabPanel } from "@mui/lab/";
 import { Box, Tab } from "@mui/material";
 import React, { ReactElement, useState } from "react";
@@ -34,7 +34,7 @@ export const LicenseTask = (props: Props): ReactElement => {
   const { business, refresh } = useUserData();
   const { Config } = useConfig();
 
-  const allFieldsHaveValues = (nameAndAddress: NameAndAddress): boolean => {
+  const allFieldsHaveValues = (nameAndAddress: LicenseSearchNameAndAddress): boolean => {
     return !!(nameAndAddress.name && nameAndAddress.addressLine1 && nameAndAddress.zipCode);
   };
 
@@ -66,7 +66,7 @@ export const LicenseTask = (props: Props): ReactElement => {
     setLicenseStatusResult(undefined);
   };
 
-  const onSubmit = (nameAndAddress: NameAndAddress): void => {
+  const onSubmit = (nameAndAddress: LicenseSearchNameAndAddress): void => {
     if (!business || !business.profileData.industryId) return;
 
     if (!allFieldsHaveValues(nameAndAddress)) {

--- a/web/src/lib/api-client/apiClient.test.ts
+++ b/web/src/lib/api-client/apiClient.test.ts
@@ -1,6 +1,6 @@
 import { generateInputFile } from "@/test/factories";
 import {
-  generateNameAndAddress,
+  generateLicenseSearchNameAndAddress,
   generateTaxIdAndBusinessName,
   generateUser,
   generateUserData,
@@ -57,7 +57,7 @@ describe("apiClient", () => {
 
   it("posts license status", async () => {
     mockAxios.post.mockResolvedValue({ data: {} });
-    const nameAndAddress = generateNameAndAddress({});
+    const nameAndAddress = generateLicenseSearchNameAndAddress({});
     await checkLicenseStatus(nameAndAddress);
     expect(mockAxios.post).toHaveBeenCalledWith("/api/license-status", nameAndAddress, {
       headers: { Authorization: "Bearer some-token" },

--- a/web/src/lib/api-client/apiClient.ts
+++ b/web/src/lib/api-client/apiClient.ts
@@ -2,7 +2,12 @@ import { getCurrentToken } from "@/lib/auth/sessionHelper";
 import { SelfRegResponse } from "@/lib/types/types";
 import { phaseChangeAnalytics, setPhaseDimension } from "@/lib/utils/analytics-helpers";
 import { getCurrentBusiness } from "@businessnjgovnavigator/shared";
-import { InputFile, NameAndAddress, NameAvailability, UserData } from "@businessnjgovnavigator/shared/";
+import {
+  InputFile,
+  LicenseSearchNameAndAddress,
+  NameAvailability,
+  UserData,
+} from "@businessnjgovnavigator/shared/";
 import axios, { AxiosError, AxiosRequestConfig } from "axios";
 
 const apiBaseUrl = process.env.API_BASE_URL || "";
@@ -21,7 +26,7 @@ export const postUserData = async (userData: UserData): Promise<UserData> => {
   });
 };
 
-export const checkLicenseStatus = (nameAndAddress: NameAndAddress): Promise<UserData> => {
+export const checkLicenseStatus = (nameAndAddress: LicenseSearchNameAndAddress): Promise<UserData> => {
   return post(`/license-status`, nameAndAddress);
 };
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

DCA Dynamics API integration for public movers. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#185893614](https://www.pivotaltracker.com/story/show/185893614)

### Approach
Built `searchLicenseStatusFactory` which returns a `SearchLicenseStatus` to use based on license type. If the license type is `Public Movers and Warehousemen` then `DynamicsLicenseStatusClient` is returned otherwise `WebserviceLicenseStatusProcessorClient` is returned.

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->
This new integration is only for public movers so make sure your industry is Moving Company.

Here is an mover business details that is present in the Dynamics API (STAGING) only available in local env:

**Business Name**: `SIMONIK MOVING`
**Business Address Line 1**: `5E Easy Street`
**ZIP Code**: `08805`

### Notes
- Update the following environment variables in API env file
  - DCA_DYNAMICS_ORG_URL
  - DCA_DYNAMICS_CLIENT_ID
  - DCA_DYNAMICS_SECRET
  - DCA_DYNAMICS_TENANT_ID
  - FEATURE_DYNAMICS_PUBLIC_MOVERS

- There is a potential refactor to combine `WebserviceLicenseStatusProcessorClient` and `WebserviceLicenseStatusClient`.

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation, if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
