### PR TITLE
feat: [#186497109] add return to previous business button on unsupport…

### DIFF
--- a/shared/src/domain-logic/getBusinessById.ts
+++ b/shared/src/domain-logic/getBusinessById.ts
@@ -1,0 +1,11 @@
+import { Business, UserData } from "../userData";
+
+export const getBusinessById = ({
+  userData,
+  previousBusinessId,
+}: {
+  userData: UserData;
+  previousBusinessId: string;
+}): Business => {
+  return userData.businesses[previousBusinessId];
+};

--- a/web/cypress/e2e/multiple-businesses.spec.ts
+++ b/web/cypress/e2e/multiple-businesses.spec.ts
@@ -55,4 +55,26 @@ describe("Multiple Businesses [feature] [all] [group2]", () => {
     cy.get('[data-testid="business-title-0"]').should("exist");
     cy.get('[data-testid="business-title-1"]').should("not.exist");
   });
+
+  it("exits out of additional business onboarding without saving when new business is unsupported", () => {
+    completeNewBusinessOnboarding({});
+    cy.url().should("contain", "/dashboard");
+
+    onDashboardPage.getDropdown().click();
+    onDashboardPage.getAddBusinessButtonInDropdown().click();
+    cy.url().should("include", "onboarding?page=1");
+
+    onOnboardingPage.selectBusinessPersona("FOREIGN");
+    onOnboardingPage.clickNext();
+
+    onOnboardingPage.checkForeignBusinessType("none");
+    onOnboardingPage.clickNext();
+
+    cy.get('[data-testid="return-to-prev-button"]').click();
+    cy.url().should("contain", "/dashboard");
+
+    onDashboardPage.getDropdown().click();
+    cy.get('[data-testid="business-title-0"]').should("exist");
+    cy.get('[data-testid="business-title-1"]').should("not.exist");
+  });
 });

--- a/web/src/lib/domain-logic/routes.ts
+++ b/web/src/lib/domain-logic/routes.ts
@@ -45,6 +45,7 @@ export enum QUERIES {
   completeFiling = "completeFiling",
   success = "success",
   additionalBusiness = "additionalBusiness",
+  previousBusinessId = "previousBusinessId",
   path = "path",
   signUp = "signUp",
   industry = "industry",

--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -334,7 +334,12 @@ const OnboardingPage = (props: Props): ReactElement => {
       setAnalyticsDimensions(newProfileData);
 
       if (determineForeignBusinessType(profileData.foreignBusinessTypeIds) === "NONE") {
-        await router.push(ROUTES.unsupported);
+        await router.push({
+          pathname: ROUTES.unsupported,
+          query: isAdditionalBusiness
+            ? { [QUERIES.additionalBusiness]: "true", [QUERIES.previousBusinessId]: previousBusiness?.id }
+            : {},
+        });
       } else if (page.current + 1 <= onboardingFlows[currentFlow].pages.length) {
         updateQueue
           .queueProfileData(newProfileData)

--- a/web/src/pages/unsupported.tsx
+++ b/web/src/pages/unsupported.tsx
@@ -1,16 +1,33 @@
 import { Content } from "@/components/Content";
+import { SupportExploreSignUpChatCards } from "@/components/SupportExploreSignUpChatCards";
 import { Heading } from "@/components/njwds-extended/Heading";
 import { PageSkeleton } from "@/components/njwds-layout/PageSkeleton";
 import { SingleColumnContainer } from "@/components/njwds/SingleColumnContainer";
-import { SupportExploreSignUpChatCards } from "@/components/SupportExploreSignUpChatCards";
+import { ReturnToPreviousBusinessBar } from "@/components/onboarding/ReturnToPreviousBusinessBar";
 import { useConfig } from "@/lib/data-hooks/useConfig";
+import { useUserData } from "@/lib/data-hooks/useUserData";
+import { QUERIES } from "@/lib/domain-logic/routes";
+import { getBusinessById } from "@businessnjgovnavigator/shared/domain-logic/getBusinessById";
+import { useRouter } from "next/router";
 import { ReactElement } from "react";
 
 const UnsupportedPage = (): ReactElement => {
   const { Config } = useConfig();
+  const { userData } = useUserData();
+  const router = useRouter();
 
   return (
     <PageSkeleton>
+      {router.query.additionalBusiness === "true" && userData ? (
+        <ReturnToPreviousBusinessBar
+          previousBusiness={getBusinessById({
+            userData,
+            previousBusinessId: router.query[QUERIES.previousBusinessId] as string,
+          })}
+        />
+      ) : (
+        <></>
+      )}
       <main className="usa-section padding-top-0 desktop:padding-top-8" id="main">
         <SingleColumnContainer>
           <div className="padding-top-5 desktop:padding-top-0">

--- a/web/test/pages/onboarding/onboarding-foreign.test.tsx
+++ b/web/test/pages/onboarding/onboarding-foreign.test.tsx
@@ -212,12 +212,11 @@ describe("onboarding - foreign business", () => {
     it("navigates to the unsupported page when the foreign business type is none", async () => {
       const { page } = renderPage({ userData });
       page.checkByLabelText(none);
-
       act(() => {
         return page.clickNext();
       });
       await waitFor(() => {
-        return expect(mockPush).toHaveBeenCalledWith(ROUTES.unsupported);
+        return expect(mockPush).toHaveBeenCalledWith({ pathname: ROUTES.unsupported, query: {} });
       });
     });
   });

--- a/web/test/pages/unsupported.test.tsx
+++ b/web/test/pages/unsupported.test.tsx
@@ -1,13 +1,58 @@
 import { getMergedConfig } from "@/contexts/configContext";
+import { QUERIES } from "@/lib/domain-logic/routes";
 import UnsupportedPage from "@/pages/unsupported";
+import { useMockRouter } from "@/test/mock/mockRouter";
+import { useMockUserData } from "@/test/mock/mockUseUserData";
+import { generateBusiness, generateUserData } from "@businessnjgovnavigator/shared";
 import { render, screen } from "@testing-library/react";
+
+jest.mock("next/router", () => ({ useRouter: jest.fn() }));
+jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
 
 const Config = getMergedConfig();
 
 describe("Unsupported", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    useMockUserData({});
+    useMockRouter({});
+  });
+
   it("renders the text when navigated to", () => {
     render(<UnsupportedPage />);
     expect(screen.getByText(Config.unsupportedNavigatorUserPage.title)).toBeInTheDocument();
     expect(screen.getByTestId("unsupported-subtitle")).toBeInTheDocument();
+  });
+
+  describe("previous business button", () => {
+    it("renders when router param additionalBusiness is true", () => {
+      useMockUserData(
+        generateUserData({
+          businesses: {
+            "prev-biz-id": generateBusiness({
+              id: "prev-biz-id",
+            }),
+          },
+        })
+      );
+      useMockRouter({ query: { additionalBusiness: "true", [QUERIES.previousBusinessId]: "prev-biz-id" } });
+      render(<UnsupportedPage />);
+      expect(screen.getByTestId("return-to-prev-button")).toBeInTheDocument();
+    });
+
+    it("doesn't render when router param additionalBusiness doesn't have a value", () => {
+      useMockUserData(
+        generateUserData({
+          businesses: {
+            "prev-biz-id": generateBusiness({
+              id: "prev-biz-id",
+            }),
+          },
+        })
+      );
+      useMockRouter({ query: {} });
+      render(<UnsupportedPage />);
+      expect(screen.queryByTestId("return-to-prev-button")).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
…ed page

<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
Added the return to previous business button to the unsupported page when adding an additional business so the user can navigate back. I used two query parameters, `additionalBusiness` and `previousBusinessId` to get the values necessary to extend the functionality of the previous business button.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#186497109](https://www.pivotaltracker.com/story/show/186497109)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
