### PR TITLE
feat: [#186829051] show error after business name validation when field is focused

### DIFF
--- a/web/src/components/tasks/business-formation/name/BusinessNameStep.test.tsx
+++ b/web/src/components/tasks/business-formation/name/BusinessNameStep.test.tsx
@@ -16,7 +16,7 @@ import {
   generateFormationFormData,
 } from "@businessnjgovnavigator/shared";
 import * as materialUi from "@mui/material";
-import { screen, within } from "@testing-library/react";
+import { fireEvent, screen, within } from "@testing-library/react";
 
 function mockMaterialUI(): typeof materialUi {
   return {
@@ -202,6 +202,36 @@ describe("Formation - BusinessNameStep", () => {
     page.fillText("Search business name", "Anything else");
     await page.searchBusinessName({ status: "AVAILABLE", similarNames: [] });
     expect(screen.queryByTestId("error-alert-SEARCH_FAILED")).not.toBeInTheDocument();
+  });
+
+  describe("after validation - when business name field is focused", () => {
+    it("shows error when business name changes", async () => {
+      const page = getPageHelper();
+      page.fillText("Search business name", "Apple Pies Rocks");
+
+      await page.searchBusinessName({ status: "AVAILABLE" });
+      expect(screen.getByTestId("available-text")).toBeInTheDocument();
+
+      const businessNameField = screen.getByLabelText("Search business name");
+      fireEvent.change(businessNameField, { target: { value: "Apple Pies Rockettes" } });
+
+      expect(
+        screen.getByText(Config.formation.fields.businessName.errorInlineNeedsToSearch)
+      ).toBeInTheDocument();
+    });
+
+    it("shows error when business name is deleted", async () => {
+      const page = getPageHelper();
+      page.fillText("Search business name", "Apple Pies Rocks");
+
+      await page.searchBusinessName({ status: "AVAILABLE" });
+      expect(screen.getByTestId("available-text")).toBeInTheDocument();
+
+      const businessNameField = screen.getByLabelText("Search business name");
+      fireEvent.change(businessNameField, { target: { value: "" } });
+
+      expect(screen.getByText(Config.formation.fields.businessName.errorInlineEmpty)).toBeInTheDocument();
+    });
   });
 
   describe("content", () => {

--- a/web/src/components/tasks/business-formation/name/BusinessNameStep.tsx
+++ b/web/src/components/tasks/business-formation/name/BusinessNameStep.tsx
@@ -1,15 +1,15 @@
 import { Content } from "@/components/Content";
+import { WithErrorBar } from "@/components/WithErrorBar";
 import { Alert } from "@/components/njwds-extended/Alert";
 import { Heading } from "@/components/njwds-extended/Heading";
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
 import { getErrorStateForField } from "@/components/tasks/business-formation/getErrorStateForField";
-import { WithErrorBar } from "@/components/WithErrorBar";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
+import { MediaQueries } from "@/lib/PageSizes";
 import { useBusinessNameSearch } from "@/lib/data-hooks/useBusinessNameSearch";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormationErrors } from "@/lib/data-hooks/useFormationErrors";
 import { useUserData } from "@/lib/data-hooks/useUserData";
-import { MediaQueries } from "@/lib/PageSizes";
 import { SearchBusinessNameError } from "@/lib/types/types";
 import { templateEval } from "@/lib/utils/helpers";
 import { TextField, useMediaQuery } from "@mui/material";
@@ -20,8 +20,15 @@ export const BusinessNameStep = (): ReactElement => {
   const { Config } = useConfig();
   const { state, setFormationFormData, setFieldsInteracted } = useContext(BusinessFormationContext);
   const { business } = useUserData();
-  const { currentName, isLoading, error, updateCurrentName, onBlurNameField, searchBusinessName } =
-    useBusinessNameSearch({ isBusinessFormation: true, isDba: false });
+  const {
+    currentName,
+    isLoading,
+    error,
+    updateCurrentName,
+    onBlurNameField,
+    onChangeNameField,
+    searchBusinessName,
+  } = useBusinessNameSearch({ isBusinessFormation: true, isDba: false });
   const { doesFieldHaveError } = useFormationErrors();
   const mountEffectOccurred = useRef<boolean>(false);
   const isTabletAndUp = useMediaQuery(MediaQueries.tabletAndUp);
@@ -66,7 +73,10 @@ export const BusinessNameStep = (): ReactElement => {
                 <TextField
                   autoComplete="no"
                   value={currentName}
-                  onChange={(event): void => updateCurrentName(event.target.value)}
+                  onChange={(event): void => {
+                    onChangeNameField(event.target.value);
+                    setFormationFormData({ ...state.formationFormData, businessName: event.target.value });
+                  }}
                   variant="outlined"
                   inputProps={{
                     "aria-label": "Search business name",

--- a/web/src/lib/data-hooks/useBusinessNameSearch.ts
+++ b/web/src/lib/data-hooks/useBusinessNameSearch.ts
@@ -73,10 +73,10 @@ export const useBusinessNameSearch = ({
     setNameAvailability(emptyNameAvailability);
   };
 
-  const onBlurNameField = (): void => {
+  const onBlurNameField = (value: string): void => {
     setFormationFormData({
       ...state.formationFormData,
-      businessName: currentName,
+      businessName: value,
     });
     setNameAvailability(emptyNameAvailability);
   };


### PR DESCRIPTION


<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
This feature affects the business name field when it is focused.

**Before**

- When the user entered a business name and validated it, if the name changed, AND
- When the user entered a business name and validated it, if the user deleted the name, the `AVAILABLE` alert persisted.


**Now**
- When the user enters a business name, validates it, and changes the name, the correct error, _`Confirm the availability of your business name.`_  fires.
- When the user enters a business name, validates it, and deletes the name, the correct error, _`Enter a business name to check availability.`_ fires.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#186829051](https://www.pivotaltracker.com/story/show/#186829051)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->


### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->
1. Enter a business name and validate it. The `AVAILABLE` alert will render.
2. Change the business name. The error _`Confirm the availability of your business name.`_  will fire.
3. Delete the business name. The error _`Enter a business name to check availability.`_ will fire.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
