### PR TITLE
Fix failing unit tests on main

### DIFF
--- a/content/src/fieldConfig/business-formation.json
+++ b/content/src/fieldConfig/business-formation.json
@@ -186,9 +186,9 @@
       },
       "canGetDistribution": {
         "label": "Partnership Rights - Receive distributions",
-        "body": "Do limited partners have the right to receive distributions from a partner? (This can  include a return of all or any part of their partner's contributions).",
-        "reviewStepYes": "**Yes**, the limited partners have the right to receive distributions from a partner. (This can  include a return of all or any part of their partner's contributions).",
-        "reviewStepNo": "**No**, the limited partners do not have the right to receive distributions from a partner. (This can  include a return of all or any part of their partner's contributions)."
+        "body": "Do limited partners have the right to receive distributions from a partner? (This can include a return of all or any part of their partner's contributions).",
+        "reviewStepYes": "**Yes**, the limited partners have the right to receive distributions from a partner. (This can include a return of all or any part of their partner's contributions).",
+        "reviewStepNo": "**No**, the limited partners do not have the right to receive distributions from a partner. (This can include a return of all or any part of their partner's contributions)."
       },
       "addressLine2": {
         "label": "Address Line 2",
@@ -268,7 +268,7 @@
         "labelSecondaryText": "(mm/dd/yyyy)",
         "errorFuture": "The NJ business effective date must be today or a future date in format MM/DD/YYYY.",
         "errorToday": "The NJ business effective date must be today and in format MM/DD/YYYY.",
-        "error30Days": "The NJ business effective  date must be today or a future date within 30 days in format MM/DD/YYYY.",
+        "error30Days": "The NJ business effective date must be today or a future date within 30 days in format MM/DD/YYYY.",
         "error90Days": "The NJ business effective date must be today or a future date within 90 days in format MM/DD/YYYY."
       },
       "businessSuffix": {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

2 spaces were added to some pieces of content that were causing failures when attempting to match strings.

Ran a global search for `(?<=\S)  (?=\S)` to validate no other additional spaces in copy.

## Code author checklist

- [ ] I have performed a self-review of my code
- [ ] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [ ] I have not used any relative imports
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
