### PR TITLE
feat: [#186657856] [#186741011] add new routes for health checks

### DIFF
--- a/api/.dependency-cruiser.js
+++ b/api/.dependency-cruiser.js
@@ -80,6 +80,10 @@ module.exports = {
     },
     {
       from: {},
+      to: { path: "http-status-codes" },
+    },
+    {
+      from: {},
       to: { path: "crypto" },
     },
     {

--- a/api/package.json
+++ b/api/package.json
@@ -51,6 +51,7 @@
     "dedent": "1.5.1",
     "express": "4.18.2",
     "helmet": "7.1.0",
+    "http-status-codes": "^2.3.0",
     "jsonwebtoken": "9.0.2",
     "lodash": "4.17.21",
     "serverless-http": "3.2.0",

--- a/api/serverless.ts
+++ b/api/serverless.ts
@@ -111,7 +111,7 @@ const serverlessConfiguration: AWS = {
   ],
   provider: {
     name: "aws",
-    runtime: "nodejs16.x",
+    runtime: "nodejs18.x",
     stage: stage,
     region: region,
     iam: {

--- a/api/src/api/healthCheckRouter.test.ts
+++ b/api/src/api/healthCheckRouter.test.ts
@@ -1,0 +1,100 @@
+import { healthCheckRouterFactory } from "@api/healthCheckRouter";
+import type { HealthCheckMethod } from "@domain/types";
+import { setupExpress } from "@libs/express";
+import type { Express } from "express";
+import { ReasonPhrases, StatusCodes } from "http-status-codes";
+import request from "supertest";
+
+const mockOKHealthCheckMethod: HealthCheckMethod = async () => {
+  return new Promise((resolve) => {
+    resolve({
+      success: true,
+      data: {
+        message: ReasonPhrases.OK,
+      },
+    });
+  });
+};
+
+const mockErrorHealthCheckMethod: HealthCheckMethod = async () => {
+  return new Promise((resolve) => {
+    resolve({
+      success: false,
+      error: {
+        message: ReasonPhrases.BAD_GATEWAY,
+        serverResponseBody: "",
+        serverResponseCode: 404,
+        timeout: false,
+      },
+    });
+  });
+};
+
+const mockTimeoutHealthCheckMethod: HealthCheckMethod = async () => {
+  return new Promise((resolve) => {
+    resolve({
+      success: false,
+      error: {
+        message: ReasonPhrases.GATEWAY_TIMEOUT,
+        timeout: true,
+      },
+    });
+  });
+};
+
+describe("healthCheckRouter", () => {
+  let app: Express;
+
+  beforeEach(async () => {
+    app = setupExpress(false);
+    app.use(
+      healthCheckRouterFactory(new Map<string, HealthCheckMethod>([["mockOK", mockOKHealthCheckMethod]])),
+      healthCheckRouterFactory(new Map<string, HealthCheckMethod>([["mockErr", mockErrorHealthCheckMethod]])),
+      healthCheckRouterFactory(
+        new Map<string, HealthCheckMethod>([["mockTimeout", mockTimeoutHealthCheckMethod]])
+      )
+    );
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => {
+      return setTimeout(resolve, 500);
+    });
+  });
+
+  describe("GET /", () => {
+    it("should return a successful response for the server's self check", async () => {
+      const response = await request(app).get("/");
+      expect(response.status).toBe(StatusCodes.OK);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.message).toEqual("OK");
+    });
+  });
+
+  describe("GET /mockOK", () => {
+    it("should return a successful response for a mocked health check", async () => {
+      const response = await request(app).get("/mockOK");
+      expect(response.status).toBe(StatusCodes.OK);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.message).toEqual("OK");
+    });
+  });
+
+  describe("GET /mockErr", () => {
+    it("should return an unsuccessful response for a errored health check", async () => {
+      const response = await request(app).get("/mockErr");
+      expect(response.status).toBe(StatusCodes.BAD_GATEWAY);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error.message).toEqual(ReasonPhrases.BAD_GATEWAY);
+    });
+  });
+
+  describe("GET /mockTimeout", () => {
+    it("should return a successful response for a mocked health check", async () => {
+      const response = await request(app).get("/mockTimeout");
+      expect(response.status).toBe(StatusCodes.GATEWAY_TIMEOUT);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error.message).toEqual(ReasonPhrases.GATEWAY_TIMEOUT);
+    });
+  });
+});

--- a/api/src/api/healthCheckRouter.ts
+++ b/api/src/api/healthCheckRouter.ts
@@ -1,0 +1,47 @@
+import type { HealthCheckMetadata, HealthCheckMethod, SuccessfulHealthCheckResponse } from "@domain/types";
+import { Router } from "express";
+import { ReasonPhrases, StatusCodes } from "http-status-codes";
+
+const requestTimestamp = (): number => Math.round(Date.now() / 1000);
+
+const healthCheckResponseStatus = (response: HealthCheckMetadata): StatusCodes => {
+  let statusCode = StatusCodes.OK;
+
+  if (!response.success && response.error) {
+    statusCode = response.error.timeout ? StatusCodes.GATEWAY_TIMEOUT : StatusCodes.BAD_GATEWAY;
+  }
+
+  return statusCode;
+};
+
+type HealthCheckEndpoint = string;
+type HealthChecks = Map<HealthCheckEndpoint, HealthCheckMethod>;
+
+export const healthCheckRouterFactory = (clients: HealthChecks): Router => {
+  const router = Router();
+
+  router.get("/", (_req, res) => {
+    res.json({
+      timestamp: requestTimestamp(),
+      success: true,
+      data: {
+        message: ReasonPhrases.OK,
+      },
+    } as SuccessfulHealthCheckResponse);
+  });
+
+  for (const [endpoint, client] of clients) {
+    router.get(`/${endpoint}`, async (_req, res) => {
+      const timestamp = requestTimestamp();
+      const healthCheckResult = await client();
+      const statusCode = healthCheckResponseStatus(healthCheckResult);
+
+      res.status(statusCode).json({
+        timestamp,
+        ...healthCheckResult,
+      });
+    });
+  }
+
+  return router;
+};

--- a/api/src/client/WebserviceLicenseStatusClient.test.ts
+++ b/api/src/client/WebserviceLicenseStatusClient.test.ts
@@ -33,4 +33,33 @@ describe("WebserviceLicenseStatusClient", () => {
     mockAxios.post.mockResolvedValue({ data: "" });
     expect(await client.search("name", "11111", "some-type")).toEqual([]);
   });
+
+  it("returns a passing health check if data can be retrieved sucessfully", async () => {
+    mockAxios.post.mockResolvedValue({});
+    expect(await client.health()).toEqual({ success: true, data: { message: "OK" } });
+  });
+
+  it("returns a failing health check if unexpected data is retrieved", async () => {
+    mockAxios.post.mockRejectedValue({ response: { status: 404 }, message: "" });
+    expect(await client.health()).toEqual({
+      success: false,
+      error: {
+        message: "Bad Gateway",
+        serverResponseBody: "",
+        serverResponseCode: 404,
+        timeout: false,
+      },
+    });
+  });
+
+  it("returns a failing health check if axios request times out", async () => {
+    mockAxios.post.mockRejectedValue({});
+    expect(await client.health()).toEqual({
+      success: false,
+      error: {
+        message: "Gateway Timeout",
+        timeout: true,
+      },
+    });
+  });
 });

--- a/api/src/client/WebserviceLicenseStatusProcessorClient.test.ts
+++ b/api/src/client/WebserviceLicenseStatusProcessorClient.test.ts
@@ -23,6 +23,7 @@ describe("WebserviceLicenseStatusProcessorClient", () => {
   beforeEach(() => {
     stubLicenseStatusClient = {
       search: jest.fn(),
+      health: jest.fn(),
     };
 
     searchLicenseStatus = WebserviceLicenseStatusProcessorClient(stubLicenseStatusClient);

--- a/api/src/client/dynamics/elevator-safety/DynamicsElevatorSafetyHealthCheckClient.test.ts
+++ b/api/src/client/dynamics/elevator-safety/DynamicsElevatorSafetyHealthCheckClient.test.ts
@@ -1,0 +1,57 @@
+import { DynamicsElevatorSafetyHealthCheckClient } from "@client/dynamics/elevator-safety/DynamicsElevatorSafetyHealthCheckClient";
+import { AccessTokenClient } from "@client/dynamics/types";
+import { HealthCheckMethod } from "@domain/types";
+import { LogWriter, LogWriterType } from "@libs/logWriter";
+import axios from "axios";
+
+jest.mock("axios");
+jest.mock("winston");
+const mockAxios = axios as jest.Mocked<typeof axios>;
+
+describe("DynamicsElevatorSafetyHealthCheckClient", () => {
+  let client: HealthCheckMethod;
+  let logger: LogWriterType;
+  let stubAccessTokenClient: jest.Mocked<AccessTokenClient>;
+
+  const ORG_URL = "www.test-org-url.com";
+
+  beforeEach(() => {
+    logger = LogWriter("NavigatorWebService", "ApiLogs", "us-test-1");
+    stubAccessTokenClient = {
+      getAccessToken: jest.fn(),
+    };
+    client = DynamicsElevatorSafetyHealthCheckClient(logger, {
+      accessTokenClient: stubAccessTokenClient,
+      orgUrl: ORG_URL,
+    });
+  });
+
+  it("returns a passing health check if data can be retrieved sucessfully", async () => {
+    mockAxios.get.mockResolvedValue({});
+    expect(await client()).toEqual({ success: true, data: { message: "OK" } });
+  });
+
+  it("returns a failing health check if unexpected data is retrieved", async () => {
+    mockAxios.get.mockRejectedValue({ response: { status: 404 }, message: "" });
+    expect(await client()).toEqual({
+      success: false,
+      error: {
+        message: "Bad Gateway",
+        serverResponseBody: "",
+        serverResponseCode: 404,
+        timeout: false,
+      },
+    });
+  });
+
+  it("returns a failing health check if axios request times out", async () => {
+    mockAxios.get.mockRejectedValue({});
+    expect(await client()).toEqual({
+      success: false,
+      error: {
+        message: "Gateway Timeout",
+        timeout: true,
+      },
+    });
+  });
+});

--- a/api/src/client/dynamics/elevator-safety/DynamicsElevatorSafetyHealthCheckClient.ts
+++ b/api/src/client/dynamics/elevator-safety/DynamicsElevatorSafetyHealthCheckClient.ts
@@ -1,0 +1,55 @@
+import type { AccessTokenClient } from "@client/dynamics/types";
+import type { HealthCheckMetadata, HealthCheckMethod } from "@domain/types";
+import type { LogWriterType } from "@libs/logWriter";
+import axios, { type AxiosError } from "axios";
+import { ReasonPhrases } from "http-status-codes";
+
+type Config = {
+  accessTokenClient: AccessTokenClient;
+  orgUrl: string;
+};
+
+export const DynamicsElevatorSafetyHealthCheckClient = (
+  logWriter: LogWriterType,
+  config: Config
+): HealthCheckMethod => {
+  return async (): Promise<HealthCheckMetadata> => {
+    const logId = logWriter.GetId();
+    const accessToken = await config.accessTokenClient.getAccessToken();
+    return axios
+      .get(`${config.orgUrl}/api/data/v9.2/ultra_elsainspections?$top=1`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      })
+      .then(() => {
+        return {
+          success: true,
+          data: {
+            message: ReasonPhrases.OK,
+          },
+        } as HealthCheckMetadata;
+      })
+      .catch((error: AxiosError) => {
+        logWriter.LogError(`Dynamics Elevator Safety Health Check Failed - Id:${logId} - Error:`, error);
+        if (error.response) {
+          return {
+            success: false,
+            error: {
+              serverResponseBody: error.message,
+              serverResponseCode: error.response.status,
+              message: ReasonPhrases.BAD_GATEWAY,
+              timeout: false,
+            },
+          } as HealthCheckMetadata;
+        }
+        return {
+          success: false,
+          error: {
+            message: ReasonPhrases.GATEWAY_TIMEOUT,
+            timeout: true,
+          },
+        } as HealthCheckMetadata;
+      });
+  };
+};

--- a/api/src/client/dynamics/fire-safety/DynamicsFireSafetyHealthCheckClient.test.ts
+++ b/api/src/client/dynamics/fire-safety/DynamicsFireSafetyHealthCheckClient.test.ts
@@ -1,0 +1,57 @@
+import { DynamicsFireSafetyHealthCheckClient } from "@client/dynamics/fire-safety/DynamicsFireSafetyHealthCheckClient";
+import { AccessTokenClient } from "@client/dynamics/types";
+import { HealthCheckMethod } from "@domain/types";
+import { LogWriter, LogWriterType } from "@libs/logWriter";
+import axios from "axios";
+
+jest.mock("axios");
+jest.mock("winston");
+const mockAxios = axios as jest.Mocked<typeof axios>;
+
+describe("DynamicsFireSafetyHealthCheckClient", () => {
+  let client: HealthCheckMethod;
+  let logger: LogWriterType;
+  let stubAccessTokenClient: jest.Mocked<AccessTokenClient>;
+
+  const ORG_URL = "www.test-org-url.com";
+
+  beforeEach(() => {
+    logger = LogWriter("NavigatorWebService", "ApiLogs", "us-test-1");
+    stubAccessTokenClient = {
+      getAccessToken: jest.fn(),
+    };
+    client = DynamicsFireSafetyHealthCheckClient(logger, {
+      accessTokenClient: stubAccessTokenClient,
+      orgUrl: ORG_URL,
+    });
+  });
+
+  it("returns a passing health check if data can be retrieved sucessfully", async () => {
+    mockAxios.get.mockResolvedValue({});
+    expect(await client()).toEqual({ success: true, data: { message: "OK" } });
+  });
+
+  it("returns a failing health check if unexpected data is retrieved", async () => {
+    mockAxios.get.mockRejectedValue({ response: { status: 404 }, message: "" });
+    expect(await client()).toEqual({
+      success: false,
+      error: {
+        message: "Bad Gateway",
+        serverResponseBody: "",
+        serverResponseCode: 404,
+        timeout: false,
+      },
+    });
+  });
+
+  it("returns a failing health check if axios request times out", async () => {
+    mockAxios.get.mockRejectedValue({});
+    expect(await client()).toEqual({
+      success: false,
+      error: {
+        message: "Gateway Timeout",
+        timeout: true,
+      },
+    });
+  });
+});

--- a/api/src/client/dynamics/fire-safety/DynamicsFireSafetyHealthCheckClient.ts
+++ b/api/src/client/dynamics/fire-safety/DynamicsFireSafetyHealthCheckClient.ts
@@ -1,0 +1,55 @@
+import type { AccessTokenClient } from "@client/dynamics/types";
+import type { HealthCheckMetadata, HealthCheckMethod } from "@domain/types";
+import type { LogWriterType } from "@libs/logWriter";
+import axios, { type AxiosError } from "axios";
+import { ReasonPhrases } from "http-status-codes";
+
+type Config = {
+  accessTokenClient: AccessTokenClient;
+  orgUrl: string;
+};
+
+export const DynamicsFireSafetyHealthCheckClient = (
+  logWriter: LogWriterType,
+  config: Config
+): HealthCheckMethod => {
+  return async (): Promise<HealthCheckMetadata> => {
+    const logId = logWriter.GetId();
+    const accessToken = await config.accessTokenClient.getAccessToken();
+    return axios
+      .get(`${config.orgUrl}/api/data/v9.2/ultra_fireinspections?$top=1`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      })
+      .then(() => {
+        return {
+          success: true,
+          data: {
+            message: ReasonPhrases.OK,
+          },
+        } as HealthCheckMetadata;
+      })
+      .catch((error: AxiosError) => {
+        logWriter.LogError(`Dynamics Fire Safety Health Check Failed - Id:${logId} - Error:`, error);
+        if (error.response) {
+          return {
+            success: false,
+            error: {
+              serverResponseBody: error.message,
+              serverResponseCode: error.response.status,
+              message: ReasonPhrases.BAD_GATEWAY,
+              timeout: false,
+            },
+          } as HealthCheckMetadata;
+        }
+        return {
+          success: false,
+          error: {
+            message: ReasonPhrases.GATEWAY_TIMEOUT,
+            timeout: true,
+          },
+        } as HealthCheckMetadata;
+      });
+  };
+};

--- a/api/src/client/dynamics/fire-safety/DynamicsFireSafetyInspectionClient.ts
+++ b/api/src/client/dynamics/fire-safety/DynamicsFireSafetyInspectionClient.ts
@@ -1,10 +1,7 @@
-import { FireSafetyInspection } from "@client/dynamics/fire-safety/types";
+import { FireSafetyInspection, FireSafetyInspectionClient } from "@client/dynamics/fire-safety/types";
 import { LogWriterType } from "@libs/logWriter";
 import axios, { AxiosError } from "axios";
 
-export interface FireSafetyInspectionClient {
-  getFireSafetyInspections: (accessToken: string, address: string) => Promise<FireSafetyInspection[]>;
-}
 export const DynamicsFireSafetyInspectionClient = (
   logWriter: LogWriterType,
   orgUrl: string

--- a/api/src/client/dynamics/housing/DynamicsHousingHealthCheckClient.test.ts
+++ b/api/src/client/dynamics/housing/DynamicsHousingHealthCheckClient.test.ts
@@ -1,0 +1,57 @@
+import { DynamicsHousingHealthCheckClient } from "@client/dynamics/housing/DynamicsHousingHealthCheckClient";
+import { AccessTokenClient } from "@client/dynamics/types";
+import { HealthCheckMethod } from "@domain/types";
+import { LogWriter, LogWriterType } from "@libs/logWriter";
+import axios from "axios";
+
+jest.mock("axios");
+jest.mock("winston");
+const mockAxios = axios as jest.Mocked<typeof axios>;
+
+describe("DynamicsHousingHealthCheckClient", () => {
+  let client: HealthCheckMethod;
+  let logger: LogWriterType;
+  let stubAccessTokenClient: jest.Mocked<AccessTokenClient>;
+
+  const ORG_URL = "www.test-org-url.com";
+
+  beforeEach(() => {
+    logger = LogWriter("NavigatorWebService", "ApiLogs", "us-test-1");
+    stubAccessTokenClient = {
+      getAccessToken: jest.fn(),
+    };
+    client = DynamicsHousingHealthCheckClient(logger, {
+      accessTokenClient: stubAccessTokenClient,
+      orgUrl: ORG_URL,
+    });
+  });
+
+  it("returns a passing health check if data can be retrieved sucessfully", async () => {
+    mockAxios.get.mockResolvedValue({});
+    expect(await client()).toEqual({ success: true, data: { message: "OK" } });
+  });
+
+  it("returns a failing health check if unexpected data is retrieved", async () => {
+    mockAxios.get.mockRejectedValue({ response: { status: 404 }, message: "" });
+    expect(await client()).toEqual({
+      success: false,
+      error: {
+        message: "Bad Gateway",
+        serverResponseBody: "",
+        serverResponseCode: 404,
+        timeout: false,
+      },
+    });
+  });
+
+  it("returns a failing health check if axios request times out", async () => {
+    mockAxios.get.mockRejectedValue({});
+    expect(await client()).toEqual({
+      success: false,
+      error: {
+        message: "Gateway Timeout",
+        timeout: true,
+      },
+    });
+  });
+});

--- a/api/src/client/dynamics/housing/DynamicsHousingHealthCheckClient.ts
+++ b/api/src/client/dynamics/housing/DynamicsHousingHealthCheckClient.ts
@@ -1,0 +1,55 @@
+import type { AccessTokenClient } from "@client/dynamics/types";
+import type { HealthCheckMetadata, HealthCheckMethod } from "@domain/types";
+import type { LogWriterType } from "@libs/logWriter";
+import axios, { type AxiosError } from "axios";
+import { ReasonPhrases } from "http-status-codes";
+
+type Config = {
+  accessTokenClient: AccessTokenClient;
+  orgUrl: string;
+};
+
+export const DynamicsHousingHealthCheckClient = (
+  logWriter: LogWriterType,
+  config: Config
+): HealthCheckMethod => {
+  return async (): Promise<HealthCheckMetadata> => {
+    const logId = logWriter.GetId();
+    const accessToken = await config.accessTokenClient.getAccessToken();
+    return axios
+      .get(`${config.orgUrl}/api/data/v9.2/ultra_propertyinterests?$top=1`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      })
+      .then(() => {
+        return {
+          success: true,
+          data: {
+            message: ReasonPhrases.OK,
+          },
+        } as HealthCheckMetadata;
+      })
+      .catch((error: AxiosError) => {
+        logWriter.LogError(`Dynamics Housing Health Check Failed - Id:${logId} - Error:`, error);
+        if (error.response) {
+          return {
+            success: false,
+            error: {
+              serverResponseBody: error.message,
+              serverResponseCode: error.response.status,
+              message: ReasonPhrases.BAD_GATEWAY,
+              timeout: false,
+            },
+          } as HealthCheckMetadata;
+        }
+        return {
+          success: false,
+          error: {
+            message: ReasonPhrases.GATEWAY_TIMEOUT,
+            timeout: true,
+          },
+        } as HealthCheckMetadata;
+      });
+  };
+};

--- a/api/src/client/dynamics/license-status/DynamicsLicenseHealthCheckClient.test.ts
+++ b/api/src/client/dynamics/license-status/DynamicsLicenseHealthCheckClient.test.ts
@@ -1,0 +1,57 @@
+import { DynamicsLicenseHealthCheckClient } from "@client/dynamics/license-status/DynamicsLicenseHealthCheckClient";
+import { AccessTokenClient } from "@client/dynamics/types";
+import { HealthCheckMethod } from "@domain/types";
+import { LogWriter, LogWriterType } from "@libs/logWriter";
+import axios from "axios";
+
+jest.mock("axios");
+jest.mock("winston");
+const mockAxios = axios as jest.Mocked<typeof axios>;
+
+describe("DynamicsLicenseHealthCheckClient", () => {
+  let client: HealthCheckMethod;
+  let logger: LogWriterType;
+  let stubAccessTokenClient: jest.Mocked<AccessTokenClient>;
+
+  const ORG_URL = "www.test-org-url.com";
+
+  beforeEach(() => {
+    logger = LogWriter("NavigatorWebService", "ApiLogs", "us-test-1");
+    stubAccessTokenClient = {
+      getAccessToken: jest.fn(),
+    };
+    client = DynamicsLicenseHealthCheckClient(logger, {
+      accessTokenClient: stubAccessTokenClient,
+      orgUrl: ORG_URL,
+    });
+  });
+
+  it("returns a passing health check if data can be retrieved sucessfully", async () => {
+    mockAxios.get.mockResolvedValue({});
+    expect(await client()).toEqual({ success: true, data: { message: "OK" } });
+  });
+
+  it("returns a failing health check if unexpected data is retrieved", async () => {
+    mockAxios.get.mockRejectedValue({ response: { status: 404 }, message: "" });
+    expect(await client()).toEqual({
+      success: false,
+      error: {
+        message: "Bad Gateway",
+        serverResponseBody: "",
+        serverResponseCode: 404,
+        timeout: false,
+      },
+    });
+  });
+
+  it("returns a failing health check if axios request times out", async () => {
+    mockAxios.get.mockRejectedValue({});
+    expect(await client()).toEqual({
+      success: false,
+      error: {
+        message: "Gateway Timeout",
+        timeout: true,
+      },
+    });
+  });
+});

--- a/api/src/client/dynamics/license-status/DynamicsLicenseHealthCheckClient.ts
+++ b/api/src/client/dynamics/license-status/DynamicsLicenseHealthCheckClient.ts
@@ -1,0 +1,55 @@
+import type { AccessTokenClient } from "@client/dynamics/types";
+import type { HealthCheckMetadata, HealthCheckMethod } from "@domain/types";
+import type { LogWriterType } from "@libs/logWriter";
+import axios, { type AxiosError } from "axios";
+import { ReasonPhrases } from "http-status-codes";
+
+type Config = {
+  accessTokenClient: AccessTokenClient;
+  orgUrl: string;
+};
+
+export const DynamicsLicenseHealthCheckClient = (
+  logWriter: LogWriterType,
+  config: Config
+): HealthCheckMethod => {
+  return async (): Promise<HealthCheckMetadata> => {
+    const logId = logWriter.GetId();
+    const accessToken = await config.accessTokenClient.getAccessToken();
+    return axios
+      .get(`${config.orgUrl}/api/data/v9.2/accounts?$top=1`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      })
+      .then(() => {
+        return {
+          success: true,
+          data: {
+            message: ReasonPhrases.OK,
+          },
+        } as HealthCheckMetadata;
+      })
+      .catch((error: AxiosError) => {
+        logWriter.LogError(`Dynamics License Status Health Check Failed - Id:${logId} - Error:`, error);
+        if (error.response) {
+          return {
+            success: false,
+            error: {
+              serverResponseBody: error.message,
+              serverResponseCode: error.response.status,
+              message: ReasonPhrases.BAD_GATEWAY,
+              timeout: false,
+            },
+          } as HealthCheckMetadata;
+        }
+        return {
+          success: false,
+          error: {
+            message: ReasonPhrases.GATEWAY_TIMEOUT,
+            timeout: true,
+          },
+        } as HealthCheckMetadata;
+      });
+  };
+};

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -8,6 +8,7 @@ import { LicenseEntity, LicenseSearchNameAndAddress, LicenseStatusResult } from 
 import { ProfileData } from "@shared/profileData";
 import { TaxFilingCalendarEvent, TaxFilingLookupState, TaxFilingOnboardingState } from "@shared/taxFiling";
 import { UserData } from "@shared/userData";
+import { ReasonPhrases } from "http-status-codes";
 import * as https from "node:https";
 
 export interface UserDataClient {
@@ -66,6 +67,7 @@ export type AddToUserTesting = (userData: UserData) => Promise<UserData>;
 
 export interface LicenseStatusClient {
   search: (name: string, zipCode: string, licenseType: string) => Promise<LicenseEntity[]>;
+  health: HealthCheckMethod;
 }
 
 export interface UserTestingClient {
@@ -117,6 +119,38 @@ export type HousingPropertyInterestStatus = (address: string) => Promise<Housing
 export type ElevatorSafetyInspectionStatus = (
   address: string
 ) => Promise<ElevatorSafetyDeviceInspectionDetails[]>;
+
+export interface SuccessfulHealthCheckMetadata {
+  success: true;
+  data?: {
+    message: HealthCheckMessage;
+  };
+}
+
+export interface UnsuccessfulHealthCheckMetadata {
+  success: false;
+  error?: {
+    message: HealthCheckMessage;
+    timeout?: boolean;
+    serverResponseCode?: number;
+    serverResponseBody?: string;
+  };
+}
+
+export type HealthCheckMetadata = SuccessfulHealthCheckMetadata | UnsuccessfulHealthCheckMetadata;
+
+export type SuccessfulHealthCheckResponse = {
+  timestamp: number;
+} & SuccessfulHealthCheckMetadata;
+
+export type UnsuccessfulHealthCheckResponse = {
+  timestamp: number;
+} & UnsuccessfulHealthCheckMetadata;
+
+export type HealthCheckResponse = SuccessfulHealthCheckResponse | UnsuccessfulHealthCheckResponse;
+
+export type HealthCheckMethod = () => Promise<HealthCheckMetadata>;
+export type HealthCheckMessage = ReasonPhrases;
 
 export type UpdateOperatingPhase = (userData: UserData) => UserData;
 export type UpdateSidebarCards = (userData: UserData) => UserData;

--- a/api/src/functions/express/index.ts
+++ b/api/src/functions/express/index.ts
@@ -37,6 +37,13 @@ export default (cognitoArn: string, vpcConfig: FnType["vpc"]): FnType => {
       {
         http: {
           method: "ANY",
+          path: "/health/{proxy+}",
+          cors: false,
+        },
+      },
+      {
+        http: {
+          method: "ANY",
           path: "/{proxy+}",
           authorizer: {
             arn: cognitoArn,

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "eslint-plugin-storybook": "^0.6.15",
     "eslint-plugin-testing-library": "6.0.1",
     "eslint-plugin-unicorn": "50.0.1",
+    "http-status-codes": "^2.3.0",
     "husky": "8.0.3",
     "identity-obj-proxy": "3.0.0",
     "jest": "29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4057,6 +4057,7 @@ __metadata:
     eslint-plugin-unicorn: 50.0.1
     express: 4.18.2
     helmet: 7.1.0
+    http-status-codes: ^2.3.0
     jest: 29.7.0
     jest-dynalite: 3.6.1
     jest-junit: 16.0.0
@@ -4231,6 +4232,7 @@ __metadata:
     gray-matter: 4.0.3
     helmet: 7.1.0
     html2canvas: 1.4.1
+    http-status-codes: ^2.3.0
     husky: 8.0.3
     identity-obj-proxy: 3.0.0
     jest: 29.7.0
@@ -20439,6 +20441,13 @@ __metadata:
     jsprim: ^2.0.2
     sshpk: ^1.14.1
   checksum: 10be2af4764e71fee0281392937050201ee576ac755c543f570d6d87134ce5e858663fe999a7adb3e4e368e1e356d0d7fec6b9542295b875726ff615188e7a0c
+  languageName: node
+  linkType: hard
+
+"http-status-codes@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "http-status-codes@npm:2.3.0"
+  checksum: dae3b99e0155441b6df28e8265ff27c56a45f82c6092f736414233e9ccf063d5ea93c1e1279e8b499c4642e2538b37995c76b1640ed3f615d0e2883d3a1dcfd5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

The first of two health check-related pull requests. (See "Notes" later for more information.) This adds or modifies the following routes to the API for health checks:

| route | description |
| ----- | ------------ |
| `/health` | [Existing] Self-check to ensure the API is up and running. |
| `/health/webservice/license-status` | Establishes a connection to the Webservice server (for Hub License Status) to ensure the server is online and that we can successfully retrieve data. |
| `/health/dynamics/elevator` | Establishes a connection to the Dynamics server (for Muni Elevator Safety) to ensure the server is online and that we can successfully retrieve data. |
| `/health/dynamics/fire-safety` | Establishes a connection to the Dynamics server (for Muni Fire Safety) to ensure the server is online and that we can successfully retrieve data. |
| `/health/dynamics/housing` | Establishes a connection to the Dynamics server (for Muni Housing) to ensure the server is online and that we can successfully retrieve data. |
| `/health/dynamics/license-status` | Establishes a connection to the Dynamics server (for Hub License Status) to ensure the server is online and that we can successfully retrieve data. |

For external services, these are the valid states:

| HTTP Code | Description | Example API Response |
| ----------- | ----------- | --- |
| HTTP 200 OK | Server is online and returns expected result. | `{timestamp: 123, success: true, data: { message: "Alive" } }` |
| HTTP 502 Bad Gateway | Server is online but returned an unexpected result. | `{timestamp: 123, success: false, error: { message: "Unexpected result.", timeout: false, serverResponseCode: 404, serverResponseBody: "Page not found." } }` |
| HTTP 504 Gateway Timeout | Server is unreachable. | `{timestamp: 123, success: false, error: { message: "Timeout of 5000ms reached.", timeout: true } }` |

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#186657856](https://www.pivotaltracker.com/story/show/186657856)

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

1. Start the dev server locally.
2. In another Terminal window, check the HTTP status code:

   ```shell
   curl -s -w "%{http_code}\n" -o /dev/null "http://localhost:5002/local/health"
   ```

3. If you would like to see the body of the request, parsed and pretty-printed:

   ```shell
   curl -s -o - "http://localhost:5002/local/health" | python -m json.tool
   ```

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

Thanks to @SirSamuelJoseph for contributing the health checks for the Muni team's work, to @somabadri for Dynamics license status, and to @jphechter for the webservice guidance.

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
