### PR TITLE
fix: design-update-for-license-status-check-tab-#186263393

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@businessnjgovnavigator/shared": "*",
     "@emotion/react": "11.11.1",
     "@emotion/styled": "11.11.0",
+    "@mui/icons-material": "^5.15.1",
     "@mui/lab": "5.0.0-alpha.155",
     "@mui/material": "5.14.20",
     "@mui/styles": "5.14.20",

--- a/web/.dependency-cruiser.js
+++ b/web/.dependency-cruiser.js
@@ -80,6 +80,10 @@ module.exports = {
     },
     {
       from: {},
+      to: { path: "@mui/icons-material/*" },
+    },
+    {
+      from: {},
       to: { path: "@mui/x-date-pickers" },
     },
     {

--- a/web/package.json
+++ b/web/package.json
@@ -50,6 +50,7 @@
     "@businessnjgovnavigator/shared": "*",
     "@emotion/react": "11.11.1",
     "@emotion/styled": "11.11.0",
+    "@mui/icons-material": "^5.15.1",
     "@mui/lab": "5.0.0-alpha.155",
     "@mui/material": "5.14.20",
     "@mui/styles": "5.14.20",

--- a/web/src/components/ChecklistTag.tsx
+++ b/web/src/components/ChecklistTag.tsx
@@ -54,7 +54,7 @@ export const ChecklistTag = (props: Props): ReactElement => {
 
   return (
     <div
-      className={`${backgroundColor} flex flex-align-center padding-y-05 padding-left-1 padding-right-2 radius-md`}
+      className={`${backgroundColor} flex flex-align-items-center padding-y-05 padding-left-1 padding-right-2 radius-md width-full tablet:width-auto`}
     >
       <Icon className={`${iconColor} usa-icon--size-3`} data-testid={`${iconName}-checklist-tag-icon`}>
         {iconName}

--- a/web/src/components/tasks/LicenseStatusReceipt.tsx
+++ b/web/src/components/tasks/LicenseStatusReceipt.tsx
@@ -2,12 +2,14 @@ import { ChecklistTag } from "@/components/ChecklistTag";
 import { HorizontalLine } from "@/components/HorizontalLine";
 import { Heading } from "@/components/njwds-extended/Heading";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
-import { Icon } from "@/components/njwds/Icon";
 import { getMergedConfig } from "@/contexts/configContext";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import analytics from "@/lib/utils/analytics";
 import { LicenseStatus, LicenseStatusItem } from "@businessnjgovnavigator/shared/";
-import { ReactElement } from "react";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import DangerousIcon from "@mui/icons-material/Dangerous";
+import WatchLaterIcon from "@mui/icons-material/WatchLater";
+import type { ReactElement } from "react";
 
 interface Props {
   items: LicenseStatusItem[];
@@ -19,30 +21,36 @@ type PermitColorScheme = {
   bgHdrColor: string;
   bgSubHdrColor: string;
   textAndIconColor: string;
-  icon: string;
+  icon: ReactElement;
 };
 
 const Config = getMergedConfig();
 
-const activePermit: PermitColorScheme = {
-  bgHdrColor: "bg-success-dark",
-  bgSubHdrColor: "bg-success-lighter",
-  textAndIconColor: "text-primary-darker",
-  icon: "check_circle_outline",
-};
-
-const pendingPermit: PermitColorScheme = {
-  bgHdrColor: "bg-secondary",
-  bgSubHdrColor: "bg-secondary-lighter",
-  textAndIconColor: "text-secondary-darker",
-  icon: "schedule",
-};
-
-const inactivePermit: PermitColorScheme = {
-  bgHdrColor: "bg-error",
-  bgSubHdrColor: "bg-error-extra-light",
-  textAndIconColor: "text-error-darker",
-  icon: "highlight_off",
+const permitColorScheme: Record<string, PermitColorScheme> = {
+  activePermit: {
+    bgHdrColor: "bg-success-dark",
+    bgSubHdrColor: "bg-success-lighter",
+    textAndIconColor: "text-primary-darker",
+    icon: (
+      <CheckCircleIcon className="display-none tablet:display-block tablet:margin-left-1 tablet:usa-icon--size-4" />
+    ),
+  },
+  pendingPermit: {
+    bgHdrColor: "bg-secondary",
+    bgSubHdrColor: "bg-secondary-lighter",
+    textAndIconColor: "text-secondary-darker",
+    icon: (
+      <WatchLaterIcon className="display-none tablet:display-block tablet:margin-left-1 tablet:usa-icon--size-4" />
+    ),
+  },
+  inactivePermit: {
+    bgHdrColor: "bg-error",
+    bgSubHdrColor: "bg-error-extra-light",
+    textAndIconColor: "text-error-darker",
+    icon: (
+      <DangerousIcon className="display-none tablet:display-block tablet:margin-left-1 tablet:usa-icon--size-4" />
+    ),
+  },
 };
 
 const LicenseStatusLookup: Record<LicenseStatus, string> = {
@@ -97,11 +105,11 @@ export const LicenseStatusReceipt = (props: Props): ReactElement => {
 
   const getPermitColorScheme = (): PermitColorScheme => {
     if (props.status === "ACTIVE") {
-      return activePermit;
+      return permitColorScheme["activePermit"];
     } else if (isPending(props.status)) {
-      return pendingPermit;
+      return permitColorScheme["pendingPermit"];
     } else {
-      return inactivePermit;
+      return permitColorScheme["inactivePermit"];
     }
   };
 
@@ -118,20 +126,21 @@ export const LicenseStatusReceipt = (props: Props): ReactElement => {
     return `${nameAndAddress.addressLine1}${secondLineAddress}, ${nameAndAddress.zipCode} NJ`;
   };
 
-  const receiptItem = (
-    item: LicenseStatusItem,
-    index: number,
-    receiptItems: LicenseStatusItem[]
-  ): ReactElement => {
+  const receiptItem = (item: LicenseStatusItem, index: number): ReactElement => {
     return (
       <div key={index} data-testid={`item-${item.status}`}>
-        <div className="flex flex-column fac tablet-flex-row width-full">
+        <div
+          className={`flex flex-column fac tablet-flex-row width-full ${
+            index === 0
+              ? ""
+              : "border-top-1px margin-top-1 tablet:margin-top-0 padding-top-2 tablet:padding-top-05"
+          }  border-base-lightest padding-bottom-05`}
+        >
           <ChecklistTag status={item.status} />
-          <span className="margin-left-2 text-left width-full margin-top-1 tablet:margin-top-0">
+          <span className="tablet:margin-left-2 text-left width-full margin-top-1 tablet:margin-top-0">
             {item.title}
           </span>
         </div>
-        {index === receiptItems.length - 1 ? <></> : <hr className="desktop:margin-bottom-1" />}
       </div>
     );
   };
@@ -161,7 +170,7 @@ export const LicenseStatusReceipt = (props: Props): ReactElement => {
           </div>
         </div>
 
-        <div className="border-2px border-white radius-lg bg-white padding-y-2 padding-x-105 margin-bottom-5 margin-top-205 shadow-3">
+        <div className="border-2px border-white radius-lg bg-white padding-y-2 padding-x-105 margin-bottom-2 margin-top-205 shadow-3">
           <div
             className={`margin-1 text-bold fdc fac radius-lg ${getPermitColorScheme().bgSubHdrColor}`}
             data-testid={`permit-${props.status}`}
@@ -179,24 +188,21 @@ export const LicenseStatusReceipt = (props: Props): ReactElement => {
                 getPermitColorScheme().textAndIconColor
               } width-full font-sans-lg text-bold`}
             >
-              <Icon className="display-none tablet:display-block tablet:margin-left-1 usa-icon--size-4">
-                {props.status === "ACTIVE"
-                  ? activePermit.icon
-                  : isPending(props.status)
-                  ? pendingPermit.icon
-                  : inactivePermit.icon}
-              </Icon>
+              {getPermitColorScheme().icon}
 
-              <p className="tablet:margin-left-1 padding-05 line-height-sans-3">{getText()}</p>
+              <p className="tablet:margin-left-1 tablet:padding-05 padding-left-1 line-height-sans-3">
+                {getText()}
+              </p>
             </div>
           </div>
           <div className="padding-2">
-            <Heading level={1} styleVariant="h4" className="margin-bottom-05-override tablet:padding-top-1">
+            <Heading
+              level={2}
+              styleVariant="h4"
+              className="margin-bottom-1 tablet:padding-top-1 border-bottom-2px border-base-lightest padding-bottom-1"
+            >
               {Config.licenseSearchTask.applicationChecklistItemsText}
             </Heading>
-
-            <hr className="tablet:margin-bottom-205" />
-
             {props.items.map(receiptItem)}
           </div>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4456,6 +4456,7 @@ __metadata:
     "@emotion/styled": 11.11.0
     "@jest/types": 29.6.3
     "@mdx-js/react": 2.3.0
+    "@mui/icons-material": ^5.15.1
     "@mui/lab": 5.0.0-alpha.155
     "@mui/material": 5.14.20
     "@mui/styles": 5.14.20
@@ -4675,6 +4676,7 @@ __metadata:
     "@emotion/styled": 11.11.0
     "@jest/types": 29.6.3
     "@mdx-js/react": 2.3.0
+    "@mui/icons-material": ^5.15.1
     "@mui/lab": 5.0.0-alpha.155
     "@mui/material": 5.14.20
     "@mui/styles": 5.14.20
@@ -7036,6 +7038,22 @@ __metadata:
   version: 5.15.0
   resolution: "@mui/core-downloads-tracker@npm:5.15.0"
   checksum: a7aadd4071ff715e618b8db647137579ca63cab4bf6e3acfe86a7d461f71605fc7ce44eeea5b1e789faae8546617b1f7d14c72a0c00fa3d59951b6eee42a6c5d
+  languageName: node
+  linkType: hard
+
+"@mui/icons-material@npm:^5.15.1":
+  version: 5.15.1
+  resolution: "@mui/icons-material@npm:5.15.1"
+  dependencies:
+    "@babel/runtime": ^7.23.5
+  peerDependencies:
+    "@mui/material": ^5.0.0
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: e769b2f6fecfd92721b182e0d6569a9950fd44d88cc7b3bd6ac5cc77d6085c26316093c9cdb750b456ff6860e47a1b6e6e749e284ecdc6b50fad659c9cb75818
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

- Added `height` of 2px to the line under “Application Checklist Items”
- Updated permit status icons to those from Material UI

**Mobile**
- Aligned "Permit Status:” and the permit status
- Updated checklist tags to full width
- Updated checklist tags and item name to be left-align 
- Decreased padding between gray container and address/permit status from 40px to 16px

**Accessibility**
- Updated “Application Checklist Items” so it's not an `<h1>` 
- Updated the `<hr>` to be borders instead, so there is no inconsistent announcement as was happening with the `<hr>`


### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#186263393](https://www.pivotaltracker.com/story/show/186263393)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
