### PR TITLE
Fix: Change formation test to reference current date in NJ

### DIFF
--- a/web/src/components/tasks/business-formation/BusinessFormation.test.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormation.test.tsx
@@ -466,7 +466,9 @@ describe("<BusinessFormation />", () => {
       expect(formationFormData.businessName).toEqual("Pizza Joint");
     });
     expect(formationFormData.businessSuffix).toEqual("LLC");
-    expect(formationFormData.businessStartDate).toEqual(getCurrentDate().format(defaultDateFormat));
+    expect(formationFormData.businessStartDate).toEqual(
+      getCurrentDateInNewJerseyFormatted(defaultDateFormat)
+    );
     expect(formationFormData.foreignDateOfFormation).toEqual(threeDaysFromNow.format(defaultDateFormat));
     expect(formationFormData.addressLine1).toEqual("1234 main street");
     expect(formationFormData.addressLine2).toEqual("Suite 304");


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

[One of out unit tests failed](https://app.circleci.com/pipelines/github/newjersey/navigator.business.nj.gov/26249/workflows/984ca4a2-0ce9-40e1-9b69-836f8665c5dd) due to the time that it ran. The test was expecting the current date, but because of the time `getCurrentDate` returned a different value than `getCurrentDateInNewJersey`.

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
