### PR TITLE
chore: update myNJ profile links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -546,7 +546,7 @@ jobs:
       - deploy-content
     environment:
       STAGE: content
-      MYNJ_PROFILE_LINK: https://myt1.state.nj.us/portal/Desktop
+      MYNJ_PROFILE_LINK: https://myt1.nj.gov/portal/Desktop
 
   deploy-accessibility-testing:
     docker:
@@ -562,7 +562,7 @@ jobs:
       - deploy-accessibility-testing
     environment:
       STAGE: testing
-      MYNJ_PROFILE_LINK: https://myt1.state.nj.us/portal/Desktop
+      MYNJ_PROFILE_LINK: https://myt1.nj.gov/portal/Desktop
 
   deploy-dev:
     docker:
@@ -579,7 +579,7 @@ jobs:
       - store-deploy-cache
     environment:
       STAGE: dev
-      MYNJ_PROFILE_LINK: https://myt1.state.nj.us/portal/Desktop
+      MYNJ_PROFILE_LINK: https://myt1.nj.gov/portal/Desktop
 
   deploy-staging:
     docker:
@@ -592,7 +592,7 @@ jobs:
       - deploy
     environment:
       STAGE: staging
-      MYNJ_PROFILE_LINK: https://myt1.state.nj.us/portal/Desktop
+      MYNJ_PROFILE_LINK: https://myt1.nj.gov/portal/Desktop
 
   deploy-production:
     docker:
@@ -605,7 +605,8 @@ jobs:
       - deploy
     environment:
       STAGE: prod
-      MYNJ_PROFILE_LINK: https://my.state.nj.us/portal/Desktop
+      MYNJ_PROFILE_LINK: https://my.state.nj.us/portal/Desktop # This needs to change when the production SSO/SLO links no longer redirect
+      # MYNJ_PROFILE_LINK: https://my.nj.gov/portal/Desktop
 
   integration-tests:
     parameters:


### PR DESCRIPTION
## Description

Update broken links driving to myNJ user profile in lower environments.

myNJ is moving from using a `.us` URL extension to `.gov`. We've made changes in our Cognito configuration to account for this. The team has not cutover to `.gov` yet. Those links redirect to `.us`. Additionally the profile link for `.gov` is not yet live. This will need to change when the cutover is complete. Expected 10 November 2023.

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
