### PR TITLE
Removing some VS Code workspace rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,9 +18,6 @@
     "source.fixAll.eslint"
   ],
   "editor.formatOnSave": true,
-  "editor.rulers": [80, 110],
-  "editor.wordWrap": "wordWrapColumn",
-  "editor.wordWrapColumn": 110,
   "eslint.validate": [
     "javascript",
     "javascriptreact",
@@ -34,21 +31,13 @@
     "*.tsx": "$(capture).test.ts, $(capture).test.tsx"
   },
   "files.exclude": {
-    "**/node_modules": false,
-    "node_modules": true,
-    "**/.next": true,
-    "*[!test]**/node_modules": true
+    "**/.next": true
   },
   "files.trimTrailingWhitespace": true,
   "indentRainbow.indicatorStyle": "light",
   "jest.autoRun": "off",
   "terminal.integrated.scrollback": 10000,
-  "todo-tree.filtering.excludeGlobs": [
-    "**/node_modules",
-    "**/dist",
-    "**/.next",
-    "**/compiled"
-  ],
+  "todo-tree.filtering.excludeGlobs": ["**/dist", "**/.next", "**/compiled"],
   "todo-tree.general.tags": [
     "BUG",
     "HACK",


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

As a part of renovate bot work I was trying to look at the contents of `node_modules`. This was hidden. Now it's not. Yes, I could have just done this on my own machine, but unless you know these directories are hidden, it's not entirely obvious that its controlled by workspace rules.

I also disabled the rulers. That's a personal preference. Generally speaking, I think rules like that should be set on a person's machine and not mandated by the code base. If we want lines to conform to a certain length that should be set in the linter so it actually enforces the rule regardless of the code editor.

## Code author checklist

- [ ] I have performed a self-review of my code
- [ ] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [ ] I have not used any relative imports
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
