### PR TITLE
fix: [#186620499] no nav menu for onboarding authenticated users

### DIFF
--- a/web/src/components/navbar/NavBar.test.tsx
+++ b/web/src/components/navbar/NavBar.test.tsx
@@ -204,6 +204,21 @@ describe("<NavBar />", () => {
         expect(screen.queryByText(Config.navigationDefaults.profileLinkText)).not.toBeInTheDocument();
         expect(screen.queryByText(Config.navigationDefaults.registerButton)).not.toBeInTheDocument();
       });
+
+      it("does not render nav menu for an onboarding authenticated user", async () => {
+        setLargeScreen(false);
+        render(
+          withAuth(<NavBar landingPage={false} showSidebar={false} />, {
+            isAuthenticated: IsAuthenticated.TRUE,
+          })
+        );
+
+        useMockRouter({ pathname: ROUTES.onboarding });
+
+        await waitFor(() => {
+          expect(screen.queryByTestId("nav-menu-open")).not.toBeInTheDocument();
+        });
+      });
     });
   });
 

--- a/web/src/components/navbar/NavBarMobile.tsx
+++ b/web/src/components/navbar/NavBarMobile.tsx
@@ -83,17 +83,19 @@ export const NavBarMobile = (props: Props): ReactElement => {
             <NavigatorLogo />
           )}
         </div>
-        <button
-          className="right-nav-menu-button radius-0"
-          data-testid="nav-menu-open"
-          aria-label="open menu"
-          onClick={(): void => {
-            analytics.event.mobile_hamburger_icon.click.open_mobile_menu();
-            open();
-          }}
-        >
-          <Icon className="font-sans-xl">menu</Icon>
-        </button>
+        {(!currentlyOnboarding() || !isAuthenticated) && (
+          <button
+            className="right-nav-menu-button radius-0"
+            data-testid="nav-menu-open"
+            aria-label="open menu"
+            onClick={(): void => {
+              analytics.event.mobile_hamburger_icon.click.open_mobile_menu();
+              open();
+            }}
+          >
+            <Icon className="font-sans-xl">menu</Icon>
+          </button>
+        )}
       </nav>
       <FocusTrappedSidebar close={close} isOpen={sidebarIsOpen}>
         <nav


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
**Problem/Undesired Behavior**: 
The hamburger menu is visible, in the mobile layout, when a registered user is onboarding (a second business). 

**Solution**:
The hamburger menu is no longer visible, in the mobile layout, when a registered user is onboarding (a second business).




### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#186620499](https://www.pivotaltracker.com/story/show/186620499)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
