### PR TITLE
fix: update formationDate to account for leap year errors

### DIFF
--- a/api/src/api/guestRouter.test.ts
+++ b/api/src/api/guestRouter.test.ts
@@ -37,7 +37,7 @@ describe("guestRouter", () => {
 
   describe("POST annualFilings", () => {
     it("calculates 3 new annual filing dates and updates them for dateOfFormation", async () => {
-      const formationDate = "2021-03-01";
+      const formationDate = "2021-04-01";
 
       const business = generateBusiness({
         profileData: generateProfileData({

--- a/api/src/api/userRouter.test.ts
+++ b/api/src/api/userRouter.test.ts
@@ -604,7 +604,7 @@ describe("userRouter", () => {
 
     it("calculates 3 new annual filing dates and updates them for dateOfFormation", async () => {
       mockJwt.decode.mockReturnValue(cognitoPayload({ id: "123" }));
-      const formationDate = "2021-03-01";
+      const formationDate = "2021-04-01";
 
       const postedUserData = generateUserDataForBusiness(
         generateBusiness({

--- a/api/src/domain/annual-filings/getAnnualFilings.test.ts
+++ b/api/src/domain/annual-filings/getAnnualFilings.test.ts
@@ -13,13 +13,13 @@ import {
 import { generateAnnualFilings } from "@test/helpers";
 
 describe("getAnnualFilings", () => {
-  it("calculates 3 new annual filing datea and updates them for dateOfFormation", async () => {
-    const formationDate = "2021-03-01";
+  it("calculates 3 new annual filing dates and updates them for dateOfFormation", async () => {
+    const formationDate = "2021-04-01";
 
     const postedUserData = generateUserDataForBusiness(
       generateBusiness({
         profileData: generateProfileData({
-          dateOfFormation: "2021-03-01",
+          dateOfFormation: formationDate,
           entityId: undefined,
           legalStructureId: "limited-liability-company",
         }),
@@ -46,7 +46,7 @@ describe("getAnnualFilings", () => {
   });
 
   it("calculates 3 new annual filing dates and overrides existing dates if needed", async () => {
-    const formationDate = "2021-03-01";
+    const formationDate = "2021-04-01";
 
     const postedUserData = generateUserDataForBusiness(
       generateBusiness({
@@ -78,7 +78,7 @@ describe("getAnnualFilings", () => {
   });
 
   it("calculates 3 new annual filing dates and updates them for dateOfFormation when there is no legalStructureId", async () => {
-    const formationDate = "2021-03-01";
+    const formationDate = "2021-04-01";
 
     const postedUserData = generateUserDataForBusiness(
       generateBusiness({
@@ -113,7 +113,7 @@ describe("getAnnualFilings", () => {
     const postedUserData = generateUserDataForBusiness(
       generateBusiness({
         profileData: generateProfileData({
-          dateOfFormation: "2021-03-01",
+          dateOfFormation: "2021-04-01",
           entityId: undefined,
           legalStructureId: "sole-proprietorship",
         }),


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

Update `formationDate` from 3-1-2021 to 4-1-2021 to ensure tests don't fail in a given leap year.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[N/A](https://www.pivotaltracker.com/story/show/)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
