### PR TITLE
feat: [#186092881] header banner, text lost during reflow

### DIFF
--- a/web/src/components/njwds/Banner.tsx
+++ b/web/src/components/njwds/Banner.tsx
@@ -5,31 +5,27 @@ export const Banner = (): ReactElement => {
     <div className="nj-banner">
       <div className="nj-banner__header">
         <div className="grid-container-widescreen desktop:padding-x-7">
-          <div className="nj-banner__inner">
-            <div className="grid-col-auto">
+          <div className="nj-banner__inner margin-y-1 row-desktop-column-mobile fas flex-align-center-desktop-start-mobile space-between">
+            <div className="flex fac margin-y-05">
               <img className="nj-banner__header-seal" src="/vendor/img/nj_state_seal.png" alt="NJ flag" />
-            </div>
-            <div className="grid-col-fill">
               <a href="https://nj.gov">Official Site of the State of New Jersey</a>
             </div>
-            <div className="grid-col-auto">
-              <div className="text-white">
-                <ul>
-                  <li>Governor Phil Murphy &bull; Lt. Governor Tahesha Way</li>
-                  <li>
-                    <a href="https://nj.gov/subscribe/" target="_blank" rel="noreferrer">
-                      <svg
-                        className="usa-icon bottom-neg-2px margin-right-05"
-                        aria-hidden="true"
-                        focusable="false"
-                        role="img"
-                      >
-                        <use xlinkHref="/vendor/img/sprite.svg#mail"></use>
-                      </svg>
-                      Get Updates
-                    </a>
-                  </li>
-                </ul>
+            <div className="flex row-desktop-column-mobile">
+              <div className="margin-right-1 padding-right-1 desktop:border-right margin-y-05">
+                Governor Phil Murphy &bull; Lt. Governor Tahesha Way
+              </div>
+              <div className="margin-y-05">
+                <a href="https://nj.gov/subscribe/" target="_blank" rel="noreferrer">
+                  <svg
+                    className="usa-icon bottom-neg-2px margin-right-05"
+                    aria-hidden="true"
+                    focusable="false"
+                    role="img"
+                  >
+                    <use xlinkHref="/vendor/img/sprite.svg#mail"></use>
+                  </svg>
+                  Get Updates
+                </a>
               </div>
             </div>
           </div>

--- a/web/src/styles/components/banner.scss
+++ b/web/src/styles/components/banner.scss
@@ -1,0 +1,15 @@
+.row-desktop-column-mobile {
+  display: flex;
+  flex-direction: column;
+  @media (min-width: $xs) {
+    flex-direction: row;
+  }
+}
+
+.flex-align-center-desktop-start-mobile {
+  display: flex;
+  align-items: flex-start;
+  @media (min-width: $xs) {
+    align-items: center;
+  }
+}

--- a/web/src/styles/main.scss
+++ b/web/src/styles/main.scss
@@ -13,6 +13,7 @@
 @import "base/height-width";
 
 @import "components/alerts.scss";
+@import "components/banner.scss";
 @import "components/buttons.scss";
 @import "components/callout.scss";
 @import "components/contextual-info.scss";


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

When we transitioned to mobile we were eliminating some text. This is a change meant to keep this other text in the mobile version

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#186092881](https://www.pivotaltracker.com/story/show/186092881).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Go onto local, open in mobile, look at top banner and compare to designs and dev / prod to see how its different

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
