### PR TITLE
feat: [#187476824] profile side navigation doesn't shrink to wrap

### DIFF
--- a/web/src/components/njwds-layout/SidebarPageLayout.tsx
+++ b/web/src/components/njwds-layout/SidebarPageLayout.tsx
@@ -12,6 +12,7 @@ export interface SidebarPageLayoutProps {
   outlineBox?: boolean;
   belowBoxComponent?: React.ReactNode;
   titleOverColumns?: React.ReactNode;
+  nonWrappingLeftColumn?: boolean;
 }
 
 export const SidebarPageLayout = ({
@@ -22,6 +23,7 @@ export const SidebarPageLayout = ({
   stackNav,
   belowBoxComponent,
   titleOverColumns,
+  nonWrappingLeftColumn,
 }: SidebarPageLayoutProps): ReactElement => {
   const isLargeScreen = useMediaQuery(MediaQueries.desktopAndUp);
   const { Config } = useConfig();
@@ -34,7 +36,7 @@ export const SidebarPageLayout = ({
 
           {isLargeScreen && titleOverColumns}
           <div className="grid-row grid-gap">
-            <div className="desktop:grid-col-9">
+            <div className={`${nonWrappingLeftColumn ? "fg10" : "desktop:grid-col-9"} `}>
               {!isLargeScreen && (
                 <div>
                   <BackButtonForLayout backButtonText={Config.taskDefaults.backToRoadmapText} />
@@ -53,14 +55,16 @@ export const SidebarPageLayout = ({
               </div>
               {belowBoxComponent}
             </div>
-            <div className="desktop:grid-col-3 order-first">
-              {isLargeScreen && (
-                <nav aria-label="Secondary">
-                  {divider && <hr className="margin-bottom-1 margin-top-0" aria-hidden={true} />}
-                  {navChildren}
-                </nav>
-              )}
-            </div>
+
+            {isLargeScreen && (
+              <nav
+                aria-label="Secondary"
+                className={`${nonWrappingLeftColumn ? "fs0 fg1" : "desktop:grid-col-3"}  order-first`}
+              >
+                {divider && <hr className="margin-bottom-1 margin-top-0" aria-hidden={true} />}
+                {navChildren}
+              </nav>
+            )}
           </div>
         </div>
       </div>

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -789,6 +789,7 @@ const ProfilePage = (props: Props): ReactElement => {
                       divider={false}
                       outlineBox={false}
                       stackNav={true}
+                      nonWrappingLeftColumn={true}
                       titleOverColumns={
                         <ProfileHeader business={business} isAuthenticated={isAuthenticated === "TRUE"} />
                       }

--- a/web/src/styles/base/flex.scss
+++ b/web/src/styles/base/flex.scss
@@ -88,6 +88,14 @@
   flex-grow: 1;
 }
 
+.fg10 {
+  flex-grow: 10;
+}
+
+.fs0 {
+  flex-shrink: 0;
+}
+
 .fww {
   flex-wrap: wrap;
 }


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/187476824)

### Approach

I decided to do this using flex. 

The idea is we flex-shrink 0 on the nav section meaning it can't shrink below the size of its content. We set a flex grow 1 on this section so it will grow, and the right nav section we set a flex grow of 10 so it will grow much more and take more of the space. 

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
