### PR TITLE
feat: [#185001723] dakota nexus remembers formation page

### DIFF
--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
@@ -2309,7 +2309,7 @@ describe("<BusinessFormationPaginator />", () => {
       expect(screen.getByTestId("business-name-step")).toBeInTheDocument();
     });
 
-    it("defaults to first formation step we go beyond page index allowed", () => {
+    it("defaults to first formation step when we go above 4 for page index", () => {
       const profileData = generateFormationProfileData({});
       const formationData = generateFormationData({
         lastVisitedPageIndex: BusinessFormationStepsConfiguration.length,
@@ -2320,7 +2320,7 @@ describe("<BusinessFormationPaginator />", () => {
       expect(screen.getByTestId("business-name-step")).toBeInTheDocument();
     });
 
-    it("defauts to first formation step when we go below 0 for page index's", () => {
+    it("defaults to first formation step when we go below 0 for page index", () => {
       const profileData = generateFormationProfileData({});
       const formationData = generateFormationData({ lastVisitedPageIndex: -1 });
 

--- a/web/src/components/tasks/business-formation/NexusFormationFlow.tsx
+++ b/web/src/components/tasks/business-formation/NexusFormationFlow.tsx
@@ -1,10 +1,11 @@
 import { Content } from "@/components/Content";
-import { CtaContainer } from "@/components/njwds-extended/cta/CtaContainer";
 import { HorizontalStepper } from "@/components/njwds-extended/HorizontalStepper";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
+import { CtaContainer } from "@/components/njwds-extended/cta/CtaContainer";
 import { ActionBarLayout } from "@/components/njwds-layout/ActionBarLayout";
 import { BusinessFormationPaginator } from "@/components/tasks/business-formation/BusinessFormationPaginator";
+import { BusinessFormationStepsConfiguration } from "@/components/tasks/business-formation/BusinessFormationStepsConfiguration";
 import { DbaFormationPaginator } from "@/components/tasks/business-formation/DbaFormationPaginator";
 import { NexusFormationStepsConfiguration } from "@/components/tasks/business-formation/NexusFormationStepsConfiguration";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
@@ -13,7 +14,7 @@ import { useUserData } from "@/lib/data-hooks/useUserData";
 import { allowFormation } from "@/lib/domain-logic/allowFormation";
 import { getNaicsDisplayMd } from "@/lib/domain-logic/getNaicsDisplayMd";
 import analytics from "@/lib/utils/analytics";
-import { openInNewTab, templateEval } from "@/lib/utils/helpers";
+import { openInNewTab, templateEval, useMountEffect } from "@/lib/utils/helpers";
 import { FormationFormData } from "@businessnjgovnavigator/shared/formationData";
 import { ReactElement, useContext } from "react";
 
@@ -21,6 +22,18 @@ export const NexusFormationFlow = (): ReactElement => {
   const { business } = useUserData();
   const { state, setStepIndex } = useContext(BusinessFormationContext);
   const { Config } = useConfig();
+
+  useMountEffect(() => {
+    if (!business) return;
+    if (
+      business.formationData.lastVisitedPageIndex > BusinessFormationStepsConfiguration.length - 1 ||
+      business.formationData.lastVisitedPageIndex < 0
+    ) {
+      setStepIndex(0);
+    } else {
+      setStepIndex(business.formationData.lastVisitedPageIndex);
+    }
+  });
 
   const addNaicsCodeData = (contentMd: string): string => {
     const naicsCode = business?.profileData.naicsCode || "";


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Added functionality so now Dakota Nexus businesses will remember their last visited page in the formation process. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#185001723](https://www.pivotaltracker.com/story/show/185001723)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

Tracked down why formationData gets reset everyone time the business structure is changed to meet the second AC on the ticket. The functionality and the test lives in the userRouter files. We explicitly reset the formationData to an empty formationData object on business structure change. 

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
