### PR TITLE
Return first matching license from Dynamics license API

### DIFF
--- a/api/src/client/dynamics/license-status/DynamicsLicenseApplicationIdClient.test.ts
+++ b/api/src/client/dynamics/license-status/DynamicsLicenseApplicationIdClient.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/no-null */
-import { MULTIPLE_MAIN_APPS_ERROR, NO_MAIN_APPS_ERROR } from "@domain/types";
+import { NO_MAIN_APPS_ERROR } from "@domain/types";
 import { LogWriter, LogWriterType } from "@libs/logWriter";
 import axios from "axios";
 import { DynamicsLicenseApplicationIdClient } from "./DynamicsLicenseApplicationIdClient";
@@ -234,7 +234,7 @@ describe("DynamicsLicenseApplicationIdClient", () => {
     ).rejects.toEqual(new Error(NO_MAIN_APPS_ERROR));
   });
 
-  it("throws MULTIPLE_MAIN_APPS error when there are multiple matching apps whose rgb_number ends with 00", async () => {
+  it("returns the first application when there are multiple matching apps whose rgb_number ends with 00", async () => {
     const mockResponseWithMultipleMainApplications = {
       value: [
         {
@@ -272,9 +272,16 @@ describe("DynamicsLicenseApplicationIdClient", () => {
         },
       ],
     };
+
+    const expected = {
+      applicationId: "1abb2efc-b705-ee11-a81c-001dd80648b3",
+      expirationDate: "2023-09-30T00:00:00Z",
+      licenseStatus: "ACTIVE",
+    };
+
     mockAxios.get.mockResolvedValue({ data: mockResponseWithMultipleMainApplications });
-    await expect(
-      client.getLicenseApplicationId(mockAccessToken, mockBusinessId, "Public Movers and Warehousemen")
-    ).rejects.toEqual(new Error(MULTIPLE_MAIN_APPS_ERROR));
+    expect(
+      await client.getLicenseApplicationId(mockAccessToken, mockBusinessId, "Public Movers and Warehousemen")
+    ).toEqual(expected);
   });
 });

--- a/api/src/client/dynamics/license-status/DynamicsLicenseApplicationIdClient.ts
+++ b/api/src/client/dynamics/license-status/DynamicsLicenseApplicationIdClient.ts
@@ -1,4 +1,4 @@
-import { MULTIPLE_MAIN_APPS_ERROR, NO_MAIN_APPS_ERROR } from "@domain/types";
+import { NO_MAIN_APPS_ERROR } from "@domain/types";
 import { LogWriterType } from "@libs/logWriter";
 import { LicenseStatus } from "@shared/license";
 import axios, { AxiosError } from "axios";
@@ -49,15 +49,11 @@ export const DynamicsLicenseApplicationIdClient = (
           throw new Error(NO_MAIN_APPS_ERROR);
         }
 
-        if (mainActiveApplications.length > 1) {
-          throw new Error(MULTIPLE_MAIN_APPS_ERROR);
-        }
-
         return processApplicationDetails(mainActiveApplications[0]);
       })
       .catch((error: AxiosError) => {
         logWriter.LogError(`Dynamics License Application Id Client - Id:${logId} - Error:`, error);
-        if (error.message === NO_MAIN_APPS_ERROR || error.message === MULTIPLE_MAIN_APPS_ERROR) throw error;
+        if (error.message === NO_MAIN_APPS_ERROR) throw error;
         throw error.response?.status;
       });
   };

--- a/api/src/client/dynamics/license-status/DynamicsLicenseStatusClient.test.ts
+++ b/api/src/client/dynamics/license-status/DynamicsLicenseStatusClient.test.ts
@@ -1,10 +1,5 @@
 import { AccessTokenClient } from "@client/dynamics/types";
-import {
-  MULTIPLE_MAIN_APPS_ERROR,
-  NO_MAIN_APPS_ERROR,
-  NO_MATCH_ERROR,
-  SearchLicenseStatus,
-} from "@domain/types";
+import { NO_MAIN_APPS_ERROR, NO_MATCH_ERROR, SearchLicenseStatus } from "@domain/types";
 import { LogWriter, LogWriterType } from "@libs/logWriter";
 import { DynamicsLicenseStatusClient } from "./DynamicsLicenseStatusClient";
 import {
@@ -113,7 +108,7 @@ describe("DynamicsLicenseStatusClient", () => {
     await expect(client(nameAndAddress, "Public Movers and Warehousemen")).rejects.toThrow(NO_MATCH_ERROR);
   });
 
-  it.each([{ errorCode: NO_MAIN_APPS_ERROR }, { errorCode: MULTIPLE_MAIN_APPS_ERROR }])(
+  it.each([{ errorCode: NO_MAIN_APPS_ERROR }])(
     "throws a $errorCode error when a sub client client throws a $errorCode error",
     async ({ errorCode }) => {
       stubBusinessAddressClient.getBusinessIdsAndLicenseSearchAddresses.mockResolvedValue([

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -169,4 +169,3 @@ export type GetCertHttpsAgent = () => Promise<https.Agent>;
 
 export const NO_MATCH_ERROR = "NO_MATCH";
 export const NO_MAIN_APPS_ERROR = "NO_MAIN_APPS";
-export const MULTIPLE_MAIN_APPS_ERROR = "MULTIPLE_MAIN_APPS";

--- a/api/src/domain/user/updateLicenseStatusFactory.test.ts
+++ b/api/src/domain/user/updateLicenseStatusFactory.test.ts
@@ -1,9 +1,4 @@
-import {
-  MULTIPLE_MAIN_APPS_ERROR,
-  NO_MAIN_APPS_ERROR,
-  NO_MATCH_ERROR,
-  UpdateLicenseStatus,
-} from "@domain/types";
+import { NO_MAIN_APPS_ERROR, NO_MATCH_ERROR, UpdateLicenseStatus } from "@domain/types";
 import { updateLicenseStatusFactory } from "@domain/user/updateLicenseStatusFactory";
 import { getCurrentDate, parseDate } from "@shared/dateHelpers";
 import { getCurrentBusiness } from "@shared/domain-logic/getCurrentBusiness";
@@ -90,7 +85,7 @@ describe("updateLicenseStatus", () => {
     expect(resultCurrentBusiness.licenseData?.items).toEqual(checklistItems);
   });
 
-  it.each([NO_MATCH_ERROR, NO_MAIN_APPS_ERROR, MULTIPLE_MAIN_APPS_ERROR])(
+  it.each([NO_MATCH_ERROR, NO_MAIN_APPS_ERROR])(
     "updates the license task status to NOT_STARTED & user license data when %s error",
     async (error: string) => {
       stubSearchLicenseStatus.mockRejectedValue(new Error(error));

--- a/api/src/domain/user/updateLicenseStatusFactory.ts
+++ b/api/src/domain/user/updateLicenseStatusFactory.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { convertIndustryToLicenseType } from "@domain/license-status/convertIndustryToLicenseType";
 import {
-  MULTIPLE_MAIN_APPS_ERROR,
   NO_MAIN_APPS_ERROR,
   NO_MATCH_ERROR,
   SearchLicenseStatusFactory,
@@ -70,11 +69,7 @@ export const updateLicenseStatusFactory = (
         });
       })
       .catch(async (error: Error) => {
-        if (
-          error.message === NO_MATCH_ERROR ||
-          error.message === NO_MAIN_APPS_ERROR ||
-          error.message === MULTIPLE_MAIN_APPS_ERROR
-        ) {
+        if (error.message === NO_MATCH_ERROR || error.message === NO_MAIN_APPS_ERROR) {
           return update(userData, {
             nameAndAddress: nameAndAddress,
             taskStatus: "NOT_STARTED",


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

We display license data to users using multiple APIs as a source. Regardless of the data source, the logic should be as close to the same as possible. MLO currently returns the first matching license, but Dynamics will return an error if more than once license is found. This work removes that error and the associated check which results in a single license being returned.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#187423161](https://www.pivotaltracker.com/story/show/187423161)

### Approach

Simply removes the error, the associated check for multiple licenses, and updates the associated tests.

### Steps to Test

License data coming from the Dynamics API should still work. Possibly more license lookups will also result in data being displayed on the frontend.

### Notes

This is not an exact way for us to display license data, but it is incrementally better than what currently exists and is consistent between data sources.

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
