### PR TITLE
fix: [#187790624] update Health Club dynamics licenseType and add test for non-00 rgb numbers

### DIFF
--- a/api/src/client/dynamics/license-status/DynamicsLicenseApplicationIdClient.test.ts
+++ b/api/src/client/dynamics/license-status/DynamicsLicenseApplicationIdClient.test.ts
@@ -234,6 +234,34 @@ describe("DynamicsLicenseApplicationIdClient", () => {
     ).rejects.toEqual(new Error(NO_MAIN_APPS_ERROR));
   });
 
+  it("does not throw NO_MAIN_APPS error when querying a Health Club license with an rgb_number that does not end with 00", async () => {
+    const mockHealthClubLicenseApplicationIdResponse = {
+      value: [
+        {
+          rgb_appnumber: "DEaseHC01830",
+          rgb_number: "HC01830",
+          rgb_startdate: "2022-02-10T05:00:00Z",
+          rgb_versioncode: 100000001,
+          rgb_expirationdate: "2024-02-09T05:00:00Z",
+          statecode: 0,
+          statuscode: 100000018,
+          rgb_applicationid: "cadc7d25-b598-ed11-aad1-001dd804fc2b",
+          _rgb_businessid_value: "02903371-5798-ed11-aad0-001dd8098598",
+        },
+      ],
+    };
+
+    const expected = {
+      applicationId: "cadc7d25-b598-ed11-aad1-001dd804fc2b",
+      expirationDate: "2024-02-09T05:00:00Z",
+      licenseStatus: "EXPIRED",
+    };
+    mockAxios.get.mockResolvedValue({ data: mockHealthClubLicenseApplicationIdResponse });
+    expect(await client.getLicenseApplicationId(mockAccessToken, mockBusinessId, "Health Club")).toEqual(
+      expected
+    );
+  });
+
   it("returns the first application when there are multiple matching apps whose rgb_number ends with 00", async () => {
     const mockResponseWithMultipleMainApplications = {
       value: [

--- a/api/src/client/dynamics/license-status/DynamicsLicenseApplicationIdClient.ts
+++ b/api/src/client/dynamics/license-status/DynamicsLicenseApplicationIdClient.ts
@@ -32,7 +32,7 @@ export const DynamicsLicenseApplicationIdClient = (
       )
       .then((response) => {
         logWriter.LogInfo(
-          `Dynamics License Application Id Client - Id:${logId} - Response: ${JSON.stringify(response.data)}`
+          `Dynamics License Application Id Client - Id:${logId} - Response: ${JSON.stringify(response?.data)}`
         );
 
         const mainActiveApplications = response.data.value
@@ -40,10 +40,12 @@ export const DynamicsLicenseApplicationIdClient = (
             (applicationDetails: LicenseApplicationIdApiResponse) =>
               applicationDetails.statecode === ACTIVE_STATECODE
           )
-          .filter(
-            (applicationDetails: LicenseApplicationIdApiResponse) =>
+          .filter((applicationDetails: LicenseApplicationIdApiResponse) => {
+            if (licenseType === "Health Club") return true;
+            return (
               applicationDetails.rgb_number && applicationDetails.rgb_number.slice(-2) === MAIN_APP_END_DIGITS
-          );
+            );
+          });
 
         if (mainActiveApplications.length === 0) {
           throw new Error(NO_MAIN_APPS_ERROR);
@@ -67,7 +69,7 @@ const licenseTypeToLicenseId: Record<string, string> = {
   "Public Movers and Warehousemen": "19391a3f-53df-eb11-bacb-001dd8028561",
   "Home Improvement Contractor": "7a391a3f-53df-eb11-bacb-001dd8028561",
   "Health Care Services": "3ac8456a-53df-eb11-bacb-001dd8028561",
-  "Health Club Services": "af8e3564-53df-eb11-bacb-001dd8028561",
+  "Health Club": "af8e3564-53df-eb11-bacb-001dd8028561",
 };
 
 const statusCodeToLicenseStatus: Record<number, LicenseStatus> = {

--- a/api/src/domain/license-status/searchLicenseStatusFactory.test.ts
+++ b/api/src/domain/license-status/searchLicenseStatusFactory.test.ts
@@ -51,7 +51,7 @@ describe("searchLicenseStatusFactory", () => {
     });
 
     it("returns dynamics status client when license type is health club services", () => {
-      const licenseType = "Health Club Services";
+      const licenseType = "Health Club";
       const licenseStatus = searchLicenseStatus(licenseType);
       licenseStatus(generateLicenseSearchNameAndAddress({}), licenseType);
       expect(stubDynamicsSearchLicenseStatus).toHaveBeenCalled();

--- a/api/src/domain/license-status/searchLicenseStatusFactory.ts
+++ b/api/src/domain/license-status/searchLicenseStatusFactory.ts
@@ -12,7 +12,7 @@ export const searchLicenseStatusFactory = (
     const licenseTypesUsingDynamicsSearch: Record<string, boolean> = {
       "Public Movers and Warehousemen": featureFlags.publicMovers,
       "Health Care Services": true,
-      "Health Club Services": true,
+      "Health Club": true,
     };
 
     const shouldUseDynamicsSearch = licenseTypesUsingDynamicsSearch[licenseType] || false;


### PR DESCRIPTION


<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

1. Update Dynamics `licenseType` to match industry `licenseType`.
2.  Add logic and relevant test to account for the Health Club industry application IDs that do not end in `00`.


### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#187790624](https://www.pivotaltracker.com/story/show/187790624).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
