### PR TITLE
feat: [#186316001] Add mini roadmap task status for screen readers

### DIFF
--- a/web/src/components/roadmap/MiniRoadmapTask.tsx
+++ b/web/src/components/roadmap/MiniRoadmapTask.tsx
@@ -15,6 +15,7 @@ interface Props {
 export const MiniRoadmapTask = (props: Props): ReactElement => {
   const { business } = useUserData();
   const taskProgress = business?.taskProgress[props.task.id] || "NOT_STARTED";
+  const taskProgressReadable = taskProgress.replace("_", " ");
 
   return (
     <Link href={`/tasks/${props.task.urlSlug}`}>
@@ -39,6 +40,7 @@ export const MiniRoadmapTask = (props: Props): ReactElement => {
               <div className={`substep-unchecked margin-right-1 ${props.active ? "active" : ""}`} />
             )}
             <span className="margin-right-05">{props.task.name}</span>
+            <span className="screen-reader-only">{taskProgressReadable}</span>
           </div>
         </UnStyledButton>
       </div>

--- a/web/src/styles/base/global.scss
+++ b/web/src/styles/base/global.scss
@@ -89,3 +89,14 @@ ol {
   background: linear-gradient(180deg, rgba(243, 239, 236, 0) 0%, #ecf3ec 100%);
   height: 80vh;
 }
+
+.screen-reader-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[186316001](https://www.pivotaltracker.com/story/show/186316001)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
I added a new span for this because we wanted the status read after the task name and not before (where it is visually). 

### Steps to Test
 Navigate to any specific task and turn on your screen reader. When reading the name of the task in the mini-roadmap, it should now read the status as well.
<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
