### PR TITLE
chore: [#186134528] empty roadmap bug when discarding new business

### DIFF
--- a/web/src/lib/data-hooks/useRoadmap.test.tsx
+++ b/web/src/lib/data-hooks/useRoadmap.test.tsx
@@ -47,6 +47,22 @@ describe("useRoadmap", () => {
     expect(mockBuildUserRoadmap).toHaveBeenCalledWith(profileData);
   });
 
+  it("doesn't rebuild roadmap when there are steps and tasks", () => {
+    const profileData = generateProfileData({});
+    useMockBusiness({ profileData, onboardingFormProgress: "COMPLETED" });
+
+    setupHook(generateRoadmap({ steps: [generateStep({})], tasks: [generateTask({})] }));
+    expect(mockBuildUserRoadmap).not.toHaveBeenCalled();
+  });
+
+  it("rebuilds roadmap when steps and tasks are empty", () => {
+    const profileData = generateProfileData({});
+    useMockBusiness({ profileData, onboardingFormProgress: "COMPLETED" });
+
+    setupHook(generateRoadmap({ steps: [], tasks: [] }));
+    expect(mockBuildUserRoadmap).toHaveBeenCalledTimes(1);
+  });
+
   it("does not build roadmap when user data is defined and form is UNSTARTED", async () => {
     const profileData = generateProfileData({});
     useMockBusiness({ profileData, onboardingFormProgress: "UNSTARTED" });

--- a/web/src/lib/data-hooks/useRoadmap.ts
+++ b/web/src/lib/data-hooks/useRoadmap.ts
@@ -31,8 +31,10 @@ export const useRoadmap = (): UseRoadmapReturnValue => {
     return [...new Set(sections)];
   }, [roadmap]);
 
+  const rebuildRoadmap = !roadmap || roadmap?.steps.length === 0 || roadmap?.tasks.length === 0;
+
   useMountEffectWhenDefined(() => {
-    if (!roadmap) {
+    if (rebuildRoadmap) {
       buildAndSetRoadmap();
     }
   }, business);


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Fix to rebuild roadmap if the steps are empty after discarding the process of starting a new business. 

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#186134528](https://www.pivotaltracker.com/story/show/186134528)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
