### PR TITLE
fix: [#187652148] resolved issues with see your tax due dates modals

### DIFF
--- a/content/src/fieldConfig/tax-access-modal.json
+++ b/content/src/fieldConfig/tax-access-modal.json
@@ -1,6 +1,8 @@
 {
   "taxAccess": {
-    "body": "To see your tax due dates, you'll first need to select your business structure.",
+    "stepOneBody": "To see your tax due dates, you'll first need to select your business structure.",
+    "stepTwoBody": "To access your tax records, we need to verify your information and get you access to New Jersey Department of Treasury's Gov2Go platform.",
+    "legalStructureDropDownHeader": "**What is your `business structure|business-structure-learn-more`?**",
     "modalResponsibleOwnerFieldErrorName": "Responsible Owner Name",
     "stepTwoNextButton": "Save",
     "modalTaxIdHeader": " `New Jersey Tax ID|tax-id`",

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -2922,14 +2922,20 @@ collections:
             widget: object
             fields:
               - { label: Modal Header, name: modalHeader, widget: text }
+              - {
+                  label: Legal Structure Drop Down Header,
+                  name: legalStructureDropDownHeader,
+                  widget: markdown,
+                }
               - { label: Step 1 Header, name: stepOneHeader, widget: text }
-              - { label: Step 2 Header, name: stepTwoHeader, widget: text }
-              - { label: Body, name: body, widget: markdown }
+              - { label: Step 1 Body, name: stepOneBody, widget: markdown }
               - { label: Step 1 Next Button, name: stepOneNextButton, widget: text }
+              - { label: Step 1 Error Banner, name: stepOneErrorBanner, widget: text }
+              - { label: Step 2 Header, name: stepTwoHeader, widget: text }
+              - { label: Step 2 Body, name: stepTwoBody, widget: markdown }
               - { label: Step 2 Next Button, name: stepTwoNextButton, widget: text }
               - { label: Step 2 Back Button, name: stepTwoBackButton, widget: text }
               - { label: Step 2 Cancel Button, name: stepTwoCancelButton, widget: text }
-              - { label: Step 1 Error Banner, name: stepOneErrorBanner, widget: text }
               - { label: Step 2 Error Banner, name: stepTwoErrorBanner, widget: text }
               - { label: BusinessName Field Header, name: modalBusinessFieldHeader, widget: markdown }
               - {

--- a/web/src/components/filings-calendar/tax-access-modal/TaxAccessModal.test.tsx
+++ b/web/src/components/filings-calendar/tax-access-modal/TaxAccessModal.test.tsx
@@ -49,7 +49,7 @@ describe("<TaxAccessModal />", () => {
       expect(screen.queryByText(Config.taxAccess.stepOneHeader)).not.toBeInTheDocument();
       expect(screen.queryByText(Config.taxAccess.stepTwoHeader)).not.toBeInTheDocument();
       expect(screen.queryByText(Config.taxAccess.stepTwoBackButton)).not.toBeInTheDocument();
-      expect(screen.getByText(Config.taxAccess.body)).toBeInTheDocument();
+      expect(screen.getByText(Config.taxAccess.stepTwoBody)).toBeInTheDocument();
       expect(screen.getByText(Config.taxAccess.stepTwoCancelButton)).toBeInTheDocument();
       expect(screen.getByLabelText("Tax id")).toBeInTheDocument();
     });
@@ -70,9 +70,10 @@ describe("<TaxAccessModal />", () => {
     it("shows step 1 question to choose a legal structure", () => {
       renderModal(undefinedLegalStructureBusiness);
       expect(screen.getByText(Config.taxAccess.stepOneHeader)).toBeInTheDocument();
-      expect(screen.getByText(Config.taxAccess.body)).toBeInTheDocument();
+      expect(screen.getByText(Config.taxAccess.stepOneBody)).toBeInTheDocument();
       expect(screen.getByLabelText("Business structure")).toBeInTheDocument();
       expect(screen.queryByText(Config.taxAccess.stepTwoHeader)).not.toBeInTheDocument();
+      expect(screen.queryByText(Config.taxAccess.stepTwoBody)).not.toBeInTheDocument();
     });
 
     it("does not save selection when closing modal", () => {
@@ -129,8 +130,9 @@ describe("<TaxAccessModal />", () => {
         })
       );
       expect(screen.queryByText(Config.taxAccess.stepOneHeader)).not.toBeInTheDocument();
+      expect(screen.queryByText(Config.taxAccess.stepOneBody)).not.toBeInTheDocument();
       expect(screen.getByText(Config.taxAccess.stepTwoHeader)).toBeInTheDocument();
-      expect(screen.getByText(Config.taxAccess.body)).toBeInTheDocument();
+      expect(screen.getByText(Config.taxAccess.stepTwoBody)).toBeInTheDocument();
       expect(screen.queryByLabelText("Business structure")).not.toBeInTheDocument();
     });
 
@@ -144,7 +146,9 @@ describe("<TaxAccessModal />", () => {
       );
       fireEvent.click(screen.getByText(Config.taxAccess.stepTwoBackButton));
       expect(screen.getByText(Config.taxAccess.stepOneHeader)).toBeInTheDocument();
+      expect(screen.getByText(Config.taxAccess.stepOneBody)).toBeInTheDocument();
       expect(screen.queryByText(Config.taxAccess.stepTwoHeader)).not.toBeInTheDocument();
+      expect(screen.queryByText(Config.taxAccess.stepTwoBody)).not.toBeInTheDocument();
       expect(screen.getByLabelText("Business structure")).toBeInTheDocument();
     });
   });

--- a/web/src/components/filings-calendar/tax-access-modal/TaxAccessModalBody.tsx
+++ b/web/src/components/filings-calendar/tax-access-modal/TaxAccessModalBody.tsx
@@ -23,7 +23,7 @@ export const TaxAccessModalBody = (props: Props): ReactElement => {
             {getHeader()}
           </Heading>
         )}
-        <Content>{Config.taxAccess.body}</Content>
+        <Content>{props.isStepOne ? Config.taxAccess.stepOneBody : Config.taxAccess.stepTwoBody}</Content>
       </div>
       <hr className="margin-y-4" />
     </>

--- a/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepOne.tsx
+++ b/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepOne.tsx
@@ -1,3 +1,4 @@
+import { Content } from "@/components/Content";
 import { FieldLabelDescriptionOnly } from "@/components/field-labels/FieldLabelDescriptionOnly";
 import { TaxAccessModalBody } from "@/components/filings-calendar/tax-access-modal/TaxAccessModalBody";
 import { LegalStructureDropDown } from "@/components/LegalStructureDropDown";
@@ -77,6 +78,7 @@ export const TaxAccessStepOne = (props: Props): ReactElement => {
         >
           <WithErrorBar hasError={!isValid()} type="ALWAYS">
             <FieldLabelDescriptionOnly fieldName="legalStructureId" bold={true} />
+            <Content>{Config.taxAccess.legalStructureDropDownHeader}</Content>
             <LegalStructureDropDown />
           </WithErrorBar>
         </ProfileDataContext.Provider>


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Having some issues with header missing and various conditional text not being renders in our tax modals

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

[Replace with ticket_id](https://www.pivotaltracker.com/story/show/187652148)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

As Oscar click on the show tax calendar or get access to tax calendar button. Go through modal steps and confirm that all drop downs have headers/titles, also that copy changes between steps. 

As Poppy or Dakota, form and then click the get access to tax calendar button. see that copy have Gov2Go text insides (see ticket for more details)

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
