### PR TITLE
feat: [#187458827] update save NJ Tax ID error state

### DIFF
--- a/web/src/components/data-fields/tax-id/SingleTaxId.tsx
+++ b/web/src/components/data-fields/tax-id/SingleTaxId.tsx
@@ -1,10 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { DataField, DataFieldProps } from "@/components/data-fields/DataField";
+import { GenericTextField } from "@/components/GenericTextField";
+import { WithErrorBar } from "@/components/WithErrorBar";
+import { DataFieldProps } from "@/components/data-fields/DataField";
 import { TaxIdDisplayStatus } from "@/components/data-fields/tax-id/TaxIdHelpers";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { formatTaxId } from "@/lib/domain-logic/formatTaxId";
+import { ProfileFormContext } from "@/contexts/profileFormContext";
 import { MediaQueries } from "@/lib/PageSizes";
+import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
+import { formatTaxId } from "@/lib/domain-logic/formatTaxId";
 import { InputAdornment, useMediaQuery } from "@mui/material";
 import { ReactElement, useContext } from "react";
 
@@ -15,9 +19,10 @@ interface Props extends Omit<DataFieldProps, "fieldName" | "handleChange" | "onV
 }
 export const SingleTaxId = ({ handleChangeOverride, validationText, ...props }: Props): ReactElement => {
   const fieldName = "taxId";
-
   const isTabletAndUp = useMediaQuery(MediaQueries.tabletAndUp);
+
   const { state, setProfileData } = useContext(ProfileDataContext);
+  const { isFormFieldInvalid } = useFormContextFieldHelpers(fieldName, ProfileFormContext);
 
   const handleChange = (value: string): void => {
     if (handleChangeOverride) {
@@ -32,23 +37,30 @@ export const SingleTaxId = ({ handleChangeOverride, validationText, ...props }: 
 
   return (
     <div className={isTabletAndUp ? "" : "flex flex-column"}>
-      <DataField
-        inputWidth={"reduced"}
-        fieldName={fieldName}
-        visualFilter={formatTaxId}
-        validationText={validationText}
-        numericProps={{ minLength: 12, maxLength: 12 }}
-        handleChange={handleChange}
-        allowMasking={true}
-        disabled={props.taxIdDisplayStatus === "password-view"}
-        type={props.taxIdDisplayStatus === "text-view" ? "text" : "password"}
-        inputProps={{
-          endAdornment: (
-            <InputAdornment position="end">{isTabletAndUp && props.getShowHideToggleButton()}</InputAdornment>
-          ),
-        }}
-        {...props}
-      />
+      <WithErrorBar hasError={isFormFieldInvalid} type="ALWAYS">
+        <GenericTextField
+          allowMasking={true}
+          disabled={props.taxIdDisplayStatus === "password-view"}
+          fieldName={fieldName}
+          formContext={ProfileFormContext}
+          handleChange={handleChange}
+          inputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                {isTabletAndUp && props.getShowHideToggleButton()}
+              </InputAdornment>
+            ),
+          }}
+          inputWidth={"reduced"}
+          numericProps={{ minLength: 12, maxLength: 12 }}
+          type={props.taxIdDisplayStatus === "text-view" ? "text" : "password"}
+          validationText={validationText}
+          value={state.profileData[fieldName] as string | undefined}
+          visualFilter={formatTaxId}
+          {...props}
+        />
+      </WithErrorBar>
+
       {!isTabletAndUp && (
         <div className="flex flex-justify-center margin-bottom-3">{props.getShowHideToggleButton()}</div>
       )}

--- a/web/src/components/data-fields/tax-id/TaxId.tsx
+++ b/web/src/components/data-fields/tax-id/TaxId.tsx
@@ -128,6 +128,7 @@ export const TaxId = (props: Props): ReactElement => {
         getShowHideToggleButton={getShowHideToggleButton}
         taxIdDisplayStatus={taxIdDisplayStatus}
         additionalValidationIsValid={additionalValidationIsValid}
+        validationText={Config.profileDefaults.fields.taxId.default.errorTextRequired}
         {...props}
       />
     );

--- a/web/src/components/tasks/TaxInput.tsx
+++ b/web/src/components/tasks/TaxInput.tsx
@@ -15,7 +15,7 @@ import { MediaQueries } from "@/lib/PageSizes";
 import { createProfileFieldErrorMap, Task } from "@/lib/types/types";
 import { useMountEffectWhenDefined } from "@/lib/utils/helpers";
 import { createEmptyProfileData, ProfileData } from "@businessnjgovnavigator/shared/profileData";
-import { createTheme, ThemeProvider, useMediaQuery } from "@mui/material";
+import { useMediaQuery } from "@mui/material";
 import { ReactElement, ReactNode, useContext, useEffect, useState } from "react";
 
 interface Props {
@@ -136,32 +136,30 @@ export const TaxInput = (props: Props): ReactElement => {
         }}
       >
         <div className={isTabletAndUp ? "flex flex-row" : ""}>
-          <ThemeProvider theme={createTheme()}>
-            {shouldLockTaxId ? (
-              <Alert variant="success" className="width-100">
-                <DisabledTaxId template={DisabledElement} />
-              </Alert>
-            ) : (
-              <>
-                <TaxId
-                  required={isAuthenticated === IsAuthenticated.TRUE}
-                  handleChangeOverride={getNeedsAccountModalFunction()}
-                />
-                <div className="tablet:margin-top-05 tablet:margin-left-2">
-                  <SecondaryButton
-                    isColor="primary"
-                    onClick={onSave}
-                    isLoading={isLoading}
-                    isSubmitButton={true}
-                    isRightMarginRemoved={true}
-                    isFullWidthOnDesktop={!isTabletAndUp}
-                  >
-                    {saveButtonText}
-                  </SecondaryButton>
-                </div>
-              </>
-            )}
-          </ThemeProvider>
+          {shouldLockTaxId ? (
+            <Alert variant="success" className="width-100">
+              <DisabledTaxId template={DisabledElement} />
+            </Alert>
+          ) : (
+            <>
+              <TaxId
+                required={isAuthenticated === IsAuthenticated.TRUE}
+                handleChangeOverride={getNeedsAccountModalFunction()}
+              />
+              <div className="tablet:margin-top-05 tablet:margin-left-2">
+                <SecondaryButton
+                  isColor="primary"
+                  onClick={onSave}
+                  isLoading={isLoading}
+                  isSubmitButton={true}
+                  isRightMarginRemoved={true}
+                  isFullWidthOnDesktop={!isTabletAndUp}
+                >
+                  {saveButtonText}
+                </SecondaryButton>
+              </div>
+            </>
+          )}
         </div>
       </ProfileDataContext.Provider>
     </ProfileFormContext.Provider>


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Updates the error state styling for the NJ Tax ID task so that it is more consistent with other fields in the application.

**Before:**
<img width="688" alt="Pasted Image at 2024_04_18_14_39 pm" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22647707/2a0d5fac-83db-43a9-a3d7-5afb31e63b80">

**After:**
![Screenshot 2024-04-22 at 3 04 58 PM](https://github.com/newjersey/navigator.business.nj.gov/assets/22647707/4a2b82df-2cc6-499d-8e43-a073650477ef)

### Ticket

[#187458827](https://www.pivotaltracker.com/story/show/187458827)

### Approach

Added the error bar, and removed an erroneous `createTheme()` call that was overriding our MUI theme.

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
