### PR TITLE
Move MYNJ_PROFILE_LINK to set-{STAGE}-env-vars jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,6 +181,7 @@ commands:
             echo 'export FORMATION_API_ACCOUNT=$FORMATION_API_ACCOUNT_DEV' >> $BASH_ENV
             echo 'export GOV2GO_REGISTRATION_API_KEY=$GOV2GO_REGISTRATION_API_KEY_DEV' >> $BASH_ENV
             echo 'export GOV2GO_REGISTRATION_BASE_URL=$GOV2GO_REGISTRATION_BASE_URL_DEV' >> $BASH_ENV
+            echo 'export MYNJ_PROFILE_LINK=$MYNJ_PROFILE_LINK_DEV' >> $BASH_ENV
             echo 'export MYNJ_ROLE_NAME=$MYNJ_ROLE_NAME_DEV' >> $BASH_ENV
             echo 'export MYNJ_SERVICE_TOKEN=$MYNJ_SERVICE_TOKEN_DEV' >> $BASH_ENV
             echo 'export MYNJ_SERVICE_URL=$MYNJ_SERVICE_URL_DEV' >> $BASH_ENV
@@ -281,6 +282,7 @@ commands:
             echo 'export FORMATION_API_ACCOUNT=$FORMATION_API_ACCOUNT_STAGING' >> $BASH_ENV
             echo 'export GOV2GO_REGISTRATION_API_KEY=$GOV2GO_REGISTRATION_API_KEY_STAGING' >> $BASH_ENV
             echo 'export GOV2GO_REGISTRATION_BASE_URL=$GOV2GO_REGISTRATION_BASE_URL_STAGING' >> $BASH_ENV
+            echo 'export MYNJ_PROFILE_LINK=$MYNJ_PROFILE_LINK_STAGING' >> $BASH_ENV
             echo 'export MYNJ_ROLE_NAME=$MYNJ_ROLE_NAME_STAGING' >> $BASH_ENV
             echo 'export MYNJ_SERVICE_TOKEN=$MYNJ_SERVICE_TOKEN_STAGING' >> $BASH_ENV
             echo 'export MYNJ_SERVICE_URL=$MYNJ_SERVICE_URL_STAGING' >> $BASH_ENV
@@ -339,6 +341,7 @@ commands:
             echo 'export FORMATION_API_ACCOUNT=$FORMATION_API_ACCOUNT_PROD' >> $BASH_ENV
             echo 'export GOV2GO_REGISTRATION_API_KEY=$GOV2GO_REGISTRATION_API_KEY_PROD' >> $BASH_ENV
             echo 'export GOV2GO_REGISTRATION_BASE_URL=$GOV2GO_REGISTRATION_BASE_URL_PROD' >> $BASH_ENV
+            echo 'export MYNJ_PROFILE_LINK=$MYNJ_PROFILE_LINK_PROD' >> $BASH_ENV
             echo 'export MYNJ_ROLE_NAME=$MYNJ_ROLE_NAME_PROD' >> $BASH_ENV
             echo 'export MYNJ_SERVICE_TOKEN=$MYNJ_SERVICE_TOKEN_PROD' >> $BASH_ENV
             echo 'export MYNJ_SERVICE_URL=$MYNJ_SERVICE_URL_PROD' >> $BASH_ENV
@@ -625,7 +628,6 @@ jobs:
       - deploy-content
     environment:
       STAGE: content
-      MYNJ_PROFILE_LINK: https://myt1.nj.gov/portal/Desktop
 
   deploy-accessibility-testing:
     docker:
@@ -641,7 +643,6 @@ jobs:
       - deploy-accessibility-testing
     environment:
       STAGE: testing
-      MYNJ_PROFILE_LINK: https://myt1.nj.gov/portal/Desktop
 
   deploy-dev:
     docker:
@@ -658,7 +659,6 @@ jobs:
       - store-deploy-cache
     environment:
       STAGE: dev
-      MYNJ_PROFILE_LINK: https://myt1.nj.gov/portal/Desktop
 
   deploy-staging:
     docker:
@@ -671,7 +671,6 @@ jobs:
       - deploy
     environment:
       STAGE: staging
-      MYNJ_PROFILE_LINK: https://myt1.nj.gov/portal/Desktop
 
   deploy-production:
     docker:
@@ -684,7 +683,6 @@ jobs:
       - deploy
     environment:
       STAGE: prod
-      MYNJ_PROFILE_LINK: https://my.nj.gov/portal/Desktop
 
   integration-tests:
     parameters:


### PR DESCRIPTION
## Description

Moves where `MYNJ_PROFILE_LINK` gets set in the CircleCI job.

These values have been set in `.circleci/config.yml` and added to Bitwarden for posterity sake.
<img width="557" alt="Screenshot 2024-05-03 at 4 20 59 PM" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22647707/a34d0b37-fc57-439d-98d8-2b0489d67878">

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
