### PR TITLE
feat: [#187166154][#187166152] Cypress Out of state None of the Above desktop and mobile Tests

### DIFF
--- a/web/cypress/e2e/onboarding-as-foreign-business.spec.ts
+++ b/web/cypress/e2e/onboarding-as-foreign-business.spec.ts
@@ -4,6 +4,7 @@ import {
 } from "@businessnjgovnavigator/cypress/support/helpers/helpers";
 import {
   onOnboardingPageNexusBusiness,
+  onOnboardingPageNoneOfTheAbove,
   onOnboardingPageRemoteSellerBusiness,
   onOnboardingPageRemoteWorkerBusiness,
 } from "@businessnjgovnavigator/cypress/support/page_objects/onboardingPageNew";
@@ -249,6 +250,49 @@ describe("Onboarding for all industries when out of state nexus business [featur
 
         cy.url().should("include", "dashboard");
         cy.get('[data-testid="header-link-to-profile"]');
+      });
+    });
+  });
+
+  describe("Onboarding for out of state - none of the above business [feature] [all] [group4]", () => {
+    describe("Desktop", () => {
+      beforeEach(() => {
+        cy.loginByCognitoApi();
+      });
+
+      it("Onboarding for Out of State - None of the Above", () => {
+        cy.url().should("include", "onboarding?page=1");
+        onOnboardingPageNoneOfTheAbove.selectBusinessPersonaRadio("FOREIGN");
+        onOnboardingPageNoneOfTheAbove.getBusinessPersonaRadio("FOREIGN").should("be.checked");
+        onOnboardingPageNoneOfTheAbove.clickNext();
+
+        cy.url().should("include", "onboarding?page=2");
+        onOnboardingPageNoneOfTheAbove.selectNoneOfTheAbove();
+        onOnboardingPageNoneOfTheAbove.getNoneOfTheAbove().should("be.checked");
+        onOnboardingPageNoneOfTheAbove.clickShowMyGuide();
+
+        cy.url().should("include", "unsupported");
+      });
+    });
+
+    describe("Mobile", () => {
+      beforeEach(() => {
+        setMobileViewport();
+        cy.loginByCognitoApi();
+      });
+
+      it("Onboarding for Out of State - None of the Above", () => {
+        cy.url().should("include", "onboarding?page=1");
+        onOnboardingPageNoneOfTheAbove.selectBusinessPersonaRadio("FOREIGN");
+        onOnboardingPageNoneOfTheAbove.getBusinessPersonaRadio("FOREIGN").should("be.checked");
+        onOnboardingPageNoneOfTheAbove.clickNext();
+
+        cy.url().should("include", "onboarding?page=2");
+        onOnboardingPageNoneOfTheAbove.selectNoneOfTheAbove();
+        onOnboardingPageNoneOfTheAbove.getNoneOfTheAbove().should("be.checked");
+        onOnboardingPageNoneOfTheAbove.clickShowMyGuide();
+
+        cy.url().should("include", "unsupported");
       });
     });
   });

--- a/web/cypress/support/page_objects/onboardingPageNew.ts
+++ b/web/cypress/support/page_objects/onboardingPageNew.ts
@@ -71,7 +71,14 @@ class OnboardingSharedElementsWithIndustryQuestion extends OnboardingSharedEleme
   }
 }
 
-class OnboardingPageNoneOfTheAbove extends OnboardingSharedElements {}
+class OnboardingPageNoneOfTheAbove extends OnboardingSharedElements {
+  getNoneOfTheAbove() {
+    return cy.get(`input[name="foreign-business-type"][value="none"]`);
+  }
+  selectNoneOfTheAbove() {
+    this.getNoneOfTheAbove().check();
+  }
+}
 
 class OnboardingPageRemoteSellerBusiness extends OnboardingSharedElements {
   getRevenueInNJCheckbox() {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
Updated Cypress Out of state None of the Above desktop and mobile Tests
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#187166154](https://www.pivotaltracker.com/story/show/187166154)
This pull request resolves [#187166152](https://www.pivotaltracker.com/story/show/187166152)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
Run Cypress tests for onboarding Foreign Business

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes
All tests should pass
<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [ ] I have not used any relative imports
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
