### PR TITLE
feat: [#186774562] switch to text/plain for all formation requests

### DIFF
--- a/api/src/client/ApiFormationClient.test.ts
+++ b/api/src/client/ApiFormationClient.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { FormationClient } from "@domain/types";
-import { LogWriter, LogWriterType } from "@libs/logWriter";
+import { DummyLogWriter, LogWriter, LogWriterType } from "@libs/logWriter";
 import { getCurrentDate, getCurrentDateISOString, parseDate, parseDateWithFormat } from "@shared/dateHelpers";
 import { defaultDateFormat } from "@shared/defaultConstants";
 import { FormationFormData, FormationLegalType, formationApiDateFormat } from "@shared/formationData";
@@ -33,6 +33,8 @@ import { UserData } from "@shared/userData";
 jest.mock("axios");
 jest.mock("winston");
 const mockAxios = axios as jest.Mocked<typeof axios>;
+
+const DEBUG = Boolean(process.env.DEBUG ?? false);
 
 const generateApiResponse = (overrides: Partial<ApiResponse>): ApiResponse => {
   return {
@@ -79,7 +81,7 @@ describe("ApiFormationClient", () => {
     logger = LogWriter("NavigatorWebService", "ApiLogs", "us-test-1");
     client = ApiFormationClient(
       { account: "12345", key: "abcdef", baseUrl: "example.com/formation" },
-      logger
+      DEBUG ? logger : DummyLogWriter
     );
   });
 
@@ -235,7 +237,7 @@ describe("ApiFormationClient", () => {
               ContactPhoneNumber: formationFormData.contactPhoneNumber,
             },
           },
-          { headers: { "Content-Type": "application/json" } }
+          { headers: { "Content-Type": "text/plain" } }
         );
       });
 
@@ -366,7 +368,7 @@ describe("ApiFormationClient", () => {
               ContactPhoneNumber: formationFormData.contactPhoneNumber,
             },
           },
-          { headers: { "Content-Type": "application/json" } }
+          { headers: { "Content-Type": "text/plain" } }
         );
       });
     });
@@ -544,7 +546,7 @@ describe("ApiFormationClient", () => {
               ContactPhoneNumber: formationFormData.contactPhoneNumber,
             },
           },
-          { headers: { "Content-Type": "application/json" } }
+          { headers: { "Content-Type": "text/plain" } }
         );
       });
 
@@ -905,7 +907,7 @@ describe("ApiFormationClient", () => {
               ContactPhoneNumber: formationFormData.contactPhoneNumber,
             },
           },
-          { headers: { "Content-Type": "application/json" } }
+          { headers: { "Content-Type": "text/plain" } }
         );
       });
 
@@ -1031,7 +1033,7 @@ describe("ApiFormationClient", () => {
               ContactPhoneNumber: formationFormData.contactPhoneNumber,
             },
           },
-          { headers: { "Content-Type": "application/json" } }
+          { headers: { "Content-Type": "text/plain" } }
         );
       });
     });
@@ -1219,7 +1221,7 @@ describe("ApiFormationClient", () => {
               ContactPhoneNumber: formationFormData.contactPhoneNumber,
             },
           },
-          { headers: { "Content-Type": "application/json" } }
+          { headers: { "Content-Type": "text/plain" } }
         );
       });
     });
@@ -1387,7 +1389,7 @@ describe("ApiFormationClient", () => {
               ContactPhoneNumber: formationFormData.contactPhoneNumber,
             },
           },
-          { headers: { "Content-Type": "application/json" } }
+          { headers: { "Content-Type": "text/plain" } }
         );
       });
 

--- a/api/src/client/ApiFormationClient.ts
+++ b/api/src/client/ApiFormationClient.ts
@@ -43,7 +43,7 @@ export const ApiFormationClient = (config: ApiConfig, logger: LogWriterType): Fo
     return axios
       .post(`${config.baseUrl}/PrepareFiling`, postBody, {
         headers: {
-          "Content-Type": foreignGoodStandingFile ? "text/plain" : "application/json",
+          "Content-Type": "text/plain",
         },
       })
       .then((response) => {

--- a/api/src/libs/logWriter.ts
+++ b/api/src/libs/logWriter.ts
@@ -14,6 +14,18 @@ const GetId = (): string => {
   return randomUUID();
 };
 
+export const DummyLogWriter: LogWriterType = {
+  LogError: () => {
+    return;
+  },
+  LogInfo: () => {
+    return;
+  },
+  GetId: () => {
+    return "";
+  },
+};
+
 export const LogWriter = (groupName: string, logStream: string, region?: string): LogWriterType => {
   const logger = winston.add(
     new WinstonCloudWatch({


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

This switches the `Content-Type` header for all Formation API calls from `application/json`/`text/plain` to always using `text/plain`.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#186774562](https://www.pivotaltracker.com/story/show/186774562)

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

This should be visible in dev right away. You should be able to form, where you cannot now.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

I also added a dummy logger to help clean up our output when running tests. That was annoying me.

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
