### PR TITLE
fix: [#186334874] Formation API responses inconsistently being receiv…

### DIFF
--- a/web/src/components/tasks/business-formation/BusinessFormation.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormation.tsx
@@ -138,7 +138,7 @@ export const BusinessFormation = (props: Props): ReactElement => {
         return false;
       }
       const completeFilingQueryParamExists = checkQueryValue(router, QUERIES.completeFiling, "true");
-      const completedPayment = business.formationData.completedFilingPayment;
+      const completedPayment = business.formationData.formationResponse?.success === true;
       const noCompletedFilingExists = !business.formationData.getFilingResponse?.success;
       return completeFilingQueryParamExists || (completedPayment && noCompletedFilingExists);
     };


### PR DESCRIPTION
…ed/saved

<!-- Please complete the following sections as necessary. -->

## Description

A number of users have reported an intermittent issue where they have been paying, receiving formation documents, confirmation emails, but not getting a success screen or having the task completed in the Navigator. It is unclear if this is an issue with the Formation API not returning a valid response, or if we are dropping the response.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#186334874](https://www.pivotaltracker.com/story/show/186334874).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
