### PR TITLE
Add script to help manage releases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pathspec==0.12.1
 platformdirs==4.2.1
 pycparser==2.22
 PyYAML==6.0.1
+requests==2.32.3

--- a/scripts/release-helper.py
+++ b/scripts/release-helper.py
@@ -1,0 +1,73 @@
+import os
+import re
+import subprocess
+
+import requests
+
+# Replace with Pivotal Tracker API token and project ID in local environment
+API_TOKEN = os.getenv('PIVOTAL_TRACKER_API_TOKEN')  # https://www.pivotaltracker.com/profile
+PROJECT_ID = os.getenv('PIVOTAL_TRACKER_PROJECT_ID')  # Found in the URL of the Pivotal Tracker project
+
+if not API_TOKEN or not PROJECT_ID:
+    raise EnvironmentError("Please set the PIVOTAL_TRACKER_API_TOKEN and PIVOTAL_TRACKER_PROJECT_ID environment variables.")
+
+def get_all_iteration_stories():
+    headers = {'X-TrackerToken': API_TOKEN}
+    stories = []
+    offset = 0
+    limit = 100  # Pivotal Tracker's default page size
+
+    while True:
+        url = f'https://www.pivotaltracker.com/services/v5/projects/{PROJECT_ID}/iterations?scope=current_backlog&offset={offset}&limit={limit}'
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        iterations = response.json()
+
+        for iteration in iterations:
+            stories.extend(iteration['stories'])
+
+        if len(iterations) < limit:
+            break
+        offset += limit
+
+    return stories
+
+def filter_non_done_tickets(stories):
+    return [story for story in stories if story['current_state'] != 'accepted']
+
+def get_commit_history():
+    result = subprocess.run(['git', 'log', '--pretty=format:%H %s'], stdout=subprocess.PIPE)
+    return result.stdout.decode('utf-8').split('\n')
+
+def find_commit_id_to_return(commit_history, non_done_ticket_ids):
+    blocking_commits = []
+    for line in commit_history:
+        commit_id, commit_message = line.split(' ', 1)
+        ticket_id_match = re.search(r'#(\d+)', commit_message)
+        if ticket_id_match:
+            ticket_id = ticket_id_match.group(1)
+            if ticket_id in non_done_ticket_ids:
+                blocking_commits.append(commit_id)
+
+    if blocking_commits:
+        latest_blocking_commit_index = commit_history.index([line for line in commit_history if blocking_commits[-1] in line][0])
+        return commit_history[latest_blocking_commit_index + 1].split(' ', 1)[0]
+
+    return commit_history[0].split(' ', 1)[0]
+
+def main():
+    iteration_stories = get_all_iteration_stories()
+    non_done_tickets = filter_non_done_tickets(iteration_stories)
+    non_done_ticket_ids = {str(ticket['id']) for ticket in non_done_tickets}
+
+    if not non_done_ticket_ids:
+        result = subprocess.run(['git', 'rev-parse', 'HEAD'], stdout=subprocess.PIPE)
+        print(result.stdout.decode('utf-8').strip())
+        return
+
+    commit_history = get_commit_history()
+    commit_id = find_commit_id_to_return(commit_history, non_done_ticket_ids)
+    print(commit_id)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Our team follows a trunk-based development paradigm. This means that all work is merged into main when completed. This main branch is then deployed to the `dev` environment where acceptance is completed. In the case where the most recent accepted ticket is not the `HEAD` of the main branch, we need to cut a release behind that point in time. This is currently a manual process where we review the Pivotal Tracker backlog and git log to find a commit ID that is a safe point of release. You can read our [Release Process](https://docs.google.com/document/d/1fJok1iZYrIg8Os3TJ2f07d0JRJIbW5QSKZ0eQ8yqA8s) for a more indepth explanation.

This script intends to help automate the process of checking for a safe point of release.

### Ticket

This pull request resolves [#187259660](https://www.pivotaltracker.com/story/show/187259660).

### Approach

- Script makes an API request to Pivotal Tracker, gets all tickets in the current iteration/backlog column
- Filters tickets that are not done
- Iterates over commit history and compares commit messages to ticket IDs
- If blocking commits are found, return the previous commit

This does consider an edge case where multiple commits reference a single ticket.
This **_does not_** consider multiple Pivotal Tracker project boards.

### Steps to Test

Build a Python venv if you do not already have one in the project

```bash
python3 -m venv venv
source venv/bin/activate
```

Install dependencies (this also adds the Requests library to requirements.txt)

```bash
pip install requirements.txt
```

To keep our secrets safe, the API token and Pivotal Tracker project ID must be added as environment variables in your shell. References to the locations of these values can be found in the script file.

```bash
export API_TOKEN=XXXXX 
export PIVOTAL_TRACKER_PROJECT_ID=XXXXX
``` 

Run the script

```bash
python3 scripts/release-helper.py
```

The script should output a commit ID that is a safe point of release.

### Notes

I tested this locally using this PT ticket as a point of consideration.

Case where a single commit is blocking release:
<img width="725" alt="Screenshot 2024-05-30 at 10 46 26 AM" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22647707/0aa7a3ab-9509-40c7-b4b9-511f454b46f1">

<img width="862" alt="Screenshot 2024-05-30 at 10 46 47 AM" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22647707/0df777cb-9333-42f6-9bb1-72b2c122c7af">

Case where multiple commits are blocking release:
<img width="714" alt="Screenshot 2024-05-30 at 11 01 50 AM" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22647707/93f3b5b4-5f8c-410e-8d4a-f60491798245">

<img width="862" alt="Screenshot 2024-05-30 at 10 46 47 AM" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22647707/0df777cb-9333-42f6-9bb1-72b2c122c7af">
(yes, this is the same output screenshot, it works but I wasn't going to take 2 screenshots of the same thing)

## Code author checklist

- [X] I have performed a self-review of my code
- [ ] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
