### PR TITLE
fix: [#186781958] change homebasedBusiness value based on officeInNJ

### DIFF
--- a/web/src/components/data-fields/ForeignBusinessTypeField.tsx
+++ b/web/src/components/data-fields/ForeignBusinessTypeField.tsx
@@ -67,6 +67,7 @@ export const ForeignBusinessTypeField = <T,>(props: Props<T>): ReactElement => {
     setProfileData({
       ...state.profileData,
       industryId: determineForeignBusinessType(ids) === "NEXUS" ? state.profileData.industryId : undefined,
+      homeBasedBusiness: ids.includes("officeInNJ") ? false : state.profileData.homeBasedBusiness,
       foreignBusinessTypeIds: ids,
     });
   };

--- a/web/test/pages/profile/profile-foreign.test.tsx
+++ b/web/test/pages/profile/profile-foreign.test.tsx
@@ -5,7 +5,7 @@ import { allLegalStructuresOfType, randomHomeBasedIndustry } from "@/test/factor
 import { markdownToText } from "@/test/helpers/helpers-utilities";
 import * as mockRouter from "@/test/mock/mockRouter";
 import { useMockRouter } from "@/test/mock/mockRouter";
-import { setupStatefulUserDataContext } from "@/test/mock/withStatefulUserData";
+import { currentBusiness, setupStatefulUserDataContext } from "@/test/mock/withStatefulUserData";
 import {
   Business,
   FormationData,
@@ -134,6 +134,46 @@ describe("profile-foreign", () => {
         }),
       });
     };
+
+    it("sets homeBasedBusiness value to false when officeInNJ is checked", async () => {
+      renderPage({
+        business: nexusForeignBusinessProfile({
+          profileDataOverrides: {
+            foreignBusinessTypeIds: ["employeeOrContractorInNJ"],
+            homeBasedBusiness: true,
+          },
+        }),
+      });
+      fireEvent.click(
+        screen.getByRole("checkbox", {
+          name: Config.profileDefaults.fields.foreignBusinessTypeIds.default.optionContent.officeInNJ,
+        })
+      );
+      clickSave();
+      await waitFor(() => {
+        expect(currentBusiness().profileData.homeBasedBusiness).toBe(false);
+      });
+    });
+
+    it("doesn't change the homeBasedBusiness value when officeInNJ value is changed", async () => {
+      renderPage({
+        business: nexusForeignBusinessProfile({
+          profileDataOverrides: {
+            foreignBusinessTypeIds: ["employeeOrContractorInNJ", "officeInNJ"],
+            homeBasedBusiness: false,
+          },
+        }),
+      });
+      fireEvent.click(
+        screen.getByRole("checkbox", {
+          name: Config.profileDefaults.fields.foreignBusinessTypeIds.default.optionContent.officeInNJ,
+        })
+      );
+      clickSave();
+      await waitFor(() => {
+        expect(currentBusiness().profileData.homeBasedBusiness).toBe(false);
+      });
+    });
 
     it("opens the default business information tab when clicked on profile", () => {
       renderPage({ business: nexusForeignBusinessProfile({}) });


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

When officeInNJ is selected in profile, homebasedBusiness value gets set to false.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#186781958](https://www.pivotaltracker.com/story/show/186781958)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
