### PR TITLE
chore: [#186598228] updated license calendar test to only use valid m…

### DIFF
--- a/web/src/lib/domain-logic/getLicenseCalendarEvents.test.ts
+++ b/web/src/lib/domain-logic/getLicenseCalendarEvents.test.ts
@@ -1,4 +1,5 @@
 import { getLicenseCalendarEvents } from "@/lib/domain-logic/getLicenseCalendarEvents";
+import { randomIntFromInterval } from "@businessnjgovnavigator/shared";
 import { getCurrentDate } from "@businessnjgovnavigator/shared/dateHelpers";
 import { defaultDateFormat } from "@businessnjgovnavigator/shared/defaultConstants";
 import { generateLicenseData } from "@businessnjgovnavigator/shared/test";
@@ -41,12 +42,16 @@ describe("getLicenseCalendarEvent", () => {
   });
 
   it("returns an array containing renewal event when within the month after expiration", () => {
-    const tenthOfMonthDate = dayjs({ year: currentDate.year(), month: currentDate.month(), day: 10 });
+    const validMonthFromJanToNov = randomIntFromInterval("0", "10");
+    const nextMonth = validMonthFromJanToNov + 1;
+
+    const tenthOfMonthDate = dayjs({ year: currentDate.year(), month: validMonthFromJanToNov, day: 10 });
+
     expect(
       getLicenseCalendarEvents(
         generateLicenseData({ expirationISO: tenthOfMonthDate.toISOString() }),
         currentDate.year(),
-        currentDate.add(1, "month").month()
+        nextMonth
       )
     ).toEqual([
       {


### PR DESCRIPTION
…onths

<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
The logic we have in place indicates that we only show calendar events for that year and the test had to be updated because it wasn't restricted to month values that reflected that. It started to fail because the current month is December, and both the expiration date and renewal date were being dynamically setup using currentDate. The test was expecting a renewal date 30 days later which would be in January of 2024 but that breaks our initial logic that we only ever return events that are in the same year, so as a solution we restricted the test to use only the months of January to November for the expiration date so the renewal date would be in the same year. 

**Note**: We explicitly test the December case in a later test, `returns an array containing only license events within the year`.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#186598228](https://www.pivotaltracker.com/story/show/186598228)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
