### PR TITLE
feat: [#186084933] onboarding step header shoudl be read a single hea…

### DIFF
--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -442,13 +442,11 @@ const OnboardingPage = (props: Props): ReactElement => {
 
   const header = (): ReactElement => {
     return (
-      <div className="margin-y-2 desktop:margin-y-0 desktop:padding-bottom-1">
-        <h1 ref={headerRef}>
-          {pageTitle}{" "}
-          <span className="text-light" data-testid={`step-${page.current.toString()}`}>
-            {evalHeaderStepsTemplate(page)}
-          </span>
-        </h1>
+      <div
+        className="margin-y-2 desktop:margin-y-0 desktop:padding-bottom-1"
+        data-testid={`step-${page.current.toString()}`}
+      >
+        <h1 ref={headerRef}>{`${[pageTitle, evalHeaderStepsTemplate(page)].join(" ")}`}</h1>
       </div>
     );
   };

--- a/web/test/pages/onboarding/helpers-onboarding.tsx
+++ b/web/test/pages/onboarding/helpers-onboarding.tsx
@@ -6,6 +6,7 @@ import {
   getEssentialQuestion,
   hasEssentialQuestion,
 } from "@/lib/domain-logic/essentialQuestions";
+import { modifyContent } from "@/lib/domain-logic/modifyContent";
 import { camelCaseToKebabCase } from "@/lib/utils/cases-helpers";
 import Onboarding from "@/pages/onboarding";
 import { withAuth } from "@/test/helpers/helpers-renderers";
@@ -355,3 +356,21 @@ export const industryIdsWithSingleRequiredEssentialQuestion = industryIdsWithSin
     return someQuestionsStartAsUndefined;
   }
 );
+
+export const composeOnBoardingTitle = (step: string, pageTitle?: string): string => {
+  const Config = getMergedConfig();
+  if (pageTitle === undefined) {
+    const pageTitleDefault = modifyContent({
+      content: Config.onboardingDefaults.pageTitle,
+      condition: () => false,
+      modificationMap: {
+        Additional: "Additional",
+        additional: "additional",
+      },
+    });
+    // return `${pageTitleDefault} ${step}`;
+    return `${[pageTitleDefault, step].join(" ")}`;
+  }
+  // return `${pageTitle} ${step}`;
+  return `${[pageTitle, step].join(" ")}`;
+};

--- a/web/test/pages/onboarding/onboarding-additional-business.test.tsx
+++ b/web/test/pages/onboarding/onboarding-additional-business.test.tsx
@@ -4,13 +4,18 @@ import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { getNavBarBusinessTitle } from "@/lib/domain-logic/getNavBarBusinessTitle";
 import { QUERIES, ROUTES } from "@/lib/domain-logic/routes";
 import { templateEval } from "@/lib/utils/helpers";
+import { evalHeaderStepsTemplate } from "@/lib/utils/onboardingPageHelpers";
 import { mockPush, useMockRouter } from "@/test/mock/mockRouter";
 import {
   currentBusiness,
   currentUserData,
   setupStatefulUserDataContext,
 } from "@/test/mock/withStatefulUserData";
-import { mockSuccessfulApiSignups, renderPage } from "@/test/pages/onboarding/helpers-onboarding";
+import {
+  composeOnBoardingTitle,
+  mockSuccessfulApiSignups,
+  renderPage,
+} from "@/test/pages/onboarding/helpers-onboarding";
 import { generateProfileData } from "@businessnjgovnavigator/shared";
 import { generateBusiness, generateUserDataForBusiness } from "@businessnjgovnavigator/shared/test";
 import { UserData, createEmptyBusiness } from "@businessnjgovnavigator/shared/userData";
@@ -47,7 +52,9 @@ describe("onboarding - additional business", () => {
     });
 
     const expectedTitle = templateEval(Config.onboardingDefaults.pageTitle, { Additional: "Additional" });
-    expect(screen.getByText(expectedTitle)).toBeInTheDocument();
+    const step = evalHeaderStepsTemplate({ current: 1, previous: 1 });
+
+    expect(screen.getByText(composeOnBoardingTitle(step, expectedTitle))).toBeInTheDocument();
   });
 
   it("returns user to previous business without saving", async () => {

--- a/web/test/pages/onboarding/onboarding-foreign.test.tsx
+++ b/web/test/pages/onboarding/onboarding-foreign.test.tsx
@@ -9,6 +9,7 @@ import {
   userDataWasNotUpdated,
 } from "@/test/mock/withStatefulUserData";
 import {
+  composeOnBoardingTitle,
   industryIdsWithSingleRequiredEssentialQuestion,
   mockEmptyApiSignups,
   renderPage,
@@ -59,18 +60,16 @@ describe("onboarding - foreign business", () => {
   describe("page headers", () => {
     it("uses special template eval for step 1 label", () => {
       renderPage({});
-      expect(
-        screen.getByText(templateEval(Config.onboardingDefaults.stepXTemplate, { currentPage: "1" }))
-      ).toBeInTheDocument();
+      const step = templateEval(Config.onboardingDefaults.stepXTemplate, { currentPage: "1" });
+      expect(screen.getByText(composeOnBoardingTitle(step))).toBeInTheDocument();
     });
 
     it("uses special template eval for step 2 label", () => {
       const userData = generateTestUserData({ businessPersona: "FOREIGN" });
       useMockRouter({ isReady: true, query: { page: "2" } });
       renderPage({ userData });
-      expect(
-        screen.getByText(templateEval(Config.onboardingDefaults.stepXTemplate, { currentPage: "2" }))
-      ).toBeInTheDocument();
+      const step = templateEval(Config.onboardingDefaults.stepXTemplate, { currentPage: "2" });
+      expect(screen.getByText(composeOnBoardingTitle(step))).toBeInTheDocument();
     });
   });
 
@@ -305,9 +304,8 @@ describe("onboarding - foreign business", () => {
 
     it("displays step 3", () => {
       renderPage({ userData });
-      expect(
-        screen.getByText(templateEval(Config.onboardingDefaults.stepXTemplate, { currentPage: "3" }))
-      ).toBeInTheDocument();
+      const step = templateEval(Config.onboardingDefaults.stepXTemplate, { currentPage: "3" });
+      expect(screen.getByText(composeOnBoardingTitle(step))).toBeInTheDocument();
     });
 
     it("displays industry question", async () => {

--- a/web/test/pages/onboarding/onboarding-owning.test.tsx
+++ b/web/test/pages/onboarding/onboarding-owning.test.tsx
@@ -3,7 +3,11 @@ import * as api from "@/lib/api-client/apiClient";
 import { templateEval } from "@/lib/utils/helpers";
 import { mockPush, useMockRouter } from "@/test/mock/mockRouter";
 import { currentBusiness, setupStatefulUserDataContext } from "@/test/mock/withStatefulUserData";
-import { mockEmptyApiSignups, renderPage } from "@/test/pages/onboarding/helpers-onboarding";
+import {
+  composeOnBoardingTitle,
+  mockEmptyApiSignups,
+  renderPage,
+} from "@/test/pages/onboarding/helpers-onboarding";
 import {
   OperatingPhaseId,
   ProfileData,
@@ -57,9 +61,9 @@ describe("onboarding - owning a business", () => {
   describe("page 1", () => {
     it("uses standard template eval for step label", () => {
       renderPage({});
-      expect(
-        screen.getByText(templateEval(Config.onboardingDefaults.stepXTemplate, { currentPage: "1" }))
-      ).toBeInTheDocument();
+      const step = templateEval(Config.onboardingDefaults.stepXTemplate, { currentPage: "1" });
+
+      expect(screen.getByText(composeOnBoardingTitle(step))).toBeInTheDocument();
     });
 
     it("displays the sector dropdown after radio selected", () => {

--- a/web/test/pages/onboarding/onboarding-shared.test.tsx
+++ b/web/test/pages/onboarding/onboarding-shared.test.tsx
@@ -11,6 +11,7 @@ import {
   setupStatefulUserDataContext,
 } from "@/test/mock/withStatefulUserData";
 import {
+  composeOnBoardingTitle,
   industriesWithOutEssentialQuestion,
   industriesWithSingleEssentialQuestion,
   mockSuccessfulApiSignups,
@@ -178,11 +179,11 @@ describe("onboarding - shared", () => {
     page.selectByValue("Industry", "e-commerce");
     page.clickBack();
 
+    const step = templateEval(Config.onboardingDefaults.stepXTemplate, { currentPage: "1" });
+
     expect(screen.getByTestId("step-1")).toBeInTheDocument();
     expect(screen.getByTestId("business-persona-owning")).toBeInTheDocument();
-    expect(
-      screen.getByText(templateEval(Config.onboardingDefaults.stepXTemplate, { currentPage: "1" }))
-    ).toBeInTheDocument();
+    expect(screen.getByText(composeOnBoardingTitle(step))).toBeInTheDocument();
     page.chooseRadio("business-persona-owning");
     page.clickNext();
     await waitFor(() => {


### PR DESCRIPTION
…der on IOS mobile

<!-- Please complete the following sections as necessary. -->

## Description

We had a span for the step part of our onboarding headers which was interfering with header navigation on IOS, so we have changed this to remove the span and corresponding styling

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#186084933](https://www.pivotaltracker.com/story/show/186084933).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

Our tests looked for the text for steps in isolation, now instead it has to look for hte entire header so I made a helper function to compose the header information including the step.

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
