### PR TITLE
chore: [#187626599] Update Not-Registered-Existing-Account Nomenclature 

### DIFF
--- a/api/src/domain/updateSidebarCards.test.ts
+++ b/api/src/domain/updateSidebarCards.test.ts
@@ -12,8 +12,7 @@ import { getCurrentBusiness } from "@shared/domain-logic/getCurrentBusiness";
 import { SIDEBAR_CARDS } from "@shared/domain-logic/sidebarCards";
 import { OperatingPhaseId, OperatingPhases } from "@shared/index";
 
-const { formationNudge, fundingNudge, goToProfile, notRegistered, notRegisteredExistingAccount } =
-  SIDEBAR_CARDS;
+const { formationNudge, fundingNudge, goToProfile, notRegistered, notRegisteredUpAndRunning } = SIDEBAR_CARDS;
 
 describe("updateRoadmapSidebarCards", () => {
   describe("not registered card", () => {
@@ -36,21 +35,21 @@ describe("updateRoadmapSidebarCards", () => {
       expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain(formationNudge);
     });
 
-    it("removes not-registered-existing-account card and adds formation nudge card", async () => {
+    it("removes not-registered-up-and-running card and adds formation nudge card", async () => {
       const userData = generateUserDataForBusiness(
         generateBusiness({
           profileData: generateProfileData({
             operatingPhase: "NEEDS_TO_FORM",
           }),
           preferences: generatePreferences({
-            visibleSidebarCards: [notRegisteredExistingAccount],
+            visibleSidebarCards: [notRegisteredUpAndRunning],
           }),
         })
       );
 
       const updatedUserData = updateSidebarCards(userData);
       expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).not.toContain(
-        notRegisteredExistingAccount
+        notRegisteredUpAndRunning
       );
       expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain(formationNudge);
     });
@@ -75,21 +74,21 @@ describe("updateRoadmapSidebarCards", () => {
       expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain("other-card");
     });
 
-    it("leaves existing cards except for not-registered-existing-account when adding formation nudge card", async () => {
+    it("leaves existing cards except for not-registered-up-and-running when adding formation nudge card", async () => {
       const userData = generateUserDataForBusiness(
         generateBusiness({
           profileData: generateProfileData({
             operatingPhase: "NEEDS_TO_FORM",
           }),
           preferences: generatePreferences({
-            visibleSidebarCards: ["other-card", notRegisteredExistingAccount],
+            visibleSidebarCards: ["other-card", notRegisteredUpAndRunning],
           }),
         })
       );
 
       const updatedUserData = updateSidebarCards(userData);
       expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).not.toContain(
-        notRegisteredExistingAccount
+        notRegisteredUpAndRunning
       );
       expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain(formationNudge);
       expect(getCurrentBusiness(updatedUserData).preferences.visibleSidebarCards).toContain("other-card");

--- a/api/src/domain/updateSidebarCards.ts
+++ b/api/src/domain/updateSidebarCards.ts
@@ -29,8 +29,8 @@ export const updateSidebarCards: UpdateSidebarCards = (userData: UserData): User
     hideCard(SIDEBAR_CARDS.notRegistered);
   }
 
-  if (operatingPhase !== "GUEST_MODE" && cards.includes(SIDEBAR_CARDS.notRegisteredExistingAccount)) {
-    hideCard(SIDEBAR_CARDS.notRegisteredExistingAccount);
+  if (operatingPhase !== "GUEST_MODE" && cards.includes(SIDEBAR_CARDS.notRegisteredUpAndRunning)) {
+    hideCard(SIDEBAR_CARDS.notRegisteredUpAndRunning);
   }
 
   if (operatingPhase === "NEEDS_TO_FORM") {

--- a/content/src/display-content/roadmap-sidebar-cards/not-registered-up-and-running.md
+++ b/content/src/display-content/roadmap-sidebar-cards/not-registered-up-and-running.md
@@ -1,5 +1,5 @@
 ---
-id: not-registered-existing-account
+id: not-registered-up-and-running
 header: "Link Your myNewJersey Account"
 hasCloseButton: false
 ctaText: ""

--- a/shared/src/domain-logic/sidebarCards.ts
+++ b/shared/src/domain-logic/sidebarCards.ts
@@ -3,5 +3,5 @@ export const SIDEBAR_CARDS = {
   fundingNudge: "funding-nudge",
   goToProfile: "go-to-profile",
   notRegistered: "not-registered",
-  notRegisteredExistingAccount: "not-registered-existing-account",
+  notRegisteredUpAndRunning: "not-registered-up-and-running",
 };

--- a/web/src/components/dashboard/SidebarCardGeneric.tsx
+++ b/web/src/components/dashboard/SidebarCardGeneric.tsx
@@ -28,7 +28,7 @@ export const SidebarCardGeneric = (props: Props): ReactElement => {
     "formation-nudge": "primary-gradient",
     "funding-nudge": "primary-gradient-reverse",
     "go-to-profile": "secondary-gradient-reverse",
-    "not-registered-existing-account": "tertiary-gradient",
+    "not-registered-up-and-running": "tertiary-gradient",
     "not-registered": "tertiary-gradient-reverse",
   };
 

--- a/web/src/pages/dashboard.tsx
+++ b/web/src/pages/dashboard.tsx
@@ -77,13 +77,13 @@ const DashboardPage = (props: Props): ReactElement => {
       if (
         business?.profileData.operatingPhase === "GUEST_MODE_OWNING" &&
         business?.profileData.businessPersona === "OWNING" &&
-        !business.preferences.visibleSidebarCards.includes("not-registered-existing-account")
+        !business.preferences.visibleSidebarCards.includes("not-registered-up-and-running")
       ) {
         await updateQueue
           ?.queuePreferences({
             visibleSidebarCards: [
               ...business.preferences.visibleSidebarCards,
-              "not-registered-existing-account",
+              "not-registered-up-and-running",
             ],
           })
           .update();

--- a/web/test/pages/dashboard.test.tsx
+++ b/web/test/pages/dashboard.test.tsx
@@ -149,7 +149,7 @@ describe("dashboard page", () => {
     expect(currentBusiness().preferences.visibleSidebarCards).toContain(SIDEBAR_CARDS.notRegistered);
   });
 
-  it("renders not-registered-existing-account card when operatingPhase is GUEST_MODE_OWNING and businessPersona is OWNING", () => {
+  it("renders not-registered-up-and-running card when operatingPhase is GUEST_MODE_OWNING and businessPersona is OWNING", () => {
     const business = generateBusiness({
       profileData: generateProfileData({
         businessPersona: "OWNING",
@@ -161,7 +161,7 @@ describe("dashboard page", () => {
     });
     renderStatefulDashboardComponent(business);
     expect(currentBusiness().preferences.visibleSidebarCards).toContain(
-      SIDEBAR_CARDS.notRegisteredExistingAccount
+      SIDEBAR_CARDS.notRegisteredUpAndRunning
     );
   });
 


### PR DESCRIPTION


<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
The `notRegisteredExistingAccount` nomenclature is misleading: At first glance, it appears as though we already know users have an account with OIT and are nudging users to register. This change allows us to see that the business is already `up-and-running` and the user needs to register to further access the benefits of Business.NJ.gov.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#187626599](https://www.pivotaltracker.com/story/show/187626599)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
