### PR TITLE
feat: [#187611847] enable landscape architecture license

### DIFF
--- a/api/src/domain/user/updateLicenseStatusFactory.test.ts
+++ b/api/src/domain/user/updateLicenseStatusFactory.test.ts
@@ -113,6 +113,7 @@ describe("updateLicenseStatus", () => {
       expect(resultCurrentBusiness.taskProgress["hvac-license"]).toEqual("NOT_STARTED");
       expect(resultCurrentBusiness.taskProgress["appraiser-license"]).toEqual("NOT_STARTED");
       expect(resultCurrentBusiness.taskProgress["public-accountant-license"]).toEqual("NOT_STARTED");
+      expect(resultCurrentBusiness.taskProgress["landscape-architect-license"]).toEqual("NOT_STARTED");
     }
   );
 
@@ -140,6 +141,7 @@ describe("updateLicenseStatus", () => {
     expect(resultCurrentBusiness.taskProgress["hvac-license"]).toEqual("IN_PROGRESS");
     expect(resultCurrentBusiness.taskProgress["appraiser-license"]).toEqual("IN_PROGRESS");
     expect(resultCurrentBusiness.taskProgress["public-accountant-license"]).toEqual("IN_PROGRESS");
+    expect(resultCurrentBusiness.taskProgress["landscape-architect-license"]).toEqual("IN_PROGRESS");
   });
 
   it("updates the license task status to COMPLETED when license is active", async () => {
@@ -161,5 +163,6 @@ describe("updateLicenseStatus", () => {
     expect(resultCurrentBusiness.taskProgress["hvac-license"]).toEqual("COMPLETED");
     expect(resultCurrentBusiness.taskProgress["appraiser-license"]).toEqual("COMPLETED");
     expect(resultCurrentBusiness.taskProgress["public-accountant-license"]).toEqual("COMPLETED");
+    expect(resultCurrentBusiness.taskProgress["landscape-architect-license"]).toEqual("COMPLETED");
   });
 });

--- a/api/src/domain/user/updateLicenseStatusFactory.ts
+++ b/api/src/domain/user/updateLicenseStatusFactory.ts
@@ -35,6 +35,7 @@ const update = (
       "architect-license": args.taskStatus,
       "hvac-license": args.taskStatus,
       "appraiser-license": args.taskStatus,
+      "landscape-architect-license": args.taskStatus,
     },
     licenseData: {
       nameAndAddress: args.nameAndAddress,

--- a/content/src/roadmaps/industries/landscape-architecture.json
+++ b/content/src/roadmaps/industries/landscape-architecture.json
@@ -63,9 +63,10 @@
     "canBeHomeBased": true,
     "canBeReseller": false
   },
-  "isEnabled": false,
+  "isEnabled": true,
   "additionalSearchTerms": "landscape architect, engineer, consulting, landscape architectural services",
   "id": "landscape-architecture",
+  "licenseType": "Landscape Architecture",
   "description": "Plans, designs, and oversees the construction of parks, gardens, playgrounds, and residential areas",
   "webflowId": "656a13628934eb2330f44bcb"
 }

--- a/web/src/components/TaskPageSwitchComponent.tsx
+++ b/web/src/components/TaskPageSwitchComponent.tsx
@@ -52,6 +52,9 @@ export const TaskPageSwitchComponent = ({
     "architect-license": <LicenseTask task={task} CMS_ONLY_disable_overlay={CMS_ONLY_disable_overlay} />,
     "hvac-license": <LicenseTask task={task} CMS_ONLY_disable_overlay={CMS_ONLY_disable_overlay} />,
     "appraiser-license": <LicenseTask task={task} CMS_ONLY_disable_overlay={CMS_ONLY_disable_overlay} />,
+    "landscape-architect-license": (
+      <LicenseTask task={task} CMS_ONLY_disable_overlay={CMS_ONLY_disable_overlay} />
+    ),
     "elevator-registration": (
       <ElevatorRegistrationTask task={task} CMS_ONLY_disable_overlay={CMS_ONLY_disable_overlay} />
     ),

--- a/web/test/pages/taskUrlSlug.test.tsx
+++ b/web/test/pages/taskUrlSlug.test.tsx
@@ -226,6 +226,7 @@ describe("task page", () => {
       "public-accountant-license",
       "register-accounting-firm",
       "register-consumer-affairs",
+      "landscape-architect-license",
     ])("loads License task screen for %s", (licenseId) => {
       renderPage(generateTask({ id: licenseId }), generateBusiness({ licenseData: undefined }));
       expect(screen.getByTestId("cta-secondary")).toBeInTheDocument();


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

Given I am a Poppy or Dakota and I am in the Landscape Architecture industry
When accessing the license task in the roadmap
Then I can check the status of my license with Consumer Affairs Dynamics system

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[#187611847](https://www.pivotaltracker.com/story/show/187611847)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

1. Access the site as a Poppy or Dakota as a Landscape Architecture (industry).
2. Click the Apply for a Landscape Architect License in the roadmap.
4. Enter the contact information for an expired business.
5. Go back to the dashboard.
6. Click the Deadlines and Opportunities card and complete the information in the modal.
7. Click the Funding Opportunities card.

The quick action tiles will appear on the dashboard.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
