### PR TITLE
chore: [#187194184] add profile address

### DIFF
--- a/content/src/fieldConfig/profile.json
+++ b/content/src/fieldConfig/profile.json
@@ -81,6 +81,67 @@
           "description": "Enter your Last Name, First Name and Middle Initial. The name must match exactly the name listed on your tax confirmation email."
         }
       },
+      "addressLine1": {
+        "default": {
+          "header": "Address Line 1"
+        },
+        "label": "Address Line 1",
+        "error": "Enter your business's street name and number."
+      },
+      "addressLine2": {
+        "default": {
+          "header": "Address Line 2"
+        },
+        "label": "Address Line 2",
+        "error": ""
+      },
+      "addressCity": {
+        "default": {
+          "header": "City"
+        },
+        "label": "City",
+        "error": "Enter a city."
+      },
+      "addressProvince": {
+        "default": {
+          "header": "Province"
+        },
+        "label": "Province",
+        "error": "Enter a Province."
+      },
+      "addressZipCode": {
+        "default": {
+          "header": "Zip Code"
+        },
+        "label": "Zip Code",
+        "error": "Enter a NJ Zip Code.",
+        "foreign": {
+          "label": "Postal Code",
+          "errorUS": "Enter a 5 digit Zip Code.",
+          "errorIntl": "Enter a 1 to 11 digit Postal Code."
+        }
+      },
+      "addressState": {
+        "default": {
+          "header": "State"
+        },
+        "label": "State",
+        "error": "Enter a state."
+      },
+      "addressMunicipality": {
+        "default": {
+          "header": "City"
+        },
+        "label": "City",
+        "error": "Select a city.",
+        "infoAlert": "**Can't find your city?** Unincorporated places are not listed here. Search for [your official jurisdiction](https://www.nj.gov/nj/gov/county/localities.html) (type in your community's name into the local name field)."
+      },
+      "general": {
+        "default": {},
+        "optionalLabel": "(Optional)",
+        "partialAddressErrorText": "Address must be complete.",
+        "maximumLengthErrorText": "${field} must be ${maxLen} characters or fewer."
+      },
       "nexusBusinessName": {
         "default": {
           "editButton": "Edit",
@@ -391,6 +452,11 @@
           "description": "Are you looking to start an appraisal management company?"
         }
       }
+    },
+    "general": {
+      "default": {},
+      "partialAddressErrorText": "Address must be complete.",
+      "maximumLengthErrorText": "${field} must be ${maxLen} characters or fewer."
     },
     "default": {
       "lockedFieldTooltipText": "This information cannot be changed because it was submitted to the NJ Department of Treasury.",

--- a/shared/src/userData.ts
+++ b/shared/src/userData.ts
@@ -1,8 +1,11 @@
 import { BusinessUser } from "./businessUser";
+import { CountriesShortCodes } from "./countries";
 import { createBusinessId } from "./domain-logic/createBusinessId";
 import { createEmptyFormationFormData, FormationData } from "./formationData";
 import { LicenseData } from "./license";
+import { Municipality } from "./municipality";
 import { createEmptyProfileData, ProfileData } from "./profileData";
+import { StateObject } from "./states";
 import { TaxFilingData } from "./taxFiling";
 
 export interface UserData {
@@ -27,6 +30,33 @@ export interface Business {
   readonly preferences: Preferences;
   readonly taxFilingData: TaxFilingData;
   readonly formationData: FormationData;
+}
+
+export interface Address {
+  readonly addressLine1: string;
+  readonly addressLine2: string;
+  readonly addressCity?: string | undefined;
+  readonly addressState?: StateObject;
+  readonly addressMunicipality?: Municipality;
+  readonly addressProvince?: string;
+  readonly addressZipCode: string;
+  readonly addressCountry: CountriesShortCodes | undefined;
+  readonly businessLocationType: string | undefined;
+}
+
+export interface AddressTextFields {
+  readonly addressLine1: string;
+  readonly addressLine2: string;
+  readonly addressCity?: string | undefined;
+  readonly addressProvince?: string;
+  readonly addressZipCode: string;
+}
+
+export interface AddressValidFields {
+  readonly addressLine1: string;
+  readonly addressLine2: string;
+  readonly addressCity?: string | undefined;
+  readonly addressZipCode: string;
 }
 
 export const CURRENT_VERSION = 135;
@@ -71,6 +101,19 @@ export const createEmptyBusiness = (id?: string): Business => {
   };
 };
 
+export const createEmptyAddress = (): Address => {
+  return {
+    addressLine1: "",
+    addressLine2: "",
+    addressCity: "",
+    addressMunicipality: undefined,
+    addressState: undefined,
+    addressZipCode: "",
+    addressCountry: undefined,
+    businessLocationType: undefined,
+  };
+};
+
 export const createEmptyUserData = (user: BusinessUser): UserData => {
   const businessId = createBusinessId();
   return {
@@ -85,6 +128,10 @@ export const createEmptyUserData = (user: BusinessUser): UserData => {
     },
   };
 };
+
+export type AddressTextField = keyof AddressTextFields;
+export type AddressFields = keyof Address;
+export type FieldsForAddressErrorHandling = keyof Address;
 
 export const sectionNames = ["PLAN", "START"] as const;
 export type SectionType = (typeof sectionNames)[number];

--- a/web/src/components/profile/ProfileAddressField.test.tsx
+++ b/web/src/components/profile/ProfileAddressField.test.tsx
@@ -1,0 +1,143 @@
+import { ProfileAddressField } from "@/components/profile/ProfileAddressField";
+import { WithStatefulAddressData } from "@/test/mock/withStatefulAddressData";
+import { generateFormationNJAddress } from "@businessnjgovnavigator/shared/test";
+import { Address } from "@businessnjgovnavigator/shared/userData";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+describe("<ProfileAddressField  />", () => {
+  const renderComponent = (address: Address): void => {
+    render(
+      <WithStatefulAddressData initialData={address}>
+        <ProfileAddressField />
+      </WithStatefulAddressData>
+    );
+  };
+
+  describe("profile address field", () => {
+    it("render profile address line 1 field with input value", () => {
+      const address = generateFormationNJAddress({
+        addressLine1: "1111 Home Alone",
+        addressMunicipality: {
+          displayName: "Newark Display Name",
+          name: "Newark",
+          county: "some-county-1",
+          id: "some-id-1",
+        },
+      });
+      renderComponent(address);
+      expect(screen.getByLabelText("Address line1")).toBeInTheDocument();
+      expect((screen.getByLabelText("Address line1") as HTMLInputElement).value).toEqual("1111 Home Alone");
+    });
+
+    it("profile address line 1 reflects changed value", () => {
+      const address = generateFormationNJAddress({
+        addressLine1: "1111 Home Alone",
+        addressMunicipality: {
+          displayName: "Newark Display Name",
+          name: "Newark",
+          county: "some-county-1",
+          id: "some-id-1",
+        },
+      });
+      renderComponent(address);
+      const addressField = screen.getByLabelText("Address line1");
+      fireEvent.change(addressField, { target: { value: "2222 South Avenue" } });
+      expect((screen.getByLabelText("Address line1") as HTMLInputElement).value).toEqual("2222 South Avenue");
+    });
+
+    it("render profile address line 2 field with input value", () => {
+      const address = generateFormationNJAddress({
+        addressLine2: "1111 Home Avenue",
+        addressMunicipality: {
+          displayName: "Newark Display Name",
+          name: "Newark",
+          county: "some-county-1",
+          id: "some-id-1",
+        },
+      });
+      renderComponent(address);
+      expect(screen.getByLabelText("Address line2")).toBeInTheDocument();
+      expect((screen.getByLabelText("Address line2") as HTMLInputElement).value).toEqual("1111 Home Avenue");
+    });
+
+    it("profile address line 2 reflects changed value", () => {
+      const address = generateFormationNJAddress({
+        addressLine2: "1111 Home Avenue",
+        addressMunicipality: {
+          displayName: "Newark Display Name",
+          name: "Newark",
+          county: "some-county-1",
+          id: "some-id-1",
+        },
+      });
+      renderComponent(address);
+      const addressField = screen.getByLabelText("Address line2");
+      fireEvent.change(addressField, { target: { value: "2222 North Avenue" } });
+      expect((screen.getByLabelText("Address line2") as HTMLInputElement).value).toEqual("2222 North Avenue");
+    });
+
+    it("render profile address zip code field with input value", () => {
+      const address = generateFormationNJAddress({
+        addressZipCode: "08437",
+        addressMunicipality: {
+          displayName: "Newark Display Name",
+          name: "Newark",
+          county: "some-county-1",
+          id: "some-id-1",
+        },
+      });
+      renderComponent(address);
+      expect(screen.getByLabelText("Address zip code")).toBeInTheDocument();
+      expect((screen.getByLabelText("Address zip code") as HTMLInputElement).value).toEqual("08437");
+    });
+
+    it("profile address zip code reflects changed value", () => {
+      const address = generateFormationNJAddress({
+        addressZipCode: "08437",
+        addressMunicipality: {
+          displayName: "Newark Display Name",
+          name: "Newark",
+          county: "some-county-1",
+          id: "some-id-1",
+        },
+      });
+      renderComponent(address);
+      const addressField = screen.getByLabelText("Address zip code");
+      fireEvent.change(addressField, { target: { value: "08123" } });
+      expect((screen.getByLabelText("Address zip code") as HTMLInputElement).value).toEqual("08123");
+    });
+
+    it("render profile address state field with input value", () => {
+      const address = generateFormationNJAddress({
+        addressState: { shortCode: "NJ", name: "New Jersey" },
+        addressMunicipality: {
+          displayName: "Newark Display Name",
+          name: "Newark",
+          county: "some-county-1",
+          id: "some-id-1",
+        },
+      });
+
+      renderComponent(address);
+      expect(screen.getByLabelText("Address state")).toBeInTheDocument();
+      expect((screen.getByLabelText("Address state") as HTMLInputElement).value).toEqual("NJ");
+    });
+
+    it("render profile address municipality field with input value", () => {
+      const address = generateFormationNJAddress({
+        addressMunicipality: {
+          displayName: "Newark Display Name",
+          name: "Newark",
+          county: "some-county-1",
+          id: "some-id-1",
+        },
+      });
+
+      renderComponent(address);
+      expect(screen.getByLabelText("Address municipality")).toBeInTheDocument();
+      expect((screen.getByLabelText("Address municipality") as HTMLInputElement).value).toEqual(
+        "Newark Display Name"
+      );
+    });
+  });
+});

--- a/web/src/components/profile/ProfileAddressField.tsx
+++ b/web/src/components/profile/ProfileAddressField.tsx
@@ -1,0 +1,118 @@
+import { ModifiedContent } from "@/components/ModifiedContent";
+import { StateDropdown } from "@/components/StateDropdown";
+import { WithErrorBar } from "@/components/WithErrorBar";
+import { ProfileAddressTextField } from "@/components/profile/ProfileAddressTextField";
+import { ProfileMunicipality } from "@/components/profile/ProfileMunicipality";
+import { AddressContext } from "@/contexts/addressContext";
+import { useAddressErrors } from "@/lib/data-hooks/useAddressErrors";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { useUserData } from "@/lib/data-hooks/useUserData";
+import { useMountEffectWhenDefined } from "@/lib/utils/helpers";
+import { isOwningBusiness } from "@businessnjgovnavigator/shared/domain-logic/businessPersonaHelpers";
+import { ReactElement, useContext } from "react";
+
+export const ProfileAddressField = (): ReactElement => {
+  const { Config } = useConfig();
+  const { setAddressData } = useContext(AddressContext);
+  const { doSomeFieldsHaveError, doesFieldHaveError, getFieldErrorLabel } = useAddressErrors();
+  const { business } = useUserData();
+
+  useMountEffectWhenDefined(() => {
+    if (business && isOwningBusiness(business)) {
+      setAddressData({
+        addressLine1: business.formationData.formationFormData.addressLine1,
+        addressLine2: business.formationData.formationFormData.addressLine2,
+        addressCity: business.formationData.formationFormData.addressCity,
+        addressMunicipality: business.formationData.formationFormData.addressMunicipality,
+        addressState: { name: "New Jersey", shortCode: "NJ" },
+        addressZipCode: business.formationData.formationFormData.addressZipCode,
+        addressCountry: "US",
+        addressProvince: business.formationData.formationFormData.addressProvince,
+        businessLocationType: business.formationData.formationFormData.businessLocationType,
+      });
+    }
+  }, business);
+
+  return (
+    <>
+      <>
+        <div id={`question-addressLine1`} className="text-field-width-default add-spacing-on-ele-scroll">
+          <ProfileAddressTextField
+            label={Config.profileDefaults.fields.addressLine1.label}
+            fieldName="addressLine1"
+            required={true}
+            validationText={getFieldErrorLabel("addressLine1")}
+            className={"margin-bottom-2"}
+            errorBarType="ALWAYS"
+          />
+        </div>
+
+        <div id={`question-addressLine2`} className="text-field-width-default add-spacing-on-ele-scroll">
+          <ProfileAddressTextField
+            label={Config.profileDefaults.fields.addressLine2.label}
+            secondaryLabel={Config.profileDefaults.fields.general.optionalLabel}
+            errorBarType="ALWAYS"
+            fieldName="addressLine2"
+            validationText={getFieldErrorLabel("addressLine2")}
+            className="margin-bottom-2"
+          />
+        </div>
+        <WithErrorBar
+          hasError={doSomeFieldsHaveError(["addressState", "addressZipCode", "addressMunicipality"])}
+          type="DESKTOP-ONLY"
+        >
+          <div className="grid-row grid-gap-1">
+            <div className="grid-col-12 tablet:grid-col-7">
+              <WithErrorBar hasError={doesFieldHaveError("addressMunicipality")} type="MOBILE-ONLY">
+                <span className="text-bold">{Config.profileDefaults.fields.addressMunicipality.label}</span>
+                <ProfileMunicipality />
+              </WithErrorBar>
+            </div>
+            <div className="grid-col-12 tablet:grid-col-5 margin-top-2 tablet:margin-top-0">
+              <WithErrorBar
+                hasError={doSomeFieldsHaveError(["addressState", "addressZipCode"])}
+                type="MOBILE-ONLY"
+              >
+                <div className="grid-row grid-gap-1">
+                  <div className="grid-col-2">
+                    <strong>
+                      <ModifiedContent>{Config.profileDefaults.fields.addressState.label}</ModifiedContent>
+                    </strong>
+                    <div
+                      id={`question-addressState`}
+                      className="text-field-width-default add-spacing-on-ele-scroll"
+                    >
+                      <StateDropdown
+                        fieldName="addressState"
+                        value={"New Jersey"}
+                        validationText={Config.profileDefaults.fields.addressState.error}
+                        disabled={true}
+                        onSelect={(): void => {}}
+                      />
+                    </div>
+                  </div>
+                  <div className="grid-col-4">
+                    <div
+                      id={`question-addressZipCode`}
+                      className="text-field-width-default add-spacing-on-ele-scroll"
+                    >
+                      <ProfileAddressTextField
+                        label={Config.profileDefaults.fields.addressZipCode.label}
+                        numericProps={{ maxLength: 5 }}
+                        required={true}
+                        errorBarType="NEVER"
+                        validationText={getFieldErrorLabel("addressZipCode")}
+                        fieldName={"addressZipCode"}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </WithErrorBar>
+            </div>
+          </div>
+        </WithErrorBar>
+        <hr aria-hidden={true} />
+      </>
+    </>
+  );
+};

--- a/web/src/components/profile/ProfileAddressTextField.test.tsx
+++ b/web/src/components/profile/ProfileAddressTextField.test.tsx
@@ -1,0 +1,43 @@
+import { ProfileAddressTextField } from "@/components/profile/ProfileAddressTextField";
+import { WithStatefulAddressData } from "@/test/mock/withStatefulAddressData";
+import { generateFormationNJAddress } from "@businessnjgovnavigator/shared/test";
+import { Address, AddressTextField, createEmptyAddress } from "@businessnjgovnavigator/shared/userData";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
+jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
+
+describe("<ProfileAddressTextField  />", () => {
+  const renderComponent = (fieldName: AddressTextField, addressData?: Address): void => {
+    render(
+      <WithStatefulAddressData initialData={addressData || createEmptyAddress()}>
+        <ProfileAddressTextField fieldName={fieldName} errorBarType={"ALWAYS"} />
+      </WithStatefulAddressData>
+    );
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("when rendering a profile address text field", () => {
+    it("rendering profile text field", () => {
+      const addressData = generateFormationNJAddress({
+        addressLine1: "1111 Add Avenue",
+      });
+      renderComponent("addressLine1", addressData);
+      expect(screen.getByLabelText("Address line1")).toBeInTheDocument();
+      expect((screen.getByLabelText("Address line1") as HTMLInputElement).value).toEqual("1111 Add Avenue");
+    });
+
+    it("reflecting text field change", () => {
+      const addressData = generateFormationNJAddress({
+        addressLine1: "1111 Add Avenue",
+      });
+      renderComponent("addressLine1", addressData);
+      const addressField = screen.getByLabelText("Address line1");
+      fireEvent.change(addressField, { target: { value: "2222 South Avenue" } });
+      expect((screen.getByLabelText("Address line1") as HTMLInputElement).value).toEqual("2222 South Avenue");
+    });
+  });
+});

--- a/web/src/components/profile/ProfileAddressTextField.tsx
+++ b/web/src/components/profile/ProfileAddressTextField.tsx
@@ -1,0 +1,52 @@
+import { GenericTextField, GenericTextFieldProps } from "@/components/GenericTextField";
+import { ModifiedContent } from "@/components/ModifiedContent";
+import { WithErrorBar } from "@/components/WithErrorBar";
+import { AddressContext } from "@/contexts/addressContext";
+import { ProfileFormContext } from "@/contexts/profileFormContext";
+import { useAddressErrors } from "@/lib/data-hooks/useAddressErrors";
+import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
+import { AddressTextField } from "@businessnjgovnavigator/shared/index";
+import { ReactElement, useContext } from "react";
+
+export interface Props extends Omit<GenericTextFieldProps, "value" | "fieldName" | "error" | "inputWidth"> {
+  fieldName: AddressTextField;
+  label?: string;
+  secondaryLabel?: string;
+  errorBarType: "ALWAYS" | "MOBILE-ONLY" | "DESKTOP-ONLY" | "NEVER";
+}
+
+export const ProfileAddressTextField = ({ className, ...props }: Props): ReactElement => {
+  const { state, setAddressData, setFieldsInteracted } = useContext(AddressContext);
+  const { doesFieldHaveError } = useAddressErrors();
+  const { setIsValid } = useFormContextFieldHelpers(props.fieldName, ProfileFormContext);
+
+  const handleChange = (value: string): void => {
+    props.handleChange && props.handleChange(value);
+    setAddressData((addressData) => ({ ...addressData, [props.fieldName]: value }));
+  };
+
+ const onValidation = (): void => {
+   setIsValid(!doesFieldHaveError(props.fieldName));
+   setFieldsInteracted([props.fieldName]);
+  };
+
+  const hasError = doesFieldHaveError(props.fieldName);
+  return (
+    <WithErrorBar className={className ?? ""} hasError={hasError} type={props.errorBarType}>
+      {props.label && (
+        <strong>
+          <ModifiedContent>{props.label}</ModifiedContent>
+        </strong>
+      )}
+      {props.secondaryLabel && <span className="margin-left-1">{props.secondaryLabel}</span>}
+      <GenericTextField
+        inputWidth={"full"}
+        value={state.addressData[props.fieldName]}
+        onValidation={onValidation}
+        {...props}
+        handleChange={handleChange}
+        error={hasError}
+      />
+    </WithErrorBar>
+  );
+};

--- a/web/src/components/profile/ProfileField.tsx
+++ b/web/src/components/profile/ProfileField.tsx
@@ -16,6 +16,7 @@ interface Props {
   noLabel?: boolean;
   hideHeader?: boolean;
   boldAltDescription?: boolean;
+  isHrVisible?: boolean;
 }
 
 export const ProfileField = (props: Props): ReactElement => {

--- a/web/src/components/profile/ProfileMunicipality.test.tsx
+++ b/web/src/components/profile/ProfileMunicipality.test.tsx
@@ -1,0 +1,52 @@
+import { WithStatefulAddressData } from "@/test/mock/withStatefulAddressData";
+import {render, screen} from "@testing-library/react";
+import {generateFormationNJAddress} from "@businessnjgovnavigator/shared/test";
+import {Address, createEmptyAddress} from "@businessnjgovnavigator/shared/userData";
+import {ProfileMunicipality} from "@/components/profile/ProfileMunicipality";
+
+jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
+jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
+
+describe("<ProfileMunicipality  />", () => {
+  const renderComponent = (addressData?: Address): void => {
+    render(
+      <WithStatefulAddressData initialData={addressData|| createEmptyAddress()}>
+        <ProfileMunicipality />
+      </WithStatefulAddressData>
+    );
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("when rendering a profile municipality dropdown", () => {
+    it("rendering profile municipality dropdown", () => {
+      const address =
+        generateFormationNJAddress({
+          addressMunicipality: {
+            displayName: 'Newark Display Name',
+            name: 'Newark',
+            county: 'some-county-1',
+            id: 'some-id-1'
+          },
+        });
+      renderComponent(address);
+      expect(screen.getByLabelText("Address municipality")).toBeInTheDocument();
+    });
+
+    it("rendering profile municipality dropdown when clicked value changes", () => {
+      const address =
+        generateFormationNJAddress({
+          addressMunicipality: {
+            displayName: 'Newark Display Name',
+            name: 'Newark',
+            county: 'some-county-1',
+            id: 'some-id-1'
+          },
+        });
+      renderComponent(address);
+      expect(screen.getByLabelText("Address municipality")).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/components/profile/ProfileMunicipality.tsx
+++ b/web/src/components/profile/ProfileMunicipality.tsx
@@ -1,0 +1,32 @@
+import { MunicipalityDropdown } from "@/components/data-fields/MunicipalityDropdown";
+import { AddressContext } from "@/contexts/addressContext";
+import { MunicipalitiesContext } from "@/contexts/municipalitiesContext";
+import { useAddressErrors } from "@/lib/data-hooks/useAddressErrors";
+import { Municipality } from "@businessnjgovnavigator/shared/municipality";
+import { ReactElement, useContext } from "react";
+
+export const ProfileMunicipality = (): ReactElement => {
+  const { state, setAddressData, setFieldsInteracted } = useContext(AddressContext);
+  const { municipalities } = useContext(MunicipalitiesContext);
+  const { doesFieldHaveError, getFieldErrorLabel } = useAddressErrors();
+
+  const onSelect = (value: Municipality | undefined): void => {
+    setAddressData((previousAddressData) => {
+      return { ...previousAddressData, addressMunicipality: value };
+    });
+  };
+
+  console.log("logggggs profile munnnnnn");
+  return (
+    <MunicipalityDropdown
+      onValidation={(): void => setFieldsInteracted(["addressMunicipality"])}
+      municipalities={municipalities}
+      fieldName={"addressMunicipality"}
+      error={doesFieldHaveError("addressMunicipality")}
+      validationLabel="Error"
+      value={state.addressData.addressMunicipality}
+      onSelect={onSelect}
+      helperText={getFieldErrorLabel("addressMunicipality")}
+    />
+  );
+};

--- a/web/src/components/tasks/business-formation/getErrorStateForAddressField.test.ts
+++ b/web/src/components/tasks/business-formation/getErrorStateForAddressField.test.ts
@@ -1,0 +1,224 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getErrorStateForAddressField } from "@/components/tasks/business-formation/getErrorStateForAddressField";
+import { generateMunicipality } from "@businessnjgovnavigator/shared";
+
+describe("getErrorStateForAddressField", () => {
+  describe("addressLine1", () => {
+    it("has error max length exceeds 35 characters", () => {
+      const address = {
+        businessLocationType: "NJ",
+        addressLine1: "abcdefghijklmnopqrstuvwxyz12345678910",
+        addressLine2: "",
+        addressCity: "",
+        addressMunicipality: undefined,
+        addressState: undefined,
+        addressZipCode: "",
+        addressCountry: undefined,
+      };
+      expect(
+        getErrorStateForAddressField({
+          field: "addressLine1",
+          addressData: address,
+        }).hasError
+      ).toEqual(true);
+    });
+
+    it("does not have error if under max length of 35 characters", () => {
+      const address = {
+        businessLocationType: "NJ",
+        addressLine1: "abcdefghijklmnopqrstuvwxyz",
+        addressLine2: "",
+        addressCity: "",
+        addressMunicipality: undefined,
+        addressState: undefined,
+        addressZipCode: "",
+        addressCountry: undefined,
+      };
+      expect(
+        getErrorStateForAddressField({
+          field: "addressLine1",
+          addressData: address,
+        }).hasError
+      ).toEqual(false);
+    });
+  });
+
+  describe("addressLine2", () => {
+    it("has error max length exceeds 35 characters", () => {
+      const address = {
+        businessLocationType: "NJ",
+        addressLine1: "324234",
+        addressLine2: "abcdefghijklmnopqrstuvwxyz12345678910",
+        addressCity: "",
+        addressMunicipality: undefined,
+        addressState: undefined,
+        addressZipCode: "",
+        addressCountry: undefined,
+      };
+      expect(
+        getErrorStateForAddressField({
+          field: "addressLine2",
+          addressData: address,
+        }).hasError
+      ).toEqual(true);
+    });
+
+    it("does not have error if under max length of 35 characters", () => {
+      const address = {
+        businessLocationType: "NJ",
+        addressLine1: "324234",
+        addressLine2: "abcdefghijklmnopqrstuvwxyz",
+        addressCity: "",
+        addressMunicipality: undefined,
+        addressState: undefined,
+        addressZipCode: "",
+        addressCountry: undefined,
+      };
+      expect(
+        getErrorStateForAddressField({
+          field: "addressLine2",
+          addressData: address,
+        }).hasError
+      ).toEqual(false);
+    });
+  });
+
+  describe("addressZipCode", () => {
+    it("has error if less than 5 digits", () => {
+      const address = {
+        businessLocationType: "NJ",
+        addressLine1: "324234",
+        addressLine2: "abcdefghijklmnopqrstuvwxyz",
+        addressCity: "",
+        addressMunicipality: undefined,
+        addressState: undefined,
+        addressZipCode: "123",
+        addressCountry: undefined,
+      };
+      expect(
+        getErrorStateForAddressField({
+          field: "addressZipCode",
+          addressData: address,
+        }).hasError
+      ).toEqual(true);
+    });
+
+    it("has error if not NJ zip code", () => {
+      const address = {
+        businessLocationType: "NJ",
+        addressLine1: "",
+        addressLine2: "",
+        addressCity: "",
+        addressMunicipality: undefined,
+        addressState: undefined,
+        addressZipCode: "01234",
+        addressCountry: undefined,
+      };
+      expect(
+        getErrorStateForAddressField({
+          field: "addressZipCode",
+          addressData: address,
+        }).hasError
+      ).toEqual(true);
+    });
+
+    it("does not have error if valid NJ zip code", () => {
+      const address = {
+        businessLocationType: "NJ",
+        addressLine1: "",
+        addressLine2: "",
+        addressCity: "",
+        addressMunicipality: undefined,
+        addressState: undefined,
+        addressZipCode: "08123",
+        addressCountry: undefined,
+      };
+      expect(
+        getErrorStateForAddressField({
+          field: "addressZipCode",
+          addressData: address,
+        }).hasError
+      ).toEqual(false);
+    });
+  });
+
+  describe("addressLine1, addressZipCode, addressMunicipality", () => {
+    it("has error if addressLine1 is filled out and no address municipality and no address zip code", () => {
+      const address = {
+        businessLocationType: "NJ",
+        addressLine1: "abcdefghijklmnopqrstuvwxyz",
+        addressLine2: "",
+        addressCity: "",
+        addressState: undefined,
+        addressMunicipality: undefined,
+        addressZipCode: "",
+        addressCountry: undefined,
+      };
+      expect(
+        getErrorStateForAddressField({
+          field: "addressMunicipality",
+          addressData: address,
+        }).hasError
+      ).toEqual(true);
+
+      expect(
+        getErrorStateForAddressField({
+          field: "addressZipCode",
+          addressData: address,
+        }).hasError
+      ).toEqual(true);
+    });
+
+    it("has error if address municipality is filled out and no address line 1 and no address zip code", () => {
+      const address = {
+        businessLocationType: "NJ",
+        addressLine1: "",
+        addressLine2: "",
+        addressCity: "",
+        addressState: undefined,
+        addressMunicipality: generateMunicipality({}),
+        addressZipCode: "",
+        addressCountry: undefined,
+      };
+      expect(
+        getErrorStateForAddressField({
+          field: "addressLine1",
+          addressData: address,
+        }).hasError
+      ).toEqual(true);
+
+      expect(
+        getErrorStateForAddressField({
+          field: "addressZipCode",
+          addressData: address,
+        }).hasError
+      ).toEqual(true);
+    });
+
+    it("has error if address zip code is filled out and no address line 1 and no address municipality", () => {
+      const address = {
+        businessLocationType: "NJ",
+        addressLine1: "",
+        addressLine2: "",
+        addressCity: "",
+        addressState: undefined,
+        addressMunicipality: undefined,
+        addressZipCode: "08212",
+        addressCountry: undefined,
+      };
+      expect(
+        getErrorStateForAddressField({
+          field: "addressLine1",
+          addressData: address,
+        }).hasError
+      ).toEqual(true);
+
+      expect(
+        getErrorStateForAddressField({
+          field: "addressMunicipality",
+          addressData: address,
+        }).hasError
+      ).toEqual(true);
+    });
+  });
+});

--- a/web/src/components/tasks/business-formation/getErrorStateForAddressField.ts
+++ b/web/src/components/tasks/business-formation/getErrorStateForAddressField.ts
@@ -1,0 +1,143 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { getMergedConfig } from "@/contexts/configContext";
+import { isZipCodeIntl } from "@/lib/domain-logic/isZipCodeIntl";
+import { isZipCodeNj } from "@/lib/domain-logic/isZipCodeNj";
+import { isZipCodeUs } from "@/lib/domain-logic/isZipCodeUs";
+import { AddressFieldErrorState } from "@/lib/types/types";
+import { templateEval } from "@/lib/utils/helpers";
+import { Address, AddressFields, FieldsForAddressErrorHandling } from "@businessnjgovnavigator/shared";
+
+export const getErrorStateForAddressField = (inputParams: {
+  field: FieldsForAddressErrorHandling;
+  addressData: Address;
+}): AddressFieldErrorState => {
+  const Config = getMergedConfig();
+  const { field, addressData } = inputParams;
+
+  const errorState = {
+    field: field,
+    label: (Config.profileDefaults.fields as any)[field].label,
+  };
+
+  const fieldWithMaxLength = (params: { required: boolean; maxLen: number }): AddressFieldErrorState => {
+    const exists = !!addressData[field];
+    const isTooLong = (addressData[field] as string)?.length > params.maxLen;
+    let label = errorState.label;
+    const isValid = params.required ? exists && !isTooLong : !isTooLong;
+    if (params.required && !exists) {
+      label = (Config.profileDefaults.fields as any)[field].error;
+    } else if (isTooLong) {
+      label = templateEval(Config.profileDefaults.fields.general.maximumLengthErrorText, {
+        field: (Config.profileDefaults.fields as any)[field].label,
+        maxLen: params.maxLen.toString(),
+      });
+    }
+    return { ...errorState, label, hasError: !isValid };
+  };
+
+  const fieldWithAssociatedFields = (params: {
+    associatedFields: AddressFields[];
+    label: string;
+  }): AddressFieldErrorState => {
+    const exists = !!addressData[field];
+    const anAssociatedFieldExists = params.associatedFields.some((it) => !!addressData[it]);
+
+    let label = errorState.label;
+    let isValid = true;
+
+    if (!exists && anAssociatedFieldExists) {
+      label = params.label;
+      isValid = false;
+    }
+
+    return { ...errorState, label, hasError: !isValid };
+  };
+
+  const combineErrorStates = (params: {
+    firstPriority: AddressFieldErrorState;
+    secondPriority: AddressFieldErrorState;
+  }): AddressFieldErrorState => {
+    let finalState: AddressFieldErrorState = { ...errorState, hasError: false };
+
+    if (params.secondPriority.hasError) {
+      finalState = params.secondPriority;
+    }
+
+    if (params.firstPriority.hasError) {
+      finalState = params.firstPriority;
+    }
+
+    return finalState;
+  };
+
+  const isForeignUser = (): boolean => {
+    return addressData.businessLocationType !== "NJ";
+  };
+
+  if (field === "addressLine1") {
+    if (isForeignUser() && addressData.businessLocationType !== undefined) {
+      return fieldWithMaxLength({ required: true, maxLen: 35 });
+    }
+
+    const maxLengthError = fieldWithMaxLength({ required: false, maxLen: 35 });
+    const partialAddressError = fieldWithAssociatedFields({
+      associatedFields: ["addressMunicipality", "addressZipCode"],
+      label: Config.profileDefaults.fields.general.partialAddressErrorText,
+    });
+
+    return combineErrorStates({ firstPriority: maxLengthError, secondPriority: partialAddressError });
+  }
+
+  if (field === "addressLine2") {
+    return fieldWithMaxLength({ required: false, maxLen: 35 });
+  }
+
+  if (field === "addressCity") {
+    return fieldWithMaxLength({ required: true, maxLen: 30 });
+  }
+
+  if (field === "addressMunicipality") {
+    return fieldWithAssociatedFields({
+      associatedFields: ["addressLine1", "addressZipCode"],
+      label: Config.profileDefaults.fields.general.partialAddressErrorText,
+    });
+  }
+
+  if (field === "addressProvince") {
+    return fieldWithMaxLength({ required: true, maxLen: 30 });
+  }
+
+  if (field === "addressZipCode") {
+    const exists = !!addressData[field];
+    let inRange = false;
+
+    if (isForeignUser() && addressData.businessLocationType !== undefined) {
+      switch (addressData.businessLocationType) {
+        case "US":
+          inRange = isZipCodeUs(addressData[field]);
+          break;
+        case "INTL":
+          inRange = isZipCodeIntl(addressData[field]);
+          break;
+      }
+      const isValid = exists && inRange;
+      return { ...errorState, hasError: !isValid, label: Config.profileDefaults.fields.addressZipCode.error };
+    }
+
+    const partialAddressError = fieldWithAssociatedFields({
+      associatedFields: ["addressMunicipality", "addressLine1"],
+      label: Config.profileDefaults.fields.general.partialAddressErrorText,
+    });
+    inRange = isZipCodeNj(addressData[field]);
+    const hasError = exists && !inRange;
+    const inRangeError = {
+      ...errorState,
+      hasError: hasError,
+      label: Config.profileDefaults.fields.addressZipCode.error,
+    };
+    return combineErrorStates({ firstPriority: inRangeError, secondPriority: partialAddressError });
+  }
+
+  return { ...errorState, hasError: false };
+};

--- a/web/src/components/tasks/business-formation/validatedFieldsForAddress.test.ts
+++ b/web/src/components/tasks/business-formation/validatedFieldsForAddress.test.ts
@@ -1,0 +1,57 @@
+import { validatedFieldsForAddress } from "@/components/tasks/business-formation/validatedFieldsForAddress";
+import { Address, AddressFields, FieldsForAddressErrorHandling } from "@businessnjgovnavigator/shared";
+
+describe("validatedFieldsForAddress", () => {
+  const validatedFields: FieldsForAddressErrorHandling[] = [
+    "addressLine1",
+    "addressMunicipality",
+    "addressState",
+    "addressZipCode",
+  ];
+
+  const foreignValidatedFields: AddressFields[] = ["addressCity"];
+
+  describe("addressFields", () => {
+    it("required validated fields for NJ", () => {
+      const address = {
+        businessLocationType: "NJ",
+        addressLine1: "addressLine1",
+        addressLine2: "addressLine2",
+        addressZipCode: "08261",
+        addressCountry: "US",
+      } as Address;
+      const expected: FieldsForAddressErrorHandling[] = [...validatedFields];
+      expected.push("addressMunicipality");
+      expect(validatedFieldsForAddress(address)).toEqual(expect.arrayContaining(expected));
+    });
+
+    it("required validated field for INTL", () => {
+      const address = {
+        businessLocationType: "INTL",
+        addressLine1: "addressLine1",
+        addressLine2: "addressLine2",
+        addressZipCode: "08261",
+        addressCountry: "US",
+      } as Address;
+      const expected: FieldsForAddressErrorHandling[] = [
+        ...validatedFields,
+        ...foreignValidatedFields,
+        "addressProvince",
+        "addressCountry",
+      ];
+      expect(validatedFieldsForAddress(address)).toEqual(expect.arrayContaining(expected));
+    });
+
+    it("required validated field for US", () => {
+      const address = {
+        businessLocationType: "US",
+        addressLine1: "addressLine1",
+        addressLine2: "addressLine2",
+        addressZipCode: "08261",
+        addressCountry: "US",
+      } as Address;
+      const expected: FieldsForAddressErrorHandling[] = [...validatedFields, ...foreignValidatedFields];
+      expect(validatedFieldsForAddress(address)).toEqual(expect.arrayContaining(expected));
+    });
+  });
+});

--- a/web/src/components/tasks/business-formation/validatedFieldsForAddress.ts
+++ b/web/src/components/tasks/business-formation/validatedFieldsForAddress.ts
@@ -1,0 +1,29 @@
+import {
+  Address,
+  AddressFields,
+  FieldsForAddressErrorHandling,
+} from "@businessnjgovnavigator/shared/userData";
+
+export const validatedFieldsForAddress = (addressData: Address): FieldsForAddressErrorHandling[] => {
+  let validatedFields: FieldsForAddressErrorHandling[] = [
+    "addressLine1",
+    "addressMunicipality",
+    "addressState",
+    "addressZipCode",
+  ];
+
+  const foreignValidatedFields: AddressFields[] = ["addressCity"];
+
+  switch (addressData.businessLocationType) {
+    case "US":
+      validatedFields = [...validatedFields, ...foreignValidatedFields];
+      break;
+    case "INTL":
+      validatedFields = [...validatedFields, ...foreignValidatedFields, "addressProvince", "addressCountry"];
+      break;
+    case "NJ":
+      validatedFields.push("addressMunicipality");
+  }
+
+  return validatedFields;
+};

--- a/web/src/contexts/addressContext.ts
+++ b/web/src/contexts/addressContext.ts
@@ -1,0 +1,29 @@
+import { FormContextType } from "@/contexts/formContext";
+import { ProfileFields, ReducedFieldStates } from "@/lib/types/types";
+import { Address, FieldsForAddressErrorHandling, createEmptyAddress } from "@businessnjgovnavigator/shared";
+import { createContext } from "react";
+
+interface AddressState {
+  addressData: Address;
+  interactedFields: FieldsForAddressErrorHandling[];
+  formContextState: FormContextType<ReducedFieldStates<ProfileFields, unknown>, unknown>;
+}
+
+interface AddressContextType {
+  state: AddressState;
+  setAddressData: React.Dispatch<React.SetStateAction<Address>>;
+  setFieldsInteracted: (
+    fields: FieldsForAddressErrorHandling[],
+    config?: { setToUninteracted: boolean }
+ ) => void;
+}
+
+export const AddressContext = createContext<AddressContextType>({
+  state: {
+    addressData: createEmptyAddress(),
+    interactedFields: [],
+    formContextState: {} as FormContextType<ReducedFieldStates<ProfileFields, unknown>, unknown>,
+  },
+  setAddressData: () => {},
+  setFieldsInteracted: () => {},
+});

--- a/web/src/lib/data-hooks/useAddressErrors.tsx
+++ b/web/src/lib/data-hooks/useAddressErrors.tsx
@@ -1,0 +1,59 @@
+import { getErrorStateForAddressField } from "@/components/tasks/business-formation/getErrorStateForAddressField";
+import { validatedFieldsForAddress } from "@/components/tasks/business-formation/validatedFieldsForAddress";
+import { AddressContext } from "@/contexts/addressContext";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { AddressFields, FieldsForAddressErrorHandling } from "@businessnjgovnavigator/shared/userData";
+import { useContext, useMemo } from "react";
+
+type AddressErrorsResponse = {
+  doesFieldHaveError: (field: FieldsForAddressErrorHandling) => boolean;
+  doSomeFieldsHaveError: (fields: AddressFields[]) => boolean;
+  getFieldErrorLabel: (field: AddressFields) => string;
+};
+
+export const useAddressErrors = (): AddressErrorsResponse => {
+  const { Config } = useConfig();
+  const { state } = useContext(AddressContext);
+
+  const validatedFields = useMemo((): FieldsForAddressErrorHandling[] => {
+    return validatedFieldsForAddress(state.addressData);
+  }, [state.addressData]);
+
+  const doesFieldHaveError = (field: FieldsForAddressErrorHandling): boolean => {
+    if (!validatedFields.includes(field)) {
+      return false;
+    }
+
+    const addressFieldErrorState = getErrorStateForAddressField({
+      field,
+      addressData: state.addressData,
+    });
+    state.formContextState.fieldStates[field].invalid =
+      addressFieldErrorState.hasError && state.interactedFields.includes(field);
+
+    state.formContextState.fieldStates[field].updated = true;
+    return addressFieldErrorState.hasError;
+  };
+
+  const doSomeFieldsHaveError = (fields: AddressFields[]): boolean => {
+    return fields
+      .filter((field) => {
+        return validatedFields.includes(field);
+      })
+      .some((field) => {
+        if (field === "addressState") return false;
+        return doesFieldHaveError(field);
+      });
+  };
+
+  const getFieldErrorLabel = (field: AddressFields): string => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (Config.profileDefaults.fields as any)[field].error;
+  };
+
+  return {
+    doesFieldHaveError,
+    doSomeFieldsHaveError,
+    getFieldErrorLabel,
+  };
+};

--- a/web/src/lib/types/types.ts
+++ b/web/src/lib/types/types.ts
@@ -1,6 +1,7 @@
 import { getMergedConfig } from "@/contexts/configContext";
 import { ContextualInfo } from "@/contexts/contextualInfoContext";
 import {
+  Address,
   BusinessPersona,
   BusinessUser,
   emptyBusinessUser,
@@ -20,7 +21,7 @@ import {
   UserData,
 } from "@businessnjgovnavigator/shared/";
 import { LicenseEventSubtype } from "@businessnjgovnavigator/shared/taxFiling";
-import { Business } from "@businessnjgovnavigator/shared/userData";
+import { Business, FieldsForAddressErrorHandling } from "@businessnjgovnavigator/shared/userData";
 
 // returns all keys in an object of a type
 // e.g. KeysOfType<Task, boolean> will give all keys in the Task that have boolean types
@@ -81,6 +82,12 @@ export type FormationFieldErrorState = {
   label: string;
 };
 
+export type AddressFieldErrorState = {
+  field: FieldsForAddressErrorHandling;
+  hasError: boolean;
+  label: string;
+};
+
 export const profileFieldsFromConfig = getMergedConfig().profileDefaults.fields;
 
 export type ProfileContentField = Exclude<
@@ -88,7 +95,7 @@ export type ProfileContentField = Exclude<
   "businessPersona"
 >;
 
-export type ProfileFields = keyof ProfileData | keyof BusinessUser;
+export type ProfileFields = keyof ProfileData | keyof BusinessUser | keyof Address;
 
 export type FieldErrorType = undefined | unknown;
 

--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -1,4 +1,3 @@
-import { UserDataErrorAlert } from "@/components/UserDataErrorAlert";
 import { NavBar } from "@/components/navbar/NavBar";
 import { Alert } from "@/components/njwds-extended/Alert";
 import { SnackbarAlert } from "@/components/njwds-extended/SnackbarAlert";
@@ -8,11 +7,11 @@ import { DevOnlySkipOnboardingButton } from "@/components/onboarding/DevOnlySkip
 import { OnboardingButtonGroup } from "@/components/onboarding/OnboardingButtonGroup";
 import { onboardingFlows as onboardingFlowObject } from "@/components/onboarding/OnboardingFlows";
 import { ReturnToPreviousBusinessBar } from "@/components/onboarding/ReturnToPreviousBusinessBar";
+import { UserDataErrorAlert } from "@/components/UserDataErrorAlert";
 import { AuthContext } from "@/contexts/authContext";
 import { MunicipalitiesContext } from "@/contexts/municipalitiesContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { ProfileFormContext } from "@/contexts/profileFormContext";
-import { MediaQueries } from "@/lib/PageSizes";
 import * as api from "@/lib/api-client/apiClient";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -23,15 +22,16 @@ import { hasEssentialQuestion } from "@/lib/domain-logic/essentialQuestions";
 import { getNextSeoTitle } from "@/lib/domain-logic/getNextSeoTitle";
 import { modifyContent } from "@/lib/domain-logic/modifyContent";
 import { QUERIES, QUERY_PARAMS_VALUES, ROUTES, routeShallowWithQuery } from "@/lib/domain-logic/routes";
+import { MediaQueries } from "@/lib/PageSizes";
 import { loadAllMunicipalities } from "@/lib/static/loadMunicipalities";
 import {
+  createProfileFieldErrorMap,
   FlowType,
   OnboardingErrors,
   OnboardingStatus,
   Page,
   ProfileError,
   UpdateQueue,
-  createProfileFieldErrorMap,
 } from "@/lib/types/types";
 import analytics from "@/lib/utils/analytics";
 import {
@@ -39,7 +39,7 @@ import {
   setAnalyticsDimensions,
   setRegistrationDimension,
 } from "@/lib/utils/analytics-helpers";
-import { OnboardingStatusLookup, getFlow, scrollToTop } from "@/lib/utils/helpers";
+import { getFlow, OnboardingStatusLookup, scrollToTop } from "@/lib/utils/helpers";
 import {
   evalHeaderStepsTemplate,
   flowQueryParamIsValid,
@@ -51,12 +51,12 @@ import {
 } from "@/lib/utils/onboardingPageHelpers";
 import { determineForeignBusinessType } from "@businessnjgovnavigator/shared";
 import {
+  createEmptyProfileData,
+  createEmptyUserData,
   Municipality,
   ProfileData,
   TaskProgress,
   UserData,
-  createEmptyProfileData,
-  createEmptyUserData,
 } from "@businessnjgovnavigator/shared/";
 import { createEmptyUser } from "@businessnjgovnavigator/shared/businessUser";
 import { isRemoteWorkerOrSellerBusiness } from "@businessnjgovnavigator/shared/domain-logic/businessPersonaHelpers";

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -34,6 +34,7 @@ import { SidebarPageLayout } from "@/components/njwds-layout/SidebarPageLayout";
 import { SingleColumnContainer } from "@/components/njwds/SingleColumnContainer";
 import { PageCircularIndicator } from "@/components/PageCircularIndicator";
 import { DevOnlyResetUserDataButton } from "@/components/profile/DevOnlyResetUserDataButton";
+import { ProfileAddressField } from "@/components/profile/ProfileAddressField";
 import { ProfileDocuments } from "@/components/profile/ProfileDocuments";
 import { ProfileErrorAlert } from "@/components/profile/ProfileErrorAlert";
 import { ProfileEscapeModal } from "@/components/profile/ProfileEscapeModal";
@@ -46,6 +47,7 @@ import { ProfileTabHeader } from "@/components/profile/ProfileTabHeader";
 import { ProfileTabNav } from "@/components/profile/ProfileTabNav";
 import { TaxDisclaimer } from "@/components/TaxDisclaimer";
 import { UserDataErrorAlert } from "@/components/UserDataErrorAlert";
+import { AddressContext } from "@/contexts/addressContext";
 import { getMergedConfig } from "@/contexts/configContext";
 import { MunicipalitiesContext } from "@/contexts/municipalitiesContext";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
@@ -64,20 +66,23 @@ import { createProfileFieldErrorMap, OnboardingStatus, profileTabs, ProfileTabs 
 import analytics from "@/lib/utils/analytics";
 import { getFlow, useMountEffectWhenDefined, useScrollToPathAnchor } from "@/lib/utils/helpers";
 import {
+  Address,
   Business,
   BusinessPersona,
   createEmptyProfileData,
   determineForeignBusinessType,
   einTaskId,
+  FieldsForAddressErrorHandling,
   ForeignBusinessType,
   formationTaskId,
+  generateFormationNJAddress,
+  hasCompletedFormation,
   LookupLegalStructureById,
   LookupOperatingPhaseById,
   Municipality,
   naicsCodeTaskId,
   ProfileData,
 } from "@businessnjgovnavigator/shared";
-import { hasCompletedFormation } from "@businessnjgovnavigator/shared/";
 import {
   isNexusBusiness,
   isStartingBusiness,
@@ -89,7 +94,6 @@ import { GetStaticPropsResult } from "next";
 import { NextSeo } from "next-seo";
 import { useRouter } from "next/router";
 import { ReactElement, ReactNode, useContext, useState } from "react";
-
 interface Props {
   municipalities: Municipality[];
   CMS_ONLY_businessPersona?: BusinessPersona; // for CMS only
@@ -105,6 +109,10 @@ const ProfilePage = (props: Props): ReactElement => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [shouldLockFormationFields, setShouldLockFormationFields] = useState<boolean>(false);
   const [isFormationDateDeletionModalOpen, setFormationDateDeletionModalOpen] = useState<boolean>(false);
+
+  const [addressData, setAddressData] = useState<Address>(generateFormationNJAddress({}));
+  const [interactedFields, setInteractedFields] = useState<FieldsForAddressErrorHandling[]>([]);
+
   const config = getMergedConfig();
   const userDataFromHook = useUserData();
   const updateQueue = userDataFromHook.updateQueue;
@@ -123,6 +131,21 @@ const ProfilePage = (props: Props): ReactElement => {
     state: formContextState,
     getInvalidFieldIds,
   } = useFormContextHelper(createProfileFieldErrorMap(), props.CMS_ONLY_tab ?? profileTabs[0]);
+
+  const setFieldsInteracted = (
+    fields: FieldsForAddressErrorHandling[],
+    config?: { setToUninteracted: boolean }
+  ): void => {
+    setInteractedFields((prevState) => {
+      const prevStateFieldRemoved = prevState.filter((it) => {
+        return !fields.includes(it);
+      });
+      if (config?.setToUninteracted) {
+        return [...prevStateFieldRemoved];
+      }
+      return [...prevStateFieldRemoved, ...fields];
+    });
+  };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const redirect = (params?: { [key: string]: any }, routerType = router.push): Promise<boolean> => {
@@ -175,6 +198,7 @@ const ProfilePage = (props: Props): ReactElement => {
   };
 
   FormFuncWrapper(
+    // Submit
     () => {
       if (!updateQueue || !business) {
         return;
@@ -216,6 +240,19 @@ const ProfilePage = (props: Props): ReactElement => {
 
       updateQueue.queueProfileData(profileData);
 
+      if (businessPersona === "OWNING") {
+        updateQueue.queueFormationFormData({
+          ...business.formationData.formationFormData,
+          addressLine1: addressData.addressLine1,
+          addressLine2: addressData.addressLine2,
+          addressMunicipality: addressData.addressMunicipality,
+          addressState: addressData.addressState,
+          addressZipCode: addressData.addressZipCode,
+          addressCountry: addressData.addressCountry,
+          addressProvince: addressData.addressProvince,
+        });
+      }
+
       (async (): Promise<void> => {
         updateQueue
           .queue(await postGetAnnualFilings(updateQueue.current()))
@@ -227,6 +264,7 @@ const ProfilePage = (props: Props): ReactElement => {
           });
       })();
     },
+    // On Change
     (isValid, _errors, pageChange) => {
       !isValid && pageChange && setAlert("ERROR");
     }
@@ -678,6 +716,8 @@ const ProfilePage = (props: Props): ReactElement => {
           <BusinessName />
         </ProfileField>
 
+        <ProfileAddressField />
+
         <ProfileField
           fieldName="responsibleOwnerName"
           isVisible={shouldShowTradeNameElements()}
@@ -776,7 +816,6 @@ const ProfilePage = (props: Props): ReactElement => {
       </>
     ),
   };
-
   return (
     <ProfileFormContext.Provider value={formContextState}>
       <MunicipalitiesContext.Provider value={{ municipalities: props.municipalities }}>
@@ -790,89 +829,101 @@ const ProfilePage = (props: Props): ReactElement => {
             onBack,
           }}
         >
-          <NextSeo title={getNextSeoTitle(config.pagesMetadata.profileTitle)} />
-          <PageSkeleton>
-            <NavBar showSidebar={true} hideMiniRoadmap={true} />
-            <main id="main" data-testid={"main"}>
-              <div className="padding-top-0 desktop:padding-top-3">
-                <ProfileEscapeModal
-                  isOpen={escapeModal}
-                  close={(): void => setEscapeModal(false)}
-                  primaryButtonOnClick={(): void => {
-                    redirect();
-                  }}
-                />
-                <FormationDateDeletionModal
-                  isOpen={isFormationDateDeletionModalOpen}
-                  handleCancel={(): void => setFormationDateDeletionModalOpen(false)}
-                  handleDelete={onSubmit}
-                />
-                <SingleColumnContainer>
-                  {alert && <ProfileSnackbarAlert alert={alert} close={(): void => setAlert(undefined)} />}
-                  <UserDataErrorAlert />
-                </SingleColumnContainer>
-                <div className="margin-top-1 desktop:margin-top-0">
-                  {business === undefined ? (
-                    <PageCircularIndicator />
-                  ) : (
-                    <SidebarPageLayout
-                      divider={false}
-                      outlineBox={false}
-                      stackNav={true}
-                      nonWrappingLeftColumn={true}
-                      titleOverColumns={
-                        <ProfileHeader business={business} isAuthenticated={isAuthenticated === "TRUE"} />
-                      }
-                      navChildren={
-                        <ProfileTabNav
-                          business={business}
-                          businessPersona={businessPersona}
-                          activeTab={profileTab}
-                          setProfileTab={(tab: ProfileTabs): void => {
-                            setProfileTab(tab);
-                          }}
-                        />
-                      }
-                    >
-                      <>
-                        <form onSubmit={onSubmit} className={`usa-prose onboarding-form margin-top-2`}>
-                          {getElements()}
-                          <div className="margin-top-2">
-                            <ActionBarLayout reverseInMobile={true}>
-                              <div className="margin-top-2 mobile-lg:margin-top-0">
-                                <SecondaryButton
-                                  isColor="primary"
-                                  onClick={(): Promise<void> => onBack()}
-                                  dataTestId="back"
-                                >
-                                  {Config.profileDefaults.default.backButtonText}
-                                </SecondaryButton>
-                              </div>
-                              <div>
-                                <div className="mobile-lg:display-inline">
-                                  <PrimaryButton
+          <AddressContext.Provider
+            value={{
+              state: {
+                addressData: addressData,
+                interactedFields: interactedFields,
+                formContextState: formContextState,
+              },
+              setAddressData,
+              setFieldsInteracted,
+            }}
+          >
+            <NextSeo title={getNextSeoTitle(config.pagesMetadata.profileTitle)} />
+            <PageSkeleton>
+              <NavBar showSidebar={true} hideMiniRoadmap={true} />
+              <main id="main" data-testid={"main"}>
+                <div className="padding-top-0 desktop:padding-top-3">
+                  <ProfileEscapeModal
+                    isOpen={escapeModal}
+                    close={(): void => setEscapeModal(false)}
+                    primaryButtonOnClick={(): void => {
+                      redirect();
+                    }}
+                  />
+                  <FormationDateDeletionModal
+                    isOpen={isFormationDateDeletionModalOpen}
+                    handleCancel={(): void => setFormationDateDeletionModalOpen(false)}
+                    handleDelete={onSubmit}
+                  />
+                  <SingleColumnContainer>
+                    {alert && <ProfileSnackbarAlert alert={alert} close={(): void => setAlert(undefined)} />}
+                    <UserDataErrorAlert />
+                  </SingleColumnContainer>
+                  <div className="margin-top-1 desktop:margin-top-0">
+                    {business === undefined ? (
+                      <PageCircularIndicator />
+                    ) : (
+                      <SidebarPageLayout
+                        divider={false}
+                        outlineBox={false}
+                        stackNav={true}
+                        nonWrappingLeftColumn={true}
+                        titleOverColumns={
+                          <ProfileHeader business={business} isAuthenticated={isAuthenticated === "TRUE"} />
+                        }
+                        navChildren={
+                          <ProfileTabNav
+                            business={business}
+                            businessPersona={businessPersona}
+                            activeTab={profileTab}
+                            setProfileTab={(tab: ProfileTabs): void => {
+                              setProfileTab(tab);
+                            }}
+                          />
+                        }
+                      >
+                        <>
+                          <form onSubmit={onSubmit} className={`usa-prose onboarding-form margin-top-2`}>
+                            {getElements()}
+                            <div className="margin-top-2">
+                              <ActionBarLayout reverseInMobile={true}>
+                                <div className="margin-top-2 mobile-lg:margin-top-0">
+                                  <SecondaryButton
                                     isColor="primary"
-                                    isSubmitButton={true}
-                                    onClick={(): void => {}}
-                                    isRightMarginRemoved={true}
-                                    dataTestId="save"
-                                    isLoading={isLoading}
+                                    onClick={(): Promise<void> => onBack()}
+                                    dataTestId="back"
                                   >
-                                    {Config.profileDefaults.default.saveButtonText}
-                                  </PrimaryButton>
+                                    {Config.profileDefaults.default.backButtonText}
+                                  </SecondaryButton>
                                 </div>
-                              </div>
-                            </ActionBarLayout>
-                          </div>
-                          <DevOnlyResetUserDataButton />
-                        </form>
-                      </>
-                    </SidebarPageLayout>
-                  )}
+                                <div>
+                                  <div className="mobile-lg:display-inline">
+                                    <PrimaryButton
+                                      isColor="primary"
+                                      isSubmitButton={true}
+                                      onClick={(): void => {}}
+                                      isRightMarginRemoved={true}
+                                      dataTestId="save"
+                                      isLoading={isLoading}
+                                    >
+                                      {Config.profileDefaults.default.saveButtonText}
+                                    </PrimaryButton>
+                                  </div>
+                                </div>
+                              </ActionBarLayout>
+                            </div>
+                            <DevOnlyResetUserDataButton />
+                          </form>
+                        </>
+                      </SidebarPageLayout>
+                    )}
+                  </div>
                 </div>
-              </div>
-            </main>
-          </PageSkeleton>
+              </main>
+            </PageSkeleton>
+          </AddressContext.Provider>
         </ProfileDataContext.Provider>
       </MunicipalitiesContext.Provider>
     </ProfileFormContext.Provider>

--- a/web/test/mock/withStatefulAddressData.tsx
+++ b/web/test/mock/withStatefulAddressData.tsx
@@ -1,0 +1,67 @@
+import { AddressContext } from "@/contexts/addressContext";
+import { MunicipalitiesContext } from "@/contexts/municipalitiesContext";
+import { ProfileFormContext } from "@/contexts/profileFormContext";
+import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
+import { createProfileFieldErrorMap } from "@/lib/types/types";
+import { Municipality } from "@businessnjgovnavigator/shared/municipality";
+import { Address } from "@businessnjgovnavigator/shared/userData";
+import { ReactElement, ReactNode, useEffect, useState } from "react";
+
+const updateSpy = jest.fn();
+
+export const WithStatefulAddressData = ({
+  children,
+  initialData,
+  initialMunicipalities,
+}: {
+  children: ReactNode;
+  initialData: Address;
+  initialMunicipalities?: Municipality[];
+}): ReactElement => {
+  const [addressData, setAddressData] = useState<Address>(initialData);
+  const { state: formContextState } = useFormContextHelper(createProfileFieldErrorMap());
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useEffect(() => {
+    updateSpy(addressData);
+  }, [addressData]);
+
+  let municipalities = [
+    {
+      displayName: "Newark Display Name",
+      name: "Newark",
+      county: "some-county-1",
+      id: "some-id-1",
+    },
+    {
+      displayName: "Trenton Display Name",
+      name: "Trenton",
+      county: "some-county-2",
+      id: "some-id-2",
+    },
+  ];
+
+  if (initialMunicipalities && initialMunicipalities.length > 0) {
+    municipalities = initialMunicipalities;
+  }
+
+  return (
+    <ProfileFormContext.Provider value={formContextState}>
+      <MunicipalitiesContext.Provider value={{ municipalities: municipalities }}>
+        <AddressContext.Provider
+          value={{
+            state: {
+              addressData: addressData,
+              interactedFields: [],
+              formContextState: formContextState,
+            },
+            setAddressData: setAddressData,
+            setFieldsInteracted: jest.fn(),
+          }}
+        >
+          {children}
+        </AddressContext.Provider>
+      </MunicipalitiesContext.Provider>
+    </ProfileFormContext.Provider>
+  );
+};

--- a/web/test/pages/profile/profile-helpers.tsx
+++ b/web/test/pages/profile/profile-helpers.tsx
@@ -12,7 +12,7 @@ import {
 import {
   BusinessPersona,
   einTaskId,
-  generateBusiness,
+  generateBusiness, generateFormationData, generateFormationFormData,
   generateMunicipality,
   generateProfileData,
   generateUserDataForBusiness,
@@ -30,11 +30,27 @@ const Config = getMergedConfig();
 
 export const generateBusinessForProfile = (overrides: Partial<Business>): Business => {
   const profileData = generateProfileData({ ...overrides.profileData });
+
+  let formationData
+
+    if(overrides && overrides.formationData){
+      formationData = generateFormationData({
+        ...overrides.formationData ?? overrides.formationData,
+        formationFormData: generateFormationFormData({...overrides.formationData.formationFormData ?? overrides.formationData.formationFormData})
+      });
+    }else{
+      formationData = generateFormationData({
+        formationFormData: generateFormationFormData({
+        })
+      });
+    }
+
+
   const taskProgress: Record<string, TaskProgress> =
     profileData.employerId && profileData.employerId.length > 0
       ? { [einTaskId]: "COMPLETED", ...overrides.taskProgress }
       : { ...overrides.taskProgress };
-  return generateBusiness({ ...overrides, profileData, taskProgress });
+  return generateBusiness({ ...overrides, profileData, formationData, taskProgress });
 };
 
 export const renderPage = ({
@@ -62,6 +78,7 @@ export const renderPage = ({
       }),
     });
 
+  console.log("initial business",JSON.stringify(initialBusiness));
   render(
     withNeedsAccountContext(
       <ThemeProvider theme={createTheme()}>
@@ -137,6 +154,26 @@ export const getEmployerIdValue = (): string => {
 
 export const getMunicipalityValue = (): string => {
   return (screen.queryByTestId("municipality") as HTMLInputElement)?.value;
+};
+
+export const getAddressLine1Value = (): string => {
+  return (screen.queryByLabelText("Address line1") as HTMLInputElement)?.value;
+};
+
+export const getAddressLine2Value = (): string => {
+  return (screen.getByLabelText("Address line2") as HTMLInputElement)?.value;
+};
+
+export const getAddressMunicipalityValue = (): string => {
+  return (screen.getByLabelText("Address municipality") as HTMLInputElement)?.value;
+};
+
+export const getAddressZipCodeValue = (): string => {
+  return (screen.getByLabelText("Address zip code") as HTMLInputElement)?.value;
+};
+
+export const getAddressStateValue = (): string => {
+  return (screen.queryByLabelText("Address state") as HTMLInputElement)?.value;
 };
 
 export const getBusinessProfileInputFieldName = (business: Business): string => {

--- a/web/test/pages/profile/profile-starting.test.tsx
+++ b/web/test/pages/profile/profile-starting.test.tsx
@@ -345,6 +345,7 @@ describe("profile - starting business", () => {
     });
 
     const initialBusiness = generateBusinessForProfile({ taxFilingData: taxData });
+
     renderPage({ business: initialBusiness });
     clickSave();
 
@@ -534,6 +535,8 @@ describe("profile - starting business", () => {
     describe("when the tax ID is initially 9 digits in length", () => {
       const businessWith9TaxId = generateBusinessForProfile({
         profileData: generateProfileData({
+          businessPersona: "STARTING",
+          legalStructureId: "limited-liability-company",
           taxId: "123456789",
         }),
       });
@@ -610,6 +613,8 @@ describe("profile - starting business", () => {
     describe("when the tax ID is initially 12 digits in length", () => {
       const businessWith12TaxId = generateBusinessForProfile({
         profileData: generateProfileData({
+          businessPersona: "STARTING",
+          legalStructureId: "limited-liability-company",
           taxId: "123456789123",
         }),
       });
@@ -661,6 +666,8 @@ describe("profile - starting business", () => {
       const businessWithEmptyTaxId = generateBusinessForProfile({
         profileData: generateProfileData({
           taxId: "",
+          businessPersona: "STARTING",
+          legalStructureId: "limited-liability-company",
         }),
       });
 


### PR DESCRIPTION
feat: [#187194184] add full address to profile

wip

fix: callout code cleanup [skip ci]

wip [skip ci]

wip [skip ci]

wip
[skip ci]

wip [skip ci]

wip [skip ci]

feat: [#187194184] formation address fields added to profile

feat: [#187194184] formation address fields added to profile

<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#00000000](https://www.pivotaltracker.com/story/show/00000000).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [ ] I have not used any relative imports
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
