### PR TITLE
chore: add script to extract front matter key from markdown files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ shared/lib
 tsconfig.tsbuildinfo
 aws_config_file_path.json
 web/fundings.csv
+
+# Python
+.venv/
+**/__pycache__/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,14 +12,24 @@
   },
   "cSpell.enabled": false,
   "cSpell.words": ["businessnjgovnavigator"],
-  "editor.codeActionsOnSave": ["source.organizeImports", "source.formatDocument", "source.fixAll.eslint"],
+  "editor.codeActionsOnSave": [
+    "source.organizeImports",
+    "source.formatDocument",
+    "source.fixAll.eslint"
+  ],
   "editor.formatOnSave": true,
   "editor.rulers": [80, 110],
   "editor.wordWrap": "wordWrapColumn",
   "editor.wordWrapColumn": 110,
-  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
   "explorer.fileNesting.enabled": true,
   "explorer.fileNesting.patterns": {
+    "*.py": "test_$(capture).py",
     "*.ts": "$(capture).test.ts, $(capture).test.tsx",
     "*.tsx": "$(capture).test.ts, $(capture).test.tsx"
   },
@@ -33,7 +43,21 @@
   "indentRainbow.indicatorStyle": "light",
   "jest.autoRun": "off",
   "terminal.integrated.scrollback": 10000,
-  "todo-tree.filtering.excludeGlobs": ["**/node_modules", "**/dist", "**/.next", "**/compiled"],
-  "todo-tree.general.tags": ["BUG", "HACK", "FIXME", "TODO", "XXX", "[ ]", "[x]", "TODO-APP"],
+  "todo-tree.filtering.excludeGlobs": [
+    "**/node_modules",
+    "**/dist",
+    "**/.next",
+    "**/compiled"
+  ],
+  "todo-tree.general.tags": [
+    "BUG",
+    "HACK",
+    "FIXME",
+    "TODO",
+    "XXX",
+    "[ ]",
+    "[x]",
+    "TODO-APP"
+  ],
   "typescript.surveys.enabled": false
 }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ for CI/CD.
 You will need Node.js (with Yarn installed via `npm` or `corepack`) installed
 for primary development. Additionally, for running the server in local
 development mode, you will need a Java runtime (for `serverless-dynamodb`) and
-Python (for the AWS CLI) installed (details below).
+Python (for the AWS CLI and some of our scripts) installed (details below).
 
 We recommend using WSL2 if developing on Windows.
 
@@ -80,10 +80,19 @@ Before you can run locally, you will need to:
   `./web/.env-template` file.
 - create a `./api/.env` that includes all the values laid out in the
   `./api/.env-template` file.
+- create a `.venv` virtual environment and install requirements if working on
+  Python:
+
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
 
 ### Run tests
 
-We use Jest for unit tests, in all of our projects. Run all tests with:
+We use Jest for our TypeScript-based unit tests across our projects. Run all
+tests with:
 
 ```shell
 yarn test
@@ -99,6 +108,12 @@ with:
 Some of the Cypress tests only run in the CI environment. When using the
 `local-feature-tests` script, make sure to have a locally running instance of
 the application.
+
+We use Python's `unittest` for our Python tests. Run all Python unit tests with:
+
+```shell
+yarn test:python
+```
 
 ### Running locally
 
@@ -288,7 +303,7 @@ If you want to change the structure of the `UserData` object, here's how:
 
 | service            | local dev & CI feature tests | local feature tests | unit tests |
 | ------------------ | ---------------------------- | ------------------- | ---------- |
-| Nextjs frontend    | 3000                         | 3001                |            |
+| Next.js frontend   | 3000                         | 3001                |            |
 | Serverless backend | 5002                         | 5001                |            |
 | DynamoDB           | 8000                         | 8001                |            |
 | Lambda port        | 5050                         | 5051                |            |

--- a/content/scripts/get_frontmatter_key.py
+++ b/content/scripts/get_frontmatter_key.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+
+import yaml
+import re
+import os
+from typing import Any, Optional
+
+
+def extract_yaml_front_matter(markdown_content: str) -> Optional[str]:
+    """
+    Extracts the YAML front matter from a Markdown file.
+
+    The function uses a regular expression to identify the YAML front matter,
+    which is expected to be delimited by lines consisting of three hyphens (---).
+
+    Args:
+        markdown_content (str): A string containing the content of the Markdown file.
+
+    Returns:
+        Optional[str]: The extracted YAML front matter as a string, or None if no
+        front matter is found.
+    """
+    pattern = re.compile(r"^---\s*$(.*?)^---\s*$", re.DOTALL | re.MULTILINE)
+
+    # Search for the YAML front matter in the content
+    match = pattern.search(markdown_content)
+
+    if match:
+        return match.group(1)  # Return the YAML content without the delimiters
+    else:
+        return None
+
+
+def get_value_from_yaml_key(yaml_content: str, key: str) -> Optional[Any]:
+    """
+    Parses a string containing YAML content and retrieves the value of a specific key.
+
+    Args:
+        yaml_content (str): A string containing the YAML content.
+        key (str): The key whose value needs to be retrieved.
+
+    Returns:
+        Optional[Any]: The value associated with the specified key, or None if the key
+        is not found or if an error occurs during YAML parsing.
+    """
+    try:
+        # Parse the YAML content
+        yaml_data = yaml.safe_load(yaml_content)
+    except yaml.YAMLError as e:
+        print(f"Error parsing YAML content: {e}")
+        return None
+
+    # Retrieve the value for the specified key
+    return yaml_data.get(key)
+
+
+def get_yaml_value_from_markdown_file(file_path: str, key: str) -> Optional[Any]:
+    """
+    Reads a Markdown file, extracts the YAML front matter, and retrieves the value of a specific key.
+
+    Args:
+        file_path (str): The path to the Markdown file.
+        key (str): The key whose value needs to be retrieved from the YAML front matter.
+
+    Returns:
+        Optional[Any]: The value associated with the specified key, or None if the file
+        cannot be read, if no YAML front matter is found, or if the key is not present.
+    """
+    try:
+        with open(file_path, "r", encoding="utf-8") as file:
+            content = file.read()
+
+            # Extract the YAML front matter
+            yaml_content = extract_yaml_front_matter(content)
+
+            if yaml_content:
+                # Retrieve the value of the specified key
+                return get_value_from_yaml_key(yaml_content, key)
+            else:
+                print("No YAML front matter found.")
+                return None
+    except FileNotFoundError:
+        print(f"File {file_path} not found.")
+        return None
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        return None
+
+
+def print_names_from_markdown_filenames(filenames: [str]) -> None:
+    """
+    Given a list of filenames that exist under the content/src directory, print the value
+    of the "name" attribute in the YAML front matter.
+
+    Args:
+        filenames ([str]): The paths to the Markdown files, excluding content/src.
+    """
+    for filename in filenames:
+        if filename.endswith(".md"):
+            file_path = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), "../src", filename
+            )
+
+            # Change this to the key you want to retrieve
+            key_to_retrieve = "name"
+            value = get_yaml_value_from_markdown_file(file_path, key_to_retrieve)
+
+            if value is not None:
+                print(f"The value of '{key_to_retrieve}' in {filename} is: {value}")
+
+
+if __name__ == "__main__":
+    print_names_from_markdown_filenames(
+        [
+            # The list of filenames should be children of content/src, like the following:
+            "certifications/lgbtq-1.md"
+        ]
+    )

--- a/content/scripts/test_get_frontmatter_key.py
+++ b/content/scripts/test_get_frontmatter_key.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+import unittest
+from unittest.mock import mock_open, patch
+from get_frontmatter_key import (
+    extract_yaml_front_matter,
+    get_value_from_yaml_key,
+    get_yaml_value_from_markdown_file,
+)
+
+MARKDOWN_NO_FRONT_MATTER = """
+# Heading
+This is a Markdown document with no front matter.
+"""
+
+MARKDOWN_WITH_FRONT_MATTER = """
+---
+title: "Sample Document"
+author: "John Doe"
+---
+# Heading
+This is a Markdown document.
+"""
+
+EXAMPLE_YAML = 'title: "Sample Document"\nauthor: "John Doe"\n'
+
+
+class TestYAMLExtraction(unittest.TestCase):
+    def test_extract_yaml_front_matter(self):
+        self.assertEqual(
+            extract_yaml_front_matter(MARKDOWN_WITH_FRONT_MATTER), f"\n{EXAMPLE_YAML}"
+        )
+
+    def test_get_value_from_yaml_key(self):
+        self.assertEqual(
+            get_value_from_yaml_key(EXAMPLE_YAML, "title"), "Sample Document"
+        )
+        self.assertIsNone(get_value_from_yaml_key(EXAMPLE_YAML, "nonexistent_key"))
+
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data=MARKDOWN_WITH_FRONT_MATTER,
+    )
+    def test_get_yaml_value_from_markdown_file(self, mock_file):
+        file_path = "dummy_path.md"
+        self.assertEqual(
+            get_yaml_value_from_markdown_file(file_path, "author"), "John Doe"
+        )
+        self.assertIsNone(
+            get_yaml_value_from_markdown_file(file_path, "nonexistent_key")
+        )
+
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data=MARKDOWN_NO_FRONT_MATTER,
+    )
+    def test_get_yaml_value_from_markdown_file_no_front_matter(self, mock_file):
+        file_path = "dummy_path.md"
+        self.assertIsNone(get_yaml_value_from_markdown_file(file_path, "title"))
+
+    @patch("builtins.open", side_effect=FileNotFoundError)
+    def test_get_yaml_value_from_markdown_file_not_found(self, mock_file):
+        file_path = "nonexistent_path.md"
+        self.assertIsNone(get_yaml_value_from_markdown_file(file_path, "title"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "jest",
     "test:ci": "jest --colors --runInBand --ci",
     "test:coverage": "jest --config jest.coverage.ts",
+    "test:python": "python -m unittest discover -b -s content/scripts -p \"test_*.py\"",
     "typecheck": "yarn workspaces foreach -v run typecheck",
     "verify:node": "check-node-version --node $(cat .nvmrc) --npm 10.2.3"
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Markdown==3.5.1
+PyYAML==6.0.1


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

Adding in a script to extract a given key from Markdown frontmatter, then added additional guidance for Python unit testing in the Readme.

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

You'll need to set up a virtual environment for Python. Follow the steps in the revised Readme.

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

To test, run `yarn test:python`.

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
