### PR TITLE
Reduce "Back" button clickable area

### DIFF
--- a/web/src/components/njwds-layout/BackButtonForLayout.tsx
+++ b/web/src/components/njwds-layout/BackButtonForLayout.tsx
@@ -18,7 +18,7 @@ export const BackButtonForLayout = (props: Props): ReactElement => {
         <a
           href={ROUTES.dashboard}
           data-testid="back-to-dashboard"
-          className="usa-link fdr fac margin-top-3 margin-bottom-3 usa-link-hover-override desktop:margin-top-0 desktop:margin-bottom-4"
+          className="usa-link fdr fac margin-top-3 margin-bottom-3 usa-link-hover-override desktop:margin-top-0 desktop:margin-bottom-4 width-max-content"
           onClick={analytics.event.task_back_to_roadmap.click.view_roadmap}
         >
           <div className="circle-3 bg-accent-cool-darkest icon-blue-bg-color-hover">


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

The "Back" button's clickable area fills the entire container width. Minimizing this to just wrap the content.

Before:
<img width="1411" alt="Screenshot 2024-05-21 at 5 33 00 PM" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22647707/16200aa4-03e8-41c8-a82d-68787abfad18">

After:
<img width="1432" alt="Screenshot 2024-05-21 at 5 33 08 PM" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22647707/f9936ce0-97cf-4636-b841-58ef5a9ef26e">

## Code author checklist

- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
