### PR TITLE
feat: [#187553558] add elevator violations card to dashboard if needed

### DIFF
--- a/api/src/api/elevatorSafetyRouter.ts
+++ b/api/src/api/elevatorSafetyRouter.ts
@@ -1,4 +1,8 @@
-import { ElevatorSafetyInspectionStatus, ElevatorSafetyRegistrationStatus } from "@domain/types";
+import {
+  ElevatorSafetyInspectionStatus,
+  ElevatorSafetyRegistrationStatus,
+  ElevatorSafetyViolationsStatus,
+} from "@domain/types";
 import {
   ElevatorSafetyDeviceInspectionDetails,
   ElevatorSafetyRegistrationSummary,
@@ -7,7 +11,8 @@ import { Router } from "express";
 
 export const elevatorSafetyRouterFactory = (
   elevatorSafetyInspection: ElevatorSafetyInspectionStatus,
-  elevatorSafetyRegistration: ElevatorSafetyRegistrationStatus
+  elevatorSafetyRegistration: ElevatorSafetyRegistrationStatus,
+  elevatorSafetyViolation: ElevatorSafetyViolationsStatus
 ): Router => {
   const router = Router();
 
@@ -16,6 +21,17 @@ export const elevatorSafetyRouterFactory = (
     elevatorSafetyInspection(address)
       .then(async (elevatorInspections: ElevatorSafetyDeviceInspectionDetails[]) => {
         return res.json(elevatorInspections);
+      })
+      .catch((error) => {
+        res.status(500).json({ error });
+      });
+  });
+
+  router.post("/elevator-safety/violations/", async (req, res) => {
+    const { address, municipalityId } = req.body;
+    elevatorSafetyViolation(address, municipalityId)
+      .then(async (violations: boolean) => {
+        return res.json(violations);
       })
       .catch((error) => {
         res.status(500).json({ error });

--- a/api/src/client/dynamics/elevator-safety/DynamicsElevatorSafetyViolationsClient.test.ts
+++ b/api/src/client/dynamics/elevator-safety/DynamicsElevatorSafetyViolationsClient.test.ts
@@ -1,0 +1,267 @@
+import { DynamicsElevatorSafetyViolationsClient } from "@client/dynamics/elevator-safety/DynamicsElevatorSafetyViolationsClient";
+import { ElevatorSafetyViolationsClient } from "@client/dynamics/elevator-safety/types";
+import { LogWriter, LogWriterType } from "@libs/logWriter";
+import axios from "axios";
+
+jest.mock("axios");
+jest.mock("winston");
+const mockAxios = axios as jest.Mocked<typeof axios>;
+
+describe("DynamicsElevatorSafetyViolationClient", () => {
+  let client: ElevatorSafetyViolationsClient;
+  let logger: LogWriterType;
+
+  const ORG_URL = "www.test-org-url.com";
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    logger = LogWriter("NavigatorWebService", "ApiLogs", "us-test-1");
+
+    client = DynamicsElevatorSafetyViolationsClient(logger, ORG_URL);
+  });
+
+  const mockAccessToken = "access-granted";
+
+  it("returns true if violations found for address", async () => {
+    const buildingResponse = [
+      {
+        _ultra_propertyinterest_value: "123",
+        ultra_buildingid: "456",
+      },
+    ];
+
+    const deviceIdsResponse = [
+      {
+        _ultra_building_value: "456",
+        ultra_elsadeviceinspectionid: "abc",
+      },
+    ];
+
+    const violationsResponse = [
+      {
+        statusCode: 1,
+        ultra_citationdate: "01/01/2020",
+      },
+    ];
+
+    const address = "address-1";
+    const municipalityId = "municipality-id-1";
+
+    mockAxios.get.mockResolvedValueOnce({ data: { value: buildingResponse } });
+    mockAxios.get.mockResolvedValueOnce({ data: { value: deviceIdsResponse } });
+    mockAxios.get.mockResolvedValueOnce({ data: { value: violationsResponse } });
+    expect(await client.getViolationsForPropertyInterest(mockAccessToken, address, municipalityId)).toEqual(
+      true
+    );
+
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/ultra_buildings?$select=ultra_buildingid&$filter=(ultra_name eq '${address}' and _ultra_municipality_value eq '${municipalityId}')`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/ultra_elsadeviceinspections?$filter=(_ultra_building_value eq '456')`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/ultra_elsacitations?$filter=(_ultra_deviceinspection_value eq abc)`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+  });
+
+  it("returns false if no buildings found for address", async () => {
+    const address = "address-1";
+    const municipalityId = "municipality-id-1";
+
+    mockAxios.get.mockResolvedValueOnce({ data: { value: [] } });
+
+    expect(await client.getViolationsForPropertyInterest(mockAccessToken, address, municipalityId)).toEqual(
+      false
+    );
+
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/ultra_buildings?$select=ultra_buildingid&$filter=(ultra_name eq '${address}' and _ultra_municipality_value eq '${municipalityId}')`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+  });
+
+  it("returns false if no device inspections are found", async () => {
+    const buildingResponse = [
+      {
+        _ultra_propertyinterest_value: "123",
+        ultra_buildingid: "456",
+      },
+    ];
+
+    const address = "address-1";
+    const municipalityId = "municipality-id-1";
+
+    mockAxios.get.mockResolvedValueOnce({ data: { value: buildingResponse } });
+    mockAxios.get.mockResolvedValueOnce({ data: { value: [] } });
+    expect(await client.getViolationsForPropertyInterest(mockAccessToken, address, municipalityId)).toEqual(
+      false
+    );
+
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/ultra_buildings?$select=ultra_buildingid&$filter=(ultra_name eq '${address}' and _ultra_municipality_value eq '${municipalityId}')`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/ultra_elsadeviceinspections?$filter=(_ultra_building_value eq '456')`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+  });
+
+  it("returns false if no violations are found for address", async () => {
+    const buildingResponse = [
+      {
+        _ultra_propertyinterest_value: "123",
+        ultra_buildingid: "456",
+      },
+    ];
+
+    const deviceIdsResponse = [
+      {
+        _ultra_building_value: "456",
+        ultra_elsadeviceinspectionid: "abc",
+      },
+    ];
+
+    const address = "address-1";
+    const municipalityId = "municipality-id-1";
+
+    mockAxios.get.mockResolvedValueOnce({ data: { value: buildingResponse } });
+    mockAxios.get.mockResolvedValueOnce({ data: { value: deviceIdsResponse } });
+    mockAxios.get.mockResolvedValueOnce({ data: { value: [] } });
+    expect(await client.getViolationsForPropertyInterest(mockAccessToken, address, municipalityId)).toEqual(
+      false
+    );
+
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/ultra_buildings?$select=ultra_buildingid&$filter=(ultra_name eq '${address}' and _ultra_municipality_value eq '${municipalityId}')`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/ultra_elsadeviceinspections?$filter=(_ultra_building_value eq '456')`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/ultra_elsacitations?$filter=(_ultra_deviceinspection_value eq abc)`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+  });
+
+  it("returns true if violations found in second building", async () => {
+    const buildingResponse = [
+      {
+        _ultra_propertyinterest_value: "123",
+        ultra_buildingid: "456",
+      },
+      {
+        _ultra_propertyinterest_value: "999",
+        ultra_buildingid: "000",
+      },
+    ];
+
+    const deviceIdsResponse = [
+      {
+        _ultra_building_value: "456",
+        ultra_elsadeviceinspectionid: "abc",
+      },
+    ];
+
+    const violationsResponse = [
+      {
+        statusCode: 1,
+        ultra_citationdate: "01/01/2020",
+      },
+    ];
+
+    const address = "address-1";
+    const municipalityId = "municipality-id-1";
+
+    mockAxios.get.mockResolvedValueOnce({ data: { value: buildingResponse } });
+    mockAxios.get.mockResolvedValueOnce({ data: { value: [] } });
+    mockAxios.get.mockResolvedValueOnce({ data: { value: deviceIdsResponse } });
+    mockAxios.get.mockResolvedValueOnce({ data: { value: violationsResponse } });
+    expect(await client.getViolationsForPropertyInterest(mockAccessToken, address, municipalityId)).toEqual(
+      true
+    );
+
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/ultra_buildings?$select=ultra_buildingid&$filter=(ultra_name eq '${address}' and _ultra_municipality_value eq '${municipalityId}')`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/ultra_elsadeviceinspections?$filter=(_ultra_building_value eq '456')`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/ultra_elsadeviceinspections?$filter=(_ultra_building_value eq '000')`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/ultra_elsacitations?$filter=(_ultra_deviceinspection_value eq abc)`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+  });
+});

--- a/api/src/client/dynamics/elevator-safety/DynamicsElevatorSafetyViolationsClient.ts
+++ b/api/src/client/dynamics/elevator-safety/DynamicsElevatorSafetyViolationsClient.ts
@@ -1,0 +1,115 @@
+import { ElevatorSafetyViolationsClient } from "@client/dynamics/elevator-safety/types";
+import { LogWriterType } from "@libs/logWriter";
+import { ElevatorSafetyViolation } from "@shared/elevatorSafety";
+import axios, { AxiosError } from "axios";
+
+export const DynamicsElevatorSafetyViolationsClient = (
+  logWriter: LogWriterType,
+  orgUrl: string
+): ElevatorSafetyViolationsClient => {
+  const getViolationsForPropertyInterest = async (
+    accessToken: string,
+    address: string,
+    municipalityId: string
+  ): Promise<boolean> => {
+    const logId = logWriter.GetId();
+    logWriter.LogInfo(`Dynamics Elevator Violations Client - Id:${logId}`);
+    let hasViolations = false;
+
+    await axios
+      .get(
+        `${orgUrl}/api/data/v9.2/ultra_buildings?$select=ultra_buildingid&$filter=(ultra_name eq '${address}' and _ultra_municipality_value eq '${municipalityId}')`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      )
+      .then(async (response) => {
+        const deviceInspectionIds: string[] = [];
+        await Promise.all(
+          response.data.value.map(async (element: DynamicsElevatorSafetyBuildingResponse) => {
+            await axios
+              .get(
+                `${orgUrl}/api/data/v9.2/ultra_elsadeviceinspections?$filter=(_ultra_building_value eq '${element.ultra_buildingid}')`,
+                {
+                  headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                  },
+                }
+              )
+              .then((response) => {
+                const inspections = response.data.value as DynamicsElevatorSafetyDeviceInspectionResponse[];
+                for (const inspection of inspections) {
+                  deviceInspectionIds.push(inspection.ultra_elsadeviceinspectionid);
+                }
+              })
+              .catch((error: AxiosError) => {
+                throw error.response?.status;
+              });
+          })
+        );
+
+        const violations: ElevatorSafetyViolation[] = [];
+        await Promise.all(
+          deviceInspectionIds.map(async (element) => {
+            await axios
+              .get(
+                `${orgUrl}/api/data/v9.2/ultra_elsacitations?$filter=(_ultra_deviceinspection_value eq ${element})`,
+                {
+                  headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                  },
+                }
+              )
+              .then((response) => {
+                const violationsResponse = response.data.value as DynamicsElevatorSafetyViolationResponse[];
+                violationsResponse.map((violation) => {
+                  const formattedViolation = processDynamicsElevatorSafetyViolationResponse(violation);
+                  violations.push(formattedViolation);
+                });
+              })
+              .catch((error: AxiosError) => {
+                throw error.response?.status;
+              });
+          })
+        );
+
+        hasViolations = violations.length > 0;
+      })
+      .catch((error: AxiosError) => {
+        logWriter.LogError(`Dynamics Elevator Safety Violation - Id:${logId} - Error:`, error);
+        throw error.response?.status;
+      });
+
+    return hasViolations;
+  };
+
+  return {
+    getViolationsForPropertyInterest,
+  };
+};
+
+function processDynamicsElevatorSafetyViolationResponse(
+  response: DynamicsElevatorSafetyViolationResponse
+): ElevatorSafetyViolation {
+  return {
+    isOpen: response.statusCode === 1,
+    citationDate: response.ultra_citationdate,
+  };
+}
+
+type DynamicsElevatorSafetyBuildingResponse = {
+  _ultra_propertyinterest_value: string;
+  ultra_buildingid: string;
+};
+
+type DynamicsElevatorSafetyDeviceInspectionResponse = {
+  _ultra_building_value: string;
+  ultra_elsadeviceinspectionid: string;
+};
+
+type DynamicsElevatorSafetyViolationResponse = {
+  statusCode: number;
+  ultra_citationdate: string;
+};

--- a/api/src/client/dynamics/elevator-safety/DynamicsElevatorSafetyViolationsStatusClient.ts
+++ b/api/src/client/dynamics/elevator-safety/DynamicsElevatorSafetyViolationsStatusClient.ts
@@ -1,0 +1,21 @@
+import { ElevatorSafetyViolationsClient } from "@client/dynamics/elevator-safety/types";
+import { AccessTokenClient } from "@client/dynamics/types";
+import { ElevatorSafetyViolationsStatus } from "@domain/types";
+
+type Config = {
+  accessTokenClient: AccessTokenClient;
+  elevatorSafetyViolationsClient: ElevatorSafetyViolationsClient;
+};
+
+export const DynamicsElevatorSafetyViolationsStatusClient = (
+  config: Config
+): ElevatorSafetyViolationsStatus => {
+  return async (address: string, municipalityId: string): Promise<boolean> => {
+    const accessToken = await config.accessTokenClient.getAccessToken();
+    return await config.elevatorSafetyViolationsClient.getViolationsForPropertyInterest(
+      accessToken,
+      address,
+      municipalityId
+    );
+  };
+};

--- a/api/src/client/dynamics/elevator-safety/types.ts
+++ b/api/src/client/dynamics/elevator-safety/types.ts
@@ -9,6 +9,14 @@ export interface ElevatorSafetyRegistrationClient {
   ) => Promise<ElevatorRegistration[]>;
 }
 
+export interface ElevatorSafetyViolationsClient {
+  getViolationsForPropertyInterest: (
+    accessToken: string,
+    address: string,
+    municipalityId: string
+  ) => Promise<boolean>;
+}
+
 export type ElevatorInspection = {
   address: string;
   deviceCount: number;

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -132,6 +132,8 @@ export type ElevatorSafetyRegistrationStatus = (
   municipalityId: string
 ) => Promise<ElevatorSafetyRegistrationSummary>;
 
+export type ElevatorSafetyViolationsStatus = (address: string, municipalityId: string) => Promise<boolean>;
+
 export interface SuccessfulHealthCheckMetadata {
   success: true;
   data?: {

--- a/api/src/functions/express/app.ts
+++ b/api/src/functions/express/app.ts
@@ -18,6 +18,8 @@ import { DynamicsElevatorSafetyInspectionClient } from "@client/dynamics/elevato
 import { DynamicsElevatorSafetyInspectionStatusClient } from "@client/dynamics/elevator-safety/DynamicsElevatorSafetyInspectionStatusClient";
 import { DynamicsElevatorSafetyRegistrationClient } from "@client/dynamics/elevator-safety/DynamicsElevatorSafetyRegistrationClient";
 import { DynamicsElevatorSafetyRegistrationStatusClient } from "@client/dynamics/elevator-safety/DynamicsElevatorSafetyRegistrationStatusClient";
+import { DynamicsElevatorSafetyViolationsClient } from "@client/dynamics/elevator-safety/DynamicsElevatorSafetyViolationsClient";
+import { DynamicsElevatorSafetyViolationsStatusClient } from "@client/dynamics/elevator-safety/DynamicsElevatorSafetyViolationsStatusClient";
 import { DynamicsFireSafetyClient } from "@client/dynamics/fire-safety/DynamicsFireSafetyClient";
 import { DynamicsFireSafetyHealthCheckClient } from "@client/dynamics/fire-safety/DynamicsFireSafetyHealthCheckClient";
 import { DynamicsFireSafetyInspectionClient } from "@client/dynamics/fire-safety/DynamicsFireSafetyInspectionClient";
@@ -175,6 +177,11 @@ const dynamicsElevatorSafetyRegistrationClient = DynamicsElevatorSafetyRegistrat
   DYNAMICS_ELEVATOR_SAFETY_URL
 );
 
+const dynamicsElevatorSafetyViolationsClient = DynamicsElevatorSafetyViolationsClient(
+  logger,
+  DYNAMICS_ELEVATOR_SAFETY_URL
+);
+
 const dynamicsElevatorSafetyInspectionStatusClient = DynamicsElevatorSafetyInspectionStatusClient(logger, {
   accessTokenClient: dynamicsElevatorSafetyAccessTokenClient,
   elevatorSafetyInspectionClient: dynamicsElevatorSafetyInspectionClient,
@@ -188,6 +195,10 @@ const dynamicsElevatorSafetyRegistrationStatusClient = DynamicsElevatorSafetyReg
     housingPropertyInterestClient: dynamicsHousingPropertyInterestClient,
   }
 );
+const dynamicsElevatorSafetyViolationsStatusClient = DynamicsElevatorSafetyViolationsStatusClient({
+  accessTokenClient: dynamicsElevatorSafetyAccessTokenClient,
+  elevatorSafetyViolationsClient: dynamicsElevatorSafetyViolationsClient,
+});
 const dynamicsElevatorSafetyHealthCheckClient = DynamicsElevatorSafetyHealthCheckClient(logger, {
   accessTokenClient: dynamicsElevatorSafetyAccessTokenClient,
   orgUrl: DYNAMICS_ELEVATOR_SAFETY_URL,
@@ -325,7 +336,8 @@ app.use(
   "/api",
   elevatorSafetyRouterFactory(
     dynamicsElevatorSafetyInspectionStatusClient,
-    dynamicsElevatorSafetyRegistrationStatusClient
+    dynamicsElevatorSafetyRegistrationStatusClient,
+    dynamicsElevatorSafetyViolationsStatusClient
   )
 );
 app.use("/api", fireSafetyRouterFactory(dynamicsFireSafetyClient));

--- a/content/src/fieldConfig/elevator-registration.json
+++ b/content/src/fieldConfig/elevator-registration.json
@@ -26,5 +26,10 @@
     "informationalReturned": "Review your returned application for any errors or missing information. You can resubmit it using the same application link in the DCA Service Portal.",
     "informationalRejected": "Review your rejected application for any errors or missing information. You can resubmit it using the same application link in the DCA Service Portal.",
     "informationalIncomplete": "Review your incomplete application. Make sure you complete all sections and submit it."
+  },
+  "elevatorViolationsCard": {
+    "violationNoticeMessage": "Your building has one or more elevator device violations you must fix by your next inspection.",
+    "violationNoticeCTA": "View My Violation Notice",
+    "violationNoticeCTALink": "https://njdcaportal.dynamics365portals.us/"
   }
 }

--- a/shared/src/elevatorSafety.ts
+++ b/shared/src/elevatorSafety.ts
@@ -18,6 +18,11 @@ export type ElevatorSafetyRegistrationSummary = {
   lookupStatus: string;
 };
 
+export type ElevatorSafetyViolation = {
+  citationDate: string;
+  isOpen: boolean;
+};
+
 export type ElevatorSafetyAddress = {
   address1: string;
   address2?: string;

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -2100,7 +2100,7 @@ collections:
                   name: deferredOnboardingSaveButtonText,
                   widget: string,
                 }
-      - label: "Elevator Registration"
+      - label: "Elevator Safety"
         name: "elevator-registration-config"
         file: "content/src/fieldConfig/elevator-registration.json"
         editor:
@@ -2173,6 +2173,15 @@ collections:
               - { label: Informational Message - Returned, name: informationalReturned, widget: string }
               - { label: Informational Message - Rejected, name: informationalRejected, widget: string }
               - { label: Informational Message - Incomplete, name: informationalIncomplete, widget: string }
+          - label: Elevator Violations Card
+            name: elevatorViolationsCard
+            collapsed: false
+            widget: object
+            fields:
+              - { label: Violation Notice Message Text, name: violationNoticeMessage, widget: string }
+              - { label: Violation Notice CTA Text, name: violationNoticeCTA, widget: string }
+              - { label: Violation Notice CTA Link, name: violationNoticeCTALink, widget: nospace }
+
 
   - name: "tasks"
     label: "Tasks - All"

--- a/web/src/components/dashboard/DashboardOnDesktop.tsx
+++ b/web/src/components/dashboard/DashboardOnDesktop.tsx
@@ -1,6 +1,7 @@
 import { UserDataErrorAlert } from "@/components/UserDataErrorAlert";
 import { DashboardHeader } from "@/components/dashboard/DashboardHeader";
 import { DeferredHomeBasedQuestion } from "@/components/dashboard/DeferredHomeBasedQuestion";
+import { ElevatorViolationsCard } from "@/components/dashboard/ElevatorViolationsCard";
 import { HideableTasks } from "@/components/dashboard/HideableTasks";
 import { Roadmap } from "@/components/dashboard/Roadmap";
 import { SidebarCardsContainer } from "@/components/dashboard/SidebarCardsContainer";
@@ -32,6 +33,7 @@ interface Props {
   operateReferences: Record<string, OperateReference>;
   fundings: Funding[];
   certifications: Certification[];
+  elevatorViolations?: boolean;
 }
 
 export const DashboardOnDesktop = (props: Props): ReactElement => {
@@ -62,6 +64,8 @@ export const DashboardOnDesktop = (props: Props): ReactElement => {
                     onSave={deferredHomeBasedOnSaveButtonClick}
                   />
                 )}
+
+                {props.elevatorViolations && <ElevatorViolationsCard />}
 
                 {operatingPhase.displayQuickActions && (
                   <QuickActionsContainer

--- a/web/src/components/dashboard/DashboardOnMobile.tsx
+++ b/web/src/components/dashboard/DashboardOnMobile.tsx
@@ -1,6 +1,7 @@
 import { UserDataErrorAlert } from "@/components/UserDataErrorAlert";
 import { DashboardHeader } from "@/components/dashboard/DashboardHeader";
 import { DeferredHomeBasedQuestion } from "@/components/dashboard/DeferredHomeBasedQuestion";
+import { ElevatorViolationsCard } from "@/components/dashboard/ElevatorViolationsCard";
 import { HideableTasks } from "@/components/dashboard/HideableTasks";
 import { Roadmap } from "@/components/dashboard/Roadmap";
 import { SidebarCardsContainer } from "@/components/dashboard/SidebarCardsContainer";
@@ -33,6 +34,7 @@ interface Props {
   operateReferences: Record<string, OperateReference>;
   fundings: Funding[];
   certifications: Certification[];
+  elevatorViolations?: boolean;
 }
 
 export const DashboardOnMobile = (props: Props): ReactElement => {
@@ -57,6 +59,8 @@ export const DashboardOnMobile = (props: Props): ReactElement => {
           <div className="margin-top-0 desktop:margin-top-0">
             <UserDataErrorAlert />
             <div className="margin-top-3">
+              {props.elevatorViolations && <ElevatorViolationsCard />}
+
               {renderDeferredHomeBasedQuestion && (
                 <DeferredHomeBasedQuestion business={business} onSave={deferredHomeBasedOnSaveButtonClick} />
               )}

--- a/web/src/components/dashboard/ElevatorViolationsCard.tsx
+++ b/web/src/components/dashboard/ElevatorViolationsCard.tsx
@@ -1,0 +1,24 @@
+import { Icon } from "@/components/njwds/Icon";
+import { getMergedConfig } from "@/contexts/configContext";
+import { openInNewTab } from "@/lib/utils/helpers";
+import { ReactElement } from "react";
+
+export const ElevatorViolationsCard = (): ReactElement => {
+  const config = getMergedConfig();
+  return (
+    <div className="radius-md padding-2 text-align-left border-2px border-error padding-2">
+      <span className={"width-55 inline-block"}>{config.elevatorViolationsCard.violationNoticeMessage}</span>
+      <span className={"inline-block float-right margin-top-1"}>
+        <button
+          className={"bg-error-dark radius-md usa-button padding-x-2"}
+          onClick={() => {
+            openInNewTab(config.elevatorViolationsCard.violationNoticeCTALink);
+          }}
+        >
+          <span className={"padding-right-1"}>{config.elevatorViolationsCard.violationNoticeCTA}</span>
+          <Icon>launch</Icon>
+        </button>
+      </span>
+    </div>
+  );
+};

--- a/web/src/lib/api-client/apiClient.ts
+++ b/web/src/lib/api-client/apiClient.ts
@@ -38,6 +38,10 @@ export const checkElevatorRegistrationStatus = (
   return post(`/elevator-safety/registration`, { address, municipalityId });
 };
 
+export const checkElevatorViolations = (address: string, municipalityId: string): Promise<boolean> => {
+  return post(`/elevator-safety/violations`, { address, municipalityId });
+};
+
 export const postBusinessFormation = (
   userData: UserData,
   returnUrl: string,

--- a/web/src/styles/base/global.scss
+++ b/web/src/styles/base/global.scss
@@ -85,6 +85,10 @@ ol {
   font-size: 1.25rem;
 }
 
+.inline-block {
+  display: inline-block;
+}
+
 .page-not-found {
   background: linear-gradient(180deg, rgba(243, 239, 236, 0) 0%, #ecf3ec 100%);
   height: 80vh;

--- a/web/src/styles/base/height-width.scss
+++ b/web/src/styles/base/height-width.scss
@@ -48,6 +48,10 @@
   width: 80%;
 }
 
+.width-55 {
+  width: 55%;
+}
+
 .width-auto {
   width: auto !important;
 }


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Adds a card to the top of the dashboard if your saved Community Affairs address has violations.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[187553558](https://www.pivotaltracker.com/story/show/187553558)

### Approach

I added a check to the dashboard and a prop to pass down to the `Mobile` and `Desktop` dashboard. The check will only be run if the user has a community affairs address

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Go through account creation and indicate you own an elevator
Fill out the ElevatorRegistration task
Return to dashboard; if the test values have any violations, you will see them on the dashboard when returning there
(can use values in NJ QA Testing doc)

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
