### PR TITLE
feat: [##184764052] change business name error from alert to inline

### DIFF
--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
@@ -518,15 +518,12 @@ describe("<BusinessFormationPaginator />", () => {
         expect(screen.getByText(Config.formation.errorBanner.incompleteStepsError)).toBeInTheDocument();
       });
 
-      it("shows error field states for each step with error", async () => {
+      it("shows error field states for each step with error except for businessName field", async () => {
         const page = preparePage({ business, displayContent });
         await page.stepperClickToBillingStep();
         page.completeRequiredBillingFields();
         await page.stepperClickToReviewStep();
         await page.clickSubmit();
-
-        await page.stepperClickToBusinessNameStep();
-        expect(screen.getByText(Config.formation.errorBanner.errorOnStep)).toBeInTheDocument();
         await page.stepperClickToBusinessStep();
         expect(screen.getByText(Config.formation.errorBanner.errorOnStep)).toBeInTheDocument();
         await page.stepperClickToContactsStep();
@@ -690,70 +687,6 @@ describe("<BusinessFormationPaginator />", () => {
             await page.clickSubmitAndGetError(filledInBusinessWithApiResponse);
             expect(page.getStepStateInStepper(LookupStepIndexByName(formationStepName))).toEqual("ERROR");
             expect(screen.getByText(Config.formation.errorBanner.incompleteStepsError)).toBeInTheDocument();
-          });
-
-          it("shows API error message on step for businessName API error", async () => {
-            const { formationFormData, formationResponse, fieldName } = businessName;
-            filledInBusiness = {
-              ...business,
-              formationData: {
-                ...business.formationData,
-                formationFormData,
-              },
-            };
-
-            const filledInBusinessWithApiResponse = {
-              ...filledInBusiness,
-              formationData: {
-                ...filledInBusiness.formationData,
-                formationResponse,
-              },
-            };
-            const page = preparePage({ business: filledInBusiness, displayContent });
-            await page.fillAndSubmitBusinessNameStep();
-            await page.stepperClickToReviewStep();
-            await page.clickSubmitAndGetError(filledInBusinessWithApiResponse);
-            await page.stepperClickToBusinessNameStep();
-
-            expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.errorBanner.errorOnStep);
-            expect(screen.getByRole("alert")).toHaveTextContent(
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (Config.formation.fields as any)[fieldName as string].label
-            );
-            expect(screen.getByRole("alert")).toHaveTextContent("very bad input");
-          });
-
-          it("removes businessName API error on blur when user changes text field", async () => {
-            const { formationFormData, formationResponse, formationStepName, fieldLabel, newTextInput } =
-              businessName;
-            filledInBusiness = {
-              ...business,
-              formationData: {
-                ...business.formationData,
-                formationFormData,
-              },
-            };
-            const filledInBusinessWithApiResponse = {
-              ...filledInBusiness,
-              formationData: {
-                ...filledInBusiness.formationData,
-                formationResponse,
-              },
-            };
-            const page = preparePage({ business: filledInBusiness, displayContent });
-            await page.fillAndSubmitBusinessNameStep();
-            await page.stepperClickToReviewStep();
-            await page.clickSubmitAndGetError(filledInBusinessWithApiResponse);
-            await page.stepperClickToBusinessNameStep();
-
-            expect(screen.getByRole("alert")).toBeInTheDocument();
-            page.fillText(fieldLabel as string as string, newTextInput as string);
-            await page.searchBusinessName({ status: "AVAILABLE" });
-            expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-            expect(screen.queryByText(Config.formation.errorBanner.errorOnStep)).not.toBeInTheDocument();
-            expect(page.getStepStateInStepper(LookupStepIndexByName(formationStepName))).toEqual(
-              "COMPLETE-ACTIVE"
-            );
           });
         });
 

--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.tsx
@@ -451,25 +451,27 @@ export const BusinessFormationPaginator = (): ReactElement => {
         );
       });
 
-      const fieldsWithErrors = dedupedFieldErrors.map((fieldError) => {
-        let configFieldName = fieldError.field as ConfigFormationFields;
+      const fieldsWithErrors = dedupedFieldErrors
+        .filter((fieldError) => fieldError.field !== "businessName")
+        .map((fieldError) => {
+          let configFieldName = fieldError.field as ConfigFormationFields;
 
-        if (fieldError.field === "members") {
-          configFieldName = getConfigFieldByLegalStructure(state.formationFormData.legalType);
-        }
+          if (fieldError.field === "members") {
+            configFieldName = getConfigFieldByLegalStructure(state.formationFormData.legalType);
+          }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const label = (Config.formation.fields as any)[configFieldName].label;
-        return {
-          name: configFieldName,
-          label,
-          children: getApiErrorMessage(fieldError.field) && (
-            <ul>
-              <li>{getApiErrorMessage(fieldError.field)}</li>
-            </ul>
-          ),
-        };
-      });
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const label = (Config.formation.fields as any)[configFieldName].label;
+          return {
+            name: configFieldName,
+            label,
+            children: getApiErrorMessage(fieldError.field) && (
+              <ul>
+                <li>{getApiErrorMessage(fieldError.field)}</li>
+              </ul>
+            ),
+          };
+        });
 
       return (
         <FieldEntryAlert

--- a/web/src/components/tasks/business-formation/getErrorStateForField.test.ts
+++ b/web/src/components/tasks/business-formation/getErrorStateForField.test.ts
@@ -88,7 +88,7 @@ describe("getErrorStateForField", () => {
       ).toEqual(Config.formation.fields.businessName.errorInlineNeedsToSearch);
     });
 
-    it("uses errorInlineUnavailable as label if name availability is UNAVAILABLE", () => {
+    it("sets label to undefined if name availability is UNAVAILABLE", () => {
       const formationFormData = generateFormationFormData({ businessName: "some name" });
       const businessNameAvailability = generateBusinessNameAvailability({ status: "UNAVAILABLE" });
       expect(
@@ -97,10 +97,10 @@ describe("getErrorStateForField", () => {
           formationFormData,
           businessNameAvailability,
         }).label
-      ).toEqual(Config.formation.fields.businessName.errorInlineUnavailable);
+      ).toEqual(undefined);
     });
 
-    it("uses errorInlineUnavailable as label if name availability is error", () => {
+    it("sets label to undefined when name availability is error", () => {
       const formationFormData = generateFormationFormData({ businessName: "some name" });
       const businessNameAvailability = generateBusinessNameAvailability({ status: "DESIGNATOR_ERROR" });
       expect(
@@ -109,7 +109,7 @@ describe("getErrorStateForField", () => {
           formationFormData,
           businessNameAvailability,
         }).label
-      ).toEqual(Config.formation.fields.businessName.errorInlineUnavailable);
+      ).toEqual(undefined);
     });
 
     it("uses field name as label if name availability is AVAILABLE", () => {

--- a/web/src/components/tasks/business-formation/getErrorStateForField.ts
+++ b/web/src/components/tasks/business-formation/getErrorStateForField.ts
@@ -152,12 +152,13 @@ export const getErrorStateForField = (inputParams: {
     const isAvailable = businessNameAvailability?.status === "AVAILABLE";
     const isValid = exists && isAvailable;
     let label = errorState.label;
+
     if (!exists) {
       label = Config.formation.fields.businessName.errorInlineEmpty;
     } else if (businessNameAvailability?.status === undefined) {
       label = Config.formation.fields.businessName.errorInlineNeedsToSearch;
     } else if (businessNameAvailability?.status !== "AVAILABLE") {
-      label = Config.formation.fields.businessName.errorInlineUnavailable;
+      label = undefined;
     }
     return { ...errorState, label, hasError: !isValid };
   }

--- a/web/src/components/tasks/business-formation/name/BusinessNameStep.tsx
+++ b/web/src/components/tasks/business-formation/name/BusinessNameStep.tsx
@@ -86,6 +86,31 @@ export const BusinessNameStep = (): ReactElement => {
                     onBlurNameField(event.target.value);
                   }}
                 />
+                {state.businessNameAvailability?.status === "UNAVAILABLE" && (
+                  <div className="text-error-dark text-bold margin-y-2" data-testid="unavailable-text">
+                    <p>
+                      {templateEval(Config.formation.fields.businessName.alertUnavailable, {
+                        name: state.formationFormData.businessName,
+                      })}
+                    </p>
+                    {state.businessNameAvailability.similarNames.length > 0 && (
+                      <>
+                        <p className="margin-bottom-1">
+                          {Config.searchBusinessNameTask.similarUnavailableNamesText}
+                        </p>
+                        <ul className="usa-list">
+                          {state.businessNameAvailability.similarNames.map((otherName) => {
+                            return (
+                              <li className="text-uppercase text-bold margin-y-0" key={otherName}>
+                                {otherName}
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      </>
+                    )}
+                  </div>
+                )}
               </WithErrorBar>
             </div>
             <div className="margin-top-05">
@@ -131,32 +156,6 @@ export const BusinessNameStep = (): ReactElement => {
               word: state.businessNameAvailability.invalidWord ?? "*unknown*",
             })}
           </Content>
-        </Alert>
-      )}
-
-      {state.businessNameAvailability?.status === "UNAVAILABLE" && (
-        <Alert variant="error" dataTestid="unavailable-text">
-          <p className="font-sans-xs">
-            {templateEval(Config.formation.fields.businessName.alertUnavailable, {
-              name: state.formationFormData.businessName,
-            })}
-          </p>
-          {state.businessNameAvailability.similarNames.length > 0 && (
-            <>
-              <p className="font-sans-xs margin-bottom-1">
-                {Config.searchBusinessNameTask.similarUnavailableNamesText}
-              </p>
-              <ul className="usa-list">
-                {state.businessNameAvailability.similarNames.map((otherName) => {
-                  return (
-                    <li className="text-uppercase text-bold margin-y-0 font-sans-xs" key={otherName}>
-                      {otherName}
-                    </li>
-                  );
-                })}
-              </ul>
-            </>
-          )}
         </Alert>
       )}
       {state.businessNameAvailability?.status === "AVAILABLE" && (


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
The business name error should no longer render as an `<Alert>`.

1. Remove the `<Alert>` that renders on the top in the Business Name Step.
2. Change the `<Alert>` that renders under the business name field in the Business Name Step to an inline error. 

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#184764052](https://www.pivotaltracker.com/story/show/184764052)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->
1. Leave the business name empty and move on to other steps in the Business Paginator and the business name no longer renders above (until you're on the Review Step).
2. Enter a business name that already exists and watch the error message render as an inline error.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
