### PR TITLE
chore: encourage ticket ID replacement

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 
 <!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->
 
-[Replace with ticket_id](https://www.pivotaltracker.com/story/show/)
+This pull request resolves [#00000000](https://www.pivotaltracker.com/story/show/00000000).
 
 ### Approach
 


### PR DESCRIPTION
## Description

Based on conversation I'm having with Anne in an internal ticket, I'm proposing a solution so that we don't have to see "replace with ticket_id" in our pull request descriptions.

This uses [closing keywords](https://docs.github.com/articles/closing-issues-using-keywords) even though they're not relevant to us as we use Pivotal Tracker, but this aligns us with other teams that use GitHub Issues.