### PR TITLE
chore: [#187815961] fix failing profile tests

### DIFF
--- a/web/test/pages/profile/profile-foreign.test.tsx
+++ b/web/test/pages/profile/profile-foreign.test.tsx
@@ -284,7 +284,6 @@ describe("profile-foreign", () => {
         legalStructureId: string;
         operatingPhase: OperatingPhaseId;
       }): void => {
-        const newark = generateMunicipality({ displayName: "Newark" });
         const business = generateBusinessForProfile({
           profileData: generateProfileData({
             legalStructureId: params.legalStructureId,
@@ -293,7 +292,7 @@ describe("profile-foreign", () => {
             foreignBusinessTypeIds: ["employeeOrContractorInNJ", "officeInNJ"],
           }),
         });
-        renderPage({ municipalities: [newark], business });
+        renderPage({ business });
       };
 
       it("locks when it is populated and tax filing state is SUCCESS", () => {

--- a/web/test/pages/profile/profile-helpers.tsx
+++ b/web/test/pages/profile/profile-helpers.tsx
@@ -49,10 +49,14 @@ export const renderPage = ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   setShowNeedsAccountModal?: jest.Mock<any, any, any>;
 }): void => {
-  const genericTown =
-    business && business.profileData.municipality
-      ? business.profileData.municipality
-      : generateMunicipality({ displayName: "GenericTown" });
+  const genericTown = generateMunicipality({ displayName: "GenericTown" });
+  const profileDataMunicipality = business && business.profileData.municipality;
+  const formationNJAddress = business && business.formationData.formationFormData.addressMunicipality;
+
+  const municipalitiesList = [genericTown];
+  if (profileDataMunicipality) municipalitiesList.push(profileDataMunicipality);
+  if (formationNJAddress) municipalitiesList.push(formationNJAddress);
+  if (municipalities) municipalitiesList.push(...municipalities);
 
   const initialBusiness =
     business ??
@@ -67,7 +71,7 @@ export const renderPage = ({
       <ThemeProvider theme={createTheme()}>
         <WithStatefulProfileFormContext>
           <WithStatefulUserData initialUserData={generateUserDataForBusiness(initialBusiness)}>
-            <Profile municipalities={municipalities ? [genericTown, ...municipalities] : [genericTown]} />
+            <Profile municipalities={municipalitiesList} />
           </WithStatefulUserData>
         </WithStatefulProfileFormContext>
       </ThemeProvider>,

--- a/web/test/pages/profile/profile-owning.test.tsx
+++ b/web/test/pages/profile/profile-owning.test.tsx
@@ -81,11 +81,6 @@ jest.mock("@/lib/utils/analytics", () => setupMockAnalytics());
 
 describe("profile - owning existing business", () => {
   let business: Business;
-  const formationWithUndefinedMunicipality = generateFormationData({
-    formationFormData: generateFormationFormData({
-      addressMunicipality: undefined,
-    }),
-  });
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -97,7 +92,6 @@ describe("profile - owning existing business", () => {
     });
     business = generateBusinessForProfile({
       profileData: generateProfileData({ businessPersona: "OWNING" }),
-      formationData: formationWithUndefinedMunicipality,
     });
   });
 
@@ -139,25 +133,23 @@ describe("profile - owning existing business", () => {
         businessPersona: "OWNING",
         industryId: "generic",
         legalStructureId: "limited-liability-company",
-        municipality: undefined,
       }),
       onboardingFormProgress: "COMPLETED",
-      formationData: formationWithUndefinedMunicipality,
     });
-    const newark = generateMunicipality({ displayName: "Newark" });
+    const randomMunicipality = generateMunicipality({ displayName: "Newark" });
 
-    renderPage({ business, municipalities: [newark] });
+    renderPage({ business, municipalities: [randomMunicipality] });
 
     fillText("Business name", "Cool Computers");
     fillText("Date of formation", date.format("MM/YYYY"));
     fillText("Address line1", "123 main st");
     fillText("Address line2", "apt 1");
-    selectByText("Address municipality", "Newark");
+    selectByText("Address municipality", randomMunicipality.displayName);
     fillText("Address zip code", "08123");
 
     selectByValue("Sector", "clean-energy");
     fillText("Existing employees", "123");
-    selectByText("Location", newark.displayName);
+    selectByText("Location", randomMunicipality.displayName);
     selectByValue("Ownership", "veteran-owned");
     selectByValue("Ownership", "woman-owned");
     chooseRadio("home-based-business-radio-true");
@@ -184,7 +176,7 @@ describe("profile - owning existing business", () => {
         homeBasedBusiness: true,
         existingEmployees: "123",
         ownershipTypeIds: ["veteran-owned", "woman-owned"],
-        municipality: newark,
+        municipality: randomMunicipality,
         dateOfFormation,
         taxId: "023456790123",
         entityId: "0234567890",
@@ -199,7 +191,7 @@ describe("profile - owning existing business", () => {
           ...business.formationData.formationFormData,
           addressLine1: "123 main st",
           addressLine2: "apt 1",
-          addressMunicipality: newark,
+          addressMunicipality: randomMunicipality,
           addressZipCode: "08123",
           addressState: {
             name: "New Jersey",
@@ -211,6 +203,7 @@ describe("profile - owning existing business", () => {
   });
 
   it("prefills form from existing user data", () => {
+    const randomMunicipality = generateMunicipality({});
     const business = generateBusinessForProfile({
       profileData: generateProfileData({
         businessPersona: "OWNING",
@@ -221,9 +214,7 @@ describe("profile - owning existing business", () => {
         dateOfFormation,
         taxId: "123456790",
         notes: "whats appppppp",
-        municipality: generateMunicipality({
-          displayName: "Newark",
-        }),
+        municipality: randomMunicipality,
         ownershipTypeIds: ["veteran-owned", "woman-owned"],
         homeBasedBusiness: false,
         existingEmployees: "123",
@@ -231,7 +222,6 @@ describe("profile - owning existing business", () => {
         sectorId: "clean-energy",
         industryId: "generic",
       }),
-      formationData: formationWithUndefinedMunicipality,
     });
 
     const veteran = LookupOwnershipTypeById("veteran-owned").name;
@@ -240,7 +230,7 @@ describe("profile - owning existing business", () => {
     renderPage({ business });
 
     expect(getBusinessNameValue()).toEqual("Applebees");
-    expect(getMunicipalityValue()).toEqual("Newark");
+    expect(getMunicipalityValue()).toEqual(randomMunicipality.displayName);
     expect(getSectorIDValue()).toEqual(LookupSectorTypeById("clean-energy").name);
     expect(screen.queryByLabelText("Ownership")).toHaveTextContent(`${veteran}, ${woman}`);
     expect(getRadioButtonFromFormControlLabel("home-based-business-radio-false")).toBeChecked();
@@ -306,7 +296,6 @@ describe("profile - owning existing business", () => {
         operatingPhase: OperatingPhaseId.UP_AND_RUNNING_OWNING,
         sectorId: "",
       }),
-      formationData: formationWithUndefinedMunicipality,
     });
     renderPage({ business });
     fireEvent.blur(screen.queryByLabelText("Sector") as HTMLElement);
@@ -330,9 +319,9 @@ describe("profile - owning existing business", () => {
   });
 
   it("returns user to dashboard from un-saved changes modal", async () => {
-    const newark = generateMunicipality({ displayName: "Newark" });
-    renderPage({ business, municipalities: [newark] });
-    selectByText("Location", newark.displayName);
+    const randomMunicipality = generateMunicipality({});
+    renderPage({ business, municipalities: [randomMunicipality] });
+    selectByText("Location", randomMunicipality.displayName);
     clickBack();
     fireEvent.click(screen.getByText(Config.profileDefaults.default.escapeModalReturn));
     await waitFor(() => {
@@ -354,10 +343,8 @@ describe("profile - owning existing business", () => {
         businessPersona: "OWNING",
         legalStructureId: randomLegalStructure({ requiresPublicFiling: true }).id,
       }),
-      formationData: formationWithUndefinedMunicipality,
     });
-    const newark = generateMunicipality({ displayName: "Newark" });
-    renderPage({ business: initialBusiness, municipalities: [newark] });
+    renderPage({ business: initialBusiness });
     expect(screen.getByLabelText("Date of formation")).toBeInTheDocument();
   });
 
@@ -367,10 +354,8 @@ describe("profile - owning existing business", () => {
         businessPersona: "OWNING",
         legalStructureId: randomLegalStructure({ requiresPublicFiling: false }).id,
       }),
-      formationData: formationWithUndefinedMunicipality,
     });
-    const newark = generateMunicipality({ displayName: "Newark" });
-    renderPage({ business: initialBusiness, municipalities: [newark] });
+    renderPage({ business: initialBusiness });
     expect(screen.queryByLabelText("Date of formation")).not.toBeInTheDocument();
   });
 
@@ -380,7 +365,6 @@ describe("profile - owning existing business", () => {
         businessPersona: "OWNING",
         naicsCode: "123456",
       }),
-      formationData: formationWithUndefinedMunicipality,
     });
     renderPage({ business: initialBusiness });
     chooseTab("numbers");
@@ -394,7 +378,6 @@ describe("profile - owning existing business", () => {
         businessPersona: "OWNING",
         naicsCode: "",
       }),
-      formationData: formationWithUndefinedMunicipality,
     });
     renderPage({ business: initialBusiness });
     chooseTab("numbers");
@@ -403,19 +386,19 @@ describe("profile - owning existing business", () => {
 
   describe("Location Section", () => {
     it("locks the location field if it is populated and tax filing state is SUCCESS", () => {
+      const randomMunicipality = generateMunicipality({});
       renderPage({
         business: generateBusinessForProfile({
           profileData: generateProfileData({
             businessPersona: "OWNING",
-            municipality: generateMunicipality({ displayName: "Trenton" }),
+            municipality: randomMunicipality,
           }),
           taxFilingData: generateTaxFilingData({
             state: "SUCCESS",
           }),
-          formationData: formationWithUndefinedMunicipality,
         }),
       });
-      expect(screen.getByText("Trenton")).toBeInTheDocument();
+      expect(screen.getByText(randomMunicipality.displayName)).toBeInTheDocument();
       expect(screen.getByTestId("locked-municipality")).toBeInTheDocument();
     });
   });
@@ -445,7 +428,6 @@ describe("profile - owning existing business", () => {
           businessPersona: "OWNING",
           legalStructureId: "limited-liability-company",
         }),
-        formationData: formationWithUndefinedMunicipality,
       });
       renderPage({ business });
       expect(screen.queryByTestId("tradeName")).not.toBeInTheDocument();
@@ -502,7 +484,6 @@ describe("profile - owning existing business", () => {
           sectorId: undefined,
           operatingPhase: OperatingPhaseId.UP_AND_RUNNING_OWNING,
         }),
-        formationData: formationWithUndefinedMunicipality,
       });
       renderPage({ business });
       clickSave();
@@ -622,6 +603,7 @@ describe("profile - owning existing business", () => {
       });
 
       it("displays alert when address city is selected then blurred", async () => {
+        const randomMunicipality = generateMunicipality({});
         const business = generateBusinessForProfile({
           profileData: generateProfileData({
             industryId: "generic",
@@ -634,10 +616,10 @@ describe("profile - owning existing business", () => {
             }),
           }),
         });
-        renderPage({ business, municipalities: [generateMunicipality({ displayName: "display name" })] });
+        renderPage({ business, municipalities: [randomMunicipality] });
 
-        selectByText("Address municipality", "display name");
-        expect(screen.getByLabelText("Address municipality")).toHaveValue("display name");
+        selectByText("Address municipality", randomMunicipality.displayName);
+        expect(screen.getByLabelText("Address municipality")).toHaveValue(randomMunicipality.displayName);
         fireEvent.blur(screen.getByLabelText("Address municipality"));
 
         clickSave();
@@ -673,7 +655,7 @@ describe("profile - owning existing business", () => {
             }),
           }),
         });
-        renderPage({ business, municipalities: [generateMunicipality({ displayName: "display name" })] });
+        renderPage({ business });
         fillText("Address line1", "a".repeat(BUSINESS_ADDRESS_LINE_1_MAX_CHAR + 1));
 
         clickSave();
@@ -707,7 +689,7 @@ describe("profile - owning existing business", () => {
             }),
           }),
         });
-        renderPage({ business, municipalities: [generateMunicipality({ displayName: "display name" })] });
+        renderPage({ business });
         fillText("Address line2", "a");
 
         clickSave();
@@ -743,7 +725,7 @@ describe("profile - owning existing business", () => {
             }),
           }),
         });
-        renderPage({ business, municipalities: [generateMunicipality({ displayName: "display name" })] });
+        renderPage({ business });
         fillText("Address line2", "a".repeat(BUSINESS_ADDRESS_LINE_2_MAX_CHAR + 1));
 
         clickSave();

--- a/web/test/pages/profile/profile-shared.test.tsx
+++ b/web/test/pages/profile/profile-shared.test.tsx
@@ -28,7 +28,6 @@ import {
   businessPersonas,
   emptyProfileData,
   generateBusiness,
-  generateFormationFormData,
   generateMunicipality,
   generateProfileData,
   randomInt,
@@ -111,12 +110,6 @@ const mockAnalytics = analytics as jest.Mocked<typeof analytics>;
 const nonOwningPersonas: BusinessPersona[] = ["STARTING", "FOREIGN"];
 
 describe("profile - shared", () => {
-  const formationWithUndefinedMunicipality = generateFormationData({
-    formationFormData: generateFormationFormData({
-      addressMunicipality: undefined,
-    }),
-  });
-
   beforeEach(() => {
     jest.resetAllMocks();
     useMockRouter({});
@@ -149,7 +142,6 @@ describe("profile - shared", () => {
         industryId: randomHomeBasedIndustry(),
         operatingPhase: randomElementFromArray(defaultDescOperatingPhases as OperatingPhase[]).id,
       }),
-      formationData: formationWithUndefinedMunicipality,
     });
 
     renderPage({ business });
@@ -171,7 +163,6 @@ describe("profile - shared", () => {
         industryId: randomHomeBasedIndustry(),
         operatingPhase: randomElementFromArray(altDescOperatingPhases as OperatingPhase[]).id,
       }),
-      formationData: formationWithUndefinedMunicipality,
     });
 
     renderPage({ business });
@@ -192,7 +183,6 @@ describe("profile - shared", () => {
         businessPersona: "OWNING",
         homeBasedBusiness: false,
       }),
-      formationData: formationWithUndefinedMunicipality,
     });
 
     renderPage({ business });
@@ -214,7 +204,6 @@ describe("profile - shared", () => {
           foreignBusinessTypeIds:
             businessPersona === "FOREIGN" ? ["employeeOrContractorInNJ", "officeInNJ"] : [],
         }),
-        formationData: formationWithUndefinedMunicipality,
       });
 
       renderPage({ business });
@@ -274,17 +263,16 @@ describe("profile - shared", () => {
       profileData: generateProfileData({
         municipality: undefined,
       }),
-      formationData: formationWithUndefinedMunicipality,
     });
 
-    const newark = generateMunicipality({ displayName: "Newark" });
-    renderPage({ business: initialBusiness, municipalities: [newark] });
-    selectByText("Location", newark.displayName);
-    expect(screen.getByLabelText("Location")).toHaveValue(newark.displayName);
+    const randomMunicipality = generateMunicipality({});
+    renderPage({ business: initialBusiness, municipalities: [randomMunicipality] });
+    selectByText("Location", randomMunicipality.displayName);
+    expect(screen.getByLabelText("Location")).toHaveValue(randomMunicipality.displayName);
     fireEvent.blur(screen.getByLabelText("Location"));
     clickSave();
     await waitFor(() => {
-      return expect(currentBusiness().profileData.municipality).toEqual(newark);
+      return expect(currentBusiness().profileData.municipality).toEqual(randomMunicipality);
     });
     expect(
       mockAnalytics.event.profile_location_question.submit.location_entered_for_first_time
@@ -292,20 +280,19 @@ describe("profile - shared", () => {
   });
 
   it("does not send analytics when municipality already existed", async () => {
-    const newark = generateMunicipality({ displayName: "Newark" });
+    const randomMunicipality = generateMunicipality({});
 
     const initialBusiness = generateBusinessForProfile({
       profileData: generateProfileData({
-        municipality: generateMunicipality({ displayName: "Jersey City" }),
+        municipality: generateMunicipality({ displayName: "Some Display Name" }),
       }),
-      formationData: formationWithUndefinedMunicipality,
     });
 
-    renderPage({ business: initialBusiness, municipalities: [newark] });
-    selectByText("Location", newark.displayName);
+    renderPage({ business: initialBusiness, municipalities: [randomMunicipality] });
+    selectByText("Location", randomMunicipality.displayName);
     clickSave();
     await waitFor(() => {
-      return expect(currentBusiness().profileData.municipality).toEqual(newark);
+      return expect(currentBusiness().profileData.municipality).toEqual(randomMunicipality);
     });
     expect(
       mockAnalytics.event.profile_location_question.submit.location_entered_for_first_time
@@ -325,7 +312,6 @@ describe("profile - shared", () => {
                 foreignBusinessTypeIds: businessPersona === "FOREIGN" ? ["none"] : [],
               }),
               taxFilingData: generateTaxFilingData({ state: randomInt() % 2 ? "SUCCESS" : "PENDING" }),
-              formationData: formationWithUndefinedMunicipality,
             });
 
             renderPage({ business });
@@ -367,7 +353,6 @@ describe("profile - shared", () => {
             profileData: generateProfileData({
               legalStructureId: randomPublicFilingLegalStructure(),
             }),
-            formationData: formationWithUndefinedMunicipality,
           });
           renderPage({ business });
           chooseTab("numbers");
@@ -385,7 +370,6 @@ describe("profile - shared", () => {
           operatingPhase,
           dateOfFormation: undefined,
         }),
-        formationData: formationWithUndefinedMunicipality,
       });
       renderPage({ business });
 
@@ -398,7 +382,6 @@ describe("profile - shared", () => {
           operatingPhase,
           dateOfFormation: undefined,
         }),
-        formationData: formationWithUndefinedMunicipality,
       });
       renderPage({ business });
 
@@ -450,7 +433,6 @@ describe("profile - shared", () => {
           businessPersona: "OWNING",
           legalStructureId: randomPublicFilingLegalStructure(),
         },
-        formationData: formationWithUndefinedMunicipality,
       });
       renderPage({ business });
       expect(
@@ -473,7 +455,6 @@ describe("profile - shared", () => {
           existingEmployees: undefined,
           legalStructureId: randomPublicFilingLegalStructure(),
         }),
-        formationData: formationWithUndefinedMunicipality,
       });
       renderPage({ business });
 
@@ -500,9 +481,6 @@ describe("profile - shared", () => {
       const business = generateBusinessForProfile({
         formationData: generateFormationData({
           completedFilingPayment: false,
-          formationFormData: generateFormationFormData({
-            addressMunicipality: undefined,
-          }),
         }),
         profileData: generateProfileData({
           dateOfFormation: undefined,
@@ -519,9 +497,6 @@ describe("profile - shared", () => {
       const business = generateBusinessForProfile({
         formationData: generateFormationData({
           completedFilingPayment: true,
-          formationFormData: generateFormationFormData({
-            addressMunicipality: undefined,
-          }),
         }),
         profileData: generateProfileData({
           dateOfFormation: undefined,
@@ -578,9 +553,6 @@ describe("profile - shared", () => {
         const business = generateBusinessForProfile({
           formationData: generateFormationData({
             completedFilingPayment: false,
-            formationFormData: generateFormationFormData({
-              addressMunicipality: undefined,
-            }),
           }),
           profileData: generateProfileData({
             dateOfFormation: "2020-8-8",
@@ -603,7 +575,6 @@ describe("profile - shared", () => {
           foreignBusinessTypeIds:
             profileData.businessPersona === "FOREIGN" ? ["employeeOrContractorInNJ"] : [],
         }),
-        formationData: formationWithUndefinedMunicipality,
       });
     };
 
@@ -656,7 +627,6 @@ describe("profile - shared", () => {
           business: generateBusinessForProfile({
             profileData: generateProfileData({
               businessPersona: businessPersona,
-              municipality: generateMunicipality({ displayName: "Trenton" }),
               industryId: industry.id,
               ...getForeignNexusProfileFields(businessPersona),
             }),
@@ -674,7 +644,6 @@ describe("profile - shared", () => {
           profileData: generateProfileData({
             businessPersona: "OWNING",
           }),
-          formationData: formationWithUndefinedMunicipality,
         }),
       });
       expect(
@@ -694,7 +663,6 @@ describe("profile - shared", () => {
             foreignBusinessTypeIds:
               businessPersona === "FOREIGN" ? ["employeeOrContractorInNJ", "officeInNJ"] : [],
           }),
-          formationData: formationWithUndefinedMunicipality,
         });
         renderPage({ business });
         clickSave();

--- a/web/test/pages/profile/profile-starting.test.tsx
+++ b/web/test/pages/profile/profile-starting.test.tsx
@@ -114,9 +114,6 @@ describe("profile - starting business", () => {
 
   describe("locks fields when formation getFiling success", () => {
     const legalStructure = "limited-liability-company";
-    const municipality = generateMunicipality({
-      displayName: "some-cool-town",
-    });
     const startingBusiness = generateBusinessForProfile({
       formationData: generateFormationData({
         completedFilingPayment: true,
@@ -127,7 +124,6 @@ describe("profile - starting business", () => {
         legalStructureId: legalStructure,
         entityId: "some-id",
         businessName: "some-name",
-        municipality: municipality,
       }),
     });
 
@@ -172,8 +168,7 @@ describe("profile - starting business", () => {
           dateOfFormation: "",
         }),
       });
-      const newark = generateMunicipality({ displayName: "Newark" });
-      renderPage({ business: initialBusiness, municipalities: [newark] });
+      renderPage({ business: initialBusiness });
       chooseTab("numbers");
       expect(getDateOfFormation()).toBeUndefined();
     });
@@ -182,8 +177,7 @@ describe("profile - starting business", () => {
       const initialBusiness = generateBusinessForProfile({
         profileData: generateProfileData({ businessPersona: "STARTING", dateOfFormation: "2020-01-01" }),
       });
-      const newark = generateMunicipality({ displayName: "Newark" });
-      renderPage({ business: initialBusiness, municipalities: [newark] });
+      renderPage({ business: initialBusiness });
       expect(getDateOfFormation()).toBe("01/2020");
     });
 
@@ -195,8 +189,7 @@ describe("profile - starting business", () => {
             dateOfFormation: "2017-10-01",
           }),
         });
-        const newark = generateMunicipality({ displayName: "Newark" });
-        renderPage({ business: initialBusiness, municipalities: [newark] });
+        renderPage({ business: initialBusiness });
         fillText("Date of formation", "");
         clickSave();
         expect(getDateOfFormation()).toBe("");
@@ -209,9 +202,8 @@ describe("profile - starting business", () => {
             dateOfFormation: "2017-10-01",
           }),
         });
-        const newark = generateMunicipality({ displayName: "Newark" });
 
-        renderPage({ business: initialBusiness, municipalities: [newark] });
+        renderPage({ business: initialBusiness });
         fillText("Date of formation", "");
 
         clickSave();
@@ -230,9 +222,8 @@ describe("profile - starting business", () => {
             dateOfFormation: "2017-10-01",
           }),
         });
-        const newark = generateMunicipality({ displayName: "Newark" });
 
-        renderPage({ business: initialBusiness, municipalities: [newark] });
+        renderPage({ business: initialBusiness });
         fillText("Date of formation", "");
 
         clickSave();
@@ -292,10 +283,10 @@ describe("profile - starting business", () => {
       },
     };
     const inputFieldName = getBusinessProfileInputFieldName(initialBusiness);
-    const newark = generateMunicipality({ displayName: "Newark" });
-    renderPage({ business: initialBusiness, municipalities: [newark] });
+    const randomMunicipality = generateMunicipality({ displayName: "Newark" });
+    renderPage({ business: initialBusiness, municipalities: [randomMunicipality] });
     fillText(inputFieldName, "Cool Computers");
-    selectByText("Location", newark.displayName);
+    selectByText("Location", randomMunicipality.displayName);
     selectByValue("Industry", "e-commerce");
     chooseRadio("home-based-business-radio-true");
 
@@ -321,7 +312,7 @@ describe("profile - starting business", () => {
         industryId: "e-commerce",
         sectorId: "retail-trade-and-ecommerce",
         homeBasedBusiness: true,
-        municipality: newark,
+        municipality: randomMunicipality,
         taxId: "023456790123",
         employerId: "023456780",
         notes: "whats appppppp",
@@ -380,7 +371,6 @@ describe("profile - starting business", () => {
       legalStructureId: string;
       operatingPhase: OperatingPhaseId;
     }): void => {
-      const newark = generateMunicipality({ displayName: "Newark" });
       const business = generateBusinessForProfile({
         profileData: generateProfileData({
           legalStructureId: params.legalStructureId,
@@ -388,21 +378,22 @@ describe("profile - starting business", () => {
           businessPersona: "STARTING",
         }),
       });
-      renderPage({ municipalities: [newark], business });
+      renderPage({ business });
     };
 
     it("locks the location field when it is populated and tax filing state is SUCCESS", () => {
+      const randomMunicipality = generateMunicipality({});
       renderPage({
         business: generateBusinessForProfile({
           profileData: generateProfileData({
-            municipality: generateMunicipality({ displayName: "Trenton" }),
+            municipality: randomMunicipality,
           }),
           taxFilingData: generateTaxFilingData({
             state: "SUCCESS",
           }),
         }),
       });
-      expect(screen.getByText("Trenton")).toBeInTheDocument();
+      expect(screen.getByText(randomMunicipality.displayName)).toBeInTheDocument();
       expect(screen.getByTestId("locked-municipality")).toBeInTheDocument();
     });
 
@@ -718,6 +709,7 @@ describe("profile - starting business", () => {
   });
 
   it("prefills form from existing user data", () => {
+    const randomMunicipality = generateMunicipality({});
     const business = generateBusinessForProfile({
       profileData: generateProfileData({
         businessPersona: "STARTING",
@@ -728,9 +720,7 @@ describe("profile - starting business", () => {
         employerId: "123456789",
         taxId: "123456790",
         notes: "whats appppppp",
-        municipality: generateMunicipality({
-          displayName: "Newark",
-        }),
+        municipality: randomMunicipality,
       }),
     });
 
@@ -738,7 +728,7 @@ describe("profile - starting business", () => {
     expect(getBusinessNameValue()).toEqual("Applebees");
 
     expect(getIndustryValue()).toEqual(LookupIndustryById("cosmetology").name);
-    expect(getMunicipalityValue()).toEqual("Newark");
+    expect(getMunicipalityValue()).toEqual(randomMunicipality.displayName);
     chooseTab("numbers");
     expect(getEmployerIdValue()).toEqual("12-3456789");
     expect(getEntityIdValue()).toEqual("1234567890");
@@ -751,9 +741,9 @@ describe("profile - starting business", () => {
     const initialBusiness = generateBusinessForProfile({
       profileData: generateProfileData({ businessPersona: "STARTING" }),
     });
-    const newark = generateMunicipality({ displayName: "Newark" });
-    renderPage({ business: initialBusiness, municipalities: [newark] });
-    selectByText("Location", newark.displayName);
+    const randomMunicipality = generateMunicipality({});
+    renderPage({ business: initialBusiness, municipalities: [randomMunicipality] });
+    selectByText("Location", randomMunicipality.displayName);
     clickBack();
     fireEvent.click(screen.getByText(Config.profileDefaults.default.escapeModalReturn));
     await waitFor(() => {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->
https://www.pivotaltracker.com/story/show/187815961

### Approach
There was an issue with how profile tests were loading municipalities leading to a mui autocomplete component error. We updated the test logic to load all possible municipalities from userData. 

Separately, we removed the logic previously added that prevented the failing of tests when the address in oscar profile was added.

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
