### PR TITLE
feat: [#188006371] add housing hotel motel license status check

### DIFF
--- a/api/src/api/housingRouter.ts
+++ b/api/src/api/housingRouter.ts
@@ -1,9 +1,12 @@
-import { HousingPropertyInterestStatus } from "@domain/types";
-import { HousingPropertyInterestDetails } from "@shared/housing";
+import { HousingHotelMotelRegistrationStatus, HousingPropertyInterestStatus } from "@domain/types";
+import { HousingPropertyInterestDetails, HousingRegistrationRequestLookupResponse } from "@shared/housing";
 import { Router } from "express";
 import { StatusCodes } from "http-status-codes";
 
-export const housingRouterFactory = (housingPropertyInterest: HousingPropertyInterestStatus): Router => {
+export const housingRouterFactory = (
+  housingPropertyInterest: HousingPropertyInterestStatus,
+  housingHotelMotelRegistrationStatus: HousingHotelMotelRegistrationStatus
+): Router => {
   const router = Router();
 
   router.post("/housing/properties/", async (req, res) => {
@@ -11,6 +14,17 @@ export const housingRouterFactory = (housingPropertyInterest: HousingPropertyInt
     housingPropertyInterest(address, municipalityId)
       .then(async (propertyInterestDetails?: HousingPropertyInterestDetails) => {
         return res.json(propertyInterestDetails);
+      })
+      .catch((error) => {
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ error });
+      });
+  });
+
+  router.post("/housing/registrations/hotelmotel", async (req, res) => {
+    const { address, municipalityId } = req.body;
+    housingHotelMotelRegistrationStatus(address, municipalityId)
+      .then(async (registrations?: HousingRegistrationRequestLookupResponse) => {
+        return res.json(registrations);
       })
       .catch((error) => {
         res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ error });

--- a/api/src/client/dynamics/elevator-safety/DynamicsElevatorSafetyRegistrationStatusClient.test.ts
+++ b/api/src/client/dynamics/elevator-safety/DynamicsElevatorSafetyRegistrationStatusClient.test.ts
@@ -63,6 +63,7 @@ describe("DynamicsElevatorSafetyRegistrationStatusClient", () => {
       BHINextInspectionDueDate: "01/01/2028",
       stateCode: 0,
       id: "12345",
+      buildingCount: 3,
     });
     stubElevatorRegistrationClient.getElevatorRegistrationsForBuilding.mockResolvedValue([]);
 
@@ -81,6 +82,7 @@ describe("DynamicsElevatorSafetyRegistrationStatusClient", () => {
       BHINextInspectionDueDate: "01/01/2028",
       stateCode: 0,
       id: "12345",
+      buildingCount: 4,
     });
     stubElevatorRegistrationClient.getElevatorRegistrationsForBuilding.mockResolvedValue([
       {
@@ -121,6 +123,7 @@ describe("DynamicsElevatorSafetyRegistrationStatusClient", () => {
       BHINextInspectionDueDate: "01/01/2028",
       stateCode: 0,
       id: "12345",
+      buildingCount: 7,
     });
     stubElevatorRegistrationClient.getElevatorRegistrationsForBuilding.mockResolvedValue([
       {

--- a/api/src/client/dynamics/housing/DynamicsHousingClient.test.ts
+++ b/api/src/client/dynamics/housing/DynamicsHousingClient.test.ts
@@ -38,6 +38,7 @@ describe("DynamicsHousingClient", () => {
       BHINextInspectionDueDate: "01-01-2028",
       stateCode: 0,
       id: "12345",
+      buildingCount: 2,
     });
 
     const result = await client("address-1", "12345");
@@ -50,6 +51,7 @@ describe("DynamicsHousingClient", () => {
       BHINextInspectionDueDate: "01-01-2028",
       stateCode: 0,
       id: "12345",
+      buildingCount: 2,
     });
   });
 

--- a/api/src/client/dynamics/housing/DynamicsHousingHotelMotelRegistrationClient.test.ts
+++ b/api/src/client/dynamics/housing/DynamicsHousingHotelMotelRegistrationClient.test.ts
@@ -1,0 +1,92 @@
+import { DynamicsHotelMotelRegistrationClient } from "@client/dynamics/housing/DynamicsHousingHotelMotelRegistrationClient";
+import { HotelMotelRegistrationClient } from "@client/dynamics/housing/types";
+import { LogWriter, LogWriterType } from "@libs/logWriter";
+import axios from "axios";
+
+jest.mock("axios");
+jest.mock("winston");
+const mockAxios = axios as jest.Mocked<typeof axios>;
+
+describe("DynamicsHousingPropertyInterestClient", () => {
+  let client: HotelMotelRegistrationClient;
+  let logger: LogWriterType;
+
+  const ORG_URL = "www.test-org-url.com";
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    logger = LogWriter("NavigatorWebService", "ApiLogs", "us-test-1");
+
+    client = DynamicsHotelMotelRegistrationClient(logger, ORG_URL);
+  });
+
+  const mockAccessToken = "access-granted";
+  const propertyInterestID = "property-interest-3";
+  const buildingCount = 4;
+
+  it("makes a successful get request and returns registration data sorted by date", async () => {
+    const housingHotelMotelRegistrationMockResponse = {
+      value: [
+        {
+          ultra_bhiregistrationrequestid: "123",
+          ultra_requestdate: "06/06/2000",
+          statuscode: "2",
+          ultra_propertyinteresttype: "100",
+        },
+        {
+          ultra_bhiregistrationrequestid: "456",
+          ultra_requestdate: "06/06/2020",
+          statuscode: "2",
+          ultra_propertyinteresttype: "100",
+        },
+      ],
+    };
+
+    mockAxios.get.mockResolvedValue({ data: housingHotelMotelRegistrationMockResponse });
+    expect(
+      await client.getHotelMotelRegistration(mockAccessToken, propertyInterestID, buildingCount)
+    ).toEqual([
+      {
+        buildingCount: 4,
+        date: "06/06/2020",
+        id: "456",
+        propertyInterestType: "100",
+        status: "Approved",
+      },
+      {
+        buildingCount: 4,
+        date: "06/06/2000",
+        id: "123",
+        propertyInterestType: "100",
+        status: "Approved",
+      },
+    ]);
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/ultra_bhiregistrationrequests?$select=ultra_bhiregistrationrequestid,ultra_requestdate,statuscode,ultra_propertyinteresttype&$filter=(_ultra_linktoexistingpropertyinterest_value eq '${propertyInterestID}' and (ultra_propertyinteresttype eq 240000001 or ultra_propertyinteresttype eq 240000016))`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+  });
+
+  it("returns empty array if there is no registrations found", async () => {
+    const housingHotelMotelRegistrationMockResponse = {
+      value: [],
+    };
+
+    mockAxios.get.mockResolvedValue({ data: housingHotelMotelRegistrationMockResponse });
+    expect(
+      await client.getHotelMotelRegistration(mockAccessToken, propertyInterestID, buildingCount)
+    ).toEqual([]);
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `${ORG_URL}/api/data/v9.2/ultra_bhiregistrationrequests?$select=ultra_bhiregistrationrequestid,ultra_requestdate,statuscode,ultra_propertyinteresttype&$filter=(_ultra_linktoexistingpropertyinterest_value eq '${propertyInterestID}' and (ultra_propertyinteresttype eq 240000001 or ultra_propertyinteresttype eq 240000016))`,
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`,
+        },
+      }
+    );
+  });
+});

--- a/api/src/client/dynamics/housing/DynamicsHousingHotelMotelRegistrationClient.ts
+++ b/api/src/client/dynamics/housing/DynamicsHousingHotelMotelRegistrationClient.ts
@@ -1,0 +1,108 @@
+import {
+  getPropertyInterestTypeIntegerFromTitle,
+  HotelMotelRegistrationClient,
+  HousingRegistrationRequest,
+  HousingRegistrationRequestResponse,
+  HousingRegistrationStatus,
+} from "@client/dynamics/housing/types";
+import { LogWriterType } from "@libs/logWriter";
+import { parseDate } from "@shared/dateHelpers";
+import axios, { AxiosError } from "axios";
+
+export const DynamicsHotelMotelRegistrationClient = (
+  logWriter: LogWriterType,
+  orgUrl: string
+): HotelMotelRegistrationClient => {
+  const getHotelMotelRegistration = async (
+    accessToken: string,
+    propertyInterestId: string,
+    buildingCount: number
+  ): Promise<HousingRegistrationRequestResponse> => {
+    const logId = logWriter.GetId();
+    logWriter.LogInfo(`Dynamics Hotel Motel Registration Client - Id:${logId}`);
+    const hotelPropertyInterestType = getPropertyInterestTypeIntegerFromTitle("Hotel");
+    const motelPropertyInterestType = getPropertyInterestTypeIntegerFromTitle("Motel");
+
+    return axios
+      .get(
+        `${orgUrl}/api/data/v9.2/ultra_bhiregistrationrequests?$select=ultra_bhiregistrationrequestid,ultra_requestdate,statuscode,ultra_propertyinteresttype&$filter=(_ultra_linktoexistingpropertyinterest_value eq '${propertyInterestId}' and (ultra_propertyinteresttype eq ${hotelPropertyInterestType} or ultra_propertyinteresttype eq ${motelPropertyInterestType}))`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      )
+      .then((response) => {
+        logWriter.LogInfo(
+          `Dynamics Hotel Motel Registration Client - Id:${logId} - Response: ${JSON.stringify(
+            response.data
+          )}`
+        );
+        const value = response.data.value as Array<DynamicsHotelMotelRegistrationResponse>;
+        if (value.length === 0) {
+          return [];
+        }
+        const registrations = value.map((registration) =>
+          processDynamicsHotelMotelRegistrationResponse(registration, buildingCount)
+        );
+        const sortedRegistrations = registrations.sort((a, b) => {
+          const dateA = parseDate(a.date);
+          const dateB = parseDate(b.date);
+          if (dateA.isAfter(dateB)) {
+            return -1;
+          }
+          return 1;
+        });
+        return sortedRegistrations;
+      })
+      .catch((error: AxiosError) => {
+        logWriter.LogError(`Dynamics Hotel Motel Registration Client - Id:${logId} - Error:`, error);
+        throw error.response?.status;
+      });
+
+    return [];
+  };
+
+  return {
+    getHotelMotelRegistration: getHotelMotelRegistration,
+  };
+};
+
+function processDynamicsHotelMotelRegistrationResponse(
+  response: DynamicsHotelMotelRegistrationResponse,
+  buildingCount: number
+): HousingRegistrationRequest {
+  return {
+    id: response.ultra_bhiregistrationrequestid,
+    date: response.ultra_requestdate,
+    status: getStatusFromStatusCode(response.statuscode),
+    propertyInterestType: response.ultra_propertyinteresttype,
+    buildingCount: buildingCount,
+  };
+}
+
+type DynamicsHotelMotelRegistrationResponse = {
+  ultra_bhiregistrationrequestid: string;
+  ultra_requestdate: string;
+  statuscode: string;
+  ultra_propertyinteresttype: number;
+};
+
+function getStatusFromStatusCode(statusCode: string): HousingRegistrationStatus {
+  switch (String(statusCode)) {
+    case "1":
+      return "In Review";
+    case "100000003":
+      return "Cancelled";
+    case "240000000":
+      return "Returned";
+    case "2":
+      return "Approved";
+    case "100000002":
+      return "Rejected";
+    case "240000003":
+      return "Incomplete";
+    default:
+      return "UNRECOGNIZED STATUS";
+  }
+}

--- a/api/src/client/dynamics/housing/DynamicsHousingHotelMotelRegistrationStatusClient.ts
+++ b/api/src/client/dynamics/housing/DynamicsHousingHotelMotelRegistrationStatusClient.ts
@@ -1,0 +1,54 @@
+import {
+  HotelMotelRegistrationClient,
+  HousingPropertyInterestClient,
+  HousingRegistrationRequestLookupResponse,
+} from "@client/dynamics/housing/types";
+import { AccessTokenClient } from "@client/dynamics/types";
+import { LogWriterType } from "@libs/logWriter";
+
+type Config = {
+  accessTokenClient: AccessTokenClient;
+  housingHotelMotelRegistrationClient: HotelMotelRegistrationClient;
+  housingPropertyInterestClient: HousingPropertyInterestClient;
+};
+
+export const DynamicsHotelMotelRegistrationStatusClient = (
+  logWriter: LogWriterType,
+  config: Config
+): ((address: string, municipalityId: string) => Promise<HousingRegistrationRequestLookupResponse>) => {
+  return async (
+    address: string,
+    municipalityId: string
+  ): Promise<HousingRegistrationRequestLookupResponse> => {
+    const accessToken = await config.accessTokenClient.getAccessToken();
+    const propertyInterest = await config.housingPropertyInterestClient.getPropertyInterest(
+      accessToken,
+      address,
+      municipalityId
+    );
+
+    if (!propertyInterest) {
+      return {
+        registrations: [],
+        lookupStatus: "NO PROPERTY INTERESTS FOUND",
+      };
+    }
+
+    const registrations = await config.housingHotelMotelRegistrationClient.getHotelMotelRegistration(
+      accessToken,
+      propertyInterest.id,
+      propertyInterest.buildingCount
+    );
+
+    if (!registrations || registrations.length === 0) {
+      return {
+        registrations: [],
+        lookupStatus: "NO REGISTRATIONS FOUND",
+      };
+    }
+    return {
+      registrations: registrations,
+      lookupStatus: "SUCCESSFUL",
+    };
+  };
+};

--- a/api/src/client/dynamics/housing/DynamicsHousingPropertyInterestClient.test.ts
+++ b/api/src/client/dynamics/housing/DynamicsHousingPropertyInterestClient.test.ts
@@ -36,6 +36,7 @@ describe("DynamicsHousingPropertyInterestClient", () => {
           statecode: 0,
           ultra_streetaddress: searchAddress,
           ultra_propertyinterestid: "12345",
+          ultra_buildingcount: 3,
         },
       ],
     };
@@ -49,9 +50,10 @@ describe("DynamicsHousingPropertyInterestClient", () => {
       BHINextInspectionDueDate: "01/01/2028",
       stateCode: 0,
       id: "12345",
+      buildingCount: 3,
     });
     expect(mockAxios.get).toHaveBeenCalledWith(
-      `${ORG_URL}/api/data/v9.2/ultra_propertyinterests?$select=createdon,ultra_isfiresafetyproperty,ultra_isbhiregisteredproperty,ultra_streetaddress,ultra_zipcode,ultra_bhinextinspectiondue_date,ultra_bhinextreinspectiondue_state,statecode&$filter=(ultra_streetaddress eq '${searchAddress}' and _ultra_municipality_value eq '${searchMunicipalityID}')&$top=1`,
+      `${ORG_URL}/api/data/v9.2/ultra_propertyinterests?$select=createdon,ultra_isfiresafetyproperty,ultra_isbhiregisteredproperty,ultra_streetaddress,ultra_zipcode,ultra_bhinextinspectiondue_date,ultra_bhinextreinspectiondue_state,statecode,ultra_buildingcount&$filter=(ultra_streetaddress eq '${searchAddress}' and _ultra_municipality_value eq '${searchMunicipalityID}')&$top=1`,
       {
         headers: {
           Authorization: `Bearer ${mockAccessToken}`,
@@ -70,7 +72,7 @@ describe("DynamicsHousingPropertyInterestClient", () => {
       undefined
     );
     expect(mockAxios.get).toHaveBeenCalledWith(
-      `${ORG_URL}/api/data/v9.2/ultra_propertyinterests?$select=createdon,ultra_isfiresafetyproperty,ultra_isbhiregisteredproperty,ultra_streetaddress,ultra_zipcode,ultra_bhinextinspectiondue_date,ultra_bhinextreinspectiondue_state,statecode&$filter=(ultra_streetaddress eq '${searchAddress}' and _ultra_municipality_value eq '${searchMunicipalityID}')&$top=1`,
+      `${ORG_URL}/api/data/v9.2/ultra_propertyinterests?$select=createdon,ultra_isfiresafetyproperty,ultra_isbhiregisteredproperty,ultra_streetaddress,ultra_zipcode,ultra_bhinextinspectiondue_date,ultra_bhinextreinspectiondue_state,statecode,ultra_buildingcount&$filter=(ultra_streetaddress eq '${searchAddress}' and _ultra_municipality_value eq '${searchMunicipalityID}')&$top=1`,
       {
         headers: {
           Authorization: `Bearer ${mockAccessToken}`,

--- a/api/src/client/dynamics/housing/DynamicsHousingPropertyInterestClient.ts
+++ b/api/src/client/dynamics/housing/DynamicsHousingPropertyInterestClient.ts
@@ -20,7 +20,7 @@ export const DynamicsHousingPropertyInterestClient = (
 
     return axios
       .get(
-        `${orgUrl}/api/data/v9.2/ultra_propertyinterests?$select=createdon,ultra_isfiresafetyproperty,ultra_isbhiregisteredproperty,ultra_streetaddress,ultra_zipcode,ultra_bhinextinspectiondue_date,ultra_bhinextreinspectiondue_state,statecode&$filter=(ultra_streetaddress eq '${address}' and _ultra_municipality_value eq '${municipalityId}')&$top=1`,
+        `${orgUrl}/api/data/v9.2/ultra_propertyinterests?$select=createdon,ultra_isfiresafetyproperty,ultra_isbhiregisteredproperty,ultra_streetaddress,ultra_zipcode,ultra_bhinextinspectiondue_date,ultra_bhinextreinspectiondue_state,statecode,ultra_buildingcount&$filter=(ultra_streetaddress eq '${address}' and _ultra_municipality_value eq '${municipalityId}')&$top=1`,
         {
           headers: {
             Authorization: `Bearer ${accessToken}`,
@@ -61,6 +61,7 @@ function processDynamicsPropertyInterestResponse(
     BHINextInspectionDueDate: response.ultra_bhinextinspectiondue_date,
     stateCode: response.statecode,
     id: response.ultra_propertyinterestid,
+    buildingCount: response.ultra_buildingcount,
   };
 }
 
@@ -73,4 +74,5 @@ type DynamicsHousingPropertyInterestResponse = {
   ultra_bhinextinspectiondue_date: string;
   statecode: number;
   ultra_propertyinterestid: string;
+  ultra_buildingcount: number;
 };

--- a/api/src/client/dynamics/housing/types.ts
+++ b/api/src/client/dynamics/housing/types.ts
@@ -14,6 +14,7 @@ export type HousingPropertyInterest = {
   BHINextInspectionDueDate: string;
   stateCode: number;
   id: string;
+  buildingCount: number;
 };
 
 export type HousingPropertyInterestResponse = HousingPropertyInterest | undefined;
@@ -22,3 +23,66 @@ export type HousingPropertyInterestInfo = (
   address: string,
   municipalityId: string
 ) => Promise<HousingPropertyInterestResponse>;
+
+export interface HotelMotelRegistrationClient {
+  getHotelMotelRegistration: (
+    accessToken: string,
+    propertyInterestId: string,
+    buildingCount: number
+  ) => Promise<HousingRegistrationRequestResponse>;
+}
+
+export type HousingRegistrationRequest = {
+  date: string;
+  propertyInterestType: number;
+  id: string;
+  status: string;
+  buildingCount: number;
+};
+
+export type HousingRegistrationRequestResponse = HousingRegistrationRequest[];
+
+export type HousingRegistrationRequestLookupResponse = {
+  registrations: HousingRegistrationRequest[];
+  lookupStatus: HousingRegistrationLookupStatus;
+};
+
+export type HousingRegistrationLookupStatus =
+  | "SUCCESSFUL"
+  | "NO REGISTRATIONS FOUND"
+  | "NO PROPERTY INTERESTS FOUND";
+
+export type HousingRegistrationRequestResponseInfo = (
+  address: string,
+  municipalityId: string
+) => Promise<HousingRegistrationRequestLookupResponse>;
+
+export type PropertyInterestTypes =
+  | "Multiple Dwelling"
+  | "Hotel"
+  | "Motel"
+  | "Condominium"
+  | "Private Dormitory"
+  | "UNRECOGNIZED STATUS";
+
+export function getPropertyInterestTypeIntegerFromTitle(title: PropertyInterestTypes): number {
+  switch (title) {
+    case "Multiple Dwelling":
+      return 240000000;
+    case "Hotel":
+      return 240000001;
+    case "Motel":
+      return 240000016;
+    default:
+      return -1;
+  }
+}
+
+export type HousingRegistrationStatus =
+  | "Approved"
+  | "Incomplete"
+  | "Returned"
+  | "Rejected"
+  | "In Review"
+  | "Cancelled"
+  | "UNRECOGNIZED STATUS";

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -6,7 +6,7 @@ import {
 } from "@shared/elevatorSafety";
 import { FireSafetyInspectionResult } from "@shared/fireSafety";
 import { FormationSubmitResponse, GetFilingResponse, InputFile } from "@shared/formationData";
-import { HousingPropertyInterestDetails } from "@shared/housing";
+import { HousingPropertyInterestDetails, HousingRegistrationRequestLookupResponse } from "@shared/housing";
 import { LicenseEntity, LicenseSearchNameAndAddress, LicenseStatusResult } from "@shared/license";
 import { ProfileData } from "@shared/profileData";
 import { TaxFilingCalendarEvent, TaxFilingLookupState, TaxFilingOnboardingState } from "@shared/taxFiling";
@@ -122,6 +122,11 @@ export type HousingPropertyInterestStatus = (
   address: string,
   municipalityId: string
 ) => Promise<HousingPropertyInterestDetails | undefined>;
+
+export type HousingHotelMotelRegistrationStatus = (
+  address: string,
+  municipalityId: string
+) => Promise<HousingRegistrationRequestLookupResponse>;
 
 export type ElevatorSafetyInspectionStatus = (
   address: string

--- a/api/src/functions/express/app.ts
+++ b/api/src/functions/express/app.ts
@@ -25,6 +25,8 @@ import { DynamicsFireSafetyHealthCheckClient } from "@client/dynamics/fire-safet
 import { DynamicsFireSafetyInspectionClient } from "@client/dynamics/fire-safety/DynamicsFireSafetyInspectionClient";
 import { DynamicsHousingClient } from "@client/dynamics/housing/DynamicsHousingClient";
 import { DynamicsHousingHealthCheckClient } from "@client/dynamics/housing/DynamicsHousingHealthCheckClient";
+import { DynamicsHotelMotelRegistrationClient } from "@client/dynamics/housing/DynamicsHousingHotelMotelRegistrationClient";
+import { DynamicsHotelMotelRegistrationStatusClient } from "@client/dynamics/housing/DynamicsHousingHotelMotelRegistrationStatusClient";
 import { DynamicsHousingPropertyInterestClient } from "@client/dynamics/housing/DynamicsHousingPropertyInterestClient";
 import { DynamicsBusinessAddressClient } from "@client/dynamics/license-status/DynamicsBusinessAddressClient";
 import { DynamicsBusinessIdsClient } from "@client/dynamics/license-status/DynamicsBusinessIdsClient";
@@ -212,6 +214,15 @@ const dynamicsHousingHealthCheckClient = DynamicsHousingHealthCheckClient(logger
   accessTokenClient: dynamicsHousingAccessTokenClient,
   orgUrl: DYNAMICS_HOUSING_URL,
 });
+const dynamicsHousingHotelMotelRegistrationClient = DynamicsHotelMotelRegistrationClient(
+  logger,
+  DYNAMICS_HOUSING_URL
+);
+const dynamicsHousingHotelMotelRegistrationStatusClient = DynamicsHotelMotelRegistrationStatusClient(logger, {
+  accessTokenClient: dynamicsHousingAccessTokenClient,
+  housingHotelMotelRegistrationClient: dynamicsHousingHotelMotelRegistrationClient,
+  housingPropertyInterestClient: dynamicsHousingPropertyInterestClient,
+});
 
 const BUSINESS_NAME_BASE_URL =
   process.env.BUSINESS_NAME_BASE_URL || `http://${IS_DOCKER ? "wiremock" : "localhost"}:9000`;
@@ -342,7 +353,10 @@ app.use(
   )
 );
 app.use("/api", fireSafetyRouterFactory(dynamicsFireSafetyClient));
-app.use("/api", housingRouterFactory(dynamicsHousingClient));
+app.use(
+  "/api",
+  housingRouterFactory(dynamicsHousingClient, dynamicsHousingHotelMotelRegistrationStatusClient)
+);
 app.use("/api", selfRegRouterFactory(userDataClient, selfRegClient));
 app.use("/api", formationRouterFactory(apiFormationClient, userDataClient, { shouldSaveDocuments }));
 app.use(

--- a/content/src/fieldConfig/housing-registration.json
+++ b/content/src/fieldConfig/housing-registration.json
@@ -1,0 +1,30 @@
+{
+  "housingRegistrationSearchTask": {
+    "errorTextFieldsRequired": "Please fill in all non-optional fields.",
+    "errorTextNoPropertyInterestFound": "We cannot find your registration. Make sure the building address you entered matches what is in your application.",
+    "errorTextNoHotelMotelRegistrations": "We cannot find your registration. Make sure you submit a registration application for your hotel, motel or guesthouse.",
+    "errorTextSearchFailed": "Sorry, something went wrong. Please try again later.",
+    "registrationStartDateText": "Application Started on ",
+    "registrationStatusText": "Application Status: ",
+    "registrationBuildingCountText": "Buildings included in this application: ",
+    "registrationFoundInReviewText": "Check back later to make sure your property is successfully registered",
+    "registrationFoundIncompleteReturnedText": "Review your incomplete or returned application(s) for any errors or missing information. If your application was returned, you can resubmit it using the same application link in the DCA Service Portal.",
+    "registrationCallToActionPrimaryText": "Register or Update My Registration with the Department of Community Affairs",
+    "registrationCallToActionSecondaryText": "Check My Registration Application Status",
+    "registrationTab1Text": "Start Application",
+    "registrationTab2Text": "Check Status",
+    "registrationInReviewMessage": "Check back later to make sure your property is successfully registered",
+    "registrationRejectedOrReturnedMessage": "Review your incomplete or returned application(s) for any errors or missing information. If your application was returned, you can resubmit it using the same application link in the DCA Service Portal.",
+    "registrationSearchPrompt": "Enter your property address exactly as it appears on your application to get automatic updates on your application status.",
+    "address1Label": "Building Street Address Line 1",
+    "address2Label": "Building Street Address Line 2 (Optional)",
+    "stateLabel": "State",
+    "municipalityLabel": "Municipality",
+    "submitText": "Submit",
+    "informationalInReview": "Check back later to make sure your property and the buildings on it are successfully registered.",
+    "informationalReturned": "Your application has missing or incorrect information. Review and resubmit it using the same application link in the DCA Service Portal.",
+    "informationalRejected": "Your application has missing or incorrect information. Review and resubmit it using the same application link in the DCA Service Portal.",
+    "informationalIncomplete": "Review your incomplete application. Make sure you complete all sections and submit it.",
+    "applicationsFoundHeader": "REGISTRATION APPLICATION(S) FOR THIS PROPERTY:"
+  }
+}

--- a/shared/src/housing.ts
+++ b/shared/src/housing.ts
@@ -20,3 +20,23 @@ export type CommunityAffairsAddress = {
   streetAddress2?: string;
   municipality: Municipality;
 };
+
+export type HousingAddress = {
+  address1: string;
+  address2?: string;
+  municipalityExternalId?: string;
+  municipalityName?: string;
+};
+
+export type HousingRegistrationRequest = {
+  date: string;
+  propertyInterestType: number;
+  id: string;
+  status: string;
+  buildingCount: number;
+};
+
+export type HousingRegistrationRequestLookupResponse = {
+  registrations: HousingRegistrationRequest[];
+  lookupStatus: string;
+};

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -2188,6 +2188,87 @@ collections:
               - { label: Violation Notice Message Text, name: violationNoticeMessage, widget: string }
               - { label: Violation Notice CTA Text, name: violationNoticeCTA, widget: string }
               - { label: Violation Notice CTA Link, name: violationNoticeCTALink, widget: nospace }
+      - label: "Housing"
+        name: "housing-registration-config"
+        file: "content/src/fieldConfig/housing-registration.json"
+        editor:
+          preview: false
+        fields:
+          - label: Housing Registration
+            name: housingRegistrationSearchTask
+            collapsed: false
+            widget: object
+            fields:
+              - { label: Registration Start Date Text, name: registrationStartDateText, widget: string }
+              - { label: Registration Status Text, name: registrationStatusText, widget: string }
+              - { label: Registration Building Count Text, name: registrationBuildingCountText, widget: string }
+              - {
+                label: Registration Application Found Header,
+                name: applicationsFoundHeader,
+                widget: string,
+              }
+              - {
+                label: Registration Found In Review Text,
+                name: registrationFoundInReviewText,
+                widget: string,
+              }
+              - {
+                label: Registration Found Incomplete/Returned Text,
+                name: registrationFoundIncompleteReturnedText,
+                widget: string,
+              }
+              - {
+                label: Registration Call to Action Primary Text,
+                name: registrationCallToActionPrimaryText,
+                widget: string,
+              }
+              - {
+                label: Registration Call to Action Secondary Text,
+                name: registrationCallToActionSecondaryText,
+                widget: string,
+              }
+              - { label: Registration Tab 1 Text, name: registrationTab1Text, widget: string }
+              - { label: Registration Tab 2 Text, name: registrationTab2Text, widget: string }
+              - {
+                label: Registration In Review Message Text,
+                name: registrationInReviewMessage,
+                widget: string,
+              }
+              - {
+                label: Registration Rejected or Returned Message,
+                name: registrationRejectedOrReturnedMessage,
+                widget: string,
+              }
+              - { label: Registration Search Prompt Text, name: registrationSearchPrompt, widget: string }
+              - { label: Address 1 Label, name: address1Label, widget: string }
+              - { label: Address 2 Label, name: address2Label, widget: string }
+              - { label: Municipality Label, name: municipalityLabel, widget: string }
+              - { label: State label, name: stateLabel, widget: string }
+              - { label: Submit Text, name: submitText, widget: string }
+              - {
+                label: Error - No Property Interest Found,
+                name: errorTextNoPropertyInterestFound,
+                widget: string,
+              }
+              - {
+                label: Error - No Hotel/Motel Registrations Found,
+                name: errorTextNoHotelMotelRegistrations,
+                widget: string,
+              }
+              - { label: Error - Missing Required Fields, name: errorTextFieldsRequired, widget: string }
+              - { label: Error - Search Failed, name: errorTextSearchFailed, widget: string }
+              - { label: Informational Message - In Review, name: informationalInReview, widget: string }
+              - { label: Informational Message - Returned, name: informationalReturned, widget: string }
+              - { label: Informational Message - Rejected, name: informationalRejected, widget: string }
+              - { label: Informational Message - Incomplete, name: informationalIncomplete, widget: string }
+          - label: Elevator Violations Card
+            name: elevatorViolationsCard
+            collapsed: false
+            widget: object
+            fields:
+              - { label: Violation Notice Message Text, name: violationNoticeMessage, widget: string }
+              - { label: Violation Notice CTA Text, name: violationNoticeCTA, widget: string }
+              - { label: Violation Notice CTA Link, name: violationNoticeCTALink, widget: nospace }
 
   - name: "tasks"
     label: "Tasks - All"

--- a/web/src/components/TaskPageSwitchComponent.tsx
+++ b/web/src/components/TaskPageSwitchComponent.tsx
@@ -1,6 +1,7 @@
 import { TaskBody } from "@/components/TaskBody";
 import { EinTask } from "@/components/tasks/EinTask";
 import { ElevatorRegistrationTask } from "@/components/tasks/ElevatorRegistrationTask";
+import { HotelMotelRegistrationTask } from "@/components/tasks/HotelMotelRegistrationTask";
 import { LicenseTask } from "@/components/tasks/LicenseTask";
 import { NaicsCodeTask } from "@/components/tasks/NaicsCodeTask";
 import { TaxTask } from "@/components/tasks/TaxTask";
@@ -64,6 +65,9 @@ export const TaskPageSwitchComponent = ({
     ),
     "elevator-registration": (
       <ElevatorRegistrationTask task={task} CMS_ONLY_disable_overlay={CMS_ONLY_disable_overlay} />
+    ),
+    "hotel-motel-registration": (
+      <HotelMotelRegistrationTask task={task} CMS_ONLY_disable_overlay={CMS_ONLY_disable_overlay} />
     ),
     "determine-naics-code": <NaicsCodeTask task={task} />,
     "priority-status-cannabis": <CannabisPriorityStatusTask task={task} />,

--- a/web/src/components/tasks/CheckHousingRegistrationStatus.tsx
+++ b/web/src/components/tasks/CheckHousingRegistrationStatus.tsx
@@ -1,0 +1,198 @@
+import { MunicipalityDropdown } from "@/components/data-fields/MunicipalityDropdown";
+import { Alert } from "@/components/njwds-extended/Alert";
+import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
+import { getMergedConfig } from "@/contexts/configContext";
+import { useUserData } from "@/lib/data-hooks/useUserData";
+import { HotelMotelRegistrationSearchError } from "@/lib/types/types";
+import { toProperCase } from "@businessnjgovnavigator/shared";
+import { HousingAddress, HousingMunicipality } from "@businessnjgovnavigator/shared/housing";
+import { Municipality } from "@businessnjgovnavigator/shared/municipality";
+import { TextField } from "@mui/material";
+import { ChangeEvent, FormEvent, ReactElement, useEffect, useState } from "react";
+
+interface Props {
+  onSubmit: (address: HousingAddress) => void;
+  error: HotelMotelRegistrationSearchError | undefined;
+  isLoading: boolean;
+  municipalities: HousingMunicipality[];
+}
+
+const Config = getMergedConfig();
+const HotelMotelSearchErrorLookup: Record<HotelMotelRegistrationSearchError, string> = {
+  NO_PROPERTY_INTEREST_FOUND: Config.housingRegistrationSearchTask.errorTextNoPropertyInterestFound,
+  NO_HOTEL_MOTEL_REGISTRATIONS_FOUND: Config.housingRegistrationSearchTask.errorTextNoHotelMotelRegistrations,
+  FIELDS_REQUIRED: Config.housingRegistrationSearchTask.errorTextFieldsRequired,
+  SEARCH_FAILED: Config.housingRegistrationSearchTask.errorTextSearchFailed,
+};
+
+export const CheckHousingRegistrationStatus = (props: Props): ReactElement => {
+  const [formValues, setFormValues] = useState<HousingAddress>({ address1: "" });
+  const [selectedMunicipality, setSelectedMunicipality] = useState<Municipality | undefined>(undefined);
+  const { business, updateQueue } = useUserData();
+
+  const formattedMunicipalities = props.municipalities.map((municipality) => {
+    return {
+      id: municipality.id,
+      name: municipality.name,
+      displayName: toProperCase(municipality.name),
+      county: municipality.county,
+    } as Municipality;
+  });
+
+  useEffect(() => {
+    const communityAffairsAddress = business?.profileData.communityAffairsAddress;
+
+    if (communityAffairsAddress) {
+      if (communityAffairsAddress.streetAddress1) {
+        setFormValues((prevValues) => {
+          return {
+            ...prevValues,
+            address1: communityAffairsAddress.streetAddress1,
+          };
+        });
+      }
+      if (communityAffairsAddress.streetAddress2) {
+        setFormValues((prevValues) => {
+          return {
+            ...prevValues,
+            address2: communityAffairsAddress.streetAddress2,
+          };
+        });
+      }
+      if (communityAffairsAddress.municipality) {
+        setSelectedMunicipality(communityAffairsAddress.municipality);
+      }
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+
+    if (business?.profileData && formValues.address1 && selectedMunicipality) {
+      const profileData = {
+        ...business?.profileData,
+        communityAffairsAddress: {
+          streetAddress1: formValues.address1,
+          streetAddress2: formValues.address2,
+          municipality: {
+            id: selectedMunicipality?.id,
+            name: selectedMunicipality?.name,
+            displayName: selectedMunicipality?.name,
+            county: selectedMunicipality?.county,
+          },
+        },
+      };
+      updateQueue?.queueProfileData(profileData).update();
+    }
+    props.onSubmit({
+      address1: formValues.address1,
+      municipalityExternalId: selectedMunicipality?.id || "",
+      municipalityName: selectedMunicipality?.name || "",
+    });
+  };
+
+  const handleChangeForKey = (
+    key: keyof HousingAddress
+  ): ((event: ChangeEvent<HTMLInputElement>) => void) => {
+    return (event: ChangeEvent<HTMLInputElement>): void => {
+      setFormValues((prevValues) => {
+        return {
+          ...prevValues,
+          [key]: event.target.value,
+        };
+      });
+    };
+  };
+
+  const getErrorAlert = (): ReactElement => {
+    if (!props.error) {
+      return <></>;
+    }
+
+    return (
+      <Alert dataTestid={`error-alert-${props.error}`} variant="error">
+        {HotelMotelSearchErrorLookup[props.error]}
+      </Alert>
+    );
+  };
+
+  return (
+    <>
+      {getErrorAlert()}
+      {Config.housingRegistrationSearchTask.registrationSearchPrompt}
+      <form onSubmit={onSubmit} className={"padding-top-1"}>
+        <div className="margin-bottom-2">
+          <label htmlFor="address-1">{Config.housingRegistrationSearchTask.address1Label}</label>
+          <TextField
+            value={formValues.address1}
+            onChange={handleChangeForKey("address1")}
+            variant="outlined"
+            inputProps={{
+              id: "address-1",
+              "data-testid": "address-1",
+            }}
+          />
+        </div>
+        <div className="margin-bottom-2">
+          <label htmlFor="address-2">{Config.housingRegistrationSearchTask.address2Label}</label>
+          <TextField
+            value={formValues.address2}
+            onChange={handleChangeForKey("address2")}
+            variant="outlined"
+            inputProps={{
+              id: "address-2",
+              "data-testid": "address-2",
+            }}
+          />
+        </div>
+        <div className="fdr flex-half">
+          <div className="flex-half padding-right-1">
+            <label htmlFor="municipality">{Config.housingRegistrationSearchTask.municipalityLabel}</label>
+            <MunicipalityDropdown
+              fieldName={"municipalities"}
+              municipalities={formattedMunicipalities}
+              helperText={""}
+              onSelect={(value) => {
+                setSelectedMunicipality(value);
+              }}
+              value={selectedMunicipality}
+              onValidation={() => {}}
+            />
+          </div>
+          <div className="flex-half padding-left-1">
+            <label htmlFor="state">{Config.housingRegistrationSearchTask.stateLabel}</label>
+            <TextField
+              value={"New Jersey"}
+              onChange={(): void => {}}
+              variant="outlined"
+              inputProps={{
+                id: "state",
+                "data-testid": "state",
+                style: {
+                  color: "#1b1b1b",
+                },
+              }}
+              disabled
+            />
+          </div>
+        </div>
+        <div className="flex flex-row">
+          <div className="mla margin-top-4">
+            <SecondaryButton
+              isColor="primary"
+              isSubmitButton={true}
+              isRightMarginRemoved={true}
+              onClick={(): void => {}}
+              isLoading={props.isLoading}
+              dataTestId="check-status-submit"
+            >
+              {Config.housingRegistrationSearchTask.submitText}
+            </SecondaryButton>
+          </div>
+        </div>
+      </form>
+    </>
+  );
+};

--- a/web/src/components/tasks/HotelMotelRegistrationTask.tsx
+++ b/web/src/components/tasks/HotelMotelRegistrationTask.tsx
@@ -1,0 +1,171 @@
+import { Content } from "@/components/Content";
+import { TaskHeader } from "@/components/TaskHeader";
+import { NeedsAccountModalWrapper } from "@/components/auth/NeedsAccountModalWrapper";
+import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
+import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
+import { CheckHousingRegistrationStatus } from "@/components/tasks/CheckHousingRegistrationStatus";
+import { HousingRegistrationStatusSummary } from "@/components/tasks/HousingRegistrationStatusSummary";
+import { UnlockedBy } from "@/components/tasks/UnlockedBy";
+import { HousingMunicipalitiesContext } from "@/contexts/housingMunicipalitiesContext";
+import * as api from "@/lib/api-client/apiClient";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { useRoadmap } from "@/lib/data-hooks/useRoadmap";
+import { HotelMotelRegistrationSearchError, Task } from "@/lib/types/types";
+import { openInNewTab } from "@/lib/utils/helpers";
+import { getModifiedTaskContent } from "@/lib/utils/roadmap-helpers";
+import {
+  HousingAddress,
+  HousingRegistrationRequestLookupResponse,
+} from "@businessnjgovnavigator/shared/housing";
+import { TabContext, TabList, TabPanel } from "@mui/lab/";
+import { Box, Tab } from "@mui/material";
+import React, { ReactElement, useContext, useState } from "react";
+
+interface Props {
+  task: Task;
+  CMS_ONLY_disable_overlay?: boolean;
+}
+
+const APPLICATION_TAB_INDEX = 0;
+const STATUS_TAB_INDEX = 1;
+
+export const HotelMotelRegistrationTask = (props: Props): ReactElement => {
+  const { roadmap } = useRoadmap();
+  const callToActionLink = getModifiedTaskContent(roadmap, props.task, "callToActionLink");
+  const [tabIndex, setTabIndex] = useState(APPLICATION_TAB_INDEX);
+  const [error, setError] = useState<HotelMotelRegistrationSearchError | undefined>(undefined);
+  const [housingAddress, setHousingAddress] = useState<HousingAddress | undefined>(undefined);
+  const [housingRegistrationLookupSummary, setHousingRegistrationLookupSummary] = useState<
+    HousingRegistrationRequestLookupResponse | undefined
+  >(undefined);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const { municipalities } = useContext(HousingMunicipalitiesContext);
+  const { Config } = useConfig();
+
+  const onSelectTab = (event: React.SyntheticEvent, newValue: string): void => {
+    const index = Number.parseInt(newValue);
+    setTabIndex(index);
+  };
+
+  const onEdit = (): void => {
+    setHousingAddress(undefined);
+    setHousingRegistrationLookupSummary(undefined);
+  };
+
+  if (municipalities.length === 0) {
+    setError(`SEARCH_FAILED`);
+  }
+
+  const onSubmit = (address: HousingAddress): void => {
+    if (address?.address1 && address?.municipalityExternalId) {
+      setIsLoading(true);
+      api
+        .checkHousingHotelMotelRegistrationStatus(address.address1, address.municipalityExternalId)
+        .then((result) => {
+          if (result.lookupStatus === "NO PROPERTY INTERESTS FOUND") {
+            setError("NO_PROPERTY_INTEREST_FOUND");
+          } else if (result.lookupStatus === "NO REGISTRATIONS FOUND") {
+            setError("NO_HOTEL_MOTEL_REGISTRATIONS_FOUND");
+          } else {
+            setError(undefined);
+            setHousingAddress(address);
+            setHousingRegistrationLookupSummary(result);
+          }
+        })
+        .catch(() => {
+          setError("SEARCH_FAILED");
+        })
+        .finally(async () => {
+          setIsLoading(false);
+        });
+    } else {
+      setError("FIELDS_REQUIRED");
+      return;
+    }
+  };
+
+  const tabStyle = {
+    border: 1,
+    borderBottom: 0,
+    borderColor: "divider",
+    fontSize: "14px",
+    fontWeight: "600",
+    color: "#757575",
+  };
+
+  return (
+    <NeedsAccountModalWrapper CMS_ONLY_disable_overlay={props.CMS_ONLY_disable_overlay}>
+      <div className="flex flex-column">
+        <TaskHeader task={props.task} />
+        <Box sx={{ width: "100%" }}>
+          <TabContext value={tabIndex.toString()}>
+            <Box>
+              <TabList
+                onChange={onSelectTab}
+                aria-label="Hotel, Motel, and Guest House Registration task"
+                sx={{ borderBottom: 1, borderColor: "divider", marginTop: ".25rem", marginLeft: ".5rem" }}
+              >
+                <Tab
+                  value="0"
+                  sx={tabStyle}
+                  label={Config.housingRegistrationSearchTask.registrationTab1Text}
+                  data-testid={"start-application-tab"}
+                />
+                <Tab
+                  value="1"
+                  sx={tabStyle}
+                  label={Config.housingRegistrationSearchTask.registrationTab2Text}
+                  data-testid={"check-status-tab"}
+                />
+              </TabList>
+            </Box>
+            <TabPanel value="0" sx={{ paddingX: 0 }}>
+              <div className="margin-top-3">
+                <UnlockedBy task={props.task} />
+                <Content>{props.task.summaryDescriptionMd || ""}</Content>
+                <Content>{getModifiedTaskContent(roadmap, props.task, "contentMd")}</Content>
+              </div>
+              <div className="flex flex-column margin-top-4 margin-bottom-1">
+                <PrimaryButton
+                  isColor={"primary"}
+                  onClick={() => {
+                    openInNewTab(callToActionLink);
+                  }}
+                >
+                  <div> {Config.housingRegistrationSearchTask.registrationCallToActionPrimaryText}</div>
+                </PrimaryButton>
+              </div>
+              <div className="flex flex-column">
+                <SecondaryButton
+                  isColor={"primary"}
+                  onClick={() => {
+                    setTabIndex(STATUS_TAB_INDEX);
+                  }}
+                >
+                  <div>{Config.housingRegistrationSearchTask.registrationCallToActionSecondaryText}</div>
+                </SecondaryButton>
+              </div>
+            </TabPanel>
+            <TabPanel value="1" sx={{ paddingX: 0 }}>
+              {housingRegistrationLookupSummary ? (
+                <HousingRegistrationStatusSummary
+                  onEdit={onEdit}
+                  summary={housingRegistrationLookupSummary}
+                  task={props.task}
+                  address={housingAddress}
+                />
+              ) : (
+                <CheckHousingRegistrationStatus
+                  onSubmit={onSubmit}
+                  error={error}
+                  isLoading={isLoading}
+                  municipalities={municipalities}
+                />
+              )}
+            </TabPanel>
+          </TabContext>
+        </Box>
+      </div>
+    </NeedsAccountModalWrapper>
+  );
+};

--- a/web/src/components/tasks/HousingRegistrationStatusSummary.tsx
+++ b/web/src/components/tasks/HousingRegistrationStatusSummary.tsx
@@ -1,0 +1,170 @@
+import { HorizontalLine } from "@/components/HorizontalLine";
+import { UserDataErrorAlert } from "@/components/UserDataErrorAlert";
+import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
+import { Icon } from "@/components/njwds/Icon";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { useUserData } from "@/lib/data-hooks/useUserData";
+import { Task } from "@/lib/types/types";
+import { toProperCase } from "@businessnjgovnavigator/shared";
+import { parseDate } from "@businessnjgovnavigator/shared/dateHelpers";
+import {
+  HousingAddress,
+  HousingRegistrationRequestLookupResponse,
+} from "@businessnjgovnavigator/shared/housing";
+import { Box } from "@mui/material";
+import { ReactElement } from "react";
+
+interface Props {
+  task: Task;
+  summary: HousingRegistrationRequestLookupResponse;
+  address: HousingAddress | undefined;
+  onEdit: () => void;
+}
+
+type CardDisplayDetails = {
+  headerColor: string;
+  bodyColor: string;
+  icon: string;
+  iconTextColor: string;
+};
+
+export const HousingRegistrationStatusSummary = (props: Props): ReactElement => {
+  const { Config } = useConfig();
+
+  const { business } = useUserData();
+
+  const getDetailsForRegistrationCard = (status: string): CardDisplayDetails => {
+    switch (status) {
+      case "Approved":
+        return {
+          headerColor: "bg-success-darker",
+          bodyColor: "bg-success-lighter",
+          icon: "check_circle",
+          iconTextColor: "text-success-darker",
+        };
+      case "Rejected":
+      case "Returned":
+      case "Incomplete":
+      case "Cancelled":
+        return {
+          headerColor: "bg-error",
+          bodyColor: "bg-error-extra-light",
+          icon: "cancel",
+          iconTextColor: "text-error-darker",
+        };
+      default:
+        return {
+          headerColor: "bg-info-dark",
+          bodyColor: "bg-info-extra-light",
+          icon: "",
+          iconTextColor: "",
+        };
+    }
+  };
+
+  const getInformationalMessageText = (status: string): string => {
+    switch (status) {
+      case "In Review":
+        return Config.housingRegistrationSearchTask.informationalInReview;
+      case "Incomplete":
+        return Config.housingRegistrationSearchTask.informationalIncomplete;
+      case "Rejected":
+        return Config.housingRegistrationSearchTask.informationalRejected;
+      case "Returned":
+        return Config.housingRegistrationSearchTask.informationalReturned;
+      default:
+        return "";
+    }
+  };
+
+  const housingRegistrationStatusCard = (date: string, status: string, index: number): ReactElement => {
+    const details = getDetailsForRegistrationCard(status);
+    const formattedDate = parseDate(date).format("MMMM d, YYYY");
+    const informationalMessage = getInformationalMessageText(status);
+
+    const getIconForRegistrationCard = (): ReactElement => {
+      switch (status) {
+        case "In Review":
+          return <img src={`/img/access_time_filled.svg`} alt="" style={{ width: "17px", height: "17px" }} />;
+        default:
+          return (
+            <>
+              <Icon className={`inline-icon ${details.iconTextColor}`}>{details.icon}</Icon>
+            </>
+          );
+      }
+    };
+
+    return (
+      <div
+        data-testid={`registration-${index}`}
+        key={index}
+        className={"bg-white margin-y-4 padding-x-4 padding-y-4 radius-lg drop-shadow-xs"}
+      >
+        <span className={"text-bold"}>
+          <span>{Config.housingRegistrationSearchTask.registrationStartDateText}</span>
+          <span data-testid={`registration-${index}-date`}>{`${formattedDate}`}</span>
+        </span>
+
+        <HorizontalLine />
+        <Box className={`${details.headerColor} fdc fg1 radius-lg margin-top-2 drop-shadow-xs`}>
+          <span className={"padding-left-2 padding-y-1 text-white"}>Application Status:</span>
+          <Box className={`${details.bodyColor} radius-bottom-lg padding-left-2 padding-y-2 `}>
+            {getIconForRegistrationCard()}
+            <span
+              data-testid={`registration-${index}-status`}
+              className={`padding-left-2 text-bold ${details.iconTextColor}`}
+            >
+              {status}
+            </span>
+            {informationalMessage && (
+              <div data-testid={`registration-${index}-informational-message`}>{informationalMessage}</div>
+            )}
+          </Box>
+        </Box>
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <Box className="bg-base-extra-light  fdc fg1 padding-y-2 radius-lg drop-shadow-xs">
+        <div className={"margin-x-4"}>
+          {business?.profileData?.businessName && (
+            <span className={"text-bold"}>{business?.profileData?.businessName}</span>
+          )}
+          <br />
+          {props.address && (
+            <span>
+              <div className={"padding-bottom-1 text-bold"}>
+                {Config.housingRegistrationSearchTask.applicationsFoundHeader}
+              </div>
+              {props.address.address1}, {toProperCase(props.address.municipalityName)} NJ
+              <UnStyledButton
+                dataTestid={"address-edit"}
+                isUnderline
+                className={"padding-x-5"}
+                onClick={props.onEdit}
+              >
+                Edit
+              </UnStyledButton>
+            </span>
+          )}
+
+          <div>
+            {props.summary.registrations.map((registration, index) => {
+              return housingRegistrationStatusCard(registration.date, registration.status, index);
+            })}
+          </div>
+
+          <HorizontalLine />
+          <div className={"padding-bottom-1"}>
+            <span className={"text-bold"}>Issuing Agency:</span> Department of Community Affairs
+          </div>
+        </div>
+      </Box>
+
+      <UserDataErrorAlert />
+    </>
+  );
+};

--- a/web/src/contexts/configContext.ts
+++ b/web/src/contexts/configContext.ts
@@ -21,6 +21,7 @@ import * as ElevatorRegistration from "@businessnjgovnavigator/content/fieldConf
 import * as FormationInterimSuccessPage from "@businessnjgovnavigator/content/fieldConfig/formation-interim-success-page.json";
 import * as FormationSuccessPage from "@businessnjgovnavigator/content/fieldConfig/formation-success-page.json";
 import * as SiteWideErrorMessages from "@businessnjgovnavigator/content/fieldConfig/global-errors-defaults.json";
+import * as HousingRegistrationSearchTask from "@businessnjgovnavigator/content/fieldConfig/housing-registration.json";
 import * as NaicsCode from "@businessnjgovnavigator/content/fieldConfig/naics-code.json";
 import * as NavigationDefaults from "@businessnjgovnavigator/content/fieldConfig/navigation-defaults.json";
 import * as NexusDbaFormation from "@businessnjgovnavigator/content/fieldConfig/nexus-dba-formation.json";
@@ -70,7 +71,8 @@ const merged = JSON.parse(
       DashboardDefaults,
       PageMetadata,
       CalloutDefaults,
-      ElevatorRegistration
+      ElevatorRegistration,
+      HousingRegistrationSearchTask
     )
   )
 );
@@ -108,7 +110,8 @@ export type ConfigType = typeof ConfigOriginal &
   typeof ElevatorRegistration &
   typeof CalloutDefaults &
   typeof DashboardDefaults &
-  typeof PageMetadata;
+  typeof PageMetadata &
+  typeof HousingRegistrationSearchTask;
 
 export const getMergedConfig = (): ConfigType => {
   return merge(
@@ -142,7 +145,8 @@ export const getMergedConfig = (): ConfigType => {
     DashboardDefaults,
     PageMetadata,
     CalloutDefaults,
-    ElevatorRegistration
+    ElevatorRegistration,
+    HousingRegistrationSearchTask
   );
 };
 

--- a/web/src/lib/api-client/apiClient.ts
+++ b/web/src/lib/api-client/apiClient.ts
@@ -9,6 +9,7 @@ import {
   UserData,
 } from "@businessnjgovnavigator/shared/";
 import { ElevatorSafetyRegistrationSummary } from "@businessnjgovnavigator/shared/elevatorSafety";
+import { HousingRegistrationRequestLookupResponse } from "@businessnjgovnavigator/shared/housing";
 import axios, { AxiosError, AxiosRequestConfig } from "axios";
 
 const apiBaseUrl = process.env.API_BASE_URL || "";
@@ -40,6 +41,13 @@ export const checkElevatorRegistrationStatus = (
 
 export const checkElevatorViolations = (address: string, municipalityId: string): Promise<boolean> => {
   return post(`/elevator-safety/violations`, { address, municipalityId });
+};
+
+export const checkHousingHotelMotelRegistrationStatus = (
+  address: string,
+  municipalityId: string
+): Promise<HousingRegistrationRequestLookupResponse> => {
+  return post(`/housing/registrations/hotelmotel`, { address, municipalityId });
 };
 
 export const postBusinessFormation = (

--- a/web/src/lib/types/types.ts
+++ b/web/src/lib/types/types.ts
@@ -481,11 +481,13 @@ export type NaicsCodeObject = {
 
 export type LicenseSearchError = "NOT_FOUND" | "FIELDS_REQUIRED" | "SEARCH_FAILED";
 
-export type ElevatorRegistrationSearchError =
-  | "NO_PROPERTY_INTEREST_FOUND"
-  | "NO_ELEVATOR_REGISTRATIONS_FOUND"
-  | "FIELDS_REQUIRED"
-  | "SEARCH_FAILED";
+export type ElevatorRegistrationSearchError = CommunityAffairsSearchError | "NO_ELEVATOR_REGISTRATIONS_FOUND";
+
+export type HotelMotelRegistrationSearchError =
+  | CommunityAffairsSearchError
+  | "NO_HOTEL_MOTEL_REGISTRATIONS_FOUND";
+
+export type CommunityAffairsSearchError = "NO_PROPERTY_INTEREST_FOUND" | "FIELDS_REQUIRED" | "SEARCH_FAILED";
 
 export type FeedbackRequestModalNames =
   | "Select Feedback"


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Adds a hotel/motel license status check, that functions similarly to the elevator registration status check

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188006371](https://www.pivotaltracker.com/story/show/188006371).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
Create an account in the Lodging industry
Answer "Yes" to the hotel/motel non-essential question
See the task in Step 4
Use the Q/A testing doc to get addresses to test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
