### PR TITLE
fix: [#187983571] remove elevator owning non-essential questions for nexus and owning users

### DIFF
--- a/web/src/components/data-fields/RadioQuestion.tsx
+++ b/web/src/components/data-fields/RadioQuestion.tsx
@@ -62,6 +62,7 @@ export const RadioQuestion = <T extends ProfileDataTypes>(props: Props<T>): Reac
           name={camelCaseToKebabCase(props.fieldName)}
           value={state.profileData[props.fieldName]?.toString() ?? ""}
           onChange={handleChange}
+          data-testid={`${props.fieldName}-radio-group`}
           row
         >
           <>

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -312,7 +312,7 @@ const ProfilePage = (props: Props): ReactElement => {
 
   const displayElevatorQuestion = (): boolean => {
     if (!business) return false;
-    return profileData.homeBasedBusiness === false;
+    return profileData.homeBasedBusiness === false && profileData.businessPersona === "STARTING";
   };
 
   const hasSubmittedTaxData =
@@ -396,16 +396,6 @@ const ProfilePage = (props: Props): ReactElement => {
           boldAltDescription={true}
         >
           <RenovationQuestion />
-        </ProfileField>
-
-        <ProfileField
-          fieldName="elevatorOwningBusiness"
-          displayAltDescription={displayAltHomeBasedBusinessDescription}
-          isVisible={displayElevatorQuestion()}
-          hideHeader={true}
-          boldAltDescription={true}
-        >
-          <ElevatorOwningBusiness />
         </ProfileField>
       </>
     ),
@@ -728,16 +718,6 @@ const ProfilePage = (props: Props): ReactElement => {
           boldAltDescription={true}
         >
           <HomeBasedBusiness />
-        </ProfileField>
-
-        <ProfileField
-          fieldName="elevatorOwningBusiness"
-          displayAltDescription={displayAltHomeBasedBusinessDescription}
-          isVisible={displayElevatorQuestion()}
-          hideHeader={true}
-          boldAltDescription={true}
-        >
-          <ElevatorOwningBusiness />
         </ProfileField>
 
         <ProfileField fieldName="ownershipTypeIds">

--- a/web/test/pages/profile/profile-foreign.test.tsx
+++ b/web/test/pages/profile/profile-foreign.test.tsx
@@ -14,7 +14,9 @@ import {
   ProfileData,
   TaxFilingData,
   defaultDateFormat,
+  emptyAddressData,
   emptyIndustrySpecificData,
+  generateFormationFormData,
   generateMunicipality,
   generateProfileData,
   getCurrentDateFormatted,
@@ -518,6 +520,27 @@ describe("profile-foreign", () => {
     it("renders the business name field for remote seller", () => {
       renderPage({ business: foreignRemoteSellerProfile });
       expect(screen.getByTestId("businessName")).toBeInTheDocument();
+    });
+  });
+
+  describe("non essential questions", () => {
+    it("does not show elevator questions for foreign businesses", async () => {
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          industryId: "generic",
+          businessPersona: "OWNING",
+          operatingPhase: OperatingPhaseId.UP_AND_RUNNING_OWNING,
+          homeBasedBusiness: false,
+        }),
+        formationData: generateFormationData({
+          formationFormData: generateFormationFormData({
+            ...emptyAddressData,
+          }),
+        }),
+      });
+      renderPage({ business });
+
+      expect(screen.queryByTestId("elevatorOwningBusiness-radio-group")).not.toBeInTheDocument();
     });
   });
 });

--- a/web/test/pages/profile/profile-owning.test.tsx
+++ b/web/test/pages/profile/profile-owning.test.tsx
@@ -750,6 +750,27 @@ describe("profile - owning existing business", () => {
     });
   });
 
+  describe("non essential questions", () => {
+    it("does not show elevator questions for owning businesses", async () => {
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          industryId: "generic",
+          businessPersona: "OWNING",
+          operatingPhase: OperatingPhaseId.UP_AND_RUNNING_OWNING,
+          homeBasedBusiness: false,
+        }),
+        formationData: generateFormationData({
+          formationFormData: generateFormationFormData({
+            ...emptyAddressData,
+          }),
+        }),
+      });
+      renderPage({ business });
+
+      expect(screen.queryByTestId("elevatorOwningBusiness-radio-group")).not.toBeInTheDocument();
+    });
+  });
+
   const getSectorIDValue = (): string => {
     return (screen.queryByLabelText("Sector") as HTMLInputElement)?.value;
   };

--- a/web/test/pages/profile/profile-starting.test.tsx
+++ b/web/test/pages/profile/profile-starting.test.tsx
@@ -33,8 +33,10 @@ import {
   UserData,
   createEmptyBusiness,
   einTaskId,
+  emptyAddressData,
   emptyIndustrySpecificData,
   formationTaskId,
+  generateFormationFormData,
   generateGetFilingResponse,
   generateMunicipality,
   generateProfileData,
@@ -1301,6 +1303,27 @@ describe("profile - starting business", () => {
         screen.getByText(Config.profileDefaults.fields.responsibleOwnerName.default.header)
       ).toBeInTheDocument();
       expect(screen.queryByTestId("responsibleOwnerName")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("non essential questions", () => {
+    it("shows elevator questions for starting businesses", async () => {
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          industryId: "generic",
+          businessPersona: "STARTING",
+          operatingPhase: OperatingPhaseId.GUEST_MODE,
+          homeBasedBusiness: false,
+        }),
+        formationData: generateFormationData({
+          formationFormData: generateFormationFormData({
+            ...emptyAddressData,
+          }),
+        }),
+      });
+      renderPage({ business });
+
+      expect(screen.getByTestId("elevatorOwningBusiness-radio-group")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Updates the non-essential question to only appear for poppies. This is because Oscars and Dakotas don't see the task that appears based on this. The non-essential question will be re-added once design is settled for those users

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#187983571](https://www.pivotaltracker.com/story/show/187983571).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
