### PR TITLE
fix: [#187920482] requests to GetFiling should be text/plain

### DIFF
--- a/api/src/client/ApiFormationClient.ts
+++ b/api/src/client/ApiFormationClient.ts
@@ -111,7 +111,11 @@ export const ApiFormationClient = (config: ApiConfig, logger: LogWriterType): Fo
       }/GetCompletedFiling data: ${JSON.stringify(postBody)}`
     );
     return axios
-      .post(`${config.baseUrl}/GetCompletedFiling`, postBody)
+      .post(`${config.baseUrl}/GetCompletedFiling`, postBody, {
+        headers: {
+          "Content-Type": "text/plain",
+        },
+      })
       .then((response) => {
         logger.LogInfo(
           `GetFiling - NICUSA - Id:${logId} - Response received: ${JSON.stringify(response.data)}`


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

This change allows us to make calls to GetFiling again, which now requires that all requests be sent as `text/plain`.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#187920482](https://www.pivotaltracker.com/story/show/187920482).

