### PR TITLE
refactor: [#187935188] move navbar calls into PageSkeleton as optional

### DIFF
--- a/web/src/components/dashboard/anytime-actions/AnytimeActionPage.tsx
+++ b/web/src/components/dashboard/anytime-actions/AnytimeActionPage.tsx
@@ -1,7 +1,6 @@
 import { Content } from "@/components/Content";
 import { HorizontalLine } from "@/components/HorizontalLine";
 import { TaskSidebarPageLayout } from "@/components/TaskSidebarPageLayout";
-import { NavBar } from "@/components/navbar/NavBar";
 import { Alert } from "@/components/njwds-extended/Alert";
 import { SingleCtaLink } from "@/components/njwds-extended/cta/SingleCtaLink";
 import { PageSkeleton } from "@/components/njwds-layout/PageSkeleton";
@@ -79,8 +78,7 @@ export const AnytimeActionPage = (props: Props): ReactElement => {
   return (
     <>
       <NextSeo title={getNextSeoTitle(props.anytimeAction.name)} />
-      <PageSkeleton>
-        <NavBar showSidebar={true} hideMiniRoadmap={true} />
+      <PageSkeleton showNavBar showSidebar hideMiniRoadmap>
         <TaskSidebarPageLayout hideMiniRoadmap={true}>
           {rswitch(props.anytimeAction.filename, {
             "government-contracting": (

--- a/web/src/components/njwds-layout/PageSkeleton.tsx
+++ b/web/src/components/njwds-layout/PageSkeleton.tsx
@@ -1,13 +1,21 @@
 import { BetaBar } from "@/components/BetaBar";
 import { LegalMessage } from "@/components/LegalMessage";
-import { Banner } from "@/components/njwds/Banner";
 import { PageFooter } from "@/components/PageFooter";
 import { SkipToMainContent } from "@/components/SkipToMainContent";
+import { NavBar } from "@/components/navbar/NavBar";
+import { Banner } from "@/components/njwds/Banner";
+import { Task } from "@/lib/types/types";
 import React, { ReactElement } from "react";
 
 interface Props {
   children: React.ReactNode;
   landingPage?: boolean;
+  showNavBar?: boolean;
+  task?: Task;
+  showSidebar?: boolean;
+  hideMiniRoadmap?: boolean;
+  logoOnly?: "NAVIGATOR_LOGO" | "NAVIGATOR_MYNJ_LOGO" | undefined;
+  previousBusinessId?: string | undefined;
 }
 
 export const PageSkeleton = (props: Props): ReactElement => {
@@ -17,7 +25,19 @@ export const PageSkeleton = (props: Props): ReactElement => {
         {!props.landingPage && <SkipToMainContent />}
         <Banner />
       </section>
-      <div className="fit-screen-content">{props.children}</div>
+      <div className="fit-screen-content">
+        {props.showNavBar && (
+          <NavBar
+            landingPage={props.landingPage}
+            task={props.task}
+            showSidebar={props.showSidebar}
+            hideMiniRoadmap={props.hideMiniRoadmap}
+            logoOnly={props.logoOnly}
+            previousBusinessId={props.previousBusinessId}
+          />
+        )}
+        {props.children}
+      </div>
       <footer>
         {!props.landingPage && (
           <>

--- a/web/src/pages/account-setup.tsx
+++ b/web/src/pages/account-setup.tsx
@@ -1,6 +1,5 @@
 import { Content } from "@/components/Content";
 import { AccountSetupForm } from "@/components/data-fields/AccountSetupForm";
-import { NavBar } from "@/components/navbar/NavBar";
 import { Alert } from "@/components/njwds-extended/Alert";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { PageSkeleton } from "@/components/njwds-layout/PageSkeleton";
@@ -112,8 +111,7 @@ const AccountSetupPage = (): ReactElement => {
   };
 
   return (
-    <PageSkeleton>
-      <NavBar logoOnly="NAVIGATOR_MYNJ_LOGO" />
+    <PageSkeleton showNavBar logoOnly="NAVIGATOR_MYNJ_LOGO">
       <main id="main" className="padding-top-0 desktop:padding-top-8">
         <SingleColumnContainer isSmallerWidth>
           <h1>{getContent().header}</h1>

--- a/web/src/pages/certification/[certificationUrlSlug].tsx
+++ b/web/src/pages/certification/[certificationUrlSlug].tsx
@@ -1,7 +1,6 @@
 import { Content } from "@/components/Content";
 import { HorizontalLine } from "@/components/HorizontalLine";
 import { TaskSidebarPageLayout } from "@/components/TaskSidebarPageLayout";
-import { NavBar } from "@/components/navbar/NavBar";
 import { Heading } from "@/components/njwds-extended/Heading";
 import { SingleCtaLink } from "@/components/njwds-extended/cta/SingleCtaLink";
 import { PageSkeleton } from "@/components/njwds-layout/PageSkeleton";
@@ -60,8 +59,7 @@ const CertificationPage = (props: Props): ReactElement => {
   return (
     <>
       {props.certification.name && <NextSeo title={getNextSeoTitle(props.certification.name)} />}
-      <PageSkeleton>
-        <NavBar showSidebar={true} hideMiniRoadmap={true} />
+      <PageSkeleton showNavBar showSidebar hideMiniRoadmap>
         <TaskSidebarPageLayout hideMiniRoadmap={true}>
           <CertificationElement certification={props.certification} />
         </TaskSidebarPageLayout>

--- a/web/src/pages/dashboard.tsx
+++ b/web/src/pages/dashboard.tsx
@@ -2,7 +2,6 @@ import { PageCircularIndicator } from "@/components/PageCircularIndicator";
 import { DashboardAlerts } from "@/components/dashboard/DashboardAlerts";
 import { DashboardOnDesktop } from "@/components/dashboard/DashboardOnDesktop";
 import { DashboardOnMobile } from "@/components/dashboard/DashboardOnMobile";
-import { NavBar } from "@/components/navbar/NavBar";
 import { PageSkeleton } from "@/components/njwds-layout/PageSkeleton";
 import { MunicipalitiesContext } from "@/contexts/municipalitiesContext";
 import { MediaQueries } from "@/lib/PageSizes";
@@ -117,8 +116,7 @@ const DashboardPage = (props: Props): ReactElement => {
   return (
     <MunicipalitiesContext.Provider value={{ municipalities: props.municipalities }}>
       <NextSeo title={getNextSeoTitle(Config.pagesMetadata.dashboardTitle)} />
-      <PageSkeleton>
-        <NavBar />
+      <PageSkeleton showNavBar>
         <main id="main">
           <DashboardAlerts />
           {isLoading && <PageCircularIndicator />}

--- a/web/src/pages/filings/[filingUrlSlug].tsx
+++ b/web/src/pages/filings/[filingUrlSlug].tsx
@@ -3,7 +3,6 @@ import { Callout } from "@/components/Callout";
 import { Content, ExternalLink } from "@/components/Content";
 import { HorizontalLine } from "@/components/HorizontalLine";
 import { TaskSidebarPageLayout } from "@/components/TaskSidebarPageLayout";
-import { NavBar } from "@/components/navbar/NavBar";
 import { Heading } from "@/components/njwds-extended/Heading";
 import { Tag } from "@/components/njwds-extended/Tag";
 import { SingleCtaLink } from "@/components/njwds-extended/cta/SingleCtaLink";
@@ -200,8 +199,7 @@ const FilingPage = (props: Props): ReactElement => {
   return (
     <>
       <NextSeo title={getNextSeoTitle(props.filing.name)} />
-      <PageSkeleton>
-        <NavBar showSidebar={true} hideMiniRoadmap={true} />
+      <PageSkeleton showNavBar showSidebar hideMiniRoadmap>
         <TaskSidebarPageLayout hideMiniRoadmap={true}>
           <FilingElement filing={props.filing} dueDate={matchingFiling?.dueDate ?? ""} />
         </TaskSidebarPageLayout>

--- a/web/src/pages/funding/[fundingUrlSlug].tsx
+++ b/web/src/pages/funding/[fundingUrlSlug].tsx
@@ -1,7 +1,6 @@
 import { Content } from "@/components/Content";
 import { HorizontalLine } from "@/components/HorizontalLine";
 import { TaskSidebarPageLayout } from "@/components/TaskSidebarPageLayout";
-import { NavBar } from "@/components/navbar/NavBar";
 import { SingleCtaLink } from "@/components/njwds-extended/cta/SingleCtaLink";
 import { PageSkeleton } from "@/components/njwds-layout/PageSkeleton";
 import { MediaQueries } from "@/lib/PageSizes";
@@ -87,8 +86,7 @@ const FundingPage = (props: Props): ReactElement => {
   return (
     <>
       <NextSeo title={getNextSeoTitle(props.funding.name)} />
-      <PageSkeleton>
-        <NavBar showSidebar={true} hideMiniRoadmap={true} />
+      <PageSkeleton showNavBar showSidebar hideMiniRoadmap>
         <TaskSidebarPageLayout hideMiniRoadmap={true}>
           <FundingElement funding={props.funding} />
         </TaskSidebarPageLayout>

--- a/web/src/pages/index.tsx
+++ b/web/src/pages/index.tsx
@@ -1,5 +1,4 @@
 import { LegalMessage } from "@/components/LegalMessage";
-import { NavBar } from "@/components/navbar/NavBar";
 import { Heading } from "@/components/njwds-extended/Heading";
 import { PageSkeleton } from "@/components/njwds-layout/PageSkeleton";
 import { Hero } from "@/components/njwds/Hero";
@@ -152,8 +151,7 @@ const Home = (): ReactElement => {
   return (
     <>
       <NextSeo title={getNextSeoTitle(config.pagesMetadata.homeTitle)} />
-      <PageSkeleton landingPage={true}>
-        <NavBar landingPage={true} />
+      <PageSkeleton showNavBar landingPage>
         <main data-testid="main">
           <Hero />
           <section ref={sectionHowItWorks} aria-label={landingPageConfig.section4HeaderText}>

--- a/web/src/pages/licenses/[licenseUrlSlug].tsx
+++ b/web/src/pages/licenses/[licenseUrlSlug].tsx
@@ -1,7 +1,6 @@
 import { Content } from "@/components/Content";
 import { HorizontalLine } from "@/components/HorizontalLine";
 import { TaskSidebarPageLayout } from "@/components/TaskSidebarPageLayout";
-import { NavBar } from "@/components/navbar/NavBar";
 import { SingleCtaLink } from "@/components/njwds-extended/cta/SingleCtaLink";
 import { PageSkeleton } from "@/components/njwds-layout/PageSkeleton";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -88,8 +87,7 @@ const LicensePage = (props: Props): ReactElement => {
   return (
     <>
       <NextSeo title={getNextSeoTitle(licenseName)} />
-      <PageSkeleton>
-        <NavBar showSidebar={true} hideMiniRoadmap={true} />
+      <PageSkeleton showNavBar showSidebar hideMiniRoadmap>
         <TaskSidebarPageLayout>
           <LicenseElement
             license={props.license}

--- a/web/src/pages/loading.tsx
+++ b/web/src/pages/loading.tsx
@@ -1,5 +1,4 @@
 import { PageCircularIndicator } from "@/components/PageCircularIndicator";
-import { NavBar } from "@/components/navbar/NavBar";
 import { PageSkeleton } from "@/components/njwds-layout/PageSkeleton";
 import { SingleColumnContainer } from "@/components/njwds/SingleColumnContainer";
 import { AuthContext } from "@/contexts/authContext";
@@ -63,8 +62,7 @@ const LoadingPage = (): ReactElement => {
   }, userData);
 
   return (
-    <PageSkeleton>
-      <NavBar logoOnly="NAVIGATOR_LOGO" />
+    <PageSkeleton showNavBar logoOnly="NAVIGATOR_LOGO">
       <main className="usa-section padding-top-0 desktop:padding-top-8" id="main">
         <SingleColumnContainer>
           <PageCircularIndicator />

--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -1,5 +1,4 @@
 import { UserDataErrorAlert } from "@/components/UserDataErrorAlert";
-import { NavBar } from "@/components/navbar/NavBar";
 import { Alert } from "@/components/njwds-extended/Alert";
 import { SnackbarAlert } from "@/components/njwds-extended/SnackbarAlert";
 import { PageSkeleton } from "@/components/njwds-layout/PageSkeleton";
@@ -465,11 +464,11 @@ const OnboardingPage = (props: Props): ReactElement => {
           }}
         >
           <NextSeo title={getNextSeoTitle(`${pageTitle} ${evalHeaderStepsTemplate(page)}`)} />
-          <PageSkeleton>
-            <NavBar
-              previousBusinessId={previousBusiness?.id}
-              logoOnly={previousBusiness ? "NAVIGATOR_LOGO" : undefined}
-            />
+          <PageSkeleton
+            showNavBar
+            previousBusinessId={previousBusiness?.id}
+            logoOnly={previousBusiness ? "NAVIGATOR_LOGO" : undefined}
+          >
             <ReturnToPreviousBusinessBar previousBusiness={previousBusiness} />
             <main className="usa-section padding-top-0 desktop:padding-top-8" id="main">
               <SingleColumnContainer isSmallerWidth>

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -25,7 +25,6 @@ import { TaxPin } from "@/components/data-fields/TaxPin";
 import { TradeName } from "@/components/data-fields/TradeName";
 import { FieldLabelProfile } from "@/components/field-labels/FieldLabelProfile";
 import { FormationDateDeletionModal } from "@/components/FormationDateDeletionModal";
-import { NavBar } from "@/components/navbar/NavBar";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
 import { ActionBarLayout } from "@/components/njwds-layout/ActionBarLayout";
@@ -808,8 +807,7 @@ const ProfilePage = (props: Props): ReactElement => {
             }}
           >
             <NextSeo title={getNextSeoTitle(config.pagesMetadata.profileTitle)} />
-            <PageSkeleton>
-              <NavBar showSidebar={true} hideMiniRoadmap={true} />
+            <PageSkeleton showNavBar showSidebar hideMiniRoadmap>
               <main id="main" data-testid={"main"}>
                 <div className="padding-top-0 desktop:padding-top-3">
                   <ProfileEscapeModal

--- a/web/src/pages/roadmap.tsx
+++ b/web/src/pages/roadmap.tsx
@@ -1,5 +1,4 @@
 import { PageCircularIndicator } from "@/components/PageCircularIndicator";
-import { NavBar } from "@/components/navbar/NavBar";
 import { PageSkeleton } from "@/components/njwds-layout/PageSkeleton";
 import { SingleColumnContainer } from "@/components/njwds/SingleColumnContainer";
 import { AuthContext } from "@/contexts/authContext";
@@ -21,8 +20,7 @@ const RoadmapPage = (): ReactElement => {
   }, [router, state.isAuthenticated]);
 
   return (
-    <PageSkeleton>
-      <NavBar logoOnly="NAVIGATOR_LOGO" />
+    <PageSkeleton showNavBar logoOnly="NAVIGATOR_LOGO">
       <main className="usa-section padding-top-0 desktop:padding-top-8" id="main">
         <SingleColumnContainer>
           <PageCircularIndicator />

--- a/web/src/pages/tasks/[taskUrlSlug].tsx
+++ b/web/src/pages/tasks/[taskUrlSlug].tsx
@@ -1,4 +1,3 @@
-import { NavBar } from "@/components/navbar/NavBar";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { PageSkeleton } from "@/components/njwds-layout/PageSkeleton";
 import { Icon } from "@/components/njwds/Icon";
@@ -98,8 +97,7 @@ const TaskPage = (props: Props): ReactElement => {
     <MunicipalitiesContext.Provider value={{ municipalities: props.municipalities }}>
       <HousingMunicipalitiesContext.Provider value={{ municipalities: props.housingMunicipalities }}>
         <NextSeo title={getNextSeoTitle(props.task.name)} />
-        <PageSkeleton>
-          <NavBar task={props.task} showSidebar={true} />
+        <PageSkeleton showNavBar showSidebar task={props.task}>
           <TaskSidebarPageLayout task={props.task} belowBoxComponent={renderNextAndPreviousButtons()}>
             {renderLoadingState && <PageCircularIndicator />}
             {!renderLoadingState && (


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Moves Navbar into the PageSkeleton component since it is always called from there

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#187935188](https://www.pivotaltracker.com/story/show/187935188).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

I poked around on several of the pages with the navbar and it looks good. I also went to pages which use PageSkeleton and not the navbar and that looks good too

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
