### PR TITLE
feat: [#186316063] revisions to account for the case where we want a snackbar after page redirect

### DIFF
--- a/content/src/fieldConfig/config.json
+++ b/content/src/fieldConfig/config.json
@@ -252,6 +252,7 @@
     "nextTaskButtonText": "Next Task",
     "editText": "Edit",
     "taskProgressSnackbarPrefix": "Your task status has been updated to",
+    "taskProgressSnackbarHeading": "Task status updated",
     "previousTaskButtonText": "Previous Task",
     "formNameText": "Form",
     "defaultCallToActionText": "Start Application",

--- a/content/src/fieldConfig/dashboard-snackbars.json
+++ b/content/src/fieldConfig/dashboard-snackbars.json
@@ -3,7 +3,7 @@
     "fundingSnackbarHeading": "Funding programs added!",
     "certificationsSnackbarBody": "Find certification programs you may be eligible for in the “For You” section on this page.",
     "deferredOnboardingSnackbarBody": "To change your answer, update your business profile any time.",
-    "opportunitiesAndDeadlinesTimeDelay": 6000,
+    "timeDelayBetweenMultipleSnackbars": 6000,
     "certificationsSnackbarHeading": "Your certification opportunities were added!",
     "fundingSnackbarBody": "Update your business profile to get personalized funding recommendations in the “For You” section on this page.",
     "calendarSnackbarBody": "Find your next reporting due date at the bottom of this page.",

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -3120,8 +3120,8 @@ collections:
                   widget: text,
                 }
               - {
-                  label: Opportunities and Deadlines Snackbar Time Delay,
-                  name: opportunitiesAndDeadlinesTimeDelay,
+                  label: Time Delay Between Multiple Snackbars (Time In Milliseconds),
+                  name: timeDelayBetweenMultipleSnackbars,
                   widget: text,
                 }
       - label: "Dashboard Calendar"
@@ -4168,7 +4168,8 @@ collections:
               - { label: Page Title, name: pageTitle, widget: string }
               - { label: Back Button Text, name: backToRoadmapText, widget: string }
               - { label: Default Call to Action Test, name: defaultCallToActionText, widget: string }
-              - { label: Task Progress - Prefix, name: taskProgressSnackbarPrefix, widget: string }
+              - { label: Task Progress Alert - Body Prefix, name: taskProgressSnackbarPrefix, widget: string }
+              - { label: Task Progress Alert - Heading, name: taskProgressSnackbarHeading, widget: string }
               - { label: Next Task Button Text, name: nextTaskButtonText, widget: string }
               - { label: Previous Task Button Text, name: previousTaskButtonText, widget: string }
               - { label: Unlocked By - Singular, name: unlockedBySingular, widget: string }

--- a/web/src/components/TaskProgressCheckbox.tsx
+++ b/web/src/components/TaskProgressCheckbox.tsx
@@ -94,7 +94,7 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
     updateQueue
       .update()
       .then(() => {
-        setSuccessSnackbarIsOpen(true);
+        if (!(isFormationTask(props.taskId) && nextStatus === "COMPLETED")) setSuccessSnackbarIsOpen(true);
         if (!redirectOnSuccess) {
           return;
         }

--- a/web/src/components/TaskStatusChangeSnackbar.tsx
+++ b/web/src/components/TaskStatusChangeSnackbar.tsx
@@ -1,4 +1,5 @@
 import { SnackbarAlert } from "@/components/njwds-extended/SnackbarAlert";
+import { useConfig } from "@/lib/data-hooks/useConfig";
 import { getTaskStatusUpdatedMessage } from "@/lib/utils/helpers";
 import { TaskProgress } from "@businessnjgovnavigator/shared/userData";
 import { ReactElement } from "react";
@@ -10,8 +11,14 @@ interface Props {
 }
 
 export const TaskStatusChangeSnackbar = (props: Props): ReactElement => {
+  const { Config } = useConfig();
   return (
-    <SnackbarAlert variant="success" isOpen={props.isOpen} close={props.close}>
+    <SnackbarAlert
+      variant="success"
+      isOpen={props.isOpen}
+      close={props.close}
+      heading={Config.taskDefaults.taskProgressSnackbarHeading}
+    >
       {getTaskStatusUpdatedMessage(props.status)}
     </SnackbarAlert>
   );

--- a/web/src/components/dashboard/DashboardAlerts.test.tsx
+++ b/web/src/components/dashboard/DashboardAlerts.test.tsx
@@ -56,6 +56,13 @@ describe("<DashboardAlerts />", () => {
     expect(screen.getByTestId("snackbar-alert-calendar")).toBeInTheDocument();
   });
 
+  it("renders task status updated snackbar when fromFormBusinessEntity query parameter is provided", () => {
+    useMockRouter({ isReady: true, query: { [QUERIES.fromFormBusinessEntity]: "true" } });
+    renderStatefulPage();
+    act(() => jest.runAllTimers());
+    expect(screen.getByTestId("checkbox-status-updated-snackbar-alert")).toBeInTheDocument();
+  });
+
   it("renders certifications snackbar when fromForming query parameter is provided", () => {
     useMockRouter({ isReady: true, query: { [QUERIES.fromForming]: "true" } });
     renderStatefulPage();

--- a/web/src/components/dashboard/DashboardAlerts.tsx
+++ b/web/src/components/dashboard/DashboardAlerts.tsx
@@ -1,10 +1,13 @@
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useQueryControlledAlert } from "@/lib/data-hooks/useQueryControlledAlert";
 import { QUERIES, ROUTES } from "@/lib/domain-logic/routes";
+import { getTaskStatusUpdatedMessage } from "@/lib/utils/helpers";
 import { ReactElement } from "react";
 
 export const DashboardAlerts = (): ReactElement => {
   const { Config } = useConfig();
+
+  const secondSnackbarTimeDelay = Config.dashboardDefaults.timeDelayBetweenMultipleSnackbars;
 
   const ProfileUpdatedAlert = useQueryControlledAlert({
     queryKey: QUERIES.success,
@@ -23,6 +26,16 @@ export const DashboardAlerts = (): ReactElement => {
     dataTestId: "snackbar-alert-calendar",
   });
 
+  const CheckboxStatusUpdated = useQueryControlledAlert({
+    queryKey: QUERIES.fromFormBusinessEntity,
+    pagePath: ROUTES.dashboard,
+    headerText: Config.taskDefaults.taskProgressSnackbarHeading,
+    bodyText: getTaskStatusUpdatedMessage("COMPLETED"),
+    variant: "success",
+    dataTestId: "checkbox-status-updated-snackbar-alert",
+    delayInMilliseconds: secondSnackbarTimeDelay,
+  });
+
   const CertificationsAlert = useQueryControlledAlert({
     queryKey: QUERIES.fromForming,
     pagePath: ROUTES.dashboard,
@@ -39,7 +52,7 @@ export const DashboardAlerts = (): ReactElement => {
     bodyText: Config.dashboardDefaults.opportunitiesAndDeadlinesBody,
     variant: "success",
     dataTestId: "deadlines-opportunities-alert",
-    delayInMilliseconds: Config.dashboardDefaults.opportunitiesAndDeadlinesTimeDelay,
+    delayInMilliseconds: secondSnackbarTimeDelay,
   });
 
   const FundingAlert = useQueryControlledAlert({
@@ -74,6 +87,7 @@ export const DashboardAlerts = (): ReactElement => {
       <>{ProfileUpdatedAlert}</>
       <>{DeadlinesAndOpportunitiesAlert}</>
       <>{CalendarAlert}</>
+      <>{CheckboxStatusUpdated}</>
       <>{CertificationsAlert}</>
       <>{FundingAlert}</>
       <>{DeferredQuestionAnsweredAlert}</>


### PR DESCRIPTION
## Description

We had a weird case where the TaskProgress Checkbox triggers a redirect and thus we needed to use our redirect alerts instead of our page alerts. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
