### PR TITLE
More descriptive EDIT button aria-labels

### DIFF
--- a/content/src/fieldConfig/business-structure-task.json
+++ b/content/src/fieldConfig/business-structure-task.json
@@ -5,6 +5,7 @@
     "saveButton": "Save Business Structure",
     "radioQuestionHeader": "Select a business structure",
     "completedHeader": "Your business structure:",
+    "ariaLabelText": "your business structure",
     "successMessage": "**${legalStructure}** is saved."
   }
 }

--- a/content/src/fieldConfig/ein.json
+++ b/content/src/fieldConfig/ein.json
@@ -2,6 +2,7 @@
   "ein": {
     "descriptionText": "Once you get your 9-digit EIN, save it below for future use.",
     "saveButtonText": "Save",
-    "successText": "EIN \"${ein}\" has been saved."
+    "successText": "EIN \"${ein}\" has been saved.",
+    "ariaLabelText": "your EIN"
   }
 }

--- a/content/src/fieldConfig/naics-code.json
+++ b/content/src/fieldConfig/naics-code.json
@@ -4,6 +4,7 @@
     "successMessage": "NAICS code ${code} has been saved.",
     "invalidValidationErrorText": "Your NAICS code is invalid",
     "hasSavedCodeHeader": "Your NAICS Code",
+    "ariaLabelText": "your NAICS code",
     "missingNAICSCodePlaceholder": "(You have not saved a NAICS Code yet)",
     "findCodeHeader": "Find Your NAICS Code",
     "findCodeBodyText": "Use the resource listed below to search and find your NAICS code. **This information is used for data and analysis purposes by State and Federal governments, and does not directly impact your business.**",

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -2432,6 +2432,12 @@ collections:
                   widget: string,
                   hint: This field supports Markdown,
                 }
+              - {
+                  label: Aria Label Text,
+                  name: ariaLabelText,
+                  widget: string,
+                  hint: This is the text that is populates the Edit/Remove button aria label. It is prepended by "Edit" or "Remove".,
+                }
   - name: "tax-task"
     label: "Tasks - Tax ID"
     delete: false
@@ -2491,6 +2497,12 @@ collections:
               - { label: Invalid Validation Error Text, name: invalidValidationErrorText, widget: string }
               - { label: Length Validation Error Text, name: lengthValidationErrorText, widget: string }
               - { label: Has Saved Code Header, name: hasSavedCodeHeader, widget: string }
+              - {
+                  label: Aria Label Text,
+                  name: ariaLabelText,
+                  widget: string,
+                  hint: This is the text that is populates the Edit/Remove button aria label. It is prepended by "Edit" or "Remove".,
+                }
               - {
                   label: Success Message,
                   name: successMessage,
@@ -2559,6 +2571,12 @@ collections:
               - { label: Header - Complete, name: completedHeader, widget: string }
               - { label: Save Button, name: saveButton, widget: string }
               - { label: SuccessMessage, name: successMessage, widget: string }
+              - {
+                  label: Aria Label Text,
+                  name: ariaLabelText,
+                  widget: string,
+                  hint: This is the text that is populates the Edit/Remove button aria label. It is prepended by "Edit" or "Remove".,
+                }
       - label: "Business Structure Prompt Component"
         name: "business-structure-prompt"
         file: content/src/fieldConfig/business-structure-prompt.json

--- a/web/src/components/DeferredLocationQuestion.tsx
+++ b/web/src/components/DeferredLocationQuestion.tsx
@@ -69,13 +69,7 @@ export const DeferredLocationQuestion = (props: Props): ReactElement => {
             {Config.deferredLocation.editText}
           </UnStyledButton>
           <span className="margin-x-105">|</span>
-          <UnStyledButton
-            style="default"
-            isUnderline
-            onClick={(): void => {
-              onRemoveLocation();
-            }}
-          >
+          <UnStyledButton style="default" isUnderline onClick={onRemoveLocation}>
             {Config.deferredLocation.removeText}
           </UnStyledButton>
         </div>

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -69,7 +69,7 @@ export const Header = (): ReactElement => {
         isTextBold
         onClick={editOnClick}
         dataTestid="header-link-to-profile"
-        isAriaLabelApplied="Link To Business Profile"
+        ariaLabel="Link To Business Profile"
       >
         {getButtonText()}
       </UnStyledButton>

--- a/web/src/components/dashboard/SidebarCardGeneric.tsx
+++ b/web/src/components/dashboard/SidebarCardGeneric.tsx
@@ -59,7 +59,7 @@ export const SidebarCardGeneric = (props: Props): ReactElement => {
                 </span>
               </h3>
               {props.card.hasCloseButton && (
-                <UnStyledButton style="default" onClick={closeSelf} isAriaLabelApplied="Close">
+                <UnStyledButton style="default" onClick={closeSelf} ariaLabel="Close">
                   <Icon className="font-sans-xl text-white">close</Icon>
                 </UnStyledButton>
               )}

--- a/web/src/components/data-fields/BusinessStructure.tsx
+++ b/web/src/components/data-fields/BusinessStructure.tsx
@@ -33,6 +33,12 @@ export const BusinessStructure = (): ReactElement => {
     return `/tasks/${urlSlug}`;
   }, [roadmap]);
 
+  const getAddOrEdit = (): string => {
+    return state.profileData.legalStructureId ? contentFromConfig.editText : contentFromConfig.addText;
+  };
+
+  const ariaLabel = `${getAddOrEdit()} ${contentFromConfig.header}`;
+
   return (
     <div data-testid="business-structure">
       <div className="flex flex-row flex-align-center">
@@ -42,8 +48,9 @@ export const BusinessStructure = (): ReactElement => {
             className="text-accent-cool-darker margin-left-2"
             href={businessStructureTaskUrl}
             data-testid={"business-structure-task-link"}
+            aria-label={ariaLabel}
           >
-            {state.profileData.legalStructureId ? contentFromConfig.editText : contentFromConfig.addText}
+            {getAddOrEdit()}
           </a>
         )}
       </div>

--- a/web/src/components/data-fields/NaicsCode.tsx
+++ b/web/src/components/data-fields/NaicsCode.tsx
@@ -42,6 +42,12 @@ export const NaicsCode = (): ReactElement => {
     return shouldLockFieldForStartingAndNexus() || shouldLockFieldForOwning();
   };
 
+  const getAddOrEdit = (): string => {
+    return state.profileData.naicsCode ? contentFromConfig.editText : contentFromConfig.addText;
+  };
+
+  const ariaLabel = `${getAddOrEdit()} ${contentFromConfig.header}`;
+
   return (
     <>
       <div className="flex flex-row flex-align-center">
@@ -58,8 +64,8 @@ export const NaicsCode = (): ReactElement => {
             </ArrowTooltip>
           </div>
         ) : (
-          <a className="text-accent-cool-darker margin-left-2" href={naicsTaskUrl}>
-            {state.profileData.naicsCode ? contentFromConfig.editText : contentFromConfig.addText}
+          <a className="text-accent-cool-darker margin-left-2" href={naicsTaskUrl} aria-label={ariaLabel}>
+            {getAddOrEdit()}
           </a>
         )}
       </div>

--- a/web/src/components/data-fields/NexusBusinessNameField.tsx
+++ b/web/src/components/data-fields/NexusBusinessNameField.tsx
@@ -41,7 +41,11 @@ export const NexusBusinessNameField = (): ReactElement => {
           <div role="heading" aria-level={3} className="text-bold margin-bottom-05">
             {contentFromConfig.outOfStateNameHeader}
           </div>
-          <a href={`/tasks/${formationTaskId}`} className="margin-left-2">
+          <a
+            href={`/tasks/${formationTaskId}`}
+            className="text-accent-cool-darker margin-left-2"
+            aria-label={`${contentFromConfig.editButton} ${contentFromConfig.outOfStateNameHeader}`}
+          >
             {contentFromConfig.editButton}
           </a>
         </div>

--- a/web/src/components/njwds-extended/UnStyledButton.tsx
+++ b/web/src/components/njwds-extended/UnStyledButton.tsx
@@ -11,7 +11,7 @@ interface Props {
   isSmallerText?: boolean;
   isTextBold?: boolean;
   isIntercomEnabled?: boolean;
-  isAriaLabelApplied?: string;
+  ariaLabel?: string;
 }
 
 // eslint-disable-next-line react/display-name
@@ -56,7 +56,7 @@ export const UnStyledButton = forwardRef(
         ref={ref}
         onClick={props.onClick}
         {...(props.dataTestid ? { "data-testid": props.dataTestid } : {})}
-        {...(props.isAriaLabelApplied ? { "aria-label": props.isAriaLabelApplied } : {})}
+        {...(props.ariaLabel ? { "aria-label": props.ariaLabel } : {})}
       >
         <div
           ref={widthRef}

--- a/web/src/components/tasks/EinDisplay.tsx
+++ b/web/src/components/tasks/EinDisplay.tsx
@@ -21,11 +21,21 @@ export const EinDisplay = (props: Props): ReactElement => {
         <div className="margin-right-1">
           <Content>{templateEval(Config.ein.successText, { ein: displayAsEin(props.employerId) })}</Content>
         </div>
-        <UnStyledButton style="default" isUnderline onClick={props.onEdit}>
+        <UnStyledButton
+          style="default"
+          isUnderline
+          onClick={props.onEdit}
+          ariaLabel={`${Config.taskDefaults.editText} ${Config.ein.ariaLabelText}`}
+        >
           {Config.taskDefaults.editText}
         </UnStyledButton>
         <span className="margin-x-105">|</span>
-        <UnStyledButton style="default" isUnderline onClick={props.onRemove}>
+        <UnStyledButton
+          style="default"
+          isUnderline
+          onClick={props.onRemove}
+          ariaLabel={`${Config.taskDefaults.removeText} ${Config.ein.ariaLabelText}`}
+        >
           {Config.taskDefaults.removeText}
         </UnStyledButton>
       </div>

--- a/web/src/components/tasks/NaicsCodeDisplay.tsx
+++ b/web/src/components/tasks/NaicsCodeDisplay.tsx
@@ -41,11 +41,21 @@ export const NaicsCodeDisplay = (props: Props): ReactElement => {
           </ArrowTooltip>
         ) : (
           <>
-            <UnStyledButton style="default" isUnderline onClick={props.onEdit}>
+            <UnStyledButton
+              style="default"
+              isUnderline
+              onClick={props.onEdit}
+              ariaLabel={`${Config.taskDefaults.editText} ${Config.determineNaicsCode.ariaLabelText}`}
+            >
               {Config.taskDefaults.editText}
             </UnStyledButton>
             <span className="margin-x-105">|</span>
-            <UnStyledButton style="default" isUnderline onClick={props.onRemove}>
+            <UnStyledButton
+              style="default"
+              isUnderline
+              onClick={props.onRemove}
+              ariaLabel={`${Config.taskDefaults.removeText} ${Config.determineNaicsCode.ariaLabelText}`}
+            >
               {Config.taskDefaults.removeText}
             </UnStyledButton>
           </>

--- a/web/src/components/tasks/business-formation/business/BusinessNameAndLegalStructure.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessNameAndLegalStructure.tsx
@@ -67,12 +67,7 @@ export const BusinessNameAndLegalStructure = ({ isReviewStep = false }: Props): 
   const legalStructureContextualInfo = (): ReactElement => {
     const label = Config.formation.legalStructure.label;
     const contextualInfo = Config.formation.legalStructure.contextualInfo;
-    return <ContextualInfoButton text={isReviewStep ? `${label}:` : label} id={contextualInfo} />;
-  };
-
-  const businessName = (): string => {
-    const label = Config.formation.fields.businessName.label;
-    return isReviewStep ? `${label}:` : label;
+    return <ContextualInfoButton text={label} id={contextualInfo} />;
   };
 
   const notEnteredBusinessName = (): ReactElement => {
@@ -99,7 +94,7 @@ export const BusinessNameAndLegalStructure = ({ isReviewStep = false }: Props): 
         <div className="padding-205 flex-half">
           <div>
             <strong>
-              <ModifiedContent>{businessName()}</ModifiedContent>
+              <ModifiedContent>{Config.formation.fields.businessName.label}</ModifiedContent>
             </strong>
           </div>
           <div className="flex">
@@ -116,6 +111,7 @@ export const BusinessNameAndLegalStructure = ({ isReviewStep = false }: Props): 
                 onClick={(): void => setStepIndex(LookupStepIndexByName("Name"))}
                 isUnderline
                 dataTestid="edit-business-name"
+                ariaLabel={`${Config.formation.general.editButtonText} ${Config.formation.fields.businessName.label}`}
               >
                 {Config.formation.general.editButtonText}
               </UnStyledButton>
@@ -137,6 +133,7 @@ export const BusinessNameAndLegalStructure = ({ isReviewStep = false }: Props): 
                     onClick={showLegalStructureModal}
                     isUnderline
                     dataTestid="edit-legal-structure"
+                    ariaLabel={`${Config.formation.general.editButtonText} ${Config.formation.legalStructure.label}`}
                   >
                     {Config.formation.general.editButtonText}
                   </UnStyledButton>

--- a/web/src/components/tasks/business-formation/review/section/ReviewSection.tsx
+++ b/web/src/components/tasks/business-formation/review/section/ReviewSection.tsx
@@ -27,7 +27,13 @@ export const ReviewSection = (props: Props): ReactElement => {
           <h2>{props.stepName}</h2>
         </div>
         <div className="margin-left-2">
-          <UnStyledButton style="default" onClick={onClick} isUnderline dataTestid={props.testId}>
+          <UnStyledButton
+            style="default"
+            onClick={onClick}
+            isUnderline
+            dataTestid={props.testId}
+            ariaLabel={`${Config.formation.general.editButtonText} ${props.stepName}`}
+          >
             {Config.formation.general.editButtonText}
           </UnStyledButton>
         </div>

--- a/web/src/components/tasks/business-structure/BusinessStructureTask.tsx
+++ b/web/src/components/tasks/business-structure/BusinessStructureTask.tsx
@@ -170,6 +170,7 @@ export const BusinessStructureTask = (props: Props): ReactElement => {
                     style="default"
                     isUnderline
                     onClick={setBackToEditing}
+                    ariaLabel={`${Config.taskDefaults.editText} ${Config.businessStructureTask.ariaLabelText}`}
                   >
                     {Config.taskDefaults.editText}
                   </UnStyledButton>
@@ -180,6 +181,7 @@ export const BusinessStructureTask = (props: Props): ReactElement => {
                     style="default"
                     isUnderline
                     onClick={removeTaskCompletion}
+                    ariaLabel={`${Config.taskDefaults.removeText} ${Config.businessStructureTask.ariaLabelText}`}
                   >
                     {Config.taskDefaults.removeText}
                   </UnStyledButton>


### PR DESCRIPTION
## Description

- make EDIT/Remove button aria-labels more descriptive
- fix styling issue with NAICS Code Edit button (profile)

### Ticket

[186094556](https://www.pivotaltracker.com/story/show/186094556)

### Steps to Test

Navigate to page in-app, use inspector to check aria-label.

## Code author checklist

- [ ] I have performed a self-review of my code
- [ ] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [ ] I have not used any relative imports
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
