### PR TITLE
chore: better split, parallelize, and execute Jest tests in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -580,7 +580,7 @@ jobs:
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID_DEV
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY_DEV
-    parallelism: 5
+    parallelism: 8
     steps:
       - set-dev-env-vars
       - attach_workspace:
@@ -589,8 +589,7 @@ jobs:
       - run:
           name: Glob, Split, and Run Unit Tests
           command: |
-            TEST=$(circleci tests glob "./{shared,web,api}/**/*.test.{j,t}{s,sx}" | circleci tests split --split-by=timings)
-            yarn test:ci -- $TEST
+            yarn test:ci --shard=$(expr $CIRCLE_NODE_INDEX + 1)/$CIRCLE_NODE_TOTAL
       - store_test_results:
           path: coverage/test_results
       - store_artifacts:

--- a/api/jest.config.ts
+++ b/api/jest.config.ts
@@ -1,35 +1,22 @@
-import type { Config } from "jest";
+import sharedConfig from "../jest.shared";
 
-export default async (): Promise<Config> => {
-  return {
-    coverageReporters: ["json-summary", "text"],
-    ...require("jest-dynalite/jest-preset"),
-    ...require("ts-jest/jest-preset"),
-    moduleNameMapper: {
-      "@shared/(.*)": "<rootDir>/../shared/src/$1",
-      "@domain/(.*)": "<rootDir>/src/domain/$1",
-      "@db/(.*)": "<rootDir>/src/db/$1",
-      "@client/(.*)": "<rootDir>/src/client/$1",
-      "@api/(.*)": "<rootDir>/src/api/$1",
-      "@functions/(.*)": "<rootDir>/src/functions/$1",
-      "@libs/(.*)": "<rootDir>/src/libs/$1",
-      "@test/(.*)": "<rootDir>/test/$1",
-      "@wiremock/(.*)": "<rootDir>/wiremock/$1",
-    },
-    reporters: [
-      "default",
-      [
-        "jest-junit",
-        {
-          outputDirectory: "../coverage/test_results",
-          uniqueOutputName: "false",
-          outputName: "api-jest.xml",
-          addFileAttribute: "true",
-        },
-      ],
-    ],
-    verbose: true,
-    globalSetup: "<rootDir>/src/setupTests.ts",
-    globalTeardown: "<rootDir>/src/teardownTests.ts",
-  };
+/** @type {import('jest').Config} */
+export default {
+  ...sharedConfig,
+  ...require("jest-dynalite/jest-preset"),
+  ...require("ts-jest/jest-preset"),
+  displayName: "api",
+  moduleNameMapper: {
+    "@shared/(.*)": "<rootDir>/../shared/src/$1",
+    "@domain/(.*)": "<rootDir>/src/domain/$1",
+    "@db/(.*)": "<rootDir>/src/db/$1",
+    "@client/(.*)": "<rootDir>/src/client/$1",
+    "@api/(.*)": "<rootDir>/src/api/$1",
+    "@functions/(.*)": "<rootDir>/src/functions/$1",
+    "@libs/(.*)": "<rootDir>/src/libs/$1",
+    "@test/(.*)": "<rootDir>/test/$1",
+    "@wiremock/(.*)": "<rootDir>/wiremock/$1",
+  },
+  globalSetup: "<rootDir>/src/setupTests.ts",
+  globalTeardown: "<rootDir>/src/teardownTests.ts",
 };

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,6 +1,0 @@
-/** @type {import('jest').Config} */
-const config = {
-  projects: ["<rootDir>/api", "<rootDir>/shared", "<rootDir>/web"],
-};
-
-export default config;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,20 @@
+import sharedConfig from "./jest.shared";
+
+/** @type {import('jest').Config} */
+export default {
+  ...sharedConfig,
+  projects: ["<rootDir>/api", "<rootDir>/shared", "<rootDir>/web"],
+  reporters: [
+    "default",
+    [
+      "jest-junit",
+      {
+        outputDirectory: "./coverage/test_results",
+        outputName: "jest.xml",
+        uniqueOutputName: "false",
+        addFileAttribute: "true",
+      },
+    ],
+  ],
+  testTimeout: 20000,
+};

--- a/jest.coverage.ts
+++ b/jest.coverage.ts
@@ -1,0 +1,17 @@
+import defaultConfig from "./jest.config";
+
+/** @type {import('jest').Config} */
+export default {
+  ...defaultConfig,
+  collectCoverage: true,
+  collectCoverageFrom: ["**/*.{js,jsx,ts,tsx,cjs,mjs}", "!**/node_modules/**"],
+  coverageDirectory: "./coverage",
+  coverageReporters: ["json-summary", "text"],
+  coveragePathIgnorePatterns: [
+    "<rootDir>/.next/",
+    "<rootDir>/public/",
+    "<rootDir>/.storybook/",
+    "<rootDir>/cypress/",
+    "<rootDir>/stories/",
+  ],
+};

--- a/jest.shared.ts
+++ b/jest.shared.ts
@@ -1,0 +1,14 @@
+/** @type {import('jest').Config} */
+export default {
+  transform: {
+    "\\.m?[jt]sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          keepClassNames: true,
+        },
+      },
+    ],
+  },
+  watchPathIgnorePatterns: ["coverage"],
+};

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
     "start:dev": "yarn workspaces foreach -ptvi run dev",
     "spellcheck": "yarn workspaces foreach -v run spellcheck",
     "sync:deps": "yarnw-sync-deps --fix",
-    "test": "yarn workspaces foreach --from '{@businessnjgovnavigator/api,@businessnjgovnavigator/shared,@businessnjgovnavigator/web}' run test --colors",
-    "test:ci": "yarn workspaces foreach --from '{@businessnjgovnavigator/api,@businessnjgovnavigator/shared,@businessnjgovnavigator/web}' run test --colors --maxWorkers=1 --ci --collectCoverageFrom='../coverage'",
+    "test": "jest",
+    "test:ci": "jest --colors --runInBand --ci",
+    "test:coverage": "jest --config jest.coverage.ts",
     "typecheck": "yarn workspaces foreach -v run typecheck",
     "verify:node": "check-node-version --node $(cat .nvmrc) --npm 10.2.3"
   },

--- a/shared/jest.config.ts
+++ b/shared/jest.config.ts
@@ -1,23 +1,8 @@
-import type { Config } from "@jest/types";
+import sharedConfig from "../jest.shared";
 
-export default async (): Promise<Config.InitialOptions> => {
-  return {
-    coverageReporters: ["json-summary", "text"],
-    reporters: [
-      "default",
-      [
-        "jest-junit",
-        {
-          outputDirectory: "../coverage/test_results",
-          uniqueOutputName: "false",
-          outputName: "shared-jest.xml",
-          addFileAttribute: "true",
-        },
-      ],
-    ],
-    // eslint-disable-next-line unicorn/prefer-module
-    ...require("ts-jest/jest-preset"),
-    verbose: true,
-    rootDir: "src",
-  };
+/** @type {import('jest').Config} */
+export default {
+  ...sharedConfig,
+  displayName: "shared",
+  rootDir: "src",
 };

--- a/web/jest.config.ts
+++ b/web/jest.config.ts
@@ -1,9 +1,17 @@
-import type { Config } from "jest";
+import sharedConfig from "../jest.shared";
 
 const esModules = ["rehype-react", "remark-gfm", "remark-parse", "remark-rehype", "unified"];
 
-const config: Config = {
-  coverageReporters: ["json-summary", "text"],
+process.env = Object.assign(process.env, {
+  FEATURE_BUSINESS_FLP: "true",
+  FEATURE_EXPORT_PDF: "true",
+  WEBFLOW_API_TOKEN: 12345678910,
+});
+
+/** @type {import('jest').Config} */
+export default {
+  ...sharedConfig,
+  displayName: "web",
   setupFilesAfterEnv: ["./setupTests.js"],
   testEnvironment: "jsdom",
   testPathIgnorePatterns: ["<rootDir>/.next/", "<rootDir>/node_modules/", "<rootDir>/cypress/"],
@@ -20,18 +28,6 @@ const config: Config = {
     "@businessnjgovnavigator/shared/(.*)": "<rootDir>/../shared/lib/shared/src/$1",
     "@businessnjgovnavigator/content/(.*)": "<rootDir>/../content/src/$1",
   },
-  reporters: [
-    "default",
-    [
-      "jest-junit",
-      {
-        outputDirectory: "../coverage/test_results",
-        outputName: "web-jest.xml",
-        uniqueOutputName: "false",
-        addFileAttribute: "true",
-      },
-    ],
-  ],
   resolver: `${__dirname}/test/resolver.js`,
   transformIgnorePatterns: [`<rootDir>/node_modules/(?!(${esModules.join("|")}))`],
   transform: {
@@ -49,13 +45,4 @@ const config: Config = {
       },
     ],
   },
-  verbose: true,
 };
-
-process.env = Object.assign(process.env, {
-  FEATURE_BUSINESS_FLP: "true",
-  FEATURE_EXPORT_PDF: "true",
-  WEBFLOW_API_TOKEN: 12345678910,
-});
-
-export default config;

--- a/web/test/pages/cms.test.tsx
+++ b/web/test/pages/cms.test.tsx
@@ -8,7 +8,10 @@ import path from "path";
 describe("cms", () => {
   describe("config", () => {
     it("allows editing all config fields in the CMS", () => {
-      const cmsConfig = fs.readFileSync(path.join(process.cwd(), "public", "mgmt", "config.yml"), "utf8");
+      const cmsConfig = fs.readFileSync(
+        path.join(process.cwd(), "web", "public", "mgmt", "config.yml"),
+        "utf8"
+      );
 
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

These changes introduce `jest`-native sharding for tests rather than splitting using CircleCI, the latter of which is not reliable in more recent versions of the `cimg` CircleCI-based Docker image.

Additionally, these changes introduce two additional optimizations:

- Execute unit tests on CircleCI with eight test runners instead of five.
- Compile all tests using `swc` rather than `tsc` (via `ts-jest`), which results in about a 5-10% speedup on its own. (Except for `api`, which continues to require `ts-jest` for now.)

Some quality-of-life changes come through these changes as well:

- No more warnings from Jest about invalid configuration due to centralization for configuration within the root-level Jest configuration file.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

`yarn test` should be unaffected by these changes.

`yarn test:coverage` has been added in case test coverage statistics are desired.

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
