### PR TITLE
Fix userData getting overwritten in onboarding flow

### DIFF
--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -147,6 +147,14 @@ const OnboardingPage = (props: Props): ReactElement => {
     setCurrentFlow(getFlow(profileData));
   }, [profileData]);
 
+  const protectUpdateQueueAgainstRaceCondition = (currentUserData: UserData | undefined): boolean => {
+    /*
+    A user cannot be authenticated and have empty userData. In order to preserve any data that may
+    have not yet returned, redirect the user to the landing page and out of the onboarding flow.
+    */
+    return state.isAuthenticated === IsAuthenticated.TRUE && currentUserData === undefined;
+  };
+
   useEffect(() => {
     (async (): Promise<void> => {
       if (
@@ -163,6 +171,12 @@ const OnboardingPage = (props: Props): ReactElement => {
       let localUpdateQueue = updateQueue;
 
       let currentUserData = updateQueue?.current();
+
+      if (protectUpdateQueueAgainstRaceCondition(currentUserData)) {
+        router.push(ROUTES.dashboard);
+        return;
+      }
+
       if (currentUserData) {
         const queryAdditionalBusiness = router.query[QUERIES.additionalBusiness] as string;
         if (queryAdditionalBusiness === "true") {

--- a/web/test/pages/onboarding/onboarding-shared.test.tsx
+++ b/web/test/pages/onboarding/onboarding-shared.test.tsx
@@ -38,6 +38,11 @@ describe("onboarding - shared", () => {
     jest.useFakeTimers();
   });
 
+  it("routes to the dashboard when the user is authenticated and userData is undefined", async () => {
+    renderPage({ userData: null });
+    expect(mockPush).toHaveBeenCalledWith(ROUTES.dashboard);
+  });
+
   it("routes to the first onboarding question when they have not answered the first question", async () => {
     useMockRouter({ isReady: true, query: { page: "3" } });
     renderPage({});


### PR DESCRIPTION
## Description

Currently, if an authenticated user enters the application using the onboarding flow, their user data may get overwritten. This most commonly occurs when someone uses a link on the static site to re-enter the application. See "Starter Kits" page for common examples of this.

### Ticket

[#187133827](https://www.pivotaltracker.com/story/show/187133827)

### Approach

Added a check that reroutes the user to the dashboard if they are authenticated but there is no userData. This operates on an assumption that there should never be an instance where the user will not have an account and empty userData in the database.

### Steps to Test

- Open application
- Complete onboarding so that user data is populated with a business
- authenticate (if not already)
- close all browser windows pointing to application
- attempt to enter the application using an onboarding query string
  - EX: navigator.business.nj.gov/onboarding?industry=home-contractor
- you should ultimately be redirected to the dashboard
  - you may land on the profile page, but that is an unrelated issue
- confirm that all user data is intact

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
