### PR TITLE
Set initial business effective date relative to NJ local date

### DIFF
--- a/api/src/client/ApiFormationHealth.ts
+++ b/api/src/client/ApiFormationHealth.ts
@@ -1,4 +1,4 @@
-import { getCurrentDateISOString, getCurrentDateInNewJerseyISOFormatted } from "@shared/dateHelpers";
+import { getCurrentDateISOString, getCurrentDateInNewJerseyISOString } from "@shared/dateHelpers";
 import { CURRENT_VERSION, UserData } from "@shared/userData";
 
 export const ApiFormationHealth: UserData = {
@@ -122,7 +122,7 @@ export const ApiFormationHealth: UserData = {
           legalType: "foreign-limited-liability-company",
           businessName: "some-business-name-72304745",
           businessSuffix: "LLC",
-          businessStartDate: getCurrentDateInNewJerseyISOFormatted(),
+          businessStartDate: getCurrentDateInNewJerseyISOString(),
           businessTotalStock: "",
           businessPurpose: "some-purpose-15247137",
           additionalProvisions: ["provision1", "provision2"],

--- a/content/src/fieldConfig/business-formation.json
+++ b/content/src/fieldConfig/business-formation.json
@@ -265,7 +265,7 @@
       "businessStartDate": {
         "label": "NJ Business Effective Date",
         "labelContextualInfo": "effective-date",
-        "labelSecondaryText": "(mm/dd/yyyy)",
+        "labelSecondaryText": "(mm/dd/yyyy) Eastern Time",
         "errorFuture": "The NJ business effective date must be today or a future date in format MM/DD/YYYY.",
         "errorToday": "The NJ business effective date must be today and in format MM/DD/YYYY.",
         "error30Days": "The NJ business effective date must be today or a future date within 30 days in format MM/DD/YYYY.",

--- a/shared/src/dateHelpers.ts
+++ b/shared/src/dateHelpers.ts
@@ -21,12 +21,12 @@ export const getCurrentDateInNewJersey = (): Dayjs => {
   return dayjs().tz("America/New_York");
 };
 
-export const getCurrentDateInNewJerseyISOFormatted = (): string => {
-  return getCurrentDateInNewJersey().toISOString();
+export const getCurrentDateFormatted = (format: string): string => {
+  return getCurrentDate().format(format);
 };
 
-export const getCurrentDateFormatted = (format: string): string => {
-  return dayjs().format(format);
+export const getCurrentDateInNewJerseyFormatted = (format: string): string => {
+  return getCurrentDateInNewJersey().format(format);
 };
 
 export const getDateInCurrentYear = (date: string): Dayjs => {
@@ -39,6 +39,10 @@ export const isDateAfterCurrentDate = (date: string): boolean => {
 
 export const getCurrentDateISOString = (): string => {
   return dayjs().toISOString();
+};
+
+export const getCurrentDateInNewJerseyISOString = (): string => {
+  return getCurrentDateInNewJersey().toISOString();
 };
 
 export const parseDate = (date: string | number | undefined): Dayjs => {

--- a/web/src/components/tasks/business-formation/BusinessFormation.test.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormation.test.tsx
@@ -20,6 +20,7 @@ import {
   generateMunicipality,
   getCurrentBusiness,
   getCurrentDate,
+  getCurrentDateInNewJerseyFormatted,
 } from "@businessnjgovnavigator/shared";
 import {
   generateFormationData,
@@ -1191,4 +1192,70 @@ describe("<BusinessFormation />", () => {
     expect(formationFormData.nonprofitTrusteesMethodSpecified).toEqual(undefined);
     expect(formationFormData.nonprofitAssetDistributionSpecified).toEqual(undefined);
   }, 60000);
+
+  describe("businessStartDate", () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("when user is in US Eastern Timezone, initial value is current date in NJ", async () => {
+      const dateFormat = "MM/DD/YYYY";
+      const expectedDateString = getCurrentDateInNewJerseyFormatted(dateFormat);
+
+      const page = preparePage({
+        business: {
+          profileData: generateProfileData({
+            legalStructureId: "limited-liability-company",
+            businessPersona: "STARTING",
+          }),
+          formationData: generateEmptyFormationData(),
+        },
+        displayContent,
+      });
+      await page.fillAndSubmitBusinessNameStep("Pizza Joint");
+      expect(screen.getByTestId("date-businessStartDate")).toHaveValue(expectedDateString);
+    });
+
+    it("when user is in Phillipine Timezone, initial value is current date in NJ", async () => {
+      const mockDate = new Date("2020-04-13T00:00:00.000+08:00");
+      const expectedDateString = "04/12/2020";
+
+      jest.useFakeTimers();
+      jest.setSystemTime(mockDate);
+
+      const page = preparePage({
+        business: {
+          profileData: generateProfileData({
+            legalStructureId: "limited-liability-company",
+            businessPersona: "STARTING",
+          }),
+          formationData: generateEmptyFormationData(),
+        },
+        displayContent,
+      });
+      await page.fillAndSubmitBusinessNameStep("Pizza Joint");
+      expect(screen.getByTestId("date-businessStartDate")).toHaveValue(expectedDateString);
+    });
+
+    it("when user is in US Pacific Timezone, initial value is current date in NJ", async () => {
+      const mockDate = new Date("2020-04-13T22:00:00.000-08:00");
+      const expectedDateString = "04/14/2020";
+
+      jest.useFakeTimers();
+      jest.setSystemTime(mockDate);
+
+      const page = preparePage({
+        business: {
+          profileData: generateProfileData({
+            legalStructureId: "limited-liability-company",
+            businessPersona: "STARTING",
+          }),
+          formationData: generateEmptyFormationData(),
+        },
+        displayContent,
+      });
+      await page.fillAndSubmitBusinessNameStep("Pizza Joint");
+      expect(screen.getByTestId("date-businessStartDate")).toHaveValue(expectedDateString);
+    });
+  });
 });

--- a/web/src/components/tasks/business-formation/BusinessFormation.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormation.tsx
@@ -29,7 +29,7 @@ import {
   foreignLegalTypePrefix,
   FormationFormData,
   FormationLegalType,
-  getCurrentDateFormatted,
+  getCurrentDateInNewJerseyFormatted,
   InputFile,
   NameAvailability,
   PublicFilingLegalType,
@@ -83,7 +83,7 @@ export const BusinessFormation = (props: Props): ReactElement => {
 
   const getBusinessStartDate = (date: string | undefined, legalType: FormationLegalType): string => {
     return !date || !isBusinessStartDateValid(date, legalType)
-      ? getCurrentDateFormatted(defaultDateFormat)
+      ? getCurrentDateInNewJerseyFormatted(defaultDateFormat)
       : date;
   };
 

--- a/web/src/components/tasks/business-formation/business/BusinessDateValidators.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessDateValidators.tsx
@@ -3,7 +3,7 @@ import {
   defaultDateDelimiter,
   defaultDateFormat,
   FormationLegalType,
-  getCurrentDate,
+  getCurrentDateInNewJersey,
   parseDateWithFormat,
 } from "@businessnjgovnavigator/shared";
 import dayjs from "dayjs";
@@ -26,18 +26,18 @@ export const isBusinessStartDateValid = (
   switch (rule) {
     case "90":
       return (
-        date.isAfter(getCurrentDate().subtract(1, "day"), "day") &&
-        date.isBefore(getCurrentDate().add(90, "day"), "day")
+        date.isAfter(getCurrentDateInNewJersey().subtract(1, "day"), "day") &&
+        date.isBefore(getCurrentDateInNewJersey().add(90, "day"), "day")
       );
     case "30":
       return (
-        date.isAfter(getCurrentDate().subtract(1, "day"), "day") &&
-        date.isBefore(getCurrentDate().add(30, "day"), "day")
+        date.isAfter(getCurrentDateInNewJersey().subtract(1, "day"), "day") &&
+        date.isBefore(getCurrentDateInNewJersey().add(30, "day"), "day")
       );
     case "Future":
-      return date.isAfter(getCurrentDate().subtract(1, "day"), "day");
+      return date.isAfter(getCurrentDateInNewJersey().subtract(1, "day"), "day");
     case "Today":
-      return date.isSame(getCurrentDate(), "day");
+      return date.isSame(getCurrentDateInNewJersey(), "day");
   }
 };
 
@@ -68,13 +68,13 @@ export const getBusinessStartDateMaxDate = (legalType: FormationLegalType): dayj
   const rule = getBusinessStartDateRule(legalType);
   switch (rule) {
     case "90":
-      return getCurrentDate().add(90, "days");
+      return getCurrentDateInNewJersey().add(90, "days");
     case "30":
-      return getCurrentDate().add(30, "days");
+      return getCurrentDateInNewJersey().add(30, "days");
     case "Future":
-      return getCurrentDate().add(100, "years");
+      return getCurrentDateInNewJersey().add(100, "years");
     case "Today":
-      return getCurrentDate();
+      return getCurrentDateInNewJersey();
   }
 };
 

--- a/web/src/components/tasks/business-formation/business/FormationDate.tsx
+++ b/web/src/components/tasks/business-formation/business/FormationDate.tsx
@@ -12,12 +12,13 @@ import {
   DateObject,
   advancedDateLibrary,
   defaultDateFormat,
-  getCurrentDate,
+  getCurrentDateInNewJersey,
   parseDateWithFormat,
 } from "@businessnjgovnavigator/shared";
 import { TextField } from "@mui/material";
 import { DatePicker, DesktopDatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import dayjs from "dayjs";
 import { ReactElement, useContext, useMemo } from "react";
 
 advancedDateLibrary();
@@ -28,6 +29,7 @@ export const FormationDate = (props: Props): ReactElement => {
   const { Config } = useConfig();
   const { state, setFormationFormData, setFieldsInteracted } = useContext(BusinessFormationContext);
   const { doesFieldHaveError } = useFormationErrors();
+  const dateFormat = "MM/DD/YYYY";
 
   const contentProps = useMemo(
     () => ({
@@ -73,15 +75,21 @@ export const FormationDate = (props: Props): ReactElement => {
     });
   };
 
+  const getMinDate = (): dayjs.Dayjs | undefined => {
+    const startDate = dayjs(getCurrentDateInNewJersey().format(dateFormat));
+    return props.fieldName === "businessStartDate" ? startDate : undefined;
+  };
+
   const Picker =
     process.env.NODE_ENV === "test" || process.env.CI === "true" ? DesktopDatePicker : DatePicker;
+
   return (
     <>
       <div className="flex">{contentProps[props.fieldName].label}</div>
       <div className="tablet:display-flex tablet:flex-row tablet:flex-justify">
         <LocalizationProvider dateAdapter={AdapterDayjs}>
           <Picker
-            minDate={props.fieldName === "businessStartDate" ? getCurrentDate() : undefined}
+            minDate={getMinDate()}
             disabled={
               props.fieldName === "businessStartDate" &&
               getBusinessStartDateRule(state.formationFormData.legalType) === "Today"
@@ -89,14 +97,14 @@ export const FormationDate = (props: Props): ReactElement => {
             maxDate={
               props.fieldName === "businessStartDate"
                 ? getBusinessStartDateMaxDate(state.formationFormData.legalType)
-                : getCurrentDate().add(100, "years")
+                : getCurrentDateInNewJersey().add(100, "years")
             }
             value={
               state.formationFormData[props.fieldName]
                 ? parseDateWithFormat(state.formationFormData[props.fieldName] ?? "", defaultDateFormat)
                 : null
             }
-            inputFormat={"MM/DD/YYYY"}
+            inputFormat={dateFormat}
             onChange={(newValue: DateObject | null): void => {
               if (newValue) {
                 handleChange(newValue.format(defaultDateFormat));


### PR DESCRIPTION
## Description

Users in time zones outside ET run the risk of getting a business effective date set to something that breaks existing validation rules. In many places throughout our application we use `dayJs` to check the current date, but this ends up being relative to the user, not the state of New Jersey. This is a small fix that attempts to fix the most common area where this causes issues: the business effective date field in the business formation task.

### Ticket

[#185761403](https://www.pivotaltracker.com/story/show/185761403)

### Approach

Utilize the timezone extension to check dates relative to the US Eastern time zone where New Jersey falls.

### Steps to Test

- Change machine timezone manually to something that will have a date different than US Eastern time. (I used Manila, Philippines as my location, but anything around the international date line should work)
- Start a new business
- Open formation task
- Check that the initial value for the business start date is the current date in NJ
- If the legal structure is one that can select a different date (ex: foreign non-profit)
    - check that the first selectable date is today's date in NJ

### Notes

There are many, many places where we are getting the current date, not necessarily relative to NJ. We should audit these. None of these have come up in user reported issues that we know of, so they may not be as pressing. Additionally, none of them should prevent a user from performing an important task, but for consistency sake we should check.

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
