### PR TITLE
release 20240216

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2024.6.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v2024.6.0...v2024.6.1) (2024-02-16)
+
+
+### Bug Fixes
+
+* [[#187064247](https://github.com/newjersey/navigator.business.nj.gov/issues/187064247)] change sign-lease urlSlug so correct task renders for non-food truck industries ([f2a52dd](https://github.com/newjersey/navigator.business.nj.gov/commit/f2a52dde83a9d8f69348772b987c6dff091a3f7f))
+
 # [2024.6.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2024.5.0...v2024.6.0) (2024-02-16)
 
 

--- a/content/src/roadmaps/tasks/sign-lease-food-truck.md
+++ b/content/src/roadmaps/tasks/sign-lease-food-truck.md
@@ -1,9 +1,9 @@
 ---
 displayname: sign-lease-food-truck
 filename: sign-lease-food-truck
-urlSlug: sign-lease
+urlSlug: sign-lease-food-truck
 name: Sign Your Location Contract
-id: sign-lease
+id: sign-lease-food-truck
 callToActionLink: ""
 callToActionText: ""
 summaryDescriptionMd: >-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businessnjgovnavigator/root",
-  "version": "2024.6.0",
+  "version": "2024.6.1",
   "description": "This is the development repository for the work-in-progress business navigator from the New Jersey Office of Innovation. For info on the existing [Business.NJ.gov](https://business.nj.gov) site, please see the [bottom of this document](https://github.com/newjersey/navigator.business.nj.gov#businessnjgov)",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
- fix: [#187064247] change sign-lease urlSlug so correct task renders for non-food truck industries
- chore(release): 2024.6.1 [skip ci]
