### PR TITLE
feat: [#185159231] Renovation Task Conditional CTA display logic

### DIFF
--- a/api/src/client/ApiFormationHealth.ts
+++ b/api/src/client/ApiFormationHealth.ts
@@ -57,6 +57,7 @@ export const ApiFormationHealth: UserData = {
         liquorLicense: true,
         requiresCpa: false,
         homeBasedBusiness: false,
+        plannedRenovationQuestion: undefined,
         cannabisLicenseType: "CONDITIONAL",
         cannabisMicrobusiness: true,
         constructionRenovationPlan: false,

--- a/api/src/db/migrations/migrations.ts
+++ b/api/src/db/migrations/migrations.ts
@@ -37,6 +37,7 @@ import { migrate_v129_to_v130 } from "@db/migrations/v130_remove_nexus_location_
 import { migrate_v130_to_v131 } from "@db/migrations/v131_add_construction_type_essential_question";
 import { migrate_v131_to_v132 } from "@db/migrations/v132_add_community_affairs_address";
 import { migrate_v132_to_v133 } from "@db/migrations/v133_change_agent_office_address_city_field";
+import { migrate_v133_to_v134 } from "@db/migrations/v134_added_planned_renovation_question_field";
 import { migrate_v12_to_v13 } from "@db/migrations/v13_add_construction_renovation_plan";
 import { migrate_v13_to_v14 } from "@db/migrations/v14_add_cleaning_aid_industry";
 import { migrate_v14_to_v15 } from "@db/migrations/v15_add_retail_industry";
@@ -270,4 +271,5 @@ export const Migrations: MigrationFunction[] = [
   migrate_v130_to_v131,
   migrate_v131_to_v132,
   migrate_v132_to_v133,
+  migrate_v133_to_v134,
 ];

--- a/api/src/db/migrations/v134_added_planned_renovation_question_field.ts
+++ b/api/src/db/migrations/v134_added_planned_renovation_question_field.ts
@@ -1,0 +1,486 @@
+import { v133Business, v133UserData } from "@db/migrations/v133_change_agent_office_address_city_field";
+
+export interface v134ProfileData extends v134IndustrySpecificData {
+  businessPersona: v134BusinessPersona;
+  businessName: string;
+  responsibleOwnerName: string;
+  tradeName: string;
+  industryId: string | undefined;
+  legalStructureId: string | undefined;
+  municipality: v134Municipality | undefined;
+  dateOfFormation: string | undefined;
+  entityId: string | undefined;
+  employerId: string | undefined;
+  taxId: string | undefined;
+  encryptedTaxId: string | undefined;
+  notes: string;
+  documents: v134ProfileDocuments;
+  ownershipTypeIds: string[];
+  existingEmployees: string | undefined;
+  taxPin: string | undefined;
+  sectorId: string | undefined;
+  naicsCode: string;
+  foreignBusinessTypeIds: v134ForeignBusinessTypeId[];
+  nexusDbaName: string;
+  needsNexusDbaName: boolean;
+  operatingPhase: v134OperatingPhase;
+  isNonprofitOnboardingRadio: boolean;
+  nonEssentialRadioAnswers: Record<string, boolean | undefined>;
+  elevatorOwningBusiness: boolean | undefined;
+  communityAffairsAddress?: v134CommunityAffairsAddress;
+}
+
+export type v134CommunityAffairsAddress = {
+  streetAddress1: string;
+  streetAddress2?: string;
+  municipality: v134Municipality;
+};
+export const migrate_v133_to_v134 = (v133Data: v133UserData): v134UserData => {
+  return {
+    ...v133Data,
+    businesses: Object.fromEntries(
+      Object.values(v133Data.businesses)
+        .map((business: v133Business) => migrate_v133Business_to_v134Business(business))
+        .map((currBusiness: v134Business) => [currBusiness.id, currBusiness])
+    ),
+    version: 134,
+  } as v134UserData;
+};
+
+const migrate_v133Business_to_v134Business = (business: v133Business): v134Business => {
+  const v134BusinessObj = {
+    ...business,
+    profileData: {
+      ...business.profileData,
+      plannedRenovationQuestion: undefined,
+    },
+  };
+
+  return v134BusinessObj as v134Business;
+};
+
+// ---------------- v134 types ----------------
+type v134TaskProgress = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+type v134OnboardingFormProgress = "UNSTARTED" | "COMPLETED";
+type v134ABExperience = "ExperienceA" | "ExperienceB";
+
+export interface v134UserData {
+  user: v134BusinessUser;
+  version: number;
+  lastUpdatedISO: string;
+  dateCreatedISO: string;
+  versionWhenCreated: number;
+  businesses: Record<string, v134Business>;
+  currentBusinessId: string;
+}
+
+export interface v134Business {
+  id: string;
+  dateCreatedISO: string;
+  lastUpdatedISO: string;
+  profileData: v134ProfileData;
+  onboardingFormProgress: v134OnboardingFormProgress;
+  taskProgress: Record<string, v134TaskProgress>;
+  taskItemChecklist: Record<string, boolean>;
+  licenseData: v134LicenseData | undefined;
+  preferences: v134Preferences;
+  taxFilingData: v134TaxFilingData;
+  formationData: v134FormationData;
+}
+export interface v134IndustrySpecificData {
+  liquorLicense: boolean;
+  requiresCpa: boolean;
+  homeBasedBusiness: boolean | undefined;
+  providesStaffingService: boolean;
+  certifiedInteriorDesigner: boolean;
+  realEstateAppraisalManagement: boolean;
+  cannabisLicenseType: v134CannabisLicenseType;
+  cannabisMicrobusiness: boolean | undefined;
+  constructionRenovationPlan: boolean | undefined;
+  carService: v134CarServiceType | undefined;
+  interstateTransport: boolean;
+  isInterstateLogisticsApplicable: boolean | undefined;
+  isInterstateMovingApplicable: boolean | undefined;
+  isChildcareForSixOrMore: boolean | undefined;
+  petCareHousing: boolean | undefined;
+  willSellPetCareItems: boolean | undefined;
+  constructionType: v134ConstructionType;
+  residentialConstructionType: v134ResidentialConstructionType;
+}
+
+type v134BusinessUser = {
+  name?: string;
+  email: string;
+  id: string;
+  receiveNewsletter: boolean;
+  userTesting: boolean;
+  externalStatus: v134ExternalStatus;
+  myNJUserKey?: string;
+  intercomHash?: string;
+  abExperience: v134ABExperience;
+};
+
+interface v134ProfileDocuments {
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+}
+
+type v134BusinessPersona = "STARTING" | "OWNING" | "FOREIGN" | undefined;
+type v134OperatingPhase =
+  | "GUEST_MODE"
+  | "NEEDS_TO_FORM"
+  | "NEEDS_BUSINESS_STRUCTURE"
+  | "FORMED"
+  | "UP_AND_RUNNING"
+  | "UP_AND_RUNNING_OWNING"
+  | "REMOTE_SELLER_WORKER"
+  | undefined;
+
+export type v134CannabisLicenseType = "CONDITIONAL" | "ANNUAL" | undefined;
+export type v134CarServiceType = "STANDARD" | "HIGH_CAPACITY" | "BOTH" | undefined;
+export type v134ConstructionType = "RESIDENTIAL" | "COMMERCIAL_OR_INDUSTRIAL" | "BOTH" | undefined;
+export type v134ResidentialConstructionType =
+  | "NEW_HOME_CONSTRUCTION"
+  | "HOME_RENOVATIONS"
+  | "BOTH"
+  | undefined;
+
+type v134ForeignBusinessTypeId =
+  | "employeeOrContractorInNJ"
+  | "officeInNJ"
+  | "propertyInNJ"
+  | "companyOperatedVehiclesInNJ"
+  | "employeesInNJ"
+  | "revenueInNJ"
+  | "transactionsInNJ"
+  | "none";
+
+type v134Municipality = {
+  name: string;
+  displayName: string;
+  county: string;
+  id: string;
+};
+
+type v134TaxFilingState = "SUCCESS" | "FAILED" | "UNREGISTERED" | "PENDING" | "API_ERROR";
+type v134TaxFilingErrorFields = "businessName" | "formFailure";
+
+type v134TaxFilingData = {
+  state?: v134TaxFilingState;
+  lastUpdatedISO?: string;
+  registeredISO?: string;
+  errorField?: v134TaxFilingErrorFields;
+  businessName?: string;
+  filings: v134TaxFilingCalendarEvent[];
+};
+
+export type v134CalendarEvent = {
+  readonly dueDate: string; // YYYY-MM-DD
+  readonly calendarEventType: "TAX-FILING" | "LICENSE";
+};
+
+export interface v134TaxFilingCalendarEvent extends v134CalendarEvent {
+  readonly identifier: string;
+  readonly calendarEventType: "TAX-FILING";
+}
+
+type v134NameAndAddress = {
+  name: string;
+  addressLine1: string;
+  addressLine2: string;
+  zipCode: string;
+};
+
+type v134LicenseData = {
+  nameAndAddress: v134NameAndAddress;
+  completedSearch: boolean;
+  lastUpdatedISO: string;
+  status: v134LicenseStatus;
+  items: v134LicenseStatusItem[];
+};
+
+type v134Preferences = {
+  roadmapOpenSections: v134SectionType[];
+  roadmapOpenSteps: number[];
+  hiddenFundingIds: string[];
+  hiddenCertificationIds: string[];
+  visibleSidebarCards: string[];
+  isCalendarFullView: boolean;
+  returnToLink: string;
+  isHideableRoadmapOpen: boolean;
+  phaseNewlyChanged: boolean;
+};
+
+type v134LicenseStatusItem = {
+  title: string;
+  status: v134CheckoffStatus;
+};
+
+type v134CheckoffStatus = "ACTIVE" | "PENDING" | "UNKNOWN";
+
+type v134LicenseStatus =
+  | "ACTIVE"
+  | "PENDING"
+  | "UNKNOWN"
+  | "EXPIRED"
+  | "BARRED"
+  | "OUT_OF_BUSINESS"
+  | "REINSTATEMENT_PENDING"
+  | "CLOSED"
+  | "DELETED"
+  | "DENIED"
+  | "VOLUNTARY_SURRENDER"
+  | "WITHDRAWN";
+
+const v134SectionNames = ["PLAN", "START"] as const;
+type v134SectionType = (typeof v134SectionNames)[number];
+
+type v134ExternalStatus = {
+  newsletter?: v134NewsletterResponse;
+  userTesting?: v134UserTestingResponse;
+};
+
+interface v134NewsletterResponse {
+  success?: boolean;
+  status: v134NewsletterStatus;
+}
+
+interface v134UserTestingResponse {
+  success?: boolean;
+  status: v134UserTestingStatus;
+}
+
+type v134NewsletterStatus = (typeof newsletterStatusList)[number];
+
+const externalStatusList = ["SUCCESS", "IN_PROGRESS", "CONNECTION_ERROR"] as const;
+
+const userTestingStatusList = [...externalStatusList] as const;
+
+type v134UserTestingStatus = (typeof userTestingStatusList)[number];
+
+const newsletterStatusList = [
+  ...externalStatusList,
+  "EMAIL_ERROR",
+  "TOPIC_ERROR",
+  "RESPONSE_WARNING",
+  "RESPONSE_ERROR",
+  "RESPONSE_FAIL",
+  "QUESTION_WARNING",
+] as const;
+
+type v134NameAvailabilityStatus =
+  | "AVAILABLE"
+  | "DESIGNATOR_ERROR"
+  | "SPECIAL_CHARACTER_ERROR"
+  | "UNAVAILABLE"
+  | "RESTRICTED_ERROR"
+  | undefined;
+
+interface v134NameAvailabilityResponse {
+  status: v134NameAvailabilityStatus;
+  similarNames: string[];
+  invalidWord?: string;
+}
+
+interface v134NameAvailability extends v134NameAvailabilityResponse {
+  lastUpdatedTimeStamp: string;
+}
+
+interface v134FormationData {
+  formationFormData: v134FormationFormData;
+  businessNameAvailability: v134NameAvailability | undefined;
+  dbaBusinessNameAvailability: v134NameAvailability | undefined;
+  formationResponse: v134FormationSubmitResponse | undefined;
+  getFilingResponse: v134GetFilingResponse | undefined;
+  completedFilingPayment: boolean;
+  lastVisitedPageIndex: number;
+}
+
+type v134InFormInBylaws = "IN_BYLAWS" | "IN_FORM" | undefined;
+
+interface v134FormationFormData extends v134FormationAddress {
+  readonly businessName: string;
+  readonly businessSuffix: v134BusinessSuffix | undefined;
+  readonly businessTotalStock: string;
+  readonly businessStartDate: string; // YYYY-MM-DD
+  readonly businessPurpose: string;
+  readonly withdrawals: string;
+  readonly combinedInvestment: string;
+  readonly dissolution: string;
+  readonly canCreateLimitedPartner: boolean | undefined;
+  readonly createLimitedPartnerTerms: string;
+  readonly canGetDistribution: boolean | undefined;
+  readonly getDistributionTerms: string;
+  readonly canMakeDistribution: boolean | undefined;
+  readonly makeDistributionTerms: string;
+  readonly hasNonprofitBoardMembers: boolean | undefined;
+  readonly nonprofitBoardMemberQualificationsSpecified: v134InFormInBylaws;
+  readonly nonprofitBoardMemberQualificationsTerms: string;
+  readonly nonprofitBoardMemberRightsSpecified: v134InFormInBylaws;
+  readonly nonprofitBoardMemberRightsTerms: string;
+  readonly nonprofitTrusteesMethodSpecified: v134InFormInBylaws;
+  readonly nonprofitTrusteesMethodTerms: string;
+  readonly nonprofitAssetDistributionSpecified: v134InFormInBylaws;
+  readonly nonprofitAssetDistributionTerms: string;
+  readonly additionalProvisions: string[] | undefined;
+  readonly agentNumberOrManual: "NUMBER" | "MANUAL_ENTRY";
+  readonly agentNumber: string;
+  readonly agentName: string;
+  readonly agentEmail: string;
+  readonly agentOfficeAddressLine1: string;
+  readonly agentOfficeAddressLine2: string;
+  readonly agentOfficeAddressCity: string;
+  readonly agentOfficeAddressZipCode: string;
+  readonly agentUseAccountInfo: boolean;
+  readonly agentUseBusinessAddress: boolean;
+  readonly members: v134FormationMember[] | undefined;
+  readonly incorporators: v134FormationIncorporator[] | undefined;
+  readonly signers: v134FormationSigner[] | undefined;
+  readonly paymentType: v134PaymentType;
+  readonly annualReportNotification: boolean;
+  readonly corpWatchNotification: boolean;
+  readonly officialFormationDocument: boolean;
+  readonly certificateOfStanding: boolean;
+  readonly certifiedCopyOfFormationDocument: boolean;
+  readonly contactFirstName: string;
+  readonly contactLastName: string;
+  readonly contactPhoneNumber: string;
+  readonly foreignStateOfFormation: v134StateObject | undefined;
+  readonly foreignDateOfFormation: string | undefined; // YYYY-MM-DD
+  readonly foreignGoodStandingFile: v134ForeignGoodStandingFileObject | undefined;
+  readonly legalType: string;
+  readonly willPracticeLaw: boolean | undefined;
+  readonly isVeteranNonprofit: boolean | undefined;
+}
+
+type v134ForeignGoodStandingFileObject = {
+  Extension: "PDF" | "PNG";
+  Content: string;
+};
+
+type v134StateObject = {
+  shortCode: string;
+  name: string;
+};
+
+interface v134FormationAddress {
+  readonly addressLine1: string;
+  readonly addressLine2: string;
+  readonly addressCity?: string;
+  readonly addressState?: v134StateObject;
+  readonly addressMunicipality?: v134Municipality;
+  readonly addressProvince?: string;
+  readonly addressZipCode: string;
+  readonly addressCountry: string;
+  readonly businessLocationType: v134FormationBusinessLocationType | undefined;
+}
+
+type v134FormationBusinessLocationType = "US" | "INTL" | "NJ";
+
+type v134SignerTitle =
+  | "Authorized Representative"
+  | "Authorized Partner"
+  | "Incorporator"
+  | "General Partner"
+  | "President"
+  | "Vice-President"
+  | "Chairman of the Board"
+  | "CEO";
+
+interface v134FormationSigner {
+  readonly name: string;
+  readonly signature: boolean;
+  readonly title: v134SignerTitle;
+}
+
+interface v134FormationIncorporator extends v134FormationSigner, v134FormationAddress {}
+
+interface v134FormationMember extends v134FormationAddress {
+  readonly name: string;
+}
+
+type v134PaymentType = "CC" | "ACH" | undefined;
+
+const llcBusinessSuffix = [
+  "LLC",
+  "L.L.C.",
+  "LTD LIABILITY CO",
+  "LTD LIABILITY CO.",
+  "LTD LIABILITY COMPANY",
+  "LIMITED LIABILITY CO",
+  "LIMITED LIABILITY CO.",
+  "LIMITED LIABILITY COMPANY",
+] as const;
+
+const llpBusinessSuffix = [
+  "Limited Liability Partnership",
+  "LLP",
+  "L.L.P.",
+  "Registered Limited Liability Partnership",
+  "RLLP",
+  "R.L.L.P.",
+] as const;
+
+export const lpBusinessSuffix = ["LIMITED PARTNERSHIP", "LP", "L.P."] as const;
+
+const corpBusinessSuffix = [
+  "Corporation",
+  "Incorporated",
+  "Company",
+  "LTD",
+  "CO",
+  "CO.",
+  "CORP",
+  "CORP.",
+  "INC",
+  "INC.",
+] as const;
+
+export const nonprofitBusinessSuffix = [
+  "A NJ NONPROFIT CORPORATION",
+  "CORPORATION",
+  "INCORPORATED",
+  "CORP",
+  "CORP.",
+  "INC",
+  "INC.",
+] as const;
+
+const foreignCorpBusinessSuffix = [...corpBusinessSuffix, "P.C.", "P.A."] as const;
+
+export const AllBusinessSuffixes = [
+  ...llcBusinessSuffix,
+  ...llpBusinessSuffix,
+  ...lpBusinessSuffix,
+  ...corpBusinessSuffix,
+  ...foreignCorpBusinessSuffix,
+  ...nonprofitBusinessSuffix,
+] as const;
+
+type v134BusinessSuffix = (typeof AllBusinessSuffixes)[number];
+
+type v134FormationSubmitResponse = {
+  success: boolean;
+  token: string | undefined;
+  formationId: string | undefined;
+  redirect: string | undefined;
+  errors: v134FormationSubmitError[];
+  lastUpdatedISO: string | undefined;
+};
+
+type v134FormationSubmitError = {
+  field: string;
+  type: "FIELD" | "UNKNOWN" | "RESPONSE";
+  message: string;
+};
+
+type v134GetFilingResponse = {
+  success: boolean;
+  entityId: string;
+  transactionDate: string;
+  confirmationNumber: string;
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+};

--- a/content/src/fieldConfig/profile.json
+++ b/content/src/fieldConfig/profile.json
@@ -267,6 +267,15 @@
           "altDescription": "Do you plan to be a `home-based business|home-based-business` ?"
         }
       },
+      "plannedRenovationQuestion": {
+        "default": {
+          "header": "Planned Renovations",
+          "radioButtonTrueText": "Yes",
+          "radioButtonFalseText": "No",
+          "altDescription": "Do you plan to do any renovations or construction on your commercial/industrial space?",
+          "description": "Do you plan to do any renovations or construction on your commercial/industrial space?"
+        }
+      },
       "legalStructureId": {
         "default": {
           "header": "Business Structure",

--- a/content/src/roadmaps/add-ons/permanent-location-business.json
+++ b/content/src/roadmaps/add-ons/permanent-location-business.json
@@ -23,11 +23,6 @@
       "task": "zoning"
     },
     {
-      "step": 3,
-      "weight": 62,
-      "task": "building-permit"
-    },
-    {
       "step": 4,
       "weight": 60,
       "task": "site-safety-permits"

--- a/content/src/roadmaps/add-ons/planned-renovation.json
+++ b/content/src/roadmaps/add-ons/planned-renovation.json
@@ -1,0 +1,11 @@
+{
+  "id": "planned-renovation",
+  "displayname": "planned-renovation",
+  "roadmapSteps": [
+    {
+      "step": 3,
+      "weight": 62,
+      "task": "building-permit"
+    }
+  ]
+}

--- a/content/src/roadmaps/tasks/building-permit.md
+++ b/content/src/roadmaps/tasks/building-permit.md
@@ -1,14 +1,43 @@
 ---
-postOnboardingQuestion: construction-renovation
 urlSlug: building-permit
 filename: building-permit
 displayname: building-permit
 name: Prepare for Site Renovation, if Applicable
 id: building-permit
-callToActionLink: ""
-callToActionText: ""
-summaryDescriptionMd: >-
-  Now that you signed your lease, it's time to obtain permits that allow you to build or renovate your site.
+notesMd: >-
+  Way back snapshot for broken link [Local (Regional) Code Enforcement Offices]:
+  https://web.archive.org/web/20230311001931/https://www.nj.gov/dca/divisions/codes/offices/localcode.html
+
+  changed to new page: https://www.nj.gov/dca/codes/offices/localcode.shtml
+
+
+  DEV NOTE for content: previously this was a drop down with 2 CTA buttons, we decided in a meeting to make the the first the CTA link and this one
+
+  callToActionYesText2: Local (Regional) Code Enforcement Offices
+  callToActionYesLink2: https://www.nj.gov/dca/codes/offices/localcode.shtml
+
+  Needs to be re-worked into the content of the page because we don't like CTA drop downs as a pattern
+
+callToActionLink: "https://www.nj.gov/dca/divisions/codes/resources/constructionpermitforms.html"
+callToActionText: "Construction Permit Application"
 ---
 
-{postOnboardingQuestion}
+Now that you signed your lease, it's time to obtain permits that allow you to build or renovate your site.
+
+---
+
+### Site Considerations
+
+- []{construction-renovation-site-drawings} **Site drawings:** Hire an architect to create site drawings that meet your business needs and budget
+- []{construction-renovation-utilities} **Utilities:** Work with your local government on any utility or water approvals you may need
+- []{construction-renovation-permits} **Construction permits:** [File for a construction permit](https://www.nj.gov/dca/divisions/codes/resources/constructionpermitforms.html) with your local government's building/construction department. Before filing, ask the construction department if any prior approvals are required for your industry
+- []{construction-renovation-contractors} **Contractors:** Hire any contractors you may need, such as plumbers, electricians, and fire prevention, HVAC or general contractors. Industry best practice is to get 3 quotes before deciding on a contractor
+
+Once you have all the necessary drawings, approvals, and contractors in place, you are in a good position to get your construction or renovation started!
+
+> **Once completed, you will have:**
+>
+> - Site drawings
+> - Utility approvals
+> - Construction permits
+> - Contractors for build out

--- a/shared/src/profileData.ts
+++ b/shared/src/profileData.ts
@@ -17,6 +17,7 @@ export interface IndustrySpecificData {
   readonly liquorLicense: boolean;
   readonly requiresCpa: boolean;
   readonly homeBasedBusiness: boolean | undefined;
+  readonly plannedRenovationQuestion: boolean | undefined;
   readonly providesStaffingService: boolean;
   readonly certifiedInteriorDesigner: boolean;
   readonly realEstateAppraisalManagement: boolean;
@@ -41,6 +42,7 @@ export const industrySpecificDataChoices: IndustrySpecificDataChoices = {
   liquorLicense: booleanChoice,
   requiresCpa: booleanChoice,
   homeBasedBusiness: booleanChoice,
+  plannedRenovationQuestion: booleanChoice,
   providesStaffingService: booleanChoice,
   certifiedInteriorDesigner: booleanChoice,
   realEstateAppraisalManagement: booleanChoice,
@@ -61,6 +63,7 @@ export const emptyIndustrySpecificData: IndustrySpecificData = {
   liquorLicense: false,
   requiresCpa: false,
   homeBasedBusiness: undefined,
+  plannedRenovationQuestion: undefined,
   cannabisLicenseType: undefined,
   cannabisMicrobusiness: undefined,
   constructionRenovationPlan: undefined,

--- a/shared/src/test/factories.ts
+++ b/shared/src/test/factories.ts
@@ -214,6 +214,7 @@ export const generateIndustrySpecificData = (
     liquorLicense: !(randomInt() % 2),
     requiresCpa: !(randomInt() % 2),
     homeBasedBusiness: !(randomInt() % 2),
+    plannedRenovationQuestion: !(randomInt() % 2),
     cannabisLicenseType: randomElementFromArray(["CONDITIONAL", "ANNUAL"]),
     cannabisMicrobusiness: !(randomInt() % 2),
     constructionRenovationPlan: !(randomInt() % 2),

--- a/shared/src/userData.ts
+++ b/shared/src/userData.ts
@@ -29,7 +29,7 @@ export interface Business {
   readonly formationData: FormationData;
 }
 
-export const CURRENT_VERSION = 133;
+export const CURRENT_VERSION = 134;
 
 export const createEmptyBusiness = (id?: string): Business => {
   return {

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -2182,7 +2182,6 @@ collections:
               - { label: Violation Notice CTA Text, name: violationNoticeCTA, widget: string }
               - { label: Violation Notice CTA Link, name: violationNoticeCTALink, widget: nospace }
 
-
   - name: "tasks"
     label: "Tasks - All"
     folder: "content/src/roadmaps/tasks"
@@ -4949,6 +4948,25 @@ collections:
                         widget: object
                         fields:
                           - { label: "Description", name: "description", widget: "markdown" }
+                  - label: Deferred Planned Renovation Question
+                    name: "plannedRenovationQuestion"
+                    collapsed: true
+                    widget: object
+                    fields:
+                      - label: Default
+                        name: "default"
+                        collapsed: false
+                        widget: object
+                        fields:
+                          - {
+                              label: "Header",
+                              name: "header",
+                              widget: "string",
+                              hint: "This question appears in the business profile",
+                            }
+                          - { label: "Radio Button Yes Text", name: "radioButtonTrueText", widget: "string" }
+                          - { label: "Radio Button No Text", name: "radioButtonFalseText", widget: "string" }
+                          - { label: "Description", name: "description", widget: "markdown", required: false }
                   - label: Home-Based Business
                     name: "homeBasedBusiness"
                     collapsed: true

--- a/web/src/components/data-fields/RenovationQuestion.tsx
+++ b/web/src/components/data-fields/RenovationQuestion.tsx
@@ -1,0 +1,6 @@
+import { RadioQuestion } from "@/components/data-fields/RadioQuestion";
+import { ReactElement } from "react";
+
+export const RenovationQuestion = (): ReactElement => {
+  return <RadioQuestion<boolean> fieldName={"plannedRenovationQuestion"} choices={[true, false]} />;
+};

--- a/web/src/lib/roadmap/buildUserRoadmap.test.ts
+++ b/web/src/lib/roadmap/buildUserRoadmap.test.ts
@@ -427,6 +427,57 @@ describe("buildUserRoadmap", () => {
       });
     });
 
+    describe("planned renovation", () => {
+      it("adds if homeBasedBusiness is false and planned renovation is true", async () => {
+        await buildUserRoadmap(
+          generateStartingProfile({ homeBasedBusiness: false, plannedRenovationQuestion: true })
+        );
+        expect(getLastCalledWith(mockRoadmapBuilder)[0].addOns).toContain("planned-renovation");
+      });
+
+      it("does NOT add if homeBasedBusiness is false and planned renovation is false", async () => {
+        await buildUserRoadmap(
+          generateStartingProfile({ homeBasedBusiness: false, plannedRenovationQuestion: false })
+        );
+        expect(getLastCalledWith(mockRoadmapBuilder)[0].addOns).not.toContain("planned-renovation");
+      });
+
+      it("does NOT add if homeBasedBusiness is true and planned renovation is true", async () => {
+        await buildUserRoadmap(
+          generateStartingProfile({ homeBasedBusiness: true, plannedRenovationQuestion: true })
+        );
+        expect(getLastCalledWith(mockRoadmapBuilder)[0].addOns).not.toContain("planned-renovation");
+      });
+
+      it("does NOT show if homeBasedBusiness is true and planned renovation is false", async () => {
+        await buildUserRoadmap(
+          generateStartingProfile({ homeBasedBusiness: true, plannedRenovationQuestion: false })
+        );
+        expect(getLastCalledWith(mockRoadmapBuilder)[0].addOns).not.toContain("planned-renovation");
+      });
+
+      it("does NOT add if homeBasedBusiness is undefined and planned renovation is undefined", async () => {
+        await buildUserRoadmap(
+          generateStartingProfile({ homeBasedBusiness: undefined, plannedRenovationQuestion: undefined })
+        );
+        expect(getLastCalledWith(mockRoadmapBuilder)[0].addOns).not.toContain("planned-renovation");
+      });
+
+      it("does NOT add if homeBasedBusiness is true and planned renovation is undefined", async () => {
+        await buildUserRoadmap(
+          generateStartingProfile({ homeBasedBusiness: true, plannedRenovationQuestion: undefined })
+        );
+        expect(getLastCalledWith(mockRoadmapBuilder)[0].addOns).not.toContain("planned-renovation");
+      });
+
+      it("does NOT add if homeBasedBusiness is false and planned renovation is undefined", async () => {
+        await buildUserRoadmap(
+          generateStartingProfile({ homeBasedBusiness: false, plannedRenovationQuestion: undefined })
+        );
+        expect(getLastCalledWith(mockRoadmapBuilder)[0].addOns).not.toContain("planned-renovation");
+      });
+    });
+
     describe("car service", () => {
       it("adds only the standard car service tasks to the roadmap if the user selects the standard choice", async () => {
         await buildUserRoadmap(

--- a/web/src/lib/roadmap/buildUserRoadmap.ts
+++ b/web/src/lib/roadmap/buildUserRoadmap.ts
@@ -106,6 +106,10 @@ const getIndustryBasedAddOns = (profileData: ProfileData, industryId: string | u
     addOns.push("home-based-transportation");
   }
 
+  if (profileData.homeBasedBusiness === false && profileData.plannedRenovationQuestion === true) {
+    addOns.push("planned-renovation");
+  }
+
   if (profileData.cannabisLicenseType === "ANNUAL") {
     addOns.push("cannabis-annual");
   }

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -16,6 +16,7 @@ import { NexusDBANameField } from "@/components/data-fields/NexusDBANameField";
 import { NonEssentialQuestionsSection } from "@/components/data-fields/non-essential-questions/NonEssentialQuestionsSection";
 import { Notes } from "@/components/data-fields/Notes";
 import { Ownership } from "@/components/data-fields/Ownership";
+import { RenovationQuestion } from "@/components/data-fields/RenovationQuestion";
 import { ResponsibleOwnerName } from "@/components/data-fields/ResponsibleOwnerName";
 import { Sectors } from "@/components/data-fields/Sectors";
 import { DisabledTaxId } from "@/components/data-fields/tax-id/DisabledTaxId";
@@ -77,7 +78,10 @@ import {
   ProfileData,
 } from "@businessnjgovnavigator/shared";
 import { hasCompletedFormation } from "@businessnjgovnavigator/shared/";
-import { isStartingBusiness } from "@businessnjgovnavigator/shared/domain-logic/businessPersonaHelpers";
+import {
+  isNexusBusiness,
+  isStartingBusiness,
+} from "@businessnjgovnavigator/shared/domain-logic/businessPersonaHelpers";
 import { nexusLocationInNewJersey } from "@businessnjgovnavigator/shared/domain-logic/nexusLocationInNewJersey";
 import dayjs from "dayjs";
 import deepEqual from "fast-deep-equal/es6/react";
@@ -292,6 +296,13 @@ const ProfilePage = (props: Props): ReactElement => {
     return isHomeBasedBusinessApplicable(profileData.industryId);
   };
 
+  const displayPlannedRenovationQuestionQuestion = (): boolean => {
+    return (
+      profileData.homeBasedBusiness === false &&
+      (isNexusBusiness(business) || profileData.businessPersona === "STARTING")
+    );
+  };
+
   const displayElevatorQuestion = (): boolean => {
     if (!business) return false;
     if (process.env.FEATURE_ELEVATOR_OWNING_BUSINESS !== "true") return false;
@@ -369,6 +380,16 @@ const ProfilePage = (props: Props): ReactElement => {
           boldAltDescription={true}
         >
           <HomeBasedBusiness />
+        </ProfileField>
+
+        <ProfileField
+          fieldName="plannedRenovationQuestion"
+          isVisible={displayPlannedRenovationQuestionQuestion()}
+          hideHeader={true}
+          displayAltDescription={true}
+          boldAltDescription={true}
+        >
+          <RenovationQuestion />
         </ProfileField>
 
         <ProfileField
@@ -555,6 +576,16 @@ const ProfilePage = (props: Props): ReactElement => {
           boldAltDescription={true}
         >
           <HomeBasedBusiness />
+        </ProfileField>
+
+        <ProfileField
+          fieldName="plannedRenovationQuestion"
+          isVisible={displayPlannedRenovationQuestionQuestion()}
+          hideHeader={true}
+          displayAltDescription={true}
+          boldAltDescription={true}
+        >
+          <RenovationQuestion />
         </ProfileField>
 
         <ProfileField

--- a/web/test/pages/profile/profile-shared.test.tsx
+++ b/web/test/pages/profile/profile-shared.test.tsx
@@ -174,6 +174,89 @@ describe("profile - shared", () => {
     ).toBeInTheDocument();
   });
 
+  it("should never show the non-essential planned renovation question for owning business, with homebase question as no", () => {
+    const business = generateBusinessForProfile({
+      profileData: generateProfileData({
+        industryId: randomHomeBasedIndustry(),
+        operatingPhase: "UP_AND_RUNNING_OWNING",
+        businessPersona: "OWNING",
+        homeBasedBusiness: false,
+      }),
+    });
+
+    renderPage({ business });
+
+    expect(
+      screen.queryByText(Config.profileDefaults.fields.plannedRenovationQuestion.default.description)
+    ).not.toBeInTheDocument();
+  });
+
+  it.each(nonOwningPersonas)(
+    "should show planned renovation question when home base question is no for %s",
+    async (businessPersona) => {
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          industryId: randomHomeBasedIndustry(),
+          operatingPhase: "UP_AND_RUNNING",
+          businessPersona: businessPersona,
+          homeBasedBusiness: false,
+          foreignBusinessTypeIds:
+            businessPersona === "FOREIGN" ? ["employeeOrContractorInNJ", "officeInNJ"] : [],
+        }),
+      });
+
+      renderPage({ business });
+
+      expect(
+        screen.getByText(Config.profileDefaults.fields.plannedRenovationQuestion.default.description)
+      ).toBeInTheDocument();
+    }
+  );
+
+  it.each(nonOwningPersonas)(
+    "should NOT show planned renovation question when home based question is yes for %s",
+    async (businessPersona) => {
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          industryId: randomHomeBasedIndustry(),
+          operatingPhase: "UP_AND_RUNNING",
+          businessPersona: businessPersona,
+          homeBasedBusiness: true,
+          foreignBusinessTypeIds:
+            businessPersona === "FOREIGN" ? ["employeeOrContractorInNJ", "officeInNJ"] : [],
+        }),
+      });
+
+      renderPage({ business });
+
+      expect(
+        screen.queryByText(Config.profileDefaults.fields.plannedRenovationQuestion.default.description)
+      ).not.toBeInTheDocument();
+    }
+  );
+
+  it.each(nonOwningPersonas)(
+    "should NOT show planned renovation question when home based question is undefined for %s",
+    async (businessPersona) => {
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          industryId: randomHomeBasedIndustry(),
+          operatingPhase: "UP_AND_RUNNING",
+          businessPersona: businessPersona,
+          homeBasedBusiness: undefined,
+          foreignBusinessTypeIds:
+            businessPersona === "FOREIGN" ? ["employeeOrContractorInNJ", "officeInNJ"] : [],
+        }),
+      });
+
+      renderPage({ business });
+
+      expect(
+        screen.queryByText(Config.profileDefaults.fields.plannedRenovationQuestion.default.description)
+      ).not.toBeInTheDocument();
+    }
+  );
+
   it("sends analytics when municipality entered for first time", async () => {
     const initialBusiness = generateBusinessForProfile({
       profileData: generateProfileData({
@@ -568,7 +651,7 @@ describe("profile - shared", () => {
   });
 
   describe("profile error alert", () => {
-    it.each(["STARTING", "FOREIGN"])(
+    it.each(nonOwningPersonas)(
       "displays alert with the header if industry field has an error when %s",
       async (businessPersona) => {
         const business = generateBusinessForProfile({


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

We wanted to have a profile question that rendered after you answered no to the home base business question call the planned rennovation question. 

If you answer no to the planned rennovation question it should render a "prepare for site rennovation" task on step 3 of your road map

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/185159231)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

- Go to profile as Nexus or Starting user
- answer no to the home base business question
- you should see a second question appear as a result of this (the planned renovation question)
- answer yes to this 
- click save
- on step 3 of your road map you should see the "prepare for site renovation" task


<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
