### PR TITLE
Update formatting in /license-tasks/pharmacy-cds.md

### DIFF
--- a/content/src/roadmaps/license-tasks/pharmacy-cds.md
+++ b/content/src/roadmaps/license-tasks/pharmacy-cds.md
@@ -1,18 +1,17 @@
 ---
-id: "pharmacy-cds"
-webflowId: "668d72eeb67e0989ab73ef3a"
-urlSlug: "pharmacy-cds"
-name: "Apply for Your Pharmacy’s Controlled Dangerous Substance (CDS) Registration"
+id: pharmacy-cds
+webflowId: 668d72eeb67e0989ab73ef3a
+urlSlug: pharmacy-cds
+name: Apply for Your Pharmacy’s Controlled Dangerous Substance (CDS) Registration
 webflowName: "Pharmacy: Controlled Dangerous Substance Registration"
-filename: "pharmacy-cds"
-callToActionLink: "https://www.njconsumeraffairs.gov/dcu/Applications/Initial-Application-for-Registration-for-Dispenser-Pharmacy.pdf"
-callToActionText: "Apply for My Pharmacy’s CDS Registration"
-agencyId: "nj-consumer-affairs"
-agencyAdditionalContext: "New Jersey Drug Control Unit"
-industryId: "pharmacy"
-licenseCertificationClassification: "undefined"
-summaryDescriptionMd: "You need CDS registration if you or your business dispense Controlled Dangerous Substances. You must already have a [New Jersey Board of Pharmacy (BOP) permit](https://www.njconsumeraffairs.gov/phar/Applications/Pharmacy-Permit-Application.pdf) before applying for CDS registration.
-"
+filename: pharmacy-cds
+callToActionLink: https://www.njconsumeraffairs.gov/dcu/Applications/Initial-Application-for-Registration-for-Dispenser-Pharmacy.pdf
+callToActionText: Apply for My Pharmacy’s CDS Registration
+agencyId: nj-consumer-affairs
+agencyAdditionalContext: New Jersey Drug Control Unit
+industryId: pharmacy
+licenseCertificationClassification: undefined
+summaryDescriptionMd: You need CDS registration if you or your business dispense Controlled Dangerous Substances. You must already have a [New Jersey Board of Pharmacy (BOP) permit](https://www.njconsumeraffairs.gov/phar/Applications/Pharmacy-Permit-Application.pdf) before applying for CDS registration.
 ---
 
 :::callout{ showHeader="true" headerText="" showIcon="false" calloutType="note" }


### PR DESCRIPTION
## Description

For some reason when the `summaryDescriptionMd` field contains quotes the CMS flips out and won't render the content correctly. Removed the quotes, fixed the issue.