### PR TITLE
create starter lambda function code for bizcontent and biztesting

### DIFF
--- a/api/serverless.ts
+++ b/api/serverless.ts
@@ -1,3 +1,5 @@
+import bizContentExpress from "@functions/bizContentExpress";
+import bizTestingExpress from "@functions/bizTestingExpress";
 import type { AWS, AwsLambdaEnvironment } from "@serverless/typescript";
 import "dotenv/config";
 import { env } from "node:process";
@@ -299,6 +301,28 @@ if (stage === "dev") {
   serverlessConfiguration.functions = {
     ...serverlessConfiguration.functions,
     githubOauth2: githubOauth2(
+      env.CI
+        ? {
+            securityGroupIds: ["${self:custom.config.infrastructure.SECURITY_GROUP}"],
+            subnetIds: [
+              "${self:custom.config.infrastructure.SUBNET_01}",
+              "${self:custom.config.infrastructure.SUBNET_02}",
+            ],
+          }
+        : undefined
+    ),
+    bizContentExpress: bizContentExpress(
+      env.CI
+        ? {
+            securityGroupIds: ["${self:custom.config.infrastructure.SECURITY_GROUP}"],
+            subnetIds: [
+              "${self:custom.config.infrastructure.SUBNET_01}",
+              "${self:custom.config.infrastructure.SUBNET_02}",
+            ],
+          }
+        : undefined
+    ),
+    bizTestingExpress: bizTestingExpress(
       env.CI
         ? {
             securityGroupIds: ["${self:custom.config.infrastructure.SECURITY_GROUP}"],

--- a/api/src/functions/bizContentExpress/app.ts
+++ b/api/src/functions/bizContentExpress/app.ts
@@ -1,0 +1,8 @@
+import { runHealthChecks } from "@libs/healthCheck";
+import { LogWriter } from "@libs/logWriter";
+
+export default async function handler(): Promise<void> {
+  const STAGE = process.env.STAGE || "local";
+  const logger = LogWriter(`BusinessNJContentService/${STAGE}`, "ApiLogs");
+  await runHealthChecks(logger);
+}

--- a/api/src/functions/bizContentExpress/index.ts
+++ b/api/src/functions/bizContentExpress/index.ts
@@ -1,0 +1,11 @@
+import { FnType } from "@functions/fnType";
+import { handlerPath } from "@libs/handlerResolver";
+
+export default (vpcConfig: FnType["vpc"]): FnType => {
+  return {
+    handler: `${handlerPath(__dirname)}/app.default`,
+    timeout: 30,
+    events: [],
+    vpc: vpcConfig,
+  };
+};

--- a/api/src/functions/bizTestingExpress/app.ts
+++ b/api/src/functions/bizTestingExpress/app.ts
@@ -1,0 +1,8 @@
+import { runHealthChecks } from "@libs/healthCheck";
+import { LogWriter } from "@libs/logWriter";
+
+export default async function handler(): Promise<void> {
+  const STAGE = process.env.STAGE || "local";
+  const logger = LogWriter(`BusinessNJTestingService/${STAGE}`, "ApiLogs");
+  await runHealthChecks(logger);
+}

--- a/api/src/functions/bizTestingExpress/index.ts
+++ b/api/src/functions/bizTestingExpress/index.ts
@@ -1,0 +1,11 @@
+import { FnType } from "@functions/fnType";
+import { handlerPath } from "@libs/handlerResolver";
+
+export default (vpcConfig: FnType["vpc"]): FnType => {
+  return {
+    handler: `${handlerPath(__dirname)}/app.default`,
+    timeout: 30,
+    events: [],
+    vpc: vpcConfig,
+  };
+};


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
This creates the function code for BizContentExpress and BizTestingExpress Lambdas.
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#187420711](https://www.pivotaltracker.com/story/show/187420711)

### Approach

-  updates `api/package.json`
-  Adds `api/src/functions/bizContentExpress/app.ts`
-  Adds `api/src/functions/bizContentExpress/index.ts`
-  Adds `api/src/functions/bizTestingExpress/app.ts`
-  Adds `api/src/functions/bizTestingExpress/index.ts`
-  Updates `yarn.lock`

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
