### PR TITLE
fix: [#186429361] dynamics license status application id filtering to…

### DIFF
--- a/api/src/client/dynamics/DynamicsLicenseApplicationIdClient.ts
+++ b/api/src/client/dynamics/DynamicsLicenseApplicationIdClient.ts
@@ -42,7 +42,7 @@ export const DynamicsLicenseApplicationIdClient = (
           )
           .filter(
             (applicationDetails: LicenseApplicationIdApiResponse) =>
-              applicationDetails.rgb_number.slice(-2) === MAIN_APP_END_DIGITS
+              applicationDetails.rgb_number && applicationDetails.rgb_number.slice(-2) === MAIN_APP_END_DIGITS
           );
 
         if (mainActiveApplications.length === 0) {


### PR DESCRIPTION
… account for null

<!-- Please complete the following sections as necessary. -->

## Description
Updated filtering to account for potential null values for rgb_number and statecode. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#186429361](https://www.pivotaltracker.com/story/show/186429361)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
