### PR TITLE
refactor: [#186006497] create Heading component

### DIFF
--- a/web/src/components/CircularIndicator.tsx
+++ b/web/src/components/CircularIndicator.tsx
@@ -1,3 +1,4 @@
+import { Heading } from "@/components/njwds-extended/Heading";
 import { CircularProgress } from "@mui/material";
 import { ReactElement } from "react";
 
@@ -8,9 +9,9 @@ export const CircularIndicator = (props?: Props): ReactElement => {
   return (
     <div className="flex flex-justify-center flex-align-center">
       <CircularProgress aria-label="loading indicator" aria-busy={true} />
-      <div className="h3-styling" style={{ marginBottom: 0, marginLeft: "1rem" }}>
+      <Heading level={0} styleVariant="h3" style={{ marginBottom: 0, marginLeft: "1rem" }}>
         {props?.displayText ?? "Loading..."}
-      </div>
+      </Heading>
     </div>
   );
 };

--- a/web/src/components/ContextInfoElement.tsx
+++ b/web/src/components/ContextInfoElement.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { Icon } from "@/components/njwds/Icon";
 import React, { forwardRef, ReactElement } from "react";
 
@@ -23,7 +24,7 @@ export const ContextInfoElement = forwardRef(
         >
           <Icon className="font-sans-xl">close</Icon>
         </button>
-        <h3>{props.header}</h3>
+        <Heading level={3}>{props.header}</Heading>
         <Content>{props.markdown}</Content>
       </aside>
     );

--- a/web/src/components/ModalZeroButton.tsx
+++ b/web/src/components/ModalZeroButton.tsx
@@ -1,3 +1,4 @@
+import { Heading } from "@/components/njwds-extended/Heading";
 import { Icon } from "@/components/njwds/Icon";
 import { ContextualInfoContext } from "@/contexts/contextualInfoContext";
 import { Breakpoint, Dialog, DialogContent, DialogTitle, IconButton } from "@mui/material";
@@ -25,7 +26,9 @@ export const ModalZeroButton = (props: Props): ReactElement => {
       disableEnforceFocus={contextualInfo.isVisible}
     >
       <DialogTitle id="modal" className="display-flex flex-row flex-align-center margin-top-1 break-word">
-        <div className="h2-styling padding-x-1 margin-0-override">{props.title}</div>
+        <Heading level={0} styleVariant="h2" className="padding-x-1 margin-0-override">
+          {props.title}
+        </Heading>
         {!props.uncloseable && (
           <IconButton
             aria-label="close"

--- a/web/src/components/TaskStatusTaxRegistrationSnackbar.tsx
+++ b/web/src/components/TaskStatusTaxRegistrationSnackbar.tsx
@@ -1,3 +1,4 @@
+import { Heading } from "@/components/njwds-extended/Heading";
 import { SnackbarAlert } from "@/components/njwds-extended/SnackbarAlert";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { ReactElement } from "react";
@@ -12,7 +13,7 @@ export const TaskStatusTaxRegistrationSnackbar = (props: Props): ReactElement =>
 
   return (
     <SnackbarAlert variant="success" isOpen={props.isOpen} close={props.close}>
-      <h2>{Config.dashboardDefaults.taxRegistrationSnackbarHeading}</h2>
+      <Heading level={2}>{Config.dashboardDefaults.taxRegistrationSnackbarHeading}</Heading>
       <p>{Config.dashboardDefaults.taxRegistrationSnackbarBody}</p>
     </SnackbarAlert>
   );

--- a/web/src/components/UserSupportActionCard.tsx
+++ b/web/src/components/UserSupportActionCard.tsx
@@ -1,3 +1,4 @@
+import { Heading } from "@/components/njwds-extended/Heading";
 import { PrimaryButton, PrimaryButtonColors } from "@/components/njwds-extended/PrimaryButton";
 import { MediaQueries } from "@/lib/PageSizes";
 import { useMediaQuery } from "@mui/material";
@@ -27,8 +28,12 @@ export const UserSupportActionCard = (props: Props): ReactElement => {
     >
       <div className="flex flex-column fac space-between padding-x-2 padding-y-6 height-full">
         <div className="text-center">
-          <h3 className="margin-0">{props.headerLine1}</h3>
-          <h3 className="margin-bottom-3">{props.headerLine2}</h3>
+          <Heading level={3} className="margin-0">
+            {props.headerLine1}
+          </Heading>
+          <Heading level={3} className="margin-bottom-3">
+            {props.headerLine2}
+          </Heading>
           <div>{props.supportingText}</div>
         </div>
         <div>

--- a/web/src/components/auth/NeedsAccountModal.tsx
+++ b/web/src/components/auth/NeedsAccountModal.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { Icon } from "@/components/njwds/Icon";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
@@ -48,9 +49,9 @@ export const NeedsAccountModal = (): ReactElement => {
       data-testid={"self-reg-modal"}
     >
       <DialogTitle sx={{ p: 5, paddingRight: 10 }}>
-        <div role="heading" aria-level={2} className="h3-styling">
+        <Heading level={0} styleVariant="h3">
           {Config.navigationDefaults.needsAccountModalTitle}
-        </div>
+        </Heading>
         <IconButton
           aria-label="close"
           onClick={(): void => setShowNeedsAccountModal(false)}

--- a/web/src/components/auth/NeedsAccountSnackbar.tsx
+++ b/web/src/components/auth/NeedsAccountSnackbar.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { SnackbarAlert } from "@/components/njwds-extended/SnackbarAlert";
 import { Icon } from "@/components/njwds/Icon";
 import { AuthContext } from "@/contexts/authContext";
@@ -64,7 +65,9 @@ export const NeedsAccountSnackbar = (): ReactElement => {
           <></>
         )}
         <div>
-          <h3 className="padding-right-2">{getTitle()}</h3>
+          <Heading level={3} className="padding-right-2">
+            {getTitle()}
+          </Heading>
           <IconButton
             aria-label="close"
             onClick={handleClose}

--- a/web/src/components/auth/RegistrationStatusSnackbar.tsx
+++ b/web/src/components/auth/RegistrationStatusSnackbar.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@/components/Content";
 import { AlertVariant } from "@/components/njwds-extended/Alert";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { SnackbarAlert } from "@/components/njwds-extended/SnackbarAlert";
 import { Icon } from "@/components/njwds/Icon";
 import { AuthContext } from "@/contexts/authContext";
@@ -65,7 +66,9 @@ export const RegistrationStatusSnackbar = (): ReactElement => {
             style={{ marginRight: "20px", width: "64px", height: "64px" }}
           />
           <div>
-            <h3 className="padding-right-2">{getSuccessTitle()}</h3>
+            <Heading level={3} className="padding-right-2">
+              {getSuccessTitle()}
+            </Heading>
             <IconButton
               aria-label="close"
               onClick={(): void => setRegistrationStatus(undefined)}

--- a/web/src/components/dashboard/HideableTasks.tsx
+++ b/web/src/components/dashboard/HideableTasks.tsx
@@ -1,5 +1,6 @@
 import { SecondaryButton } from "@/components//njwds-extended/SecondaryButton";
 import { Roadmap } from "@/components/dashboard/Roadmap";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { Icon } from "@/components/njwds/Icon";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useRoadmap } from "@/lib/data-hooks/useRoadmap";
@@ -37,7 +38,9 @@ export const HideableTasks = (): ReactElement => {
   return (
     <div className="margin-top-7" data-testid="hideableTasks">
       <div className={`${isTabletAndUp ? "flex flex-align-center" : ""} margin-bottom-205`}>
-        <h2 className="margin-bottom-0 text-medium">{Config.dashboardDefaults.upAndRunningTaskHeader}</h2>
+        <Heading level={2} className="margin-bottom-0 text-medium">
+          {Config.dashboardDefaults.upAndRunningTaskHeader}
+        </Heading>
         <div className={`mla ${isTabletAndUp ? "" : "margin-top-2"}`}>
           <SecondaryButton size={"small"} isColor={"border-base-light"} onClick={handleToggleClick}>
             <div className="fdr fac">

--- a/web/src/components/dashboard/SectionAccordion.tsx
+++ b/web/src/components/dashboard/SectionAccordion.tsx
@@ -1,3 +1,4 @@
+import { Heading } from "@/components/njwds-extended/Heading";
 import { Icon } from "@/components/njwds/Icon";
 import { SectionAccordionContext } from "@/contexts/sectionAccordionContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -19,7 +20,7 @@ export const SectionAccordion = (props: Props): ReactElement => {
   const dropdownIconClasses = props.mini
     ? "usa-icon--size-5 text-base-light"
     : "usa-icon--size-5 margin-left-1";
-  const headerClasses = props.mini ? "h3-styling" : "margin-top-3 tablet:margin-left-3 h3-styling";
+  const headerClasses = props.mini ? "" : "margin-top-3 tablet:margin-left-3";
   const dividerClasses = props.mini ? "margin-y-2" : "margin-y-3";
   const sectionName = props.sectionType.toLowerCase();
   const isOpen = business?.preferences.roadmapOpenSections.includes(props.sectionType) ?? false;
@@ -59,9 +60,13 @@ export const SectionAccordion = (props: Props): ReactElement => {
             data-testid={`${sectionName}-header`}
           >
             <div className="margin-y-05">
-              <h2 className={`flex flex-align-center margin-0-override ${headerClasses}`}>
+              <Heading
+                level={2}
+                styleVariant="h3"
+                className={`flex flex-align-center margin-0-override ${headerClasses}`}
+              >
                 <div className="inline">{Config.sectionHeaders[props.sectionType]}</div>
-              </h2>
+              </Heading>
             </div>
           </AccordionSummary>
           <AccordionDetails>{props.children}</AccordionDetails>

--- a/web/src/components/dashboard/SidebarCardGeneric.tsx
+++ b/web/src/components/dashboard/SidebarCardGeneric.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { Icon } from "@/components/njwds/Icon";
@@ -53,11 +54,11 @@ export const SidebarCardGeneric = (props: Props): ReactElement => {
         {props.headerText && (
           <div className="radius-top-md">
             <div className="flex flex-justify">
-              <h3 className="margin-bottom-0 text-white">
+              <Heading level={3} className="margin-bottom-0 text-white">
                 <span>
                   <ModifiedContent>{props.headerText}</ModifiedContent>
                 </span>
-              </h3>
+              </Heading>
               {props.card.hasCloseButton && (
                 <UnStyledButton style="default" onClick={closeSelf} ariaLabel="Close">
                   <Icon className="font-sans-xl text-white">close</Icon>

--- a/web/src/components/dashboard/SidebarCardsList.tsx
+++ b/web/src/components/dashboard/SidebarCardsList.tsx
@@ -1,6 +1,7 @@
 import { Content } from "@/components/Content";
 import { OpportunityCard } from "@/components/dashboard/OpportunityCard";
 import { SidebarCard } from "@/components/dashboard/SidebarCard";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { Icon } from "@/components/njwds/Icon";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -180,12 +181,12 @@ export const SidebarCardsList = (props: SidebarCardsListProps): ReactElement => 
     <>
       {isDesktopAndUp && (
         <>
-          <h2 className="h2-styling margin-top-0 font-weight-normal">
+          <Heading level={2} className="margin-top-0 font-weight-normal">
             {Config.dashboardDefaults.sidebarHeading}
             <span data-testid="for-you-counter" className="margin-left-05 text-base">
               ({getForYouCardCount(business, props.certifications, props.fundings)})
             </span>
-          </h2>
+          </Heading>
           <hr className="margin-top-2 margin-bottom-3 bg-cool-lighter" aria-hidden={true} />
         </>
       )}

--- a/web/src/components/data-fields/BusinessPersonaQuestion.tsx
+++ b/web/src/components/data-fields/BusinessPersonaQuestion.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { ConfigType } from "@/contexts/configContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { ProfileFormContext } from "@/contexts/profileFormContext";
@@ -40,9 +41,9 @@ export const BusinessPersonaQuestion = <T,>(props: FormContextFieldProps<T>): Re
 
   return (
     <>
-      <div role="heading" aria-level={2} className="h3-styling margin-bottom-05-override">
+      <Heading level={2} styleVariant="h3" className="margin-bottom-05-override">
         {contentFromConfig.header}
-      </div>
+      </Heading>
       <Content>{contentFromConfig.description}</Content>
       <FormControl fullWidth>
         <RadioGroup

--- a/web/src/components/field-labels/FieldLabelOnboarding.tsx
+++ b/web/src/components/field-labels/FieldLabelOnboarding.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@/components/Content";
 import { ContextualInfoButton } from "@/components/ContextualInfoButton";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { getProfileConfig } from "@/lib/domain-logic/getProfileConfig";
@@ -29,7 +30,7 @@ export const FieldLabelOnboarding = (props: Props): ReactElement => {
 
   return (
     <>
-      <div role="heading" aria-level={2} className="h3-styling margin-bottom-05-override">
+      <Heading level={2} styleVariant="h3" className="margin-bottom-05-override">
         {contentFromConfig.headerContextualInfo ? (
           <ContextualInfoButton text={contentFromConfig.header} id={contentFromConfig.headerContextualInfo} />
         ) : (
@@ -41,7 +42,7 @@ export const FieldLabelOnboarding = (props: Props): ReactElement => {
             <span className="text-light">{unboldedHeader}</span>
           </>
         )}
-      </div>
+      </Heading>
       {props.isAltDescriptionDisplayed && altDescription && <Content>{altDescription}</Content>}
       {!props.isAltDescriptionDisplayed && description && <Content>{description}</Content>}
     </>

--- a/web/src/components/filings-calendar/FilingsCalendar.tsx
+++ b/web/src/components/filings-calendar/FilingsCalendar.tsx
@@ -4,6 +4,7 @@ import { EmptyCalendar } from "@/components/filings-calendar/EmptyCalendar";
 import { FilingsCalendarAsList } from "@/components/filings-calendar/FilingsCalendarAsList";
 import { FilingsCalendarGrid } from "@/components/filings-calendar/FilingsCalendarGrid";
 import { FilingsCalendarTaxAccess } from "@/components/filings-calendar/FilingsCalendarTaxAccess";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
 import { ThreeYearSelector } from "@/components/njwds-extended/ThreeYearSelector";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
@@ -130,7 +131,9 @@ export const FilingsCalendar = (props: Props): ReactElement => {
       <div className="calendar-container" data-testid="filings-calendar">
         <div className="flex mobile-lg:flex-align-end flex-justify flex-column mobile-lg:flex-row">
           <div className="flex flex-align-end">
-            <h2 className="margin-bottom-0 text-medium">{Config.dashboardDefaults.calendarHeader}</h2>
+            <Heading level={2} className="margin-bottom-0 text-medium">
+              {Config.dashboardDefaults.calendarHeader}
+            </Heading>
             <div className="margin-top-05 margin-left-1 margin-bottom-05">
               <ArrowTooltip title={Config.dashboardDefaults.calendarTooltip}>
                 <div className="fdr fac font-body-lg text-green" data-testid="calendar-tooltip">

--- a/web/src/components/filings-calendar/tax-access-modal/TaxAccessModalBody.tsx
+++ b/web/src/components/filings-calendar/tax-access-modal/TaxAccessModalBody.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { ReactElement } from "react";
 
@@ -17,7 +18,11 @@ export const TaxAccessModalBody = (props: Props): ReactElement => {
   return (
     <>
       <div className="margin-y-3">
-        {props.showHeader && <h2 className="h4-styling">{getHeader()}</h2>}
+        {props.showHeader && (
+          <Heading level={2} styleVariant="h4">
+            {getHeader()}
+          </Heading>
+        )}
         <Content>{Config.taxAccess.body}</Content>
       </div>
       <hr className="margin-y-4" />

--- a/web/src/components/njwds-extended/Alert.tsx
+++ b/web/src/components/njwds-extended/Alert.tsx
@@ -1,3 +1,4 @@
+import { Heading } from "@/components/njwds-extended/Heading";
 import { ReactElement, ReactNode } from "react";
 
 export interface AlertProps {
@@ -36,7 +37,11 @@ export const Alert = (props: Props): ReactElement => {
   return (
     <div className={className} {...alertRole} {...(dataTestid ? { "data-testid": dataTestid } : {})}>
       <div className="usa-alert__body">
-        {heading && <h3 className="margin-bottom-0">{heading}</h3>}
+        {heading && (
+          <Heading level={3} className="margin-bottom-0">
+            {heading}
+          </Heading>
+        )}
         <div className="usa-alert__text">{children}</div>
       </div>
     </div>

--- a/web/src/components/njwds-extended/Heading.test.tsx
+++ b/web/src/components/njwds-extended/Heading.test.tsx
@@ -1,0 +1,44 @@
+import { Heading } from "@/components/njwds-extended/Heading";
+import { render, screen } from "@testing-library/react";
+
+describe("Heading component", () => {
+  const sampleHeadingText = "Hello, navigator!";
+
+  it("should render an h1 with h1-styling by default", async () => {
+    render(<Heading level={1}>{sampleHeadingText}</Heading>);
+    expect(screen.getByText(sampleHeadingText).tagName).toEqual("H1");
+  });
+
+  it("should render an h2 with h3-styling when so desired", async () => {
+    render(
+      <Heading level={2} styleVariant="h3">
+        {sampleHeadingText}
+      </Heading>
+    );
+    const headingElement = screen.getByText(sampleHeadingText);
+    expect(headingElement.tagName).toEqual("H2");
+    expect(headingElement).toHaveClass("h3-styling");
+  });
+
+  it("should render an h3 with no styling when so desired", async () => {
+    render(
+      <Heading level={3} styleVariant="rawElement">
+        {sampleHeadingText}
+      </Heading>
+    );
+    const headingElement = screen.getByText(sampleHeadingText);
+    expect(headingElement.tagName).toEqual("H3");
+    expect(headingElement).not.toHaveClass("h3-styling");
+  });
+
+  it("should pass additional classes to the rendered element", async () => {
+    render(
+      <Heading level={4} className="navigator">
+        {sampleHeadingText}
+      </Heading>
+    );
+    const headingElement = screen.getByText(sampleHeadingText);
+    expect(headingElement.tagName).toEqual("H4");
+    expect(headingElement).toHaveClass("navigator");
+  });
+});

--- a/web/src/components/njwds-extended/Heading.tsx
+++ b/web/src/components/njwds-extended/Heading.tsx
@@ -1,0 +1,113 @@
+import { ReactElement } from "react";
+
+type HeadingLevel = 0 | 1 | 2 | 3 | 4;
+type HeadingStyleVariant = "h1" | "h1Large" | "h2" | "h3" | "h4" | "h5" | "h6" | "rawElement";
+
+type HeadingStyles = {
+  [variant in HeadingStyleVariant]: string;
+};
+
+const variantClasses: HeadingStyles = {
+  h1: "h1-styling",
+  h1Large: "h1-styling-large",
+  h2: "h2-styling",
+  h3: "h3-styling",
+  h4: "h4-styling",
+  h5: "h5-styling",
+  h6: "h6-styling",
+  rawElement: "",
+};
+
+const determineClassNames = (
+  level: HeadingLevel,
+  styleVariant?: HeadingStyleVariant | undefined,
+  className?: string | undefined
+): string => {
+  const classStrings = [];
+  let styleClass: string;
+
+  switch (level) {
+    case 1:
+      styleClass = variantClasses["h1"];
+      break;
+    case 2:
+      styleClass = variantClasses["h2"];
+      break;
+    case 3:
+      styleClass = variantClasses["h3"];
+      break;
+    case 4:
+      styleClass = variantClasses["h4"];
+      break;
+    default:
+      styleClass = variantClasses["rawElement"];
+      break;
+  }
+
+  if (styleVariant) {
+    styleClass = variantClasses[styleVariant];
+  }
+
+  if (styleClass.length > 0) {
+    classStrings.push(styleClass);
+  }
+
+  if (className) {
+    classStrings.push(className);
+  }
+
+  const concatenatedClassList = classStrings.join(" ");
+
+  return concatenatedClassList;
+};
+
+interface Props extends React.HTMLProps<HTMLHeadingElement> {
+  level: HeadingLevel;
+  styleVariant?: HeadingStyleVariant | undefined;
+}
+
+export const Heading: React.FC<Props> = (props) => {
+  let headingElement: ReactElement;
+  const { level, styleVariant, children, className, ...defaultProps } = props;
+  const classList = determineClassNames(level, styleVariant, className);
+
+  switch (level) {
+    case 1:
+      headingElement = (
+        <h1 {...defaultProps} className={classList}>
+          {children}
+        </h1>
+      );
+      break;
+    case 2:
+      headingElement = (
+        <h2 {...defaultProps} className={classList}>
+          {children}
+        </h2>
+      );
+      break;
+    case 3:
+      headingElement = (
+        <h3 {...defaultProps} className={classList}>
+          {children}
+        </h3>
+      );
+      break;
+    case 4:
+      headingElement = (
+        <h4 {...defaultProps} className={classList}>
+          {children}
+        </h4>
+      );
+      break;
+    default:
+      headingElement = (
+        <div {...defaultProps} className={classList}>
+          {children}
+        </div>
+      );
+      break;
+  }
+
+  return headingElement;
+};

--- a/web/src/components/njwds/Hero.tsx
+++ b/web/src/components/njwds/Hero.tsx
@@ -1,4 +1,5 @@
 import { LandingPageTiles } from "@/components/LandingPageTiles";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { ROUTES } from "@/lib/domain-logic/routes";
@@ -91,9 +92,9 @@ export const Hero = (props: Props): ReactElement => {
                 }`}
               >
                 <div className="border-top-1 border-primary" />
-                <h2 className="h1-styling margin-y-4 desktop:margin-y-3">
+                <Heading level={2} styleVariant="h1" className="margin-y-4 desktop:margin-y-3">
                   {landingPageConfig.section2HeaderText}
-                </h2>
+                </Heading>
                 <div className="font-sans-lg line-height-120 text-base-dark margin-bottom-4 desktop:margin-bottom-3">
                   {landingPageConfig.section2SupportingText}
                 </div>
@@ -127,9 +128,9 @@ export const Hero = (props: Props): ReactElement => {
               }`}
             >
               <div className="border-top-1 border-accent-cool-darker"></div>
-              <h2 className="h1-styling margin-y-4 desktop:margin-y-3">
+              <Heading level={2} styleVariant="h1" className="margin-y-4 desktop:margin-y-3">
                 {landingPageConfig.section3HeaderText}
-              </h2>
+              </Heading>
               <div className="font-sans-lg line-height-120 text-base-dark margin-bottom-4 desktop:margin-bottom-3">
                 {landingPageConfig.section3SupportingText}
               </div>

--- a/web/src/components/post-onboarding/PostOnboardingRadioQuestion.tsx
+++ b/web/src/components/post-onboarding/PostOnboardingRadioQuestion.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { postOnboardingCheckboxes } from "@/lib/domain-logic/postOnboardingCheckboxes";
 import { PostOnboarding } from "@/lib/types/types";
@@ -69,14 +70,9 @@ export const PostOnboardingRadioQuestion = (props: Props): ReactElement => {
       {props.postOnboardingQuestion.question && (
         <>
           <div className="margin-top-205">
-            <div
-              role="heading"
-              aria-level={2}
-              data-testid={props.postOnboardingQuestion.filename}
-              className="h4-styling "
-            >
+            <Heading level={2} styleVariant="h4" data-testid={props.postOnboardingQuestion.filename}>
               {props.postOnboardingQuestion.question}
-            </div>
+            </Heading>
           </div>
           <FormControl fullWidth>
             <RadioGroup

--- a/web/src/components/profile/ProfileTabHeader.tsx
+++ b/web/src/components/profile/ProfileTabHeader.tsx
@@ -1,3 +1,4 @@
+import { Heading } from "@/components/njwds-extended/Heading";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { ProfileTabs } from "@/lib/types/types";
 import { ReactElement } from "react";
@@ -25,9 +26,9 @@ export const ProfileTabHeader = (props: Props): ReactElement => {
   return (
     <div data-testid="profile-header">
       <hr className="margin-top-4 margin-bottom-2" aria-hidden={true} />
-      <h2 className="margin-bottom-4" style={{ fontWeight: 300 }}>
+      <Heading level={2} className="margin-bottom-4" style={{ fontWeight: 300 }}>
         {getTitle()}
-      </h2>
+      </Heading>
     </div>
   );
 };

--- a/web/src/components/search/MatchCollection.tsx
+++ b/web/src/components/search/MatchCollection.tsx
@@ -1,3 +1,4 @@
+import { Heading } from "@/components/njwds-extended/Heading";
 import { Icon } from "@/components/njwds/Icon";
 import { ConfigMatchList } from "@/components/search/ConfigMatchList";
 import { MatchList } from "@/components/search/MatchList";
@@ -46,12 +47,12 @@ export const MatchCollection = (props: Props): ReactElement => {
   return (
     <Accordion expanded={isOpen} onChange={(): void => setIsOpen((prev) => !prev)}>
       <AccordionSummary expandIcon={<Icon className="usa-icon--size-5 margin-left-1">expand_more</Icon>}>
-        <h2 className="margin-y-2">
+        <Heading level={2} className="margin-y-2">
           {collectionTitle}
           <span style={{ fontWeight: 300 }} className="margin-left-1">
             ({totalMatches})
           </span>
-        </h2>
+        </Heading>
       </AccordionSummary>
       <AccordionDetails>
         {Object.keys(props.matchedCollections).map((it) => (

--- a/web/src/components/tasks/NaicsCodeDisplay.tsx
+++ b/web/src/components/tasks/NaicsCodeDisplay.tsx
@@ -1,6 +1,7 @@
 import { ArrowTooltip } from "@/components/ArrowTooltip";
 import { Content } from "@/components/Content";
 import { Alert } from "@/components/njwds-extended/Alert";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { Icon } from "@/components/njwds/Icon";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -20,7 +21,9 @@ export const NaicsCodeDisplay = (props: Props): ReactElement => {
 
   return (
     <>
-      <h2 className="text-normal">{Config.determineNaicsCode.hasSavedCodeHeader}</h2>
+      <Heading level={2} className="text-normal">
+        {Config.determineNaicsCode.hasSavedCodeHeader}
+      </Heading>
       <Alert variant="success">
         <Content>{templateEval(Config.determineNaicsCode.successMessage, { code: props.code })}</Content>
       </Alert>

--- a/web/src/components/tasks/NaicsCodeInput.tsx
+++ b/web/src/components/tasks/NaicsCodeInput.tsx
@@ -1,6 +1,7 @@
 import { Content, ExternalLink } from "@/components/Content";
 import { FieldLabelProfile } from "@/components/field-labels/FieldLabelProfile";
 import { GenericTextField } from "@/components/GenericTextField";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { getMergedConfig } from "@/contexts/configContext";
@@ -145,7 +146,9 @@ export const NaicsCodeInput = (props: Props): ReactElement => {
 
   return (
     <>
-      <h2 className="text-normal">{Config.determineNaicsCode.findCodeHeader}</h2>
+      <Heading level={2} className="text-normal">
+        {Config.determineNaicsCode.findCodeHeader}
+      </Heading>
       {industryCodes.length > 0 && (
         <>
           <Content>{Config.determineNaicsCode.suggestedCodeBodyText}</Content>

--- a/web/src/components/tasks/business-formation/BusinessFormationTextBox.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationTextBox.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { Icon } from "@/components/njwds/Icon";
 import { BusinessFormationTextField } from "@/components/tasks/business-formation/BusinessFormationTextField";
@@ -45,7 +46,7 @@ export const BusinessFormationTextBox = (props: Props): ReactElement => {
   return (
     <>
       <div className="flex flex-column mobile-lg:flex-row mobile-lg:flex-align-center margin-bottom-2">
-        <h2 className="h3-styling margin-0-override">
+        <Heading level={2} styleVariant="h3" className="margin-0-override">
           {props.title}{" "}
           {props.required ? (
             <></>
@@ -54,7 +55,7 @@ export const BusinessFormationTextBox = (props: Props): ReactElement => {
               {props.optionalLabel ?? Config.formation.general.optionalLabel}
             </span>
           )}
-        </h2>
+        </Heading>
         <div className="mobile-lg:margin-left-auto flex mobile-lg:flex-justify-center">
           {!isExpanded && (
             <UnStyledButton

--- a/web/src/components/tasks/business-formation/billing/BillingStep.tsx
+++ b/web/src/components/tasks/business-formation/billing/BillingStep.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { FormationChooseDocuments } from "@/components/tasks/business-formation/billing/FormationChooseDocuments";
 import { FormationChooseNotifications } from "@/components/tasks/business-formation/billing/FormationChooseNotifications";
 import { PaymentTypeTable } from "@/components/tasks/business-formation/billing/PaymentTypeTable";
@@ -16,7 +17,7 @@ export const BillingStep = (): ReactElement => {
 
   return (
     <div data-testid="billing-step">
-      <h3>{Config.formation.sections.contactInfoHeader}</h3>
+      <Heading level={3}>{Config.formation.sections.contactInfoHeader}</Heading>
       <WithErrorBar
         hasError={doSomeFieldsHaveError(["contactFirstName", "contactLastName"])}
         type="DESKTOP-ONLY"
@@ -63,7 +64,7 @@ export const BillingStep = (): ReactElement => {
         </div>
       </div>
       <hr className="margin-y-3" />
-      <h3>{Config.formation.sections.servicesHeader}</h3>
+      <Heading level={3}>{Config.formation.sections.servicesHeader}</Heading>
       <Content>{Config.formation.sections.servicesDescription}</Content>
       <FormationChooseDocuments />
       <PaymentTypeTable />

--- a/web/src/components/tasks/business-formation/billing/FormationChooseNotifications.tsx
+++ b/web/src/components/tasks/business-formation/billing/FormationChooseNotifications.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { Checkbox, FormControlLabel, FormGroup } from "@mui/material";
@@ -30,7 +31,7 @@ export const FormationChooseNotifications = (): ReactElement => {
 
   return (
     <div className="margin-top-3">
-      <h3>{Config.formation.sections.notificationsHeader}</h3>
+      <Heading level={3}>{Config.formation.sections.notificationsHeader}</Heading>
       <Content>{Config.formation.sections.notificationsDescription}</Content>
       <FormGroup>
         <FormControlLabel

--- a/web/src/components/tasks/business-formation/business/AdditionalProvisions.tsx
+++ b/web/src/components/tasks/business-formation/business/AdditionalProvisions.tsx
@@ -1,6 +1,7 @@
 import { Content } from "@/components/Content";
 import { GenericTextField } from "@/components/GenericTextField";
 import { ModifiedContent } from "@/components/ModifiedContent";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { Icon } from "@/components/njwds/Icon";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
@@ -59,10 +60,10 @@ export const AdditionalProvisions = (): ReactElement => {
   return (
     <>
       <div className="flex flex-column mobile-lg:flex-row mobile-lg:flex-align-center margin-bottom-2">
-        <div role="heading" aria-level={2} className="h3-styling margin-0-override">
+        <Heading level={2} styleVariant="h3" className="margin-0-override">
           {Config.formation.fields.additionalProvisions.label}{" "}
           <span className="text-normal font-body-lg">{Config.formation.general.optionalLabel}</span>
-        </div>
+        </Heading>
         <div className="mobile-lg:margin-left-auto flex mobile-lg:flex-justify-center">
           {!isExpanded && (
             <UnStyledButton style="default" onClick={handleAddButtonClick} dataTestid="show-provisions">

--- a/web/src/components/tasks/business-formation/business/BusinessNameAndLegalStructure.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessNameAndLegalStructure.tsx
@@ -2,6 +2,7 @@ import { Content } from "@/components/Content";
 import { ContextualInfoButton } from "@/components/ContextualInfoButton";
 import { ModalTwoButton } from "@/components/ModalTwoButton";
 import { ModifiedContent } from "@/components/ModifiedContent";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { LookupStepIndexByName } from "@/components/tasks/business-formation/BusinessFormationStepsConfiguration";
 import { ReviewNotEntered } from "@/components/tasks/business-formation/review/section/ReviewNotEntered";
@@ -82,7 +83,9 @@ export const BusinessNameAndLegalStructure = ({ isReviewStep = false }: Props): 
     <>
       <div className="flex space-between margin-bottom-2 flex-align-center">
         <div className="maxw-mobile-lg ">
-          <h2 className="h3-styling">{Config.formation.sections.businessNameAndStructureHeader}</h2>
+          <Heading level={2} styleVariant="h3">
+            {Config.formation.sections.businessNameAndStructureHeader}
+          </Heading>
         </div>
       </div>
 

--- a/web/src/components/tasks/business-formation/business/ForeignCertificate.tsx
+++ b/web/src/components/tasks/business-formation/business/ForeignCertificate.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@/components/Content";
 import { FileInput } from "@/components/njwds-extended/FileInput";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { FormControl } from "@mui/material";
@@ -17,11 +18,15 @@ export const ForeignCertificate = (props: Props): ReactElement => {
   return (
     <>
       <FormControl variant="outlined" fullWidth className="padding-bottom-1">
-        <h3 data-testid="foreign-certificate-of-good-standing-header" className="margin-0-override">
+        <Heading
+          level={3}
+          data-testid="foreign-certificate-of-good-standing-header"
+          className="margin-0-override"
+        >
           <Content className="h3-styling margin-0-override">
             {Config.formation.fields.foreignGoodStandingFile.contextualLabel}
           </Content>
-        </h3>
+        </Heading>
         <FileInput
           acceptedFileTypes={{
             errorMessage: Config.formation.fields.foreignGoodStandingFile.errorMessageFileType,

--- a/web/src/components/tasks/business-formation/business/MainBusinessAddressNj.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusinessAddressNj.tsx
@@ -2,6 +2,7 @@ import { CannabisLocationAlert } from "@/components/CannabisLocationAlert";
 import { Content } from "@/components/Content";
 import { ModifiedContent } from "@/components/ModifiedContent";
 import { Alert } from "@/components/njwds-extended/Alert";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { StateDropdown } from "@/components/StateDropdown";
 import { FormationMunicipality } from "@/components/tasks/business-formation/business/FormationMunicipality";
@@ -49,10 +50,10 @@ export const MainBusinessAddressNj = (): ReactElement => {
         data-testid={"main-business-address-container-header"}
         className="flex flex-column mobile-lg:flex-row mobile-lg:flex-align-center margin-bottom-2"
       >
-        <div role="heading" aria-level={2} className="h3-styling margin-0-override">
+        <Heading level={2} styleVariant="h3" className="margin-0-override">
           {Config.formation.sections.addressHeader}{" "}
           <span className="text-normal font-body-lg">{Config.formation.general.optionalLabel}</span>
-        </div>
+        </Heading>
         <div className="mobile-lg:margin-left-auto flex mobile-lg:flex-justify-center">
           {!isExpanded && (
             <div data-testid={"add-address-button"}>

--- a/web/src/components/tasks/business-formation/business/MainBusinessForeignAddressFlow.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusinessForeignAddressFlow.tsx
@@ -1,4 +1,5 @@
 import { CannabisLocationAlert } from "@/components/CannabisLocationAlert";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { MainBusinessIntl } from "@/components/tasks/business-formation/business/MainBusinessAddressIntl";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -51,9 +52,9 @@ export const MainBusinessForeignAddressFlow = (): ReactElement => {
 
   return (
     <>
-      <h3 className="margin-bottom-3" data-testid="main-business-address-container-header">
+      <Heading level={3} className="margin-bottom-3" data-testid="main-business-address-container-header">
         {Config.formation.sections.addressHeader}
-      </h3>
+      </Heading>
       <CannabisLocationAlert industryId={business?.profileData.industryId} />
       <FormControl variant="outlined" fullWidth className="padding-bottom-2">
         <RadioGroup

--- a/web/src/components/tasks/business-formation/business/NonprofitProvisions.tsx
+++ b/web/src/components/tasks/business-formation/business/NonprofitProvisions.tsx
@@ -1,3 +1,4 @@
+import { Heading } from "@/components/njwds-extended/Heading";
 import { FormationRadio } from "@/components/tasks/business-formation/business/FormationRadio";
 import { FormationTextArea } from "@/components/tasks/business-formation/business/FormationTextArea";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
@@ -77,9 +78,9 @@ export const NonprofitProvisions = (): ReactElement => {
   return (
     <>
       <div className="flex flex-column mobile-lg:flex-row mobile-lg:flex-align-center margin-bottom-2">
-        <div role="heading" aria-level={2} className="h3-styling margin-0-override">
+        <Heading level={2} styleVariant="h3" className="margin-0-override">
           {Config.formation.nonprofitProvisions.label}
-        </div>
+        </Heading>
       </div>
 
       <FormationRadio

--- a/web/src/components/tasks/business-formation/business/PartnershipRights.tsx
+++ b/web/src/components/tasks/business-formation/business/PartnershipRights.tsx
@@ -1,3 +1,4 @@
+import { Heading } from "@/components/njwds-extended/Heading";
 import { FormationRadio } from "@/components/tasks/business-formation/business/FormationRadio";
 import { FormationTextArea } from "@/components/tasks/business-formation/business/FormationTextArea";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
@@ -43,9 +44,9 @@ export const PartnershipRights = (): ReactElement => {
   return (
     <>
       <div className="flex flex-column mobile-lg:flex-row mobile-lg:flex-align-center margin-bottom-2">
-        <div role="heading" aria-level={2} className="h3-styling margin-bottom-0">
+        <Heading level={2} styleVariant="h3" className="margin-bottom-0">
           {Config.formation.partnershipRights.label}
-        </div>
+        </Heading>
       </div>
 
       {getRadio("canCreateLimitedPartner", Config.formation.fields.canCreateLimitedPartner.body)}

--- a/web/src/components/tasks/business-formation/contacts/Addresses.tsx
+++ b/web/src/components/tasks/business-formation/contacts/Addresses.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { SnackbarAlert } from "@/components/njwds-extended/SnackbarAlert";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { Icon } from "@/components/njwds/Icon";
@@ -312,7 +313,9 @@ export const Addresses = <T extends FormationMember | FormationIncorporator>(
         </SnackbarAlert>
       )}
       <div className={`margin-bottom-3 ${styles.membersTable}`} data-testid={`addresses-${props.fieldName}`}>
-        <h3 style={{ display: "inline" }}>{props.displayContent.header}</h3>
+        <Heading level={3} style={{ display: "inline" }}>
+          {props.displayContent.header}
+        </Heading>
         {props.displayContent.subheader && (
           <span className="margin-left-1">
             <span className="h6-styling">{props.displayContent.subheader}</span>

--- a/web/src/components/tasks/business-formation/contacts/RegisteredAgent.tsx
+++ b/web/src/components/tasks/business-formation/contacts/RegisteredAgent.tsx
@@ -1,6 +1,7 @@
 import { Content } from "@/components/Content";
 import { MunicipalityDropdown } from "@/components/data-fields/MunicipalityDropdown";
 import { ModifiedContent } from "@/components/ModifiedContent";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { StateDropdown } from "@/components/StateDropdown";
 import { BusinessFormationTextField } from "@/components/tasks/business-formation/BusinessFormationTextField";
 import { FormationField } from "@/components/tasks/business-formation/FormationField";
@@ -132,7 +133,7 @@ export const RegisteredAgent = (): ReactElement => {
 
   return (
     <>
-      <h3>{Config.formation.registeredAgent.label}</h3>
+      <Heading level={3}>{Config.formation.registeredAgent.label}</Heading>
       <Content>{Config.formation.registeredAgent.sectionDescription}</Content>
       <div id="registeredAgent">
         <FormControl fullWidth>

--- a/web/src/components/tasks/business-formation/contacts/Signatures.tsx
+++ b/web/src/components/tasks/business-formation/contacts/Signatures.tsx
@@ -2,6 +2,7 @@
 import { Content } from "@/components/Content";
 import { GenericTextField } from "@/components/GenericTextField";
 import { ModifiedContent } from "@/components/ModifiedContent";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { Icon } from "@/components/njwds/Icon";
 import {
@@ -337,7 +338,7 @@ export const Signatures = (): ReactElement => {
   return (
     <>
       <div className="grid-col">
-        <h3>{Config.formation.fields.signers.label}</h3>
+        <Heading level={3}>{Config.formation.fields.signers.label}</Heading>
         <Content>{getDescription()}</Content>
         <div className={`grid-row margin-y-2 flex-align-start`}>
           <div className={`grid-col`} data-testid="signers-0">

--- a/web/src/components/tasks/business-formation/name/BusinessNameStep.tsx
+++ b/web/src/components/tasks/business-formation/name/BusinessNameStep.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@/components/Content";
 import { Alert } from "@/components/njwds-extended/Alert";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
 import { getErrorStateForField } from "@/components/tasks/business-formation/getErrorStateForField";
 import { WithErrorBar } from "@/components/WithErrorBar";
@@ -55,7 +56,7 @@ export const BusinessNameStep = (): ReactElement => {
   return (
     <div data-testid="business-name-step">
       <form onSubmit={doSearch} className="usa-prose grid-container padding-0">
-        <h3>{Config.formation.fields.businessName.header}</h3>
+        <Heading level={3}>{Config.formation.fields.businessName.header}</Heading>
         <Content>{Config.formation.fields.businessName.description}</Content>
         <WithErrorBar hasError={hasError} type="DESKTOP-ONLY">
           <div className="text-bold margin-top-1">{Config.formation.fields.businessName.label}</div>

--- a/web/src/components/tasks/business-formation/name/NexusSearchBusinessNameStep.tsx
+++ b/web/src/components/tasks/business-formation/name/NexusSearchBusinessNameStep.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { NexusAvailable } from "@/components/tasks/business-formation/name/NexusAvailable";
 import { NexusUnavailable } from "@/components/tasks/business-formation/name/NexusUnavailable";
 import { SearchBusinessNameForm } from "@/components/tasks/search-business-name/SearchBusinessNameForm";
@@ -12,7 +13,7 @@ export const NexusSearchBusinessNameStep = (): ReactElement => {
 
   return (
     <div data-testid={"nexus-name-step"}>
-      <h3>{Config.formation.fields.businessName.overrides.foreign.header}</h3>
+      <Heading level={3}>{Config.formation.fields.businessName.overrides.foreign.header}</Heading>
       <Content>{Config.formation.fields.businessName.overrides.foreign.description}</Content>
       <SearchBusinessNameForm
         unavailable={NexusUnavailable}

--- a/web/src/components/tasks/business-formation/review/section/ReviewSection.tsx
+++ b/web/src/components/tasks/business-formation/review/section/ReviewSection.tsx
@@ -1,3 +1,4 @@
+import { Heading } from "@/components/njwds-extended/Heading";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { LookupStepIndexByName } from "@/components/tasks/business-formation/BusinessFormationStepsConfiguration";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
@@ -24,7 +25,7 @@ export const ReviewSection = (props: Props): ReactElement => {
     <>
       <div className={"flex space-between"}>
         <div className={"maxw-mobile-lg margin-bottom-2"}>
-          <h2>{props.stepName}</h2>
+          <Heading level={2}>{props.stepName}</Heading>
         </div>
         <div className="margin-left-2">
           <UnStyledButton

--- a/web/src/components/tasks/business-formation/review/section/ReviewSubSection.tsx
+++ b/web/src/components/tasks/business-formation/review/section/ReviewSubSection.tsx
@@ -1,3 +1,4 @@
+import { Heading } from "@/components/njwds-extended/Heading";
 import { ReactElement, ReactNode } from "react";
 
 interface Props {
@@ -15,7 +16,7 @@ export const ReviewSubSection = (props: Props): ReactElement => {
         className={`flex space-between ${props.marginOverride ?? "margin-top-4"}`}
       >
         <div className={"maxw-mobile-lg"}>
-          <h3>{props.header}</h3>
+          <Heading level={3}>{props.header}</Heading>
         </div>
       </div>
       {props.children}

--- a/web/src/components/tasks/business-formation/success/FormationSuccessPage.tsx
+++ b/web/src/components/tasks/business-formation/success/FormationSuccessPage.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { FormationSuccessDocument } from "@/components/tasks/business-formation/success/FormationSuccessDocument";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useDocuments } from "@/lib/data-hooks/useDocuments";
@@ -23,7 +24,9 @@ export const FormationSuccessPage = (props: Props): ReactElement => {
     <>
       <div className="fdc fac margin-bottom-2" data-testid="formation-success-page">
         <img src={`/img/trophy-illustration.svg`} alt="" />
-        <h2 className="margin-bottom-0">{Config.formation.successPage.header}</h2>
+        <Heading level={2} className="margin-bottom-0">
+          {Config.formation.successPage.header}
+        </Heading>
         <p className="text-center">{Config.formation.successPage.subheader}</p>
         <p className="text-center">{Config.formation.successPage.body}</p>
       </div>

--- a/web/src/components/tasks/business-structure/BusinessStructureTask.tsx
+++ b/web/src/components/tasks/business-structure/BusinessStructureTask.tsx
@@ -1,6 +1,7 @@
 import { ArrowTooltip } from "@/components/ArrowTooltip";
 import { Content } from "@/components/Content";
 import { Alert } from "@/components/njwds-extended/Alert";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { Icon } from "@/components/njwds/Icon";
@@ -155,7 +156,9 @@ export const BusinessStructureTask = (props: Props): ReactElement => {
       )}
       {business && !showRadioQuestion && (
         <>
-          <h3>{Config.businessStructureTask.completedHeader}</h3>
+          <Heading level={2} styleVariant="h3">
+            {Config.businessStructureTask.completedHeader}
+          </Heading>
           <Alert variant="success">
             <div className={`flex ${isLargeScreen ? "flex-row" : "flex-column"}`} data-testid="success-alert">
               <Content>

--- a/web/src/components/tasks/business-structure/LegalStructureRadio.tsx
+++ b/web/src/components/tasks/business-structure/LegalStructureRadio.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@/components/Content";
 import { Alert } from "@/components/njwds-extended/Alert";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { ConfigType } from "@/contexts/configContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
@@ -74,7 +75,9 @@ export const LegalStructureRadio = (props: Props): ReactElement => {
           </Alert>
         </div>
       )}
-      <h3>{Config.businessStructureTask.radioQuestionHeader}</h3>
+      <Heading level={2} styleVariant="h3">
+        {Config.businessStructureTask.radioQuestionHeader}
+      </Heading>
       <WithErrorBar hasError={isFormFieldInvalid} type="ALWAYS">
         <div className="margin-top-3">
           <FormControl variant="outlined" fullWidth>

--- a/web/src/components/tasks/cannabis/CannabisApplicationQuestionsTab.tsx
+++ b/web/src/components/tasks/cannabis/CannabisApplicationQuestionsTab.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@/components/Content";
 import { HorizontalLine } from "@/components/HorizontalLine";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { MicrobusinessRadioQuestion } from "@/components/tasks/cannabis/MicrobusinessRadioQuestion";
 import { PriorityStatusCheckboxes } from "@/components/tasks/cannabis/PriorityStatusCheckboxes";
@@ -22,15 +23,15 @@ export const CannabisApplicationQuestionsTab = (props: Props): ReactElement => {
       <Content>{Config.cannabisApplyForLicense.applicationQuestionsText}</Content>
       <HorizontalLine />
       <div className="margin-top-2">
-        <div role="heading" aria-level={2} className="h3-styling margin-bottom-2 text-normal">
+        <Heading level={2} styleVariant="h3" className="margin-bottom-2 text-normal">
           {Config.cannabisApplyForLicense.businessSizeHeader}
-        </div>
+        </Heading>
         <MicrobusinessRadioQuestion />
       </div>
       <div className="margin-top-4 margin-bottom-2">
-        <div role="heading" aria-level={2} className="h3-styling margin-bottom-2 text-normal">
+        <Heading level={2} styleVariant="h3" className="margin-bottom-2 text-normal">
           {Config.cannabisApplyForLicense.priorityStatusHeader}
-        </div>
+        </Heading>
         {!props.noPriorityStatus && (
           <>
             <Content>{Config.cannabisApplyForLicense.priorityStatusText}</Content>

--- a/web/src/components/tasks/cannabis/CannabisApplicationRequirementsTab.tsx
+++ b/web/src/components/tasks/cannabis/CannabisApplicationRequirementsTab.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
 import { Icon } from "@/components/njwds/Icon";
@@ -40,9 +41,9 @@ export const CannabisApplicationRequirementsTab = (props: Props): ReactElement =
                 aria-controls={`${Config.cannabisApplyForLicense.generalApplicationNeeds}-content`}
                 expandIcon={<Icon className="usa-icon--size-5 margin-left-1">expand_more</Icon>}
               >
-                <div role="heading" aria-level={2} className="h3-styling margin-y-3-override">
+                <Heading level={2} styleVariant="h3" className="margin-y-3-override">
                   {Config.cannabisApplyForLicense.generalApplicationNeeds}
-                </div>
+                </Heading>
               </AccordionSummary>
               <AccordionDetails>
                 <div data-testid="annualGeneralRequirements">
@@ -59,9 +60,9 @@ export const CannabisApplicationRequirementsTab = (props: Props): ReactElement =
                 aria-controls={`${Config.cannabisApplyForLicense.generalApplicationNeeds}-content`}
                 expandIcon={<Icon className="usa-icon--size-5 margin-left-1">expand_more</Icon>}
               >
-                <div role="heading" aria-level={2} className="h3-styling margin-y-3-override">
+                <Heading level={2} styleVariant="h3" className="margin-y-3-override">
                   {Config.cannabisApplyForLicense.generalApplicationNeeds}
-                </div>
+                </Heading>
               </AccordionSummary>
               <AccordionDetails>
                 <div data-testid="conditionalGeneralRequirements">
@@ -79,9 +80,9 @@ export const CannabisApplicationRequirementsTab = (props: Props): ReactElement =
                 aria-controls={`${Config.cannabisApplyForLicense.microbusinessApplicationNeeds}-content`}
                 expandIcon={<Icon className="usa-icon--size-5 margin-left-1">expand_more</Icon>}
               >
-                <div role="heading" aria-level={2} className="h3-styling margin-y-3-override">
+                <Heading level={2} styleVariant="h3" className="margin-y-3-override">
                   {Config.cannabisApplyForLicense.microbusinessApplicationNeeds}
-                </div>
+                </Heading>
               </AccordionSummary>
               <AccordionDetails>
                 <div data-testid="microbusinessRequirements">
@@ -99,9 +100,9 @@ export const CannabisApplicationRequirementsTab = (props: Props): ReactElement =
                 aria-controls={`${Config.cannabisApplyForLicense.priorityStatusApplicationNeeds}-content`}
                 expandIcon={<Icon className="usa-icon--size-5 margin-left-1">expand_more</Icon>}
               >
-                <div role="heading" aria-level={2} className="h3-styling margin-y-3-override">
+                <Heading level={2} styleVariant="h3" className="margin-y-3-override">
                   {Config.cannabisApplyForLicense.priorityStatusApplicationNeeds}
-                </div>
+                </Heading>
               </AccordionSummary>
               <AccordionDetails>
                 {props.priorityStatusState.diverselyOwned && (

--- a/web/src/components/tasks/cannabis/CannabisPriorityRequirements.tsx
+++ b/web/src/components/tasks/cannabis/CannabisPriorityRequirements.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { PrimaryButtonDropdown } from "@/components/njwds-extended/PrimaryButtonDropdown";
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
@@ -122,7 +123,7 @@ export const CannabisPriorityRequirements = (props: Props): ReactElement => {
         {!displayNoPriorityType && (
           <>
             <div className="margin-bottom-3">{Config.cannabisPriorityStatus.secondTabDescriptionText}</div>
-            <h2>{Config.cannabisPriorityStatus.secondTabHeaderText}</h2>
+            <Heading level={2}>{Config.cannabisPriorityStatus.secondTabHeaderText}</Heading>
           </>
         )}
         {displayMWPriorityType && (
@@ -133,7 +134,9 @@ export const CannabisPriorityRequirements = (props: Props): ReactElement => {
                 expandIcon={<Icon className="usa-icon--size-5 margin-left-1">expand_more</Icon>}
                 aria-controls={`${Config.cannabisPriorityStatus.minorityOrWomenHeaderText}-content`}
               >
-                <h3 className="margin-y-3">{Config.cannabisPriorityStatus.minorityOrWomenHeaderText}</h3>
+                <Heading level={3} className="margin-y-3">
+                  {Config.cannabisPriorityStatus.minorityOrWomenHeaderText}
+                </Heading>
               </AccordionSummary>
               <AccordionDetails>
                 <Content>{Config.cannabisPriorityStatus.minorityWomenOwnedRequirements}</Content>
@@ -149,7 +152,9 @@ export const CannabisPriorityRequirements = (props: Props): ReactElement => {
                 expandIcon={<Icon className="usa-icon--size-5 margin-left-1">expand_more</Icon>}
                 aria-controls={`${Config.cannabisPriorityStatus.veteranHeaderText}-content`}
               >
-                <h3 className="margin-y-3">{Config.cannabisPriorityStatus.veteranHeaderText}</h3>
+                <Heading level={3} className="margin-y-3">
+                  {Config.cannabisPriorityStatus.veteranHeaderText}
+                </Heading>
               </AccordionSummary>
               <AccordionDetails>
                 <Content>{Config.cannabisPriorityStatus.veteranOwnedRequirements}</Content>
@@ -165,7 +170,9 @@ export const CannabisPriorityRequirements = (props: Props): ReactElement => {
                 expandIcon={<Icon className="usa-icon--size-5 margin-left-1">expand_more</Icon>}
                 aria-controls={`${Config.cannabisPriorityStatus.socialEquityHeaderText}-content`}
               >
-                <h3 className="margin-y-3">{Config.cannabisPriorityStatus.socialEquityHeaderText}</h3>
+                <Heading level={3} className="margin-y-3">
+                  {Config.cannabisPriorityStatus.socialEquityHeaderText}
+                </Heading>
               </AccordionSummary>
               <AccordionDetails>
                 <Content>{Config.cannabisPriorityStatus.socialEquityRequirements}</Content>
@@ -180,7 +187,9 @@ export const CannabisPriorityRequirements = (props: Props): ReactElement => {
               <AccordionSummary
                 aria-controls={`${Config.cannabisPriorityStatus.impactZoneHeaderText}-content`}
               >
-                <h3 className="margin-y-3">{Config.cannabisPriorityStatus.impactZoneHeaderText}</h3>
+                <Heading level={3} className="margin-y-3">
+                  {Config.cannabisPriorityStatus.impactZoneHeaderText}
+                </Heading>
               </AccordionSummary>
               <AccordionDetails>
                 <Content>{Config.cannabisPriorityStatus.impactZoneText}</Content>

--- a/web/src/lib/cms/previews/CannabisEligibilityModalPreview.tsx
+++ b/web/src/lib/cms/previews/CannabisEligibilityModalPreview.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@/components/Content";
 import { ModalTwoButton } from "@/components/ModalTwoButton";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { ConfigContext } from "@/contexts/configContext";
 import { PreviewProps } from "@/lib/cms/helpers/previewHelpers";
 import { usePreviewConfig } from "@/lib/cms/helpers/usePreviewConfig";
@@ -14,7 +15,7 @@ const CannabisEligibilityModalPreview = (props: PreviewProps): ReactElement => {
 
   return (
     <ConfigContext.Provider value={{ config, setOverrides: setConfig }}>
-      <h2>Eligibility Modal</h2>
+      <Heading level={2}>Eligibility Modal</Heading>
       <button className="margin-2" onClick={(): void => setModalOpen(true)}>
         Open Modal
       </button>

--- a/web/src/lib/cms/previews/CannabisLicensePreview.tsx
+++ b/web/src/lib/cms/previews/CannabisLicensePreview.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { CannabisApplyForLicenseTask } from "@/components/tasks/cannabis/CannabisApplyForLicenseTask";
 import { ConfigContext } from "@/contexts/configContext";
 import { PreviewProps } from "@/lib/cms/helpers/previewHelpers";
@@ -31,10 +32,12 @@ const CannabisLicensePreview = (props: PreviewProps): ReactElement => {
       <div className="cms" ref={ref} style={{ margin: 40, pointerEvents: "none" }}>
         {tab === "1" && (
           <>
-            <h2>No Priority Status Selected</h2>
+            <Heading level={2}>No Priority Status Selected</Heading>
             <Content>{config.cannabisApplyForLicense.priorityStatusNoneSelectedText}</Content>
             <hr className="margin-y-5" />
-            <h2 className="margin-bottom-5">Priority Status Selected</h2>
+            <Heading level={2} className="margin-bottom-5">
+              Priority Status Selected
+            </Heading>
           </>
         )}
         <CannabisApplyForLicenseTask

--- a/web/src/lib/cms/previews/CannabisPriorityStatusPreview.tsx
+++ b/web/src/lib/cms/previews/CannabisPriorityStatusPreview.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@/components/Content";
 import { Alert } from "@/components/njwds-extended/Alert";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { CannabisPriorityStatusTask } from "@/components/tasks/cannabis/CannabisPriorityStatusTask";
 import { ConfigContext } from "@/contexts/configContext";
 import { PreviewProps } from "@/lib/cms/helpers/previewHelpers";
@@ -32,7 +33,7 @@ const CannabisPriorityStatusPreview = (props: PreviewProps): ReactElement => {
         {tab === "1" && (
           <>
             <hr className="margin-y-4" />
-            <h2>Priority Status Types</h2>
+            <Heading level={2}>Priority Status Types</Heading>
 
             <Alert variant="info">
               <Content>{templateEval(config.cannabisPriorityStatus.phrase1, priorityStatusTypes)}</Content>

--- a/web/src/lib/cms/previews/DashboardCalendarPreview.tsx
+++ b/web/src/lib/cms/previews/DashboardCalendarPreview.tsx
@@ -1,5 +1,6 @@
 import { HideableTasks } from "@/components/dashboard/HideableTasks";
 import { FilingsCalendar } from "@/components/filings-calendar/FilingsCalendar";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { ConfigContext } from "@/contexts/configContext";
 import { PreviewProps } from "@/lib/cms/helpers/previewHelpers";
 import { usePreviewConfig } from "@/lib/cms/helpers/usePreviewConfig";
@@ -76,12 +77,12 @@ const DashboardCalendarPreview = (props: PreviewProps): ReactElement => {
     <ConfigContext.Provider value={{ config, setOverrides: setConfig }}>
       <div className="cms" ref={ref} style={{ margin: 40, pointerEvents: "none" }}>
         <ThemeProvider theme={createTheme()}>
-          <h2>Empty calendar</h2>
+          <Heading level={2}>Empty calendar</Heading>
           <FilingsCalendar operateReferences={{}} CMS_ONLY_fakeBusiness={emptyFilingsUserData} />
 
           <hr className="margin-top-6" />
 
-          <h2>Calendar with filings, list view</h2>
+          <Heading level={2}>Calendar with filings, list view</Heading>
           <FilingsCalendar
             operateReferences={operateReferences}
             CMS_ONLY_fakeBusiness={filingsBusinessList}
@@ -89,7 +90,7 @@ const DashboardCalendarPreview = (props: PreviewProps): ReactElement => {
 
           <hr className="margin-top-6" />
 
-          <h2>Calendar with filings, grid view</h2>
+          <Heading level={2}>Calendar with filings, grid view</Heading>
           <FilingsCalendar
             operateReferences={operateReferences}
             CMS_ONLY_fakeBusiness={filingsBusinessGrid}

--- a/web/src/lib/cms/previews/DashboardSnackbarsPreview.tsx
+++ b/web/src/lib/cms/previews/DashboardSnackbarsPreview.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { SnackbarAlert } from "@/components/njwds-extended/SnackbarAlert";
 import { ConfigContext } from "@/contexts/configContext";
 import { PreviewProps } from "@/lib/cms/helpers/previewHelpers";
@@ -13,7 +14,7 @@ const DashboardSnackbarsPreview = (props: PreviewProps): ReactElement => {
   return (
     <ConfigContext.Provider value={{ config, setOverrides: setConfig }}>
       <div className="cms" ref={ref} style={{ margin: 40, pointerEvents: "none" }}>
-        <h2>Calendar Snackbar</h2>
+        <Heading level={2}>Calendar Snackbar</Heading>
         <SnackbarAlert
           variant="success"
           isOpen={true}
@@ -23,7 +24,7 @@ const DashboardSnackbarsPreview = (props: PreviewProps): ReactElement => {
           <Content>{config.dashboardDefaults.calendarSnackbarBody}</Content>
         </SnackbarAlert>
 
-        <h2>Certifications Snackbar</h2>
+        <Heading level={2}>Certifications Snackbar</Heading>
         <SnackbarAlert
           variant="success"
           isOpen={true}
@@ -33,7 +34,7 @@ const DashboardSnackbarsPreview = (props: PreviewProps): ReactElement => {
           <Content>{config.dashboardDefaults.certificationsSnackbarBody}</Content>
         </SnackbarAlert>
 
-        <h2>Deferred Onboarding Snackbar</h2>
+        <Heading level={2}>Deferred Onboarding Snackbar</Heading>
         <SnackbarAlert
           variant="success"
           isOpen={true}
@@ -43,7 +44,7 @@ const DashboardSnackbarsPreview = (props: PreviewProps): ReactElement => {
           <Content>{config.dashboardDefaults.deferredOnboardingSnackbarBody}</Content>
         </SnackbarAlert>
 
-        <h2>Tax Registration Snackbar</h2>
+        <Heading level={2}>Tax Registration Snackbar</Heading>
         <SnackbarAlert
           variant="success"
           isOpen={true}
@@ -53,7 +54,7 @@ const DashboardSnackbarsPreview = (props: PreviewProps): ReactElement => {
           <Content>{config.dashboardDefaults.taxRegistrationSnackbarBody}</Content>
         </SnackbarAlert>
 
-        <h2>Funding Snackbar</h2>
+        <Heading level={2}>Funding Snackbar</Heading>
         <SnackbarAlert
           variant="success"
           isOpen={true}
@@ -63,7 +64,7 @@ const DashboardSnackbarsPreview = (props: PreviewProps): ReactElement => {
           <Content>{config.dashboardDefaults.fundingSnackbarBody}</Content>
         </SnackbarAlert>
 
-        <h2>Hidden Tasks Snackbar</h2>
+        <Heading level={2}>Hidden Tasks Snackbar</Heading>
         <SnackbarAlert
           variant="success"
           isOpen={true}

--- a/web/src/lib/cms/previews/NexusDbaFormationPreview.tsx
+++ b/web/src/lib/cms/previews/NexusDbaFormationPreview.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@/components/Content";
 import { ModalTwoButton } from "@/components/ModalTwoButton";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { ConfigContext } from "@/contexts/configContext";
 import { PreviewProps } from "@/lib/cms/helpers/previewHelpers";
 import { usePreviewConfig } from "@/lib/cms/helpers/usePreviewConfig";
@@ -16,7 +17,7 @@ const NexusDbaFormationPreview = (props: PreviewProps): ReactElement => {
     <ConfigContext.Provider value={{ config, setOverrides: setConfig }}>
       <div className="cms" ref={ref} style={{ margin: 40, pointerEvents: "none" }}>
         <div ref={ref} style={{ pointerEvents: "all" }}>
-          <h2>CTA Modal</h2>
+          <Heading level={2}>CTA Modal</Heading>
           <button onClick={(): void => setModalOpen(true)}>Open CTA Modal</button>
         </div>
 

--- a/web/src/lib/cms/previews/ProfileFieldsPreview.tsx
+++ b/web/src/lib/cms/previews/ProfileFieldsPreview.tsx
@@ -20,6 +20,7 @@ import { TaxId } from "@/components/data-fields/tax-id/TaxId";
 import { TaxPin } from "@/components/data-fields/TaxPin";
 import { FieldLabelOnboarding } from "@/components/field-labels/FieldLabelOnboarding";
 import { FieldLabelProfile } from "@/components/field-labels/FieldLabelProfile";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { ProfileDocuments } from "@/components/profile/ProfileDocuments";
 import { LegalStructureRadio } from "@/components/tasks/business-structure/LegalStructureRadio";
 import { ConfigContext } from "@/contexts/configContext";
@@ -159,7 +160,7 @@ const ProfileFieldsPreview = (props: PreviewProps): ReactElement => {
           <NaicsCode />
 
           <div className="margin-top-3">
-            <h4>----Input Label On Naics Code Task----</h4>
+            <Heading level={4}>----Input Label On Naics Code Task----</Heading>
             <FieldLabelProfile fieldName={"naicsCode"} isAltDescriptionDisplayed ignoreContextualInfo />
           </div>
 

--- a/web/src/lib/cms/previews/ProfileMiscPreview.tsx
+++ b/web/src/lib/cms/previews/ProfileMiscPreview.tsx
@@ -1,4 +1,5 @@
 import { Alert } from "@/components/njwds-extended/Alert";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { ProfileEscapeModal } from "@/components/profile/ProfileEscapeModal";
 import { ProfileSnackbarAlert } from "@/components/profile/ProfileSnackbarAlert";
 import { ConfigContext } from "@/contexts/configContext";
@@ -25,7 +26,7 @@ const ProfilePreviewMisc = (props: PreviewProps): ReactElement => {
   return (
     <ConfigContext.Provider value={{ config, setOverrides: setConfig }}>
       <div className="cms" ref={ref} style={{ margin: 40, pointerEvents: "none" }}>
-        <h2>Escape Modal:</h2>
+        <Heading level={2}>Escape Modal:</Heading>
         <div ref={ref} style={{ pointerEvents: "all" }}>
           <button onClick={(): void => setModalOpen(true)}>Open Modal</button>
         </div>
@@ -36,23 +37,25 @@ const ProfilePreviewMisc = (props: PreviewProps): ReactElement => {
         />
         <hr className="margin-y-4" />
 
-        <h2>Success Alert:</h2>
+        <Heading level={2}>Success Alert:</Heading>
         <ProfileSnackbarAlert alert="SUCCESS" close={(): void => {}} />
         <hr className="margin-y-4" />
 
-        <h2>Error Alert</h2>
+        <Heading level={2}>Error Alert</Heading>
         <ProfileSnackbarAlert alert="ERROR" close={(): void => {}} />
         <hr className="margin-y-4" />
 
-        <h2>Essential Question Alert Banner</h2>
+        <Heading level={2}>Essential Question Alert Banner</Heading>
         <Alert variant="error">{config.profileDefaults.default.essentialQuestionAlertText}</Alert>
 
         <hr className="margin-y-4" />
-        <h2>Essential Question Inline Error Text</h2>
+        <Heading level={2}>Essential Question Inline Error Text</Heading>
         {config.siteWideErrorMessages.errorRadioButton}
         <hr className="margin-y-4" />
 
-        <h2 className="margin-bottom-4">Misc Buttons & Labels:</h2>
+        <Heading level={2} className="margin-bottom-4">
+          Misc Buttons & Labels:
+        </Heading>
         <Profile
           municipalities={[]}
           CMS_ONLY_tab="documents"
@@ -61,7 +64,7 @@ const ProfilePreviewMisc = (props: PreviewProps): ReactElement => {
         />
         <hr className="margin-y-4" />
 
-        <h2>Cannabis Location Alert: </h2>
+        <Heading level={2}>Cannabis Location Alert: </Heading>
         <Alert variant="warning">{config.profileDefaults.default.cannabisLocationAlert}</Alert>
       </div>
     </ConfigContext.Provider>

--- a/web/src/pages/filings/[filingUrlSlug].tsx
+++ b/web/src/pages/filings/[filingUrlSlug].tsx
@@ -2,6 +2,7 @@ import { ArrowTooltip } from "@/components/ArrowTooltip";
 import { Content, ExternalLink, GreenBox } from "@/components/Content";
 import { HorizontalLine } from "@/components/HorizontalLine";
 import { NavBar } from "@/components/navbar/NavBar";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { Tag } from "@/components/njwds-extended/Tag";
 import { Icon } from "@/components/njwds/Icon";
 import { PageSkeleton } from "@/components/PageSkeleton";
@@ -146,7 +147,9 @@ export const FilingElement = (props: {
                   .toLowerCase()
                   .replaceAll(" ", "-")}-content`}
               >
-                <h3 className="margin-y-3">{Config.filingDefaults.additionalInfo}</h3>
+                <Heading level={3} className="margin-y-3">
+                  {Config.filingDefaults.additionalInfo}
+                </Heading>
               </AccordionSummary>
               <AccordionDetails>
                 <Content>{props.filing.additionalInfo}</Content>

--- a/web/src/pages/index.tsx
+++ b/web/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import { LegalMessage } from "@/components/LegalMessage";
 import { NavBar } from "@/components/navbar/NavBar";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { Hero } from "@/components/njwds/Hero";
 import { PageSkeleton } from "@/components/PageSkeleton";
 import { SupportExploreSignUpChatCards } from "@/components/SupportExploreSignUpChatCards";
@@ -114,17 +115,25 @@ const Home = (props: Props): ReactElement => {
             {isDesktopAndUp ? (
               <>
                 <div className="landing-feature-text">
-                  <h2 className="h1-styling text-base-darkest margin-bottom-4 desktop:margin-bottom-3">
+                  <Heading
+                    level={2}
+                    styleVariant="h1"
+                    className="text-base-darkest margin-bottom-4 desktop:margin-bottom-3"
+                  >
                     {headingText}
-                  </h2>
+                  </Heading>
                   <div className="text-base-dark">{supportingText}</div>
                 </div>
               </>
             ) : (
               <>
-                <h2 className="h1-styling text-base-darkest margin-right-2 margin-left-2 margin-top-10">
+                <Heading
+                  level={2}
+                  styleVariant="h1"
+                  className="text-base-darkest margin-right-2 margin-left-2 margin-top-10"
+                >
                   {headingText}
-                </h2>
+                </Heading>
                 <img src={imageSrc} alt={imageAlt} />
               </>
             )}
@@ -156,9 +165,13 @@ const Home = (props: Props): ReactElement => {
           <Hero isWelcomePage={props.isWelcomePage} />
           <section ref={sectionHowItWorks} aria-label={landingPageConfig.section4HeaderText}>
             <div className="minh-mobile margin-top-2 desktop:margin-top-neg-205  padding-bottom-6 text-center bg-base-extra-light">
-              <h2 className="text-accent-cool-darker h1-styling margin-bottom-6 padding-top-6">
+              <Heading
+                level={2}
+                styleVariant="h1"
+                className="text-accent-cool-darker margin-bottom-6 padding-top-6"
+              >
                 {landingPageConfig.section4HeaderText}
-              </h2>
+              </Heading>
               <div
                 className={`flex ${
                   isDesktopAndUp ? "flex-row flex-justify-center" : "flex-column flex-align-center"
@@ -225,9 +238,12 @@ const Home = (props: Props): ReactElement => {
           >
             <div className="bg-base-extra-light padding-x-2 desktop:padding-x-0 desktop:padding-bottom-10">
               <div className="desktop:grid-container-widescreen flex flex-column flex-align-center">
-                <h2 className="base-darkest margin-top-7 text-center margin-bottom-5 desktop:margin-top-10 desktop:margin-bottom-8">
+                <Heading
+                  level={2}
+                  className="base-darkest margin-top-7 text-center margin-bottom-5 desktop:margin-top-10 desktop:margin-bottom-8"
+                >
                   {landingPageConfig.section6Header}
-                </h2>
+                </Heading>
 
                 <SupportExploreSignUpChatCards />
                 <div className="green-divider-center width-10 desktop:width-mobile margin-top-2 desktop:margin-top-10"></div>

--- a/web/src/pages/mgmt/deadlinks.tsx
+++ b/web/src/pages/mgmt/deadlinks.tsx
@@ -1,4 +1,5 @@
 import { MgmtAuth } from "@/components/auth/MgmtAuth";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { SingleColumnContainer } from "@/components/njwds/SingleColumnContainer";
 import { PageSkeleton } from "@/components/PageSkeleton";
 import { findDeadContextualInfo, findDeadTasks } from "@/lib/static/admin/findDeadLinks";
@@ -20,13 +21,15 @@ const DeadLinksPage = (props: Props): ReactElement => {
   const authedView = (
     <>
       <h1>Dead Content</h1>
-      <h2 data-testid="dl-task-header">Tasks not referenced in any roadmap:</h2>
+      <Heading level={2} data-testid="dl-task-header">
+        Tasks not referenced in any roadmap:
+      </Heading>
       <ul>
         {props.deadTasks.map((task, i) => {
           return <li key={i}>{task}</li>;
         })}
       </ul>
-      <h2>Contextual infos not referenced anywhere:</h2>
+      <Heading level={2}>Contextual infos not referenced anywhere:</Heading>
       <ul>
         {props.deadContextualInfo.map((info, i) => {
           return <li key={i}>{info}</li>;

--- a/web/src/pages/mgmt/deadurls.tsx
+++ b/web/src/pages/mgmt/deadurls.tsx
@@ -1,4 +1,5 @@
 import { MgmtAuth } from "@/components/auth/MgmtAuth";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { SingleColumnContainer } from "@/components/njwds/SingleColumnContainer";
 import { PageSkeleton } from "@/components/PageSkeleton";
@@ -53,14 +54,14 @@ const DeadUrlsPage = (props: Props): ReactElement => {
   const authedView = (
     <>
       <h1>Dead URLs</h1>
-      <h2>
+      <Heading level={2}>
         NOTE: this only works locally, (ask a dev to run this locally for results
         https://www.pivotaltracker.com/story/show/185355762)
-      </h2>
+      </Heading>
       <PrimaryButton onClick={handleDownloadClick} isColor={"primary"}>
         Click Here to Download, as a txt file
       </PrimaryButton>
-      <h2>Potentially broken links:</h2>
+      <Heading level={2}>Potentially broken links:</Heading>
       {Object.keys(props.deadLinks).map((page, i) => {
         return (
           <div key={i}>

--- a/web/src/pages/unsupported.tsx
+++ b/web/src/pages/unsupported.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { SingleColumnContainer } from "@/components/njwds/SingleColumnContainer";
 import { PageSkeleton } from "@/components/PageSkeleton";
 import { SupportExploreSignUpChatCards } from "@/components/SupportExploreSignUpChatCards";
@@ -13,7 +14,9 @@ const UnsupportedPage = (): ReactElement => {
       <main className="usa-section padding-top-0 desktop:padding-top-8" id="main">
         <SingleColumnContainer>
           <div className="padding-top-5 desktop:padding-top-0">
-            <h2 className="base-darkest text-left">{Config.unsupportedNavigatorUserPage.title}</h2>
+            <Heading level={2} className="base-darkest text-left">
+              {Config.unsupportedNavigatorUserPage.title}
+            </Heading>
             <div
               data-testid="unsupported-subtitle"
               className="base-darkest margin-bottom-5 desktop:margin-top-2"

--- a/web/stories/Atoms/Colors.stories.tsx
+++ b/web/stories/Atoms/Colors.stories.tsx
@@ -1,3 +1,4 @@
+import { Heading } from "@/components/njwds-extended/Heading";
 import { Meta, StoryObj } from "@storybook/react";
 
 const Template = () => {
@@ -17,7 +18,9 @@ const Template = () => {
 
   const neutralBase = (
     <div className="flex flex-row">
-      <div className="h1-styling margin-right-4 width-card-lg">Neutral/Base</div>
+      <Heading level={3} styleVariant="h1" className="margin-right-4 width-card-lg">
+        Neutral/Base
+      </Heading>
       {renderColor("base-extra-light", "#f8f8f8")}
       {renderColor("base-lightest", "#f0f0f0")}
       {renderColor("base-lighter", "#e6e6e6")}
@@ -30,7 +33,9 @@ const Template = () => {
 
   const primary = (
     <div className="flex flex-row margin-top-4">
-      <div className="h1-styling margin-right-4 width-card-lg">Primary</div>
+      <Heading level={3} styleVariant="h1" className="margin-right-4 width-card-lg">
+        Primary
+      </Heading>
       {renderColor("primary-extra-extra-light", "#fbfdf9")}
       {renderColor("primary-extra-light", "#f2f7eb")}
       {renderColor("primary-lightest", "#d9e9bf")}
@@ -47,7 +52,9 @@ const Template = () => {
 
   const secondary = (
     <div className="flex flex-row margin-top-4">
-      <div className="h1-styling margin-right-4 width-card-lg">Secondary</div>
+      <Heading level={3} styleVariant="h1" className="margin-right-4 width-card-lg">
+        Secondary
+      </Heading>
       {renderColor("secondary-lighter", "#cfe8ff")}
       {renderColor("secondary-light", "#73b3e7")}
       {renderColor("secondary-vivid", "#0076d6")}
@@ -60,7 +67,9 @@ const Template = () => {
 
   const accentCool = (
     <div className="flex flex-row margin-top-4">
-      <div className="h1-styling margin-right-4 width-card-lg">Accent Cool</div>
+      <Heading level={3} styleVariant="h1" className="margin-right-4 width-card-lg">
+        Accent Cool
+      </Heading>
       {renderColor("accent-cool-lightest", "#ecf4fb")}
       {renderColor("accent-cool-lighter", "#d9e8f6")}
       {renderColor("accent-cool-light", "#aacdec")}
@@ -75,7 +84,9 @@ const Template = () => {
 
   const accentWarm = (
     <div className="flex flex-row margin-top-4">
-      <div className="h1-styling margin-right-4 width-card-lg">Accent Warm</div>
+      <Heading level={3} styleVariant="h1" className="margin-right-4 width-card-lg">
+        Accent Warm
+      </Heading>
       {renderColor("accent-warm-extra-light", "#fff4dc")}
       {renderColor("accent-warm-lighter", "#ffe396")}
       {renderColor("accent-warm-light", "#e5a000")}
@@ -87,7 +98,9 @@ const Template = () => {
 
   const success = (
     <div className="flex flex-row margin-top-4">
-      <div className="h1-styling margin-right-4 width-card-lg">Success</div>
+      <Heading level={3} styleVariant="h1" className="margin-right-4 width-card-lg">
+        Success
+      </Heading>
       {renderColor("success-extra-light", "#ecf3ec")}
       {renderColor("success-lighter", "#c9e8c9")}
       {renderColor("success-light", "#70e17b")}
@@ -99,7 +112,9 @@ const Template = () => {
 
   const info = (
     <div className="flex flex-row margin-top-4">
-      <div className="h1-styling margin-right-4 width-card-lg">Info</div>
+      <Heading level={3} styleVariant="h1" className="margin-right-4 width-card-lg">
+        Info
+      </Heading>
       {renderColor("info-extra-light", "#e7f6f8")}
       {renderColor("info-light", "#99deea")}
       {renderColor("info", "#00bde3")}
@@ -112,7 +127,9 @@ const Template = () => {
 
   const warning = (
     <div className="flex flex-row margin-top-4">
-      <div className="h1-styling margin-right-4 width-card-lg">Warning</div>
+      <Heading level={3} styleVariant="h1" className="margin-right-4 width-card-lg">
+        Warning
+      </Heading>
       {renderColor("warning-extra-light", "#faf3d1")}
       {renderColor("warning-light", "#fee685")}
       {renderColor("warning", "#ffbe2e")}
@@ -123,7 +140,9 @@ const Template = () => {
 
   const error = (
     <div className="flex flex-row margin-top-4">
-      <div className="h1-styling margin-right-4 width-card-lg">Error</div>
+      <Heading level={3} styleVariant="h1" className="margin-right-4 width-card-lg">
+        Error
+      </Heading>
       {renderColor("error-extra-light", "#f4e3db")}
       {renderColor("error-light", "#f39268")}
       {renderColor("error", "#d54309")}
@@ -134,7 +153,9 @@ const Template = () => {
 
   const shades = (
     <div className="flex flex-row margin-top-4">
-      <div className="h1-styling margin-right-4 width-card-lg">Shades</div>
+      <Heading level={3} styleVariant="h1" className="margin-right-4 width-card-lg">
+        Shades
+      </Heading>
       {renderColor("white", "#ffffff")}
       {renderColor("disabled", "#757575")}
     </div>
@@ -142,7 +163,9 @@ const Template = () => {
 
   const coolNeutral = (
     <div className="flex flex-row margin-top-4">
-      <div className="h1-styling margin-right-4 width-card-lg">Cool Neutral</div>
+      <Heading level={3} styleVariant="h1" className="margin-right-4 width-card-lg">
+        Cool Neutral
+      </Heading>
       {renderColor("cool-extra-light", "#f9fbfb")}
       {renderColor("cool-lighter", "#ddeded")}
     </div>
@@ -150,7 +173,9 @@ const Template = () => {
 
   const accentCooler = (
     <div className="flex flex-row margin-top-4">
-      <div className="h1-styling margin-right-4 width-card-lg">Accent Cooler</div>
+      <Heading level={3} styleVariant="h1" className="margin-right-4 width-card-lg">
+        Accent Cooler
+      </Heading>
       {renderColor("accent-cooler-lightest", "#ece6f2")}
       {renderColor("accent-cooler-light", "#c1add3")}
       {renderColor("accent-cooler", "#835da4")}
@@ -161,7 +186,9 @@ const Template = () => {
 
   const accentHot = (
     <div className="flex flex-row margin-top-4">
-      <div className="h1-styling margin-right-4 width-card-lg">Accent Hot</div>
+      <Heading level={3} styleVariant="h1" className="margin-right-4 width-card-lg">
+        Accent Hot
+      </Heading>
       {renderColor("accent-hot-extra-light", "#fae8e0")}
       {renderColor("accent-hot", "#be4e1e")}
     </div>
@@ -169,7 +196,9 @@ const Template = () => {
 
   const accentSemiCool = (
     <div className="flex flex-row margin-top-4">
-      <div className="h1-styling margin-right-4 width-card-lg">Accent Semi Cool</div>
+      <Heading level={3} styleVariant="h1" className="margin-right-4 width-card-lg">
+        Accent Semi Cool
+      </Heading>
       {renderColor("accent-semi-cool-extra-light", "#effffb")}
       {renderColor("accent-semi-cool-lightest", "#defff8")}
       {renderColor("accent-semi-cool-light", "#BDFFF2")}
@@ -181,7 +210,9 @@ const Template = () => {
 
   return (
     <div>
-      <div className="h1-styling-large margin-y-4">Theme Palette</div>
+      <Heading level={2} styleVariant="h1Large" className="margin-y-4">
+        Theme Palette
+      </Heading>
       <div className="margin-y-6">
         <div>{neutralBase}</div>
         <div>{primary}</div>
@@ -189,7 +220,9 @@ const Template = () => {
         <div>{accentCool}</div>
         <div>{accentWarm}</div>
       </div>
-      <div className="h1-styling-large margin-bottom-4 margin-top-10">Alert Palette</div>
+      <Heading level={2} styleVariant="h1Large" className="margin-bottom-4 margin-top-10">
+        Alert Palette
+      </Heading>
       <div className="margin-y-6">
         <div>{success}</div>
         <div>{info}</div>
@@ -197,7 +230,9 @@ const Template = () => {
         <div>{error}</div>
         <div>{shades}</div>
       </div>
-      <div className="h1-styling-large margin-bottom-4 margin-top-10">New Colors</div>
+      <Heading level={2} styleVariant="h1Large" className="margin-bottom-4 margin-top-10">
+        New Colors
+      </Heading>
       <div>{coolNeutral}</div>
       <div>{accentCooler}</div>
       <div>{accentHot}</div>

--- a/web/stories/Atoms/DropShadows.stories.tsx
+++ b/web/stories/Atoms/DropShadows.stories.tsx
@@ -1,3 +1,4 @@
+import { Heading } from "@/components/njwds-extended/Heading";
 import { Meta, StoryObj } from "@storybook/react";
 
 const Template = () => {
@@ -5,7 +6,9 @@ const Template = () => {
   const renderColor = (variable: string) => (
     <div className="bg-white width-mobile-lg height-mobile-lg ">
       <div className="grid-row margin-y-6" key={variable}>
-        <div className="h1-styling ">Shadow ({variable})</div>
+        <Heading level={2} styleVariant="h1">
+          Shadow ({variable})
+        </Heading>
         <div
           className={`drop-shadow-${variable} margin-left-5 width-mobile height-15 bg-success-extra-light`}
         />
@@ -15,7 +18,9 @@ const Template = () => {
 
   return (
     <div className="grid-container">
-      <div className="h1-styling-large margin-y-4">Drop Shadows</div>
+      <Heading level={1} styleVariant="h1Large" className="margin-y-4">
+        Drop Shadows
+      </Heading>
       {shadows.map((shadow) => renderColor(shadow))}
     </div>
   );

--- a/web/stories/Atoms/Gradients.stories.tsx
+++ b/web/stories/Atoms/Gradients.stories.tsx
@@ -1,3 +1,4 @@
+import { Heading } from "@/components/njwds-extended/Heading";
 import { Meta, StoryObj } from "@storybook/react";
 
 const Template = () => {
@@ -33,15 +34,21 @@ const Template = () => {
 
   return (
     <div>
-      <div className="h1-styling-large margin-y-4">Primary Gradient</div>
+      <Heading level={2} styleVariant="h1Large" className="margin-y-4">
+        Primary Gradient
+      </Heading>
       <div className="margin-y-2">
         <div>{PrimaryGradient}</div>
       </div>
-      <div className="h1-styling-large margin-y-4">Secondary Gradient</div>
+      <Heading level={2} styleVariant="h1Large" className="margin-y-4">
+        Secondary Gradient
+      </Heading>
       <div className="margin-y-2">
         <div>{SecondaryGradient}</div>
       </div>
-      <div className="h1-styling-large margin-y-4">Tertiary Gradient</div>
+      <Heading level={2} styleVariant="h1Large" className="margin-y-4">
+        Tertiary Gradient
+      </Heading>
       <div className="margin-y-2">
         <div>{TertiaryGradient}</div>
       </div>

--- a/web/stories/Atoms/Typography.stories.tsx
+++ b/web/stories/Atoms/Typography.stories.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
 import { Meta, StoryObj } from "@storybook/react";
 import { ReactElement } from "react";
 
@@ -73,25 +74,25 @@ const Template = () => {
 
   const h2 = {
     title: <div>H2</div>,
-    usaProseElement: <h2>Hello</h2>,
+    usaProseElement: <Heading level={2}>Hello</Heading>,
     usaProseCSS: <div className="h2-styling">Hello</div>,
-    element: <h2>Hello</h2>,
+    element: <Heading level={2}>Hello</Heading>,
     cSS: <div className="h2-styling">Hello</div>,
   };
 
   const h3 = {
     title: <div>H3</div>,
-    usaProseElement: <h3>Hello</h3>,
+    usaProseElement: <Heading level={3}>Hello</Heading>,
     usaProseCSS: <div className="h3-styling">Hello</div>,
-    element: <h3>Hello</h3>,
+    element: <Heading level={3}>Hello</Heading>,
     cSS: <div className="h3-styling">Hello</div>,
   };
 
   const h4 = {
     title: <div>H4</div>,
-    usaProseElement: <h4>Hello</h4>,
+    usaProseElement: <Heading level={4}>Hello</Heading>,
     usaProseCSS: <div className="h4-styling">Hello</div>,
-    element: <h4>Hello</h4>,
+    element: <Heading level={4}>Hello</Heading>,
     cSS: <div className="h4-styling">Hello</div>,
   };
 
@@ -182,7 +183,9 @@ const Template = () => {
         <div className={`grid-row padding-1`}>
           <div className="grid-col-2 margin-right-3">H Element Text Normal</div>
           <div className="grid-col-auto">
-            <h3 className={"font-weight-normal"}>This is heading text with normal font weight</h3>
+            <Heading level={3} className={"font-weight-normal"}>
+              This is heading text with normal font weight
+            </Heading>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

The first of two pull requests for this Pivotal Tracker story, due to the extent and nature of the changes needed to accomplish this work.

This introduces the `<Heading>` component and applies it throughout the site in replacement of all `<h2>`, `<h3>`, `<h4>`, and `<div role="heading">` elements to allow for seamless differential styling between the appropriate heading element and the desired heading typographical style. (`<h1>`, `<h5>`, and `<h6>` are out-of-scope for this story for various reasons.)

Use the element as follows:

```typescript
<Heading level={...} styleVariant="..." {...}>Heading text here</Heading>
```

Where the following attributes can be set:

| attribute | description |
| --- | --- |
| `level={...}` | **Required.** Heading level. Allowed values of 1, 2, 3, 4 corresponding to `<h1>`, `<h2>`, `<h3>`, and `<h4>`, respectively. If a `<div>` is desired instead, pass a value of 0.  |
| `styleVariant="..."` | **Optional.** If looking to override the default styling of that heading level (`h1-styling`, etc.), pass it the style variant you want. Allowable values are "h1", "h2", "h3", "h4", "h5", "h6", and "rawElement", the last of which chosen if you don't want any of the default heading style classes. |
| `{ ... }` | **Optional.** Besides `level` and `styleVariant`, any valid JSX prop for an `<h1>`, `<h2>`, `<h3>`, or `<h4>` tag can be passed as a prop to the `<Heading>` element, allowing for flexibility. These are all passed transparently except for `className`, which gets concatenated to the end of the `className` string that gets sent to the actual HTML element in the virtual DOM. |

For example, this component:

```typescript
<Heading level={2} styleVariant="h3" className="padding-right-2" data-bar="foo">Hello, world!</Heading>
```

should be rendered as the following HTML element:

```html
<h2 class="h3-styling padding-right-2" data-bar="foo">Hello, world!</h2>
```

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#186006497](https://www.pivotaltracker.com/story/show/186006497)

> **Note:** This PR will only address the "Select a Business Structure" part of the story. The others will be addressed in a follow-up PR.

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

No additional steps are required before testing this work.

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

There should not be very much to test here, as this work should fairly transparently map the existing heading elements to the new heading element equivalents. Testing just involves seeing if any of the non-`<h1>` headers on the site appear as before.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

The steps for completion of the rest of this story will require a re-think of how tasks are structured, and with 63 file changes so far, this seemed a natural place to pause for feedback before moving onto that step.

Nothing has been added to the Engineering FAQ, but I'm open to adding documentation if so desired.

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
