### PR TITLE
Keep hide/show roadmap button inline on mobile

### DIFF
--- a/web/src/components/dashboard/HideableTasks.tsx
+++ b/web/src/components/dashboard/HideableTasks.tsx
@@ -14,7 +14,7 @@ export const HideableTasks = (): ReactElement => {
   const { updateQueue, business } = useUserData();
   const { roadmap } = useRoadmap();
   const { Config } = useConfig();
-  const isTabletAndUp = useMediaQuery(MediaQueries.tabletAndUp);
+  const isXSMobile = useMediaQuery(MediaQueries.isXSMobile);
 
   const handleToggleClick = (): void => {
     if (!business || !updateQueue) {
@@ -37,12 +37,17 @@ export const HideableTasks = (): ReactElement => {
 
   return (
     <div className="margin-top-7" data-testid="hideableTasks">
-      <div className={`${isTabletAndUp ? "flex flex-align-center" : ""} margin-bottom-205`}>
+      <div className={`flex flex-align-center margin-bottom-205`}>
         <Heading level={2} className="margin-bottom-0 text-medium">
           {Config.dashboardRoadmapHeaderDefaults.RoadmapTasksHeaderText}
         </Heading>
-        <div className={`mla ${isTabletAndUp ? "" : "margin-top-2"}`}>
-          <SecondaryButton size={"small"} isColor={"border-base-light"} onClick={handleToggleClick}>
+        <div className={`mla`}>
+          <SecondaryButton
+            className={`${isXSMobile ? "padding-x-0 margin-bottom-2" : ""}`}
+            size={"small"}
+            isColor={"border-base-light"}
+            onClick={handleToggleClick}
+          >
             <div className="fdr fac">
               <Icon>{business?.preferences.isHideableRoadmapOpen ? "visibility_off" : "visibility"}</Icon>
               <span className="margin-left-05 line-height-sans-2">

--- a/web/src/components/njwds-extended/SecondaryButton.tsx
+++ b/web/src/components/njwds-extended/SecondaryButton.tsx
@@ -15,6 +15,7 @@ type OmitGenericButtonProps = Omit<
 
 interface Props extends OmitGenericButtonProps {
   isColor: "primary" | "border-base-light";
+  className?: string;
   size?: "small" | "regular";
 }
 
@@ -25,11 +26,8 @@ const colors = {
 };
 
 export const SecondaryButton = (props: Props): ReactElement => {
+  const classNames = `${colors[props.isColor]} ${props.className}`;
   return (
-    <GenericButton
-      {...props}
-      isVerticalPaddingRemoved={props.size === "small"}
-      className={colors[props.isColor]}
-    />
+    <GenericButton {...props} isVerticalPaddingRemoved={props.size === "small"} className={classNames} />
   );
 };


### PR DESCRIPTION
## Description

**Before:**
<img width="352" alt="Screenshot 2024-06-21 at 9 57 42 AM" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22647707/75705de9-2dde-4229-b036-c7dd0c042236">

**After:**
<img width="353" alt="Screenshot 2024-06-21 at 10 16 14 AM" src="https://github.com/newjersey/navigator.business.nj.gov/assets/22647707/5ab8323d-e48a-498d-9c76-5a2fe9b40669">

### Ticket

This pull request resolves [#187415906](https://www.pivotaltracker.com/story/show/187415906).

### Approach

Worked with Amanda to align on an implementation. This did require removing padding from the hide/show button.

### Steps to Test

- View application in mobile
- Using a business that has formed, go to dashboard
- scroll down to roadmap to see the Business Tasks heading and hide/show button

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
