### PR TITLE
feat: [#187790624] enable health club license status check

### DIFF
--- a/api/src/client/dynamics/license-status/DynamicsLicenseApplicationIdClient.ts
+++ b/api/src/client/dynamics/license-status/DynamicsLicenseApplicationIdClient.ts
@@ -67,6 +67,7 @@ const licenseTypeToLicenseId: Record<string, string> = {
   "Public Movers and Warehousemen": "19391a3f-53df-eb11-bacb-001dd8028561",
   "Home Improvement Contractor": "7a391a3f-53df-eb11-bacb-001dd8028561",
   "Health Care Services": "3ac8456a-53df-eb11-bacb-001dd8028561",
+  "Health Club Services": "af8e3564-53df-eb11-bacb-001dd8028561",
 };
 
 const statusCodeToLicenseStatus: Record<number, LicenseStatus> = {

--- a/api/src/domain/license-status/searchLicenseStatusFactory.test.ts
+++ b/api/src/domain/license-status/searchLicenseStatusFactory.test.ts
@@ -49,6 +49,14 @@ describe("searchLicenseStatusFactory", () => {
       expect(stubDynamicsSearchLicenseStatus).toHaveBeenCalled();
       expect(stubWebServiceSearchLicenseStatus).not.toHaveBeenCalled();
     });
+
+    it("returns dynamics status client when license type is health club services", () => {
+      const licenseType = "Health Club Services";
+      const licenseStatus = searchLicenseStatus(licenseType);
+      licenseStatus(generateLicenseSearchNameAndAddress({}), licenseType);
+      expect(stubDynamicsSearchLicenseStatus).toHaveBeenCalled();
+      expect(stubWebServiceSearchLicenseStatus).not.toHaveBeenCalled();
+    });
   });
 
   describe("when license type is not included in dynamics", () => {

--- a/api/src/domain/license-status/searchLicenseStatusFactory.ts
+++ b/api/src/domain/license-status/searchLicenseStatusFactory.ts
@@ -12,6 +12,7 @@ export const searchLicenseStatusFactory = (
     const licenseTypesUsingDynamicsSearch: Record<string, boolean> = {
       "Public Movers and Warehousemen": featureFlags.publicMovers,
       "Health Care Services": true,
+      "Health Club Services": true,
     };
 
     const shouldUseDynamicsSearch = licenseTypesUsingDynamicsSearch[licenseType] || false;

--- a/api/src/domain/user/updateLicenseStatusFactory.test.ts
+++ b/api/src/domain/user/updateLicenseStatusFactory.test.ts
@@ -114,6 +114,7 @@ describe("updateLicenseStatus", () => {
       expect(resultCurrentBusiness.taskProgress["appraiser-license"]).toEqual("NOT_STARTED");
       expect(resultCurrentBusiness.taskProgress["public-accountant-license"]).toEqual("NOT_STARTED");
       expect(resultCurrentBusiness.taskProgress["landscape-architect-license"]).toEqual("NOT_STARTED");
+      expect(resultCurrentBusiness.taskProgress["health-club-registration"]).toEqual("NOT_STARTED");
     }
   );
 
@@ -142,6 +143,7 @@ describe("updateLicenseStatus", () => {
     expect(resultCurrentBusiness.taskProgress["appraiser-license"]).toEqual("IN_PROGRESS");
     expect(resultCurrentBusiness.taskProgress["public-accountant-license"]).toEqual("IN_PROGRESS");
     expect(resultCurrentBusiness.taskProgress["landscape-architect-license"]).toEqual("IN_PROGRESS");
+    expect(resultCurrentBusiness.taskProgress["health-club-registration"]).toEqual("IN_PROGRESS");
   });
 
   it("updates the license task status to COMPLETED when license is active", async () => {
@@ -164,5 +166,6 @@ describe("updateLicenseStatus", () => {
     expect(resultCurrentBusiness.taskProgress["appraiser-license"]).toEqual("COMPLETED");
     expect(resultCurrentBusiness.taskProgress["public-accountant-license"]).toEqual("COMPLETED");
     expect(resultCurrentBusiness.taskProgress["landscape-architect-license"]).toEqual("COMPLETED");
+    expect(resultCurrentBusiness.taskProgress["health-club-registration"]).toEqual("COMPLETED");
   });
 });

--- a/api/src/domain/user/updateLicenseStatusFactory.ts
+++ b/api/src/domain/user/updateLicenseStatusFactory.ts
@@ -36,6 +36,7 @@ const update = (
       "hvac-license": args.taskStatus,
       "appraiser-license": args.taskStatus,
       "landscape-architect-license": args.taskStatus,
+      "health-club-registration": args.taskStatus,
     },
     licenseData: {
       nameAndAddress: args.nameAndAddress,

--- a/content/src/roadmaps/industries/health-club.json
+++ b/content/src/roadmaps/industries/health-club.json
@@ -58,6 +58,7 @@
   "isEnabled": true,
   "additionalSearchTerms": "health spa, strength training and conditioning, athletic club, boxing club, fitness center, gym, swim club, sports club, exercise",
   "id": "health-club",
+  "licenseType": "Health Club",
   "description": "A gym, spa, or similar business providing services or facilities for physical fitness or physical well-being",
   "webflowId": "660d922207f6969e35490f1a"
 }

--- a/web/src/components/TaskPageSwitchComponent.tsx
+++ b/web/src/components/TaskPageSwitchComponent.tsx
@@ -55,6 +55,9 @@ export const TaskPageSwitchComponent = ({
     "landscape-architect-license": (
       <LicenseTask task={task} CMS_ONLY_disable_overlay={CMS_ONLY_disable_overlay} />
     ),
+    "health-club-registration": (
+      <LicenseTask task={task} CMS_ONLY_disable_overlay={CMS_ONLY_disable_overlay} />
+    ),
     "elevator-registration": (
       <ElevatorRegistrationTask task={task} CMS_ONLY_disable_overlay={CMS_ONLY_disable_overlay} />
     ),

--- a/web/test/pages/taskUrlSlug.test.tsx
+++ b/web/test/pages/taskUrlSlug.test.tsx
@@ -227,6 +227,7 @@ describe("task page", () => {
       "register-accounting-firm",
       "register-consumer-affairs",
       "landscape-architect-license",
+      "health-club-registration",
     ])("loads License task screen for %s", (licenseId) => {
       renderPage(generateTask({ id: licenseId }), generateBusiness({ licenseData: undefined }));
       expect(screen.getByTestId("cta-secondary")).toBeInTheDocument();


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
Enable health club license status check.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#187790624](https://www.pivotaltracker.com/story/show/187790624).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

1. Access the site as a Poppy or Dakota as a Health Club (industry).
2. Click the `Register Your Business as a Health Club, Spa, Fitness Club, or Gym` task in the roadmap.
3. Enter the contact information for a business.
4. The license status will display for the business.

**NOTE:** There is no reinstatement action (anytime action) for this industry. 


### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
