### PR TITLE
Remove Redundancy in SidebarCardGeneric

### DIFF
--- a/web/src/components/dashboard/SidebarCard.tsx
+++ b/web/src/components/dashboard/SidebarCard.tsx
@@ -18,14 +18,7 @@ export const SidebarCard = (props: Props): ReactElement => {
         [SIDEBAR_CARDS.fundingNudge]: <SidebarCardFundingNudge card={props.card} />,
         [SIDEBAR_CARDS.formationNudge]: <SidebarCardFormationNudge card={props.card} />,
         [SIDEBAR_CARDS.goToProfile]: <SidebarCardGoToProfileNudge card={props.card} />,
-        default: (
-          <SidebarCardGeneric
-            card={props.card}
-            headerText={props.card.header}
-            bodyText={props.card.contentMd}
-            preBodySpanButtonText={props.card.preBodySpanButtonText}
-          />
-        ),
+        default: <SidebarCardGeneric card={props.card} />,
       })}
     </>
   );

--- a/web/src/components/dashboard/SidebarCardFormationNudge.tsx
+++ b/web/src/components/dashboard/SidebarCardFormationNudge.tsx
@@ -43,12 +43,7 @@ export const SidebarCardFormationNudge = (props: Props): ReactElement => {
         close={(): void => setModalOpen(false)}
         onSave={updateFormationDateAndTaskProgress}
       />
-      <SidebarCardGeneric
-        card={props.card}
-        bodyText={props.card.contentMd}
-        headerText={props.card.header}
-        ctaOnClick={onClick}
-      />
+      <SidebarCardGeneric card={props.card} ctaOnClick={onClick} />
     </>
   );
 };

--- a/web/src/components/dashboard/SidebarCardFundingNudge.tsx
+++ b/web/src/components/dashboard/SidebarCardFundingNudge.tsx
@@ -41,12 +41,7 @@ export const SidebarCardFundingNudge = (props: Props): ReactElement => {
         handleClose={(): void => setModalOpen(false)}
         onContinue={updateToUpAndRunningAndCompleteTaxTask}
       />
-      <SidebarCardGeneric
-        card={props.card}
-        headerText={props.card.header}
-        bodyText={props.card.contentMd}
-        ctaOnClick={onClick}
-      />
+      <SidebarCardGeneric card={props.card} ctaOnClick={onClick} />
     </>
   );
 };

--- a/web/src/components/dashboard/SidebarCardGeneric.tsx
+++ b/web/src/components/dashboard/SidebarCardGeneric.tsx
@@ -10,9 +10,6 @@ import { ModifiedContent } from "../ModifiedContent";
 
 type Props = {
   card: SidebarCardContent;
-  bodyText: string;
-  headerText: string | undefined;
-  preBodySpanButtonText?: string;
   preBodyButtonOnClick?: () => void;
   ctaOnClick?: () => void;
 };
@@ -50,12 +47,12 @@ export const SidebarCardGeneric = (props: Props): ReactElement => {
         className={`padding-3 radius-md margin-bottom-3 ${sideBarCardGradientBackground[props.card.id]}`}
         {...{ "data-testid": props.card.id }}
       >
-        {props.headerText && (
+        {props.card.header && (
           <div className="radius-top-md">
             <div className="flex flex-justify">
               <Heading level={3} className="margin-0-override text-white">
                 <span>
-                  <ModifiedContent>{props.headerText}</ModifiedContent>
+                  <ModifiedContent>{props.card.header}</ModifiedContent>
                 </span>
               </Heading>
               {props.card.hasCloseButton && (
@@ -71,7 +68,7 @@ export const SidebarCardGeneric = (props: Props): ReactElement => {
             !props.card.header && "radius-top-md"
           }`}
         >
-          {props.preBodySpanButtonText && (
+          {props.card.preBodySpanButtonText && (
             <div style={{ float: "left" }}>
               <UnStyledButton
                 isTextBold
@@ -79,13 +76,13 @@ export const SidebarCardGeneric = (props: Props): ReactElement => {
                 dataTestid={`${props.card.id}-preBodyButtonText`}
               >
                 <span className="text-white text-underline margin-right-05">
-                  {props.preBodySpanButtonText}
+                  {props.card.preBodySpanButtonText}
                 </span>
               </UnStyledButton>
             </div>
           )}
           <Content className="text-white display-inline anchor-element-text-white-override">
-            {props.bodyText}
+            {props.card.contentMd}
           </Content>
           {props.ctaOnClick && props.card.ctaText && (
             <div className="margin-top-205 flex flex-justify-center desktop:flex-justify-end">

--- a/web/src/components/dashboard/SidebarCardGoToProfileNudge.tsx
+++ b/web/src/components/dashboard/SidebarCardGoToProfileNudge.tsx
@@ -17,13 +17,5 @@ export const SidebarCardGoToProfileNudge = (props: Props): ReactElement => {
     router.push(ROUTES.profile);
   };
 
-  return (
-    <SidebarCardGeneric
-      card={props.card}
-      headerText={props.card.header}
-      bodyText={props.card.contentMd}
-      preBodySpanButtonText={"Go to your profile"}
-      preBodyButtonOnClick={onClick}
-    />
-  );
+  return <SidebarCardGeneric card={props.card} preBodyButtonOnClick={onClick} />;
 };

--- a/web/stories/Molecules/Cards/SideBarCards.stories.tsx
+++ b/web/stories/Molecules/Cards/SideBarCards.stories.tsx
@@ -19,37 +19,45 @@ type Story = StoryObj<typeof SidebarCardGeneric>;
 
 export const FormationNudge: Story = {
   args: {
-    card: generateSidebarCardContent({ id: "formation-nudge" }),
-    bodyText: "Formation Card Body Text",
-    headerText: "Formation Card",
+    card: generateSidebarCardContent({
+      id: "formation-nudge",
+      contentMd: "Formation Card Body Text",
+      header: "Formation Card",
+    }),
     ctaOnClick: () => {},
   },
 };
 
 export const FundingNudge: Story = {
   args: {
-    card: generateSidebarCardContent({ id: "funding-nudge" }),
-    bodyText: "Funding Card Body Text",
-    headerText: "Funding Card",
+    card: generateSidebarCardContent({
+      id: "funding-nudge",
+      contentMd: "Funding Card Body Text",
+      header: "Funding Card",
+    }),
     ctaOnClick: () => {},
   },
 };
 
 export const NotRegistered: Story = {
   args: {
-    card: generateSidebarCardContent({ id: "not-registered" }),
-    bodyText: "Not Registered",
-    headerText: "Not Registered",
+    card: generateSidebarCardContent({
+      id: "not-registered",
+      contentMd: "Not Registered",
+      header: "Not Registered",
+    }),
     ctaOnClick: () => {},
   },
 };
 
 export const GoToProfile: Story = {
   args: {
-    card: generateSidebarCardContent({ id: "go-to-profile" }),
-    bodyText: "Card Body Text",
-    headerText: "Go to Profile",
-    preBodySpanButtonText: "Go to Your Profile",
+    card: generateSidebarCardContent({
+      id: "go-to-profile",
+      contentMd: "Card Body Text",
+      header: "Go to Profile",
+      preBodySpanButtonText: "Go to Your Profile",
+    }),
     ctaOnClick: () => {},
   },
 };


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Small refactor opportunity I noticed while working on a renovate bot ticket. The `card` prop has all this data and most cases we're extracting them and passing them in as individual props.

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
