### PR TITLE
feat: [#187003755] add full address to poppy profile

### DIFF
--- a/api/src/api/userRouter.test.ts
+++ b/api/src/api/userRouter.test.ts
@@ -770,7 +770,7 @@ describe("userRouter", () => {
         expect(formationDataPut).toEqual(completedFormationData);
       });
 
-      it("allows changing the legal structure (and clears formationData) if formation is not completed", async () => {
+      it("allows changing the legal structure (and clears formationData while preserving address) if formation is not completed", async () => {
         mockJwt.decode.mockReturnValue(cognitoPayload({ id: "123" }));
 
         const existingUserData = generateUserDataForBusiness(
@@ -779,6 +779,18 @@ describe("userRouter", () => {
             formationData: generateFormationData({
               formationResponse: generateFormationSubmitResponse({}),
               getFilingResponse: generateGetFilingResponse({ success: false }),
+              formationFormData: {
+                ...createEmptyFormationFormData(),
+                addressLine1: "123 Testing Way",
+                addressLine2: "Test Suite",
+                addressMunicipality: {
+                  displayName: "Newark Display Name",
+                  name: "Newark",
+                  county: "",
+                  id: "",
+                },
+                addressZipCode: "07781",
+              },
             }),
           }),
           { user: generateUser({ id: "123" }) }
@@ -809,7 +821,18 @@ describe("userRouter", () => {
           .legalStructureId;
         expect(legalStructurePut).toEqual("c-corporation");
         expect(formationDataPut).toEqual({
-          formationFormData: createEmptyFormationFormData(),
+          formationFormData: {
+            ...createEmptyFormationFormData(),
+            addressLine1: "123 Testing Way",
+            addressLine2: "Test Suite",
+            addressMunicipality: {
+              displayName: "Newark Display Name",
+              name: "Newark",
+              county: "",
+              id: "",
+            },
+            addressZipCode: "07781",
+          },
           formationResponse: undefined,
           getFilingResponse: undefined,
           completedFilingPayment: false,

--- a/api/src/api/userRouter.ts
+++ b/api/src/api/userRouter.ts
@@ -209,7 +209,6 @@ export const userRouterFactory = (
 
     if (legalStructureHasChanged(oldUserData, userData)) {
       // prevent legal structure from changing if business has been formed
-
       if (businessHasFormed(oldUserData)) {
         const oldBusiness = getCurrentBusiness(oldUserData);
 
@@ -222,13 +221,25 @@ export const userRouterFactory = (
         }));
       }
 
+      const formationFormData =
+        userData.businesses[userData.currentBusinessId].formationData.formationFormData;
+      const address = {
+        addressLine1: formationFormData.addressLine1,
+        addressLine2: formationFormData.addressLine2,
+        addressCity: formationFormData.addressCity,
+        addressMunicipality: formationFormData.addressMunicipality,
+        addressZipCode: formationFormData.addressZipCode,
+      };
       return modifyCurrentBusiness(userData, (business) => ({
         ...business,
         formationData: {
           formationResponse: undefined,
           getFilingResponse: undefined,
           completedFilingPayment: false,
-          formationFormData: createEmptyFormationFormData(),
+          formationFormData: {
+            ...createEmptyFormationFormData(),
+            ...address,
+          },
           businessNameAvailability: undefined,
           dbaBusinessNameAvailability: undefined,
           lastVisitedPageIndex: 0,

--- a/content/src/fieldConfig/profile.json
+++ b/content/src/fieldConfig/profile.json
@@ -133,6 +133,11 @@
           "description": ""
         }
       },
+      "businessAddress": {
+        "default": {
+          "header": "Business Address"
+        }
+      },
       "dateOfFormation": {
         "default": {
           "header": "Business Effective Date",

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -4393,6 +4393,17 @@ collections:
                               widget: "string",
                             }
                           - { label: "Description", name: "description", widget: "markdown" }
+                  - label: Business Address
+                    name: "businessAddress"
+                    collapsed: true
+                    widget: object
+                    fields:
+                      - label: Default
+                        name: "default"
+                        collapsed: false
+                        widget: object
+                        fields:
+                          - { label: "Header", name: "header", widget: "string" }
                   - label: Business Name
                     name: "businessName"
                     collapsed: true

--- a/web/src/components/profile/ProfileAddressLockedFields.test.tsx
+++ b/web/src/components/profile/ProfileAddressLockedFields.test.tsx
@@ -1,0 +1,75 @@
+import { ProfileAddressLockedFields } from "@/components/profile/ProfileAddressLockedFields";
+import { generateAddress } from "@/test/factories";
+import { WithStatefulAddressData } from "@/test/mock/withStatefulAddressData";
+import { Address, emptyAddressData, Municipality } from "@businessnjgovnavigator/shared/";
+import { generateMunicipality } from "@businessnjgovnavigator/shared/test";
+import { render, screen, within } from "@testing-library/react";
+
+describe("ProfileAddressLockedFields", () => {
+  const renderComponent = ({
+    address,
+    municipalities,
+  }: {
+    address?: Address;
+    municipalities?: Municipality[];
+  }): void => {
+    render(
+      <WithStatefulAddressData
+        initialData={address || emptyAddressData}
+        municipalities={municipalities || [generateMunicipality({})]}
+      >
+        <ProfileAddressLockedFields />
+      </WithStatefulAddressData>
+    );
+  };
+
+  it("renders required profile address locked fields", () => {
+    const address = generateAddress({
+      addressLine1: "1111 Home Alone",
+      addressLine2: "",
+      addressMunicipality: generateMunicipality({ displayName: "Allendale" }),
+      addressState: { shortCode: "NJ", name: "New Jersey" },
+      addressZipCode: "00893",
+    });
+    renderComponent({ address });
+
+    const addressLine1 = screen.getByTestId("locked-profileAddressLine1");
+    expect(within(addressLine1).getByText("1111 Home Alone")).toBeInTheDocument();
+    const addressMuniStateZip = screen.getByTestId("locked-profileAddressMuniStateZip");
+    expect(within(addressMuniStateZip).getByText("Allendale, NJ 00893")).toBeInTheDocument();
+    expect(screen.queryByTestId("locked-profileAddressLine2")).not.toBeInTheDocument();
+  });
+
+  it("renders profile address locked fields with Address Line 2", () => {
+    const address = generateAddress({
+      addressLine1: "1111 Home Alone",
+      addressLine2: "Suite 10",
+      addressMunicipality: generateMunicipality({ displayName: "Allendale" }),
+      addressState: { shortCode: "NJ", name: "New Jersey" },
+      addressZipCode: "00893",
+    });
+    renderComponent({ address });
+
+    const addressLine1 = screen.getByTestId("locked-profileAddressLine1");
+    expect(within(addressLine1).getByText("1111 Home Alone")).toBeInTheDocument();
+    const addressLine2 = screen.getByTestId("locked-profileAddressLine2");
+    expect(within(addressLine2).getByText("Suite 10")).toBeInTheDocument();
+    const addressMuniStateZip = screen.getByTestId("locked-profileAddressMuniStateZip");
+    expect(within(addressMuniStateZip).getByText("Allendale, NJ 00893")).toBeInTheDocument();
+  });
+
+  it("does not render when address fields are empty", () => {
+    const address = generateAddress({
+      addressLine1: "",
+      addressLine2: "",
+      addressMunicipality: undefined,
+      addressState: undefined,
+      addressZipCode: "",
+    });
+    renderComponent({ address });
+
+    expect(screen.queryByTestId("locked-profileAddressLine1")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("locked-profileAddressLine2")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("locked-profileAddressMuniStateZip")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/profile/ProfileAddressLockedFields.tsx
+++ b/web/src/components/profile/ProfileAddressLockedFields.tsx
@@ -1,0 +1,31 @@
+import { AddressContext } from "@/contexts/addressContext";
+import { getMergedConfig } from "@/contexts/configContext";
+import { ReactElement, useContext } from "react";
+
+export const ProfileAddressLockedFields = (): ReactElement => {
+  const { state } = useContext(AddressContext);
+
+  const Config = getMergedConfig();
+  return (
+    <div className="margin-top-4 margin-bottom-4" data-testid={"locked-profileAddressFields"}>
+      <div className="text-bold margin-bottom-05">
+        {Config.profileDefaults.fields.businessAddress.default.header}
+      </div>
+
+      {state.addressData.addressLine1 &&
+        state.addressData.addressMunicipality &&
+        state.addressData.addressState &&
+        state.addressData.addressZipCode && (
+          <>
+            <div data-testid={"locked-profileAddressLine1"}>{state.addressData.addressLine1}</div>
+            {state.addressData.addressLine2 && (
+              <div data-testid={"locked-profileAddressLine2"}>{state.addressData.addressLine2}</div>
+            )}
+            <div
+              data-testid={"locked-profileAddressMuniStateZip"}
+            >{`${state.addressData.addressMunicipality?.displayName}, ${state.addressData.addressState?.shortCode} ${state.addressData.addressZipCode}`}</div>
+          </>
+        )}
+    </div>
+  );
+};

--- a/web/src/components/profile/ProfileNewJerseyAddress.test.tsx
+++ b/web/src/components/profile/ProfileNewJerseyAddress.test.tsx
@@ -1,24 +1,32 @@
 import { ProfileNewJerseyAddress } from "@/components/profile/ProfileNewJerseyAddress";
 import { getMergedConfig } from "@/contexts/configContext";
 import { generateAddress } from "@/test/factories";
+import { useMockBusiness } from "@/test/mock/mockUseUserData";
 import { WithStatefulAddressData } from "@/test/mock/withStatefulAddressData";
-import { Address, emptyAddressData, Municipality } from "@businessnjgovnavigator/shared/";
+import {
+  emptyAddressData,
+  generateBusiness,
+  generateFormationData,
+  generateFormationFormData,
+  generateProfileData,
+  Municipality,
+} from "@businessnjgovnavigator/shared/";
 import { generateMunicipality } from "@businessnjgovnavigator/shared/test";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 
 const Config = getMergedConfig();
 
+jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
+
 describe("<ProfileNewJerseyAddress  />", () => {
-  const renderComponent = ({
-    address,
-    municipalities,
-  }: {
-    address?: Address;
-    municipalities?: Municipality[];
-  }): void => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const renderComponent = ({ municipalities }: { municipalities?: Municipality[] }): void => {
     render(
       <WithStatefulAddressData
-        initialData={address || emptyAddressData}
+        initialData={emptyAddressData}
         municipalities={municipalities || [generateMunicipality({})]}
       >
         <ProfileNewJerseyAddress />
@@ -30,7 +38,15 @@ describe("<ProfileNewJerseyAddress  />", () => {
     const address = generateAddress({
       addressLine1: "1111 Home Alone",
     });
-    renderComponent({ address });
+    useMockBusiness(
+      generateBusiness({
+        formationData: generateFormationData({
+          completedFilingPayment: false,
+          formationFormData: generateFormationFormData({ ...address }),
+        }),
+      })
+    );
+    renderComponent({});
     expect(screen.getByLabelText("Address line1")).toHaveValue("1111 Home Alone");
   });
 
@@ -38,7 +54,16 @@ describe("<ProfileNewJerseyAddress  />", () => {
     const address = generateAddress({
       addressLine1: "",
     });
-    renderComponent({ address });
+    useMockBusiness(
+      generateBusiness({
+        formationData: generateFormationData({
+          completedFilingPayment: false,
+          formationFormData: generateFormationFormData({ ...address }),
+        }),
+      })
+    );
+    renderComponent({});
+
     expect(screen.getByLabelText("Address line1")).toHaveValue("");
     fillText("Address line1", "1111 Home Alone");
     expect(screen.getByLabelText("Address line1")).toHaveValue("1111 Home Alone");
@@ -48,7 +73,16 @@ describe("<ProfileNewJerseyAddress  />", () => {
     const address = generateAddress({
       addressLine1: "",
     });
-    renderComponent({ address });
+    useMockBusiness(
+      generateBusiness({
+        formationData: generateFormationData({
+          completedFilingPayment: false,
+          formationFormData: generateFormationFormData({ ...address }),
+        }),
+      })
+    );
+    renderComponent({});
+
     blurInput("Address line1");
     expect(screen.getByText(Config.formation.fields.addressLine1.error)).toBeInTheDocument();
   });
@@ -57,7 +91,16 @@ describe("<ProfileNewJerseyAddress  />", () => {
     const address = generateAddress({
       addressLine2: "1111 Home Alone",
     });
-    renderComponent({ address });
+    useMockBusiness(
+      generateBusiness({
+        formationData: generateFormationData({
+          completedFilingPayment: false,
+          formationFormData: generateFormationFormData({ ...address }),
+        }),
+      })
+    );
+    renderComponent({});
+
     expect(screen.getByLabelText("Address line2")).toHaveValue("1111 Home Alone");
   });
 
@@ -65,7 +108,16 @@ describe("<ProfileNewJerseyAddress  />", () => {
     const address = generateAddress({
       addressLine2: "",
     });
-    renderComponent({ address });
+    useMockBusiness(
+      generateBusiness({
+        formationData: generateFormationData({
+          completedFilingPayment: false,
+          formationFormData: generateFormationFormData({ ...address }),
+        }),
+      })
+    );
+    renderComponent({});
+
     expect(screen.getByLabelText("Address line2")).toHaveValue("");
     fillText("Address line2", "1111 Home Alone");
     expect(screen.getByLabelText("Address line2")).toHaveValue("1111 Home Alone");
@@ -76,7 +128,16 @@ describe("<ProfileNewJerseyAddress  />", () => {
       ...emptyAddressData,
       addressLine2: "123",
     });
-    renderComponent({ address });
+    useMockBusiness(
+      generateBusiness({
+        formationData: generateFormationData({
+          completedFilingPayment: false,
+          formationFormData: generateFormationFormData({ ...address }),
+        }),
+      })
+    );
+    renderComponent({});
+
     blurInput("Address line2");
     expect(screen.getByText(Config.formation.fields.addressLine1.error)).toBeInTheDocument();
     expect(screen.getByText(Config.formation.fields.addressMunicipality.error)).toBeInTheDocument();
@@ -87,7 +148,16 @@ describe("<ProfileNewJerseyAddress  />", () => {
     const address = generateAddress({
       addressZipCode: "08437",
     });
-    renderComponent({ address });
+    useMockBusiness(
+      generateBusiness({
+        formationData: generateFormationData({
+          completedFilingPayment: false,
+          formationFormData: generateFormationFormData({ ...address }),
+        }),
+      })
+    );
+    renderComponent({});
+
     expect(screen.getByLabelText("Address zip code")).toHaveValue("08437");
   });
 
@@ -95,7 +165,16 @@ describe("<ProfileNewJerseyAddress  />", () => {
     const address = generateAddress({
       addressZipCode: "",
     });
-    renderComponent({ address });
+    useMockBusiness(
+      generateBusiness({
+        formationData: generateFormationData({
+          completedFilingPayment: false,
+          formationFormData: generateFormationFormData({ ...address }),
+        }),
+      })
+    );
+    renderComponent({});
+
     expect(screen.getByLabelText("Address zip code")).toHaveValue("");
     fillText("Address zip code", "08437");
     expect(screen.getByLabelText("Address zip code")).toHaveValue("08437");
@@ -105,9 +184,16 @@ describe("<ProfileNewJerseyAddress  />", () => {
     const address = generateAddress({
       addressState: undefined,
     });
-    renderComponent({
-      address,
-    });
+    useMockBusiness(
+      generateBusiness({
+        formationData: generateFormationData({
+          completedFilingPayment: false,
+          formationFormData: generateFormationFormData({ ...address }),
+        }),
+      })
+    );
+    renderComponent({});
+
     expect(screen.getByLabelText("Address state")).toHaveValue("NJ");
     expect(screen.getByLabelText("Address state")).toBeDisabled();
   });
@@ -116,12 +202,32 @@ describe("<ProfileNewJerseyAddress  />", () => {
     const address = generateAddress({
       addressZipCode: "",
     });
-    renderComponent({ address });
+    useMockBusiness(
+      generateBusiness({
+        formationData: generateFormationData({
+          completedFilingPayment: false,
+          formationFormData: generateFormationFormData({ ...address }),
+        }),
+      })
+    );
+    renderComponent({});
+
     blurInput("Address zip code");
     expect(screen.getByText(Config.formation.fields.addressZipCode.error)).toBeInTheDocument();
   });
 
   it("renders disabled profile address state field", () => {
+    const address = generateAddress({
+      addressZipCode: "",
+    });
+    useMockBusiness(
+      generateBusiness({
+        formationData: generateFormationData({
+          completedFilingPayment: false,
+          formationFormData: generateFormationFormData({ ...address }),
+        }),
+      })
+    );
     renderComponent({});
     expect(screen.getByLabelText("Address state")).toBeDisabled();
   });
@@ -131,8 +237,15 @@ describe("<ProfileNewJerseyAddress  />", () => {
     const address = generateAddress({
       addressMunicipality: municipality,
     });
+    useMockBusiness(
+      generateBusiness({
+        formationData: generateFormationData({
+          completedFilingPayment: false,
+          formationFormData: generateFormationFormData({ ...address }),
+        }),
+      })
+    );
     renderComponent({
-      address,
       municipalities: [municipality],
     });
     expect(screen.getByLabelText("Address municipality")).toHaveValue("Newark Display Name");
@@ -143,8 +256,15 @@ describe("<ProfileNewJerseyAddress  />", () => {
     const address = generateAddress({
       addressMunicipality: undefined,
     });
+    useMockBusiness(
+      generateBusiness({
+        formationData: generateFormationData({
+          completedFilingPayment: false,
+          formationFormData: generateFormationFormData({ ...address }),
+        }),
+      })
+    );
     renderComponent({
-      address,
       municipalities: [municipality],
     });
     selectByText("Address municipality", "Newark Display Name");
@@ -156,12 +276,71 @@ describe("<ProfileNewJerseyAddress  />", () => {
     const address = generateAddress({
       addressMunicipality: undefined,
     });
+    useMockBusiness(
+      generateBusiness({
+        formationData: generateFormationData({
+          completedFilingPayment: false,
+          formationFormData: generateFormationFormData({ ...address }),
+        }),
+      })
+    );
     renderComponent({
-      address,
       municipalities: [municipality],
     });
     blurInput("Address municipality");
     expect(screen.getByText(Config.formation.fields.addressMunicipality.error)).toBeInTheDocument();
+  });
+
+  it("renders profile locked fields when completed filing payment is true", async () => {
+    const municipality = generateMunicipality({ displayName: "Allendale", name: "Allendale" });
+    const address = generateAddress({
+      addressLine1: "1111 Home Alone",
+      addressLine2: "Suite 10",
+      addressMunicipality: municipality,
+      addressState: { shortCode: "NJ", name: "New Jersey" },
+      addressZipCode: "00893",
+    });
+    useMockBusiness(
+      generateBusiness({
+        profileData: generateProfileData({ businessPersona: "STARTING" }),
+        formationData: generateFormationData({
+          completedFilingPayment: true,
+          formationFormData: generateFormationFormData({ ...address }),
+        }),
+      })
+    );
+    renderComponent({
+      municipalities: [municipality],
+    });
+    expect(screen.getByTestId("locked-profileAddressLine1")).toBeInTheDocument();
+    expect(screen.getByTestId("locked-profileAddressLine2")).toBeInTheDocument();
+    expect(screen.getByTestId("locked-profileAddressMuniStateZip")).toBeInTheDocument();
+  });
+
+  it("does not render profile locked fields when address fields are not entered and completed filing payment is true", async () => {
+    const municipality = generateMunicipality({ displayName: "Allendale", name: "Allendale" });
+    const address = generateAddress({
+      addressLine1: "",
+      addressLine2: "",
+      addressMunicipality: undefined,
+      addressState: undefined,
+      addressZipCode: "",
+    });
+    useMockBusiness(
+      generateBusiness({
+        profileData: generateProfileData({ businessPersona: "STARTING" }),
+        formationData: generateFormationData({
+          completedFilingPayment: true,
+          formationFormData: generateFormationFormData({ ...address }),
+        }),
+      })
+    );
+    renderComponent({
+      municipalities: [municipality],
+    });
+    expect(screen.queryByTestId("locked-profileAddressLine1")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("locked-profileAddressLine2")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("locked-profileAddressMuniStateZip")).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/components/profile/ProfileNewJerseyAddress.tsx
+++ b/web/src/components/profile/ProfileNewJerseyAddress.tsx
@@ -3,6 +3,7 @@ import { StateDropdown } from "@/components/StateDropdown";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { AddressMunicipalityDropdown } from "@/components/data-fields/address/AddressMunicipalityDropdown";
 import { AddressTextField } from "@/components/data-fields/address/AddressTextField";
+import { ProfileAddressLockedFields } from "@/components/profile/ProfileAddressLockedFields";
 import { AddressContext } from "@/contexts/addressContext";
 import { ProfileFormContext } from "@/contexts/profileFormContext";
 import { useAddressErrors } from "@/lib/data-hooks/useAddressErrors";
@@ -10,7 +11,6 @@ import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { useMountEffectWhenDefined } from "@/lib/utils/helpers";
-import { isOwningBusiness } from "@businessnjgovnavigator/shared/domain-logic/businessPersonaHelpers";
 import { ReactElement, useContext } from "react";
 
 export const ProfileNewJerseyAddress = (): ReactElement => {
@@ -34,7 +34,7 @@ export const ProfileNewJerseyAddress = (): ReactElement => {
   const { setIsValid: setIsValidZipCode } = useFormContextFieldHelpers("addressZipCode", ProfileFormContext);
 
   useMountEffectWhenDefined(() => {
-    if (business && isOwningBusiness(business)) {
+    if (business) {
       setAddressData({
         addressLine1: business.formationData.formationFormData.addressLine1,
         addressLine2: business.formationData.formationFormData.addressLine2,
@@ -52,87 +52,93 @@ export const ProfileNewJerseyAddress = (): ReactElement => {
     setIsValidZipCode(!doesFieldHaveError("addressZipCode"));
   };
 
+  const isAddressFieldsDisabled = business?.formationData.completedFilingPayment;
+
   return (
     <>
-      <div className="margin-y-4">
-        <div id={`question-addressLine1`} className="text-field-width-default add-spacing-on-ele-scroll">
-          <AddressTextField
-            label={Config.formation.fields.addressLine1.label}
-            fieldName="addressLine1"
-            validationText={getFieldErrorLabel("addressLine1")}
-            className={"margin-bottom-2"}
-            errorBarType="ALWAYS"
-            onValidation={onValidation}
-          />
-        </div>
-        <div id={`question-addressLine2`} className="text-field-width-default add-spacing-on-ele-scroll">
-          <AddressTextField
-            label={Config.formation.fields.addressLine2.label}
-            secondaryLabel={Config.formation.general.optionalLabel}
-            errorBarType="ALWAYS"
-            fieldName="addressLine2"
-            validationText={getFieldErrorLabel("addressLine2")}
-            className="margin-bottom-2"
-            onValidation={onValidation}
-          />
-        </div>
-        <div className="text-field-width-default">
-          <WithErrorBar
-            hasError={doSomeFieldsHaveError(["addressState", "addressZipCode", "addressMunicipality"])}
-            type="DESKTOP-ONLY"
-          >
-            <div className="grid-row tablet:grid-gap-2">
-              <div className="grid-col-12 tablet:grid-col-6">
-                <WithErrorBar hasError={doesFieldHaveError("addressMunicipality")} type="MOBILE-ONLY">
-                  <span className="text-bold">{Config.formation.fields.addressCity.label}</span>
-                  <AddressMunicipalityDropdown onValidation={onValidation} />
-                </WithErrorBar>
-              </div>
-              <div className="grid-col-12 tablet:grid-col-6">
-                <WithErrorBar
-                  hasError={doSomeFieldsHaveError(["addressState", "addressZipCode"])}
-                  type="MOBILE-ONLY"
-                >
-                  <div className="grid-row grid-gap tablet:grid-gap-2">
-                    <div className="grid-col-6">
-                      <strong>
-                        <ModifiedContent>{Config.formation.fields.addressState.label}</ModifiedContent>
-                      </strong>
-                      <div
-                        id={`question-addressState`}
-                        className="text-field-width-default add-spacing-on-ele-scroll"
-                      >
-                        <StateDropdown
-                          fieldName="addressState"
-                          value={"New Jersey"}
-                          validationText={Config.formation.fields.addressState.error}
-                          disabled={true}
-                          onSelect={(): void => {}}
-                        />
+      {isAddressFieldsDisabled ? (
+        <ProfileAddressLockedFields />
+      ) : (
+        <div className="margin-y-4">
+          <div id={`question-addressLine1`} className="text-field-width-default add-spacing-on-ele-scroll">
+            <AddressTextField
+              label={Config.formation.fields.addressLine1.label}
+              fieldName="addressLine1"
+              validationText={getFieldErrorLabel("addressLine1")}
+              className={"margin-bottom-2"}
+              errorBarType="ALWAYS"
+              onValidation={onValidation}
+            />
+          </div>
+          <div id={`question-addressLine2`} className="text-field-width-default add-spacing-on-ele-scroll">
+            <AddressTextField
+              label={Config.formation.fields.addressLine2.label}
+              secondaryLabel={Config.formation.general.optionalLabel}
+              errorBarType="ALWAYS"
+              fieldName="addressLine2"
+              validationText={getFieldErrorLabel("addressLine2")}
+              className="margin-bottom-2"
+              onValidation={onValidation}
+            />
+          </div>
+          <div className="text-field-width-default">
+            <WithErrorBar
+              hasError={doSomeFieldsHaveError(["addressState", "addressZipCode", "addressMunicipality"])}
+              type="DESKTOP-ONLY"
+            >
+              <div className="grid-row tablet:grid-gap-2">
+                <div className="grid-col-12 tablet:grid-col-6">
+                  <WithErrorBar hasError={doesFieldHaveError("addressMunicipality")} type="MOBILE-ONLY">
+                    <span className="text-bold">{Config.formation.fields.addressCity.label}</span>
+                    <AddressMunicipalityDropdown onValidation={onValidation} />
+                  </WithErrorBar>
+                </div>
+                <div className="grid-col-12 tablet:grid-col-6">
+                  <WithErrorBar
+                    hasError={doSomeFieldsHaveError(["addressState", "addressZipCode"])}
+                    type="MOBILE-ONLY"
+                  >
+                    <div className="grid-row grid-gap tablet:grid-gap-2">
+                      <div className="grid-col-6">
+                        <strong>
+                          <ModifiedContent>{Config.formation.fields.addressState.label}</ModifiedContent>
+                        </strong>
+                        <div
+                          id={`question-addressState`}
+                          className="text-field-width-default add-spacing-on-ele-scroll"
+                        >
+                          <StateDropdown
+                            fieldName="addressState"
+                            value={"New Jersey"}
+                            validationText={Config.formation.fields.addressState.error}
+                            disabled={true}
+                            onSelect={(): void => {}}
+                          />
+                        </div>
+                      </div>
+                      <div className="grid-col-6">
+                        <div
+                          id={`question-addressZipCode`}
+                          className="text-field-width-default add-spacing-on-ele-scroll"
+                        >
+                          <AddressTextField
+                            label={Config.formation.fields.addressZipCode.label}
+                            numericProps={{ maxLength: 5 }}
+                            errorBarType="NEVER"
+                            validationText={getFieldErrorLabel("addressZipCode")}
+                            fieldName={"addressZipCode"}
+                            onValidation={onValidation}
+                          />
+                        </div>
                       </div>
                     </div>
-                    <div className="grid-col-6">
-                      <div
-                        id={`question-addressZipCode`}
-                        className="text-field-width-default add-spacing-on-ele-scroll"
-                      >
-                        <AddressTextField
-                          label={Config.formation.fields.addressZipCode.label}
-                          numericProps={{ maxLength: 5 }}
-                          errorBarType="NEVER"
-                          validationText={getFieldErrorLabel("addressZipCode")}
-                          fieldName={"addressZipCode"}
-                          onValidation={onValidation}
-                        />
-                      </div>
-                    </div>
-                  </div>
-                </WithErrorBar>
+                  </WithErrorBar>
+                </div>
               </div>
-            </div>
-          </WithErrorBar>
+            </WithErrorBar>
+          </div>
         </div>
-      </div>
+      )}
       <hr aria-hidden={true} />
     </>
   );

--- a/web/src/components/tasks/business-formation/BusinessFormation.test.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormation.test.tsx
@@ -321,6 +321,7 @@ describe("<BusinessFormation />", () => {
     page.selectByText("Business suffix", "LLC");
     const threeDaysFromNow = getCurrentDate().add(3, "days");
     page.selectDate(threeDaysFromNow, "Business start date");
+    fireEvent.click(screen.getByText(Config.formation.sections.addressAddButtonText));
     page.fillText("Address line1", "1234 main street");
     page.fillText("Address line2", "Suite 304");
     page.fillText("Address zip code", "08001");
@@ -546,6 +547,8 @@ describe("<BusinessFormation />", () => {
     page.selectByText("Business suffix", "LLP");
     const threeDaysFromNow = getCurrentDate().add(3, "days");
     page.selectDate(threeDaysFromNow, "Business start date");
+    fireEvent.click(screen.getByText(Config.formation.sections.addressAddButtonText));
+
     page.fillText("Address line1", "1234 main street");
     page.fillText("Address line2", "Suite 304");
     page.fillText("Address zip code", "08001");
@@ -765,6 +768,7 @@ describe("<BusinessFormation />", () => {
     page.selectByText("Business suffix", "LP");
     const threeDaysFromNow = getCurrentDate().add(3, "days");
     page.selectDate(threeDaysFromNow, "Business start date");
+    fireEvent.click(screen.getByText(Config.formation.sections.addressAddButtonText));
     page.fillText("Address line1", "1234 main street");
     page.fillText("Address line2", "Suite 304");
     page.fillText("Address zip code", "08001");
@@ -900,6 +904,7 @@ describe("<BusinessFormation />", () => {
     page.fillText("Business total stock", "123");
     const threeDaysFromNow = getCurrentDate().add(3, "days");
     page.selectDate(threeDaysFromNow, "Business start date");
+    fireEvent.click(screen.getByText(Config.formation.sections.addressAddButtonText));
     page.fillText("Address line1", "1234 main street");
     page.fillText("Address line2", "Suite 304");
     page.fillText("Address zip code", "08001");
@@ -1012,6 +1017,7 @@ describe("<BusinessFormation />", () => {
     page.selectDate(threeDaysFromNow, "Business start date");
     page.chooseRadio("isVeteranNonprofit-true");
 
+    fireEvent.click(screen.getByText(Config.formation.sections.addressAddButtonText));
     page.fillText("Address line1", "1234 main street");
     page.fillText("Address line2", "Suite 304");
     page.fillText("Address zip code", "08001");

--- a/web/src/components/tasks/business-formation/BusinessFormation.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormation.tsx
@@ -100,7 +100,7 @@ export const BusinessFormation = (props: Props): ReactElement => {
         business.formationData.formationFormData.businessStartDate,
         legalStructureId
       ),
-      addressMunicipality: business.profileData.municipality,
+      addressMunicipality: business.formationData.formationFormData.addressMunicipality,
       legalType: legalStructureId,
       contactFirstName: business.formationData.formationFormData.contactFirstName || splitName.firstName,
       contactLastName: business.formationData.formationFormData.contactLastName || splitName.lastName,

--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
@@ -345,19 +345,20 @@ describe("<BusinessFormationPaginator />", () => {
         it("saves municipality to profile", async () => {
           const businessWithMunicipality = {
             ...business,
-            profileData: {
-              ...business.profileData,
-              municipality: generateMunicipality({ displayName: "Newark", name: "Newark" }),
+            formationData: {
+              ...business.formationData,
+              formationFormData: {
+                ...business.formationData.formationFormData,
+                addressMunicipality: generateMunicipality({ displayName: "New Town", name: "New Town" }),
+              },
             },
           };
           const page = preparePage({
             business: businessWithMunicipality,
             displayContent,
-            municipalities: [generateMunicipality({ displayName: "New Town", name: "New Town" })],
           });
           await page.stepperClickToBusinessStep();
 
-          expect((screen.getByLabelText("Address municipality") as HTMLInputElement).value).toEqual("Newark");
           page.selectByText("Address municipality", "New Town");
           expect((screen.getByLabelText("Address municipality") as HTMLInputElement).value).toEqual(
             "New Town"
@@ -404,23 +405,27 @@ describe("<BusinessFormationPaginator />", () => {
         it("does not send analytics when municipality was already entered", async () => {
           const businessWithMunicipality = {
             ...business,
-            profileData: {
-              ...business.profileData,
-              municipality: generateMunicipality({ displayName: "Newark" }),
+            formationData: {
+              ...business.formationData,
+              formationFormData: {
+                ...business.formationData.formationFormData,
+                addressMunicipality: generateMunicipality({ displayName: "New Town" }),
+              },
             },
           };
 
           const page = preparePage({
             business: businessWithMunicipality,
             displayContent,
-            municipalities: [generateMunicipality({ displayName: "New Town" })],
           });
           await page.stepperClickToBusinessStep();
           page.selectByText("Address municipality", "New Town");
 
           switchStepFunction();
           await waitFor(() => {
-            expect(currentBusiness().profileData.municipality?.displayName).toEqual("New Town");
+            expect(
+              currentBusiness().formationData.formationFormData.addressMunicipality?.displayName
+            ).toEqual("New Town");
           });
 
           expect(
@@ -472,11 +477,21 @@ describe("<BusinessFormationPaginator />", () => {
       });
 
       it("shows existing inline errors when visiting an INCOMPLETE step with inline errors", async () => {
-        const page = preparePage({ business, displayContent });
+        const businessWithMunicipality = {
+          ...business,
+          formationData: {
+            ...business.formationData,
+            formationFormData: {
+              ...business.formationData.formationFormData,
+              addressMunicipality: generateMunicipality({ displayName: "Newark", name: "Newark" }),
+            },
+          },
+        };
+
+        const page = preparePage({ business: businessWithMunicipality, displayContent });
         await page.stepperClickToBusinessStep();
         page.fillText("Address zip code", "22222");
         expect(screen.getByText(Config.formation.fields.addressZipCode.error)).toBeInTheDocument();
-
         switchStepFunction();
         expect(page.getStepStateInStepper(LookupStepIndexByName("Business"))).toEqual("INCOMPLETE");
 

--- a/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
@@ -13,7 +13,6 @@ import { useMockRoadmap } from "@/test/mock/mockUseRoadmap";
 import { currentBusiness } from "@/test/mock/withStatefulUserData";
 import {
   FormationFormData,
-  Municipality,
   ProfileData,
   PublicFilingLegalType,
   businessStructureTaskId,
@@ -65,8 +64,7 @@ describe("Formation - BusinessStep", () => {
 
   const getPageHelper = async (
     initialProfileData: Partial<ProfileData>,
-    formationFormData: Partial<FormationFormData>,
-    municipalities?: Municipality[]
+    formationFormData: Partial<FormationFormData>
   ): Promise<FormationPageHelpers> => {
     const profileData = generateFormationProfileData(initialProfileData);
     const isForeign = initialProfileData.businessPersona === "FOREIGN";
@@ -87,7 +85,6 @@ describe("Formation - BusinessStep", () => {
     const page = preparePage({
       business: generateBusiness({ profileData, formationData }),
       displayContent,
-      municipalities,
     });
     if (isForeign) {
       await page.submitNexusBusinessNameStep();
@@ -130,13 +127,13 @@ describe("Formation - BusinessStep", () => {
     const page = await getPageHelper(
       {
         legalStructureId: "limited-liability-company",
-        municipality: generateMunicipality({ displayName: "Newark", name: "Newark" }),
       },
       {
         businessSuffix: "LTD LIABILITY CO",
         businessStartDate: getCurrentDateFormatted(defaultDateFormat),
         addressLine1: "123 main street",
         addressLine2: "suite 102",
+        addressMunicipality: generateMunicipality({ displayName: "Newark", name: "Newark" }),
         addressState: { name: "New Jersey", shortCode: "NJ" },
         addressZipCode: "07601",
         businessPurpose: "some cool purpose",
@@ -939,10 +936,9 @@ describe("Formation - BusinessStep", () => {
     it("displays City (Main Address) from profile data", async () => {
       await getPageHelper(
         {
-          municipality: generateMunicipality({ displayName: "Newark", name: "Newark" }),
           businessPersona: "STARTING",
         },
-        {}
+        { addressMunicipality: generateMunicipality({ displayName: "Newark", name: "Newark" }) }
       );
       expect((screen.getByLabelText("Address municipality") as HTMLInputElement).value).toEqual("Newark");
     });

--- a/web/src/components/tasks/business-formation/contacts/Addresses.test.tsx
+++ b/web/src/components/tasks/business-formation/contacts/Addresses.test.tsx
@@ -209,13 +209,13 @@ describe("Formation - Addresses", () => {
         const page = await getPageHelper(
           {
             legalStructureId: "limited-partnership",
-            municipality: generateMunicipality({ displayName: "Hampton Borough", name: "Hampton" }),
           },
           {
             contactFirstName: "John",
             contactLastName: "Smith",
             addressLine1: "123 Address",
             addressLine2: "business suite 201",
+            addressMunicipality: generateMunicipality({ displayName: "Hampton Borough", name: "Hampton" }),
             addressState: { shortCode: "NJ", name: "New Jersey" },
             addressZipCode: "07601",
           }

--- a/web/src/components/tasks/business-formation/contacts/Members.test.tsx
+++ b/web/src/components/tasks/business-formation/contacts/Members.test.tsx
@@ -252,11 +252,6 @@ describe("Formation - Members Field", () => {
         const page = await getPageHelper(
           {
             legalStructureId,
-            municipality: generateMunicipality({
-              displayName: "Hampton Borough",
-              name: "Hampton",
-              ...generateFormationUSAddress({}),
-            }),
           },
           {
             members: [],
@@ -264,6 +259,12 @@ describe("Formation - Members Field", () => {
             contactLastName: "Smith",
             addressLine1: "123 Address",
             addressLine2: "business suite 201",
+            addressMunicipality: generateMunicipality({
+              displayName: "Hampton Borough",
+              name: "Hampton",
+              ...generateFormationUSAddress({}),
+            }),
+
             addressCountry: "US",
             addressState: { shortCode: "NJ", name: "New Jersey" },
             addressZipCode: "07601",
@@ -284,7 +285,6 @@ describe("Formation - Members Field", () => {
         const page = await getPageHelper(
           {
             legalStructureId,
-            municipality: generateMunicipality({ displayName: "Hampton Borough", name: "Hampton" }),
           },
           {
             members: [generateFormationMember({})],
@@ -292,6 +292,7 @@ describe("Formation - Members Field", () => {
             contactLastName: "Smith",
             addressLine1: "123 Address",
             addressLine2: "business suite 201",
+            addressMunicipality: generateMunicipality({ displayName: "Hampton Borough", name: "Hampton" }),
             addressCountry: "US",
             addressState: { shortCode: "NJ", name: "New Jersey" },
             addressZipCode: "07601",
@@ -312,11 +313,6 @@ describe("Formation - Members Field", () => {
         const page = await getPageHelper(
           {
             legalStructureId,
-            municipality: generateMunicipality({
-              displayName: "Hampton Borough",
-              name: "Hampton",
-              ...generateFormationUSAddress({}),
-            }),
           },
           {
             members: [],
@@ -324,6 +320,12 @@ describe("Formation - Members Field", () => {
             contactLastName: "Smith",
             addressLine1: "123 Address",
             addressLine2: "business suite 201",
+            addressMunicipality: generateMunicipality({
+              displayName: "Hampton Borough",
+              name: "Hampton",
+              ...generateFormationUSAddress({}),
+            }),
+
             addressCountry: "US",
             addressState: { shortCode: "NJ", name: "New Jersey" },
             addressZipCode: "07601",

--- a/web/src/components/tasks/business-formation/contacts/RegisteredAgent.test.tsx
+++ b/web/src/components/tasks/business-formation/contacts/RegisteredAgent.test.tsx
@@ -146,7 +146,7 @@ describe("Formation - Registered Agent Field", () => {
 
   it("auto-fills and disables agent address from Address when box checked", async () => {
     const page = await getPageHelper(
-      { municipality: generateMunicipality({ name: "New Test City", displayName: "New Test City" }) },
+      {},
       {
         agentNumberOrManual: "MANUAL_ENTRY",
         agentOfficeAddressLine1: "Old Add 123",
@@ -156,6 +156,7 @@ describe("Formation - Registered Agent Field", () => {
         agentOfficeAddressZipCode: "07001",
         addressLine1: "New Add 123",
         addressLine2: "New Add 456",
+        addressMunicipality: generateMunicipality({ name: "New Test City", displayName: "New Test City" }),
         addressZipCode: "07002",
         addressState: { shortCode: "NJ", name: "New Jersey" },
         addressCountry: "US",
@@ -251,11 +252,12 @@ describe("Formation - Registered Agent Field", () => {
 
   it("un-disables fields but leaves values when user unchecks same Address box", async () => {
     const page = await getPageHelper(
-      { municipality: generateMunicipality({ name: "New Test City", displayName: "New Test City" }) },
+      {},
       {
         agentNumberOrManual: "MANUAL_ENTRY",
         addressLine1: "New Add 123",
         addressLine2: "New Add 456",
+        addressMunicipality: generateMunicipality({ name: "New Test City", displayName: "New Test City" }),
         addressZipCode: "07002",
         addressState: { shortCode: "NJ", name: "New Jersey" },
         addressCountry: "US",

--- a/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
@@ -462,11 +462,11 @@ describe("Formation - ReviewStep", () => {
       await renderStep(
         {
           businessPersona: "STARTING",
-          municipality: generateMunicipality({
-            displayName: "Some city",
-          }),
         },
         {
+          addressMunicipality: generateMunicipality({
+            displayName: "Some city",
+          }),
           businessLocationType: "NJ",
         }
       );

--- a/web/src/components/tasks/business-structure/BusinessStructureTask.test.tsx
+++ b/web/src/components/tasks/business-structure/BusinessStructureTask.test.tsx
@@ -296,6 +296,7 @@ describe("<BusinessStructureTask />", () => {
       }),
       taskProgress: { [taskId]: "COMPLETED" },
     });
+
     renderTask(business);
     fireEvent.click(screen.getByText(Config.taskDefaults.removeText));
 

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -74,7 +74,6 @@ import {
   ForeignBusinessType,
   formationTaskId,
   hasCompletedFormation,
-  isOwningBusiness,
   LookupLegalStructureById,
   LookupOperatingPhaseById,
   Municipality,
@@ -219,9 +218,8 @@ const ProfilePage = (props: Props): ReactElement => {
       }
 
       updateQueue.queueProfileData(profileData);
-      if (isOwningBusiness(business)) {
-        updateQueue.queueFormationFormData(addressData);
-      }
+
+      updateQueue.queueFormationFormData(addressData);
 
       (async (): Promise<void> => {
         updateQueue
@@ -529,6 +527,9 @@ const ProfilePage = (props: Props): ReactElement => {
         >
           <BusinessName />
         </ProfileField>
+
+        <ProfileNewJerseyAddress />
+
         <ProfileField
           fieldName="responsibleOwnerName"
           isVisible={shouldShowTradeNameElements()}

--- a/web/test/helpers/helpers-formation.tsx
+++ b/web/test/helpers/helpers-formation.tsx
@@ -107,6 +107,7 @@ export const preparePage = ({
           formationFormData: createEmptyFormationFormData(),
         }),
   });
+
   const internalMunicipalities = [
     profileData?.municipality ?? generateMunicipality({ displayName: "GenericTown" }),
     ...(municipalities ?? []),

--- a/web/test/pages/profile/profile-starting.test.tsx
+++ b/web/test/pages/profile/profile-starting.test.tsx
@@ -50,6 +50,10 @@ import {
 
 import analytics from "@/lib/utils/analytics";
 import {
+  BUSINESS_ADDRESS_LINE_1_MAX_CHAR,
+  BUSINESS_ADDRESS_LINE_2_MAX_CHAR,
+} from "@/lib/utils/formation-helpers";
+import {
   chooseRadio,
   chooseTab,
   clickBack,
@@ -322,6 +326,16 @@ describe("profile - starting business", () => {
         employerId: "023456780",
         notes: "whats appppppp",
       },
+      formationData: {
+        ...initialBusiness.formationData,
+        formationFormData: {
+          ...initialBusiness.formationData.formationFormData,
+          addressState: {
+            name: "New Jersey",
+            shortCode: "NJ",
+          },
+        },
+      },
       taskProgress: {
         [einTaskId]: "COMPLETED",
         [naicsCodeTaskId]: "NOT_STARTED",
@@ -353,6 +367,16 @@ describe("profile - starting business", () => {
 
     expect(currentBusiness()).toEqual({
       ...initialBusiness,
+      formationData: {
+        ...initialBusiness.formationData,
+        formationFormData: {
+          ...initialBusiness.formationData.formationFormData,
+          addressState: {
+            name: "New Jersey",
+            shortCode: "NJ",
+          },
+        },
+      },
       taxFilingData: { ...taxData, filings: [] },
     });
   });
@@ -1351,6 +1375,295 @@ describe("profile - starting business", () => {
       });
       renderPage({ business });
       expect(screen.queryByTestId(dataTestId)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("address data", () => {
+    it("displays alert when address line 1 is filled then blurred", async () => {
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          industryId: "acupuncture",
+          businessPersona: "STARTING",
+          operatingPhase: OperatingPhaseId.NEEDS_TO_FORM,
+        }),
+        formationData: generateFormationData({
+          formationFormData: generateFormationFormData({
+            ...emptyAddressData,
+          }),
+        }),
+      });
+      renderPage({ business });
+      fillText("Address line1", "123 Apple Pie Lane");
+
+      clickSave();
+      const profileAlert = screen.getByTestId("profile-error-alert");
+      await waitFor(() => {
+        expect(profileAlert).toBeInTheDocument();
+      });
+      expect(
+        within(profileAlert).queryByText(Config.formation.fields.addressLine1.label)
+      ).not.toBeInTheDocument();
+      expect(
+        within(profileAlert).queryByText(Config.formation.fields.addressLine2.label)
+      ).not.toBeInTheDocument();
+      expect(within(profileAlert).getByText(Config.formation.fields.addressCity.label)).toBeInTheDocument();
+      expect(
+        within(profileAlert).getByText(Config.formation.fields.addressZipCode.label)
+      ).toBeInTheDocument();
+    });
+
+    it("displays alert when zip code is filled with valid zip and then blurred", async () => {
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          industryId: "acupuncture",
+          businessPersona: "STARTING",
+          operatingPhase: OperatingPhaseId.NEEDS_TO_FORM,
+        }),
+        formationData: generateFormationData({
+          formationFormData: generateFormationFormData({
+            ...emptyAddressData,
+          }),
+        }),
+      });
+      renderPage({ business });
+      fillText("Address zip code", "07711");
+
+      clickSave();
+      const profileAlert = screen.getByTestId("profile-error-alert");
+      await waitFor(() => {
+        expect(profileAlert).toBeInTheDocument();
+      });
+
+      expect(within(profileAlert).getByText(Config.formation.fields.addressLine1.label)).toBeInTheDocument();
+      expect(
+        within(profileAlert).queryByText(Config.formation.fields.addressLine2.label)
+      ).not.toBeInTheDocument();
+      expect(
+        within(profileAlert).getByText(Config.formation.fields.addressMunicipality.label)
+      ).toBeInTheDocument();
+      expect(
+        within(profileAlert).queryByText(Config.formation.fields.addressZipCode.label)
+      ).not.toBeInTheDocument();
+    });
+
+    it("displays alert when zip code is filled with invalid zip and then blurred", async () => {
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          industryId: "acupuncture",
+          businessPersona: "STARTING",
+          operatingPhase: OperatingPhaseId.NEEDS_TO_FORM,
+        }),
+        formationData: generateFormationData({
+          formationFormData: generateFormationFormData({
+            ...emptyAddressData,
+          }),
+        }),
+      });
+      renderPage({ business });
+      fillText("Address zip code", "1234");
+
+      clickSave();
+      const profileAlert = screen.getByTestId("profile-error-alert");
+      await waitFor(() => {
+        expect(profileAlert).toBeInTheDocument();
+      });
+
+      expect(within(profileAlert).getByText(Config.formation.fields.addressLine1.label)).toBeInTheDocument();
+      expect(
+        within(profileAlert).queryByText(Config.formation.fields.addressLine2.label)
+      ).not.toBeInTheDocument();
+      expect(
+        within(profileAlert).getByText(Config.formation.fields.addressMunicipality.label)
+      ).toBeInTheDocument();
+      expect(
+        within(profileAlert).getByText(Config.formation.fields.addressZipCode.label)
+      ).toBeInTheDocument();
+    });
+
+    it("displays alert when address city is selected then blurred", async () => {
+      const randomMunicipality = generateMunicipality({});
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          industryId: "acupuncture",
+          businessPersona: "STARTING",
+          operatingPhase: OperatingPhaseId.NEEDS_TO_FORM,
+        }),
+        formationData: generateFormationData({
+          formationFormData: generateFormationFormData({
+            ...emptyAddressData,
+          }),
+        }),
+      });
+      renderPage({ business, municipalities: [randomMunicipality] });
+
+      selectByText("Address municipality", randomMunicipality.displayName);
+      expect(screen.getByLabelText("Address municipality")).toHaveValue(randomMunicipality.displayName);
+      fireEvent.blur(screen.getByLabelText("Address municipality"));
+
+      clickSave();
+      const profileAlert = screen.getByTestId("profile-error-alert");
+
+      await waitFor(() => {
+        expect(profileAlert).toBeInTheDocument();
+      });
+      expect(
+        within(profileAlert).getByText(Config.formation.fields.addressZipCode.label)
+      ).toBeInTheDocument();
+      expect(within(profileAlert).getByText(Config.formation.fields.addressLine1.label)).toBeInTheDocument();
+      expect(
+        within(profileAlert).queryByText(Config.formation.fields.addressLine2.label)
+      ).not.toBeInTheDocument();
+      expect(
+        within(profileAlert).queryByText(Config.formation.fields.addressMunicipality.label)
+      ).not.toBeInTheDocument();
+    });
+
+    it("displays alert when max character limit for business line 1 is reached", async () => {
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          industryId: "acupuncture",
+          businessPersona: "STARTING",
+          operatingPhase: OperatingPhaseId.NEEDS_TO_FORM,
+        }),
+        formationData: generateFormationData({
+          formationFormData: generateFormationFormData({
+            ...emptyAddressData,
+          }),
+        }),
+      });
+      renderPage({ business });
+      fillText("Address line1", "a".repeat(BUSINESS_ADDRESS_LINE_1_MAX_CHAR + 1));
+
+      clickSave();
+      const profileAlert = screen.getByTestId("profile-error-alert");
+
+      await waitFor(() => {
+        expect(profileAlert).toBeInTheDocument();
+      });
+      expect(within(profileAlert).getByText(Config.formation.fields.addressLine1.label)).toBeInTheDocument();
+      expect(
+        within(profileAlert).queryByText(Config.formation.fields.addressLine2.label)
+      ).not.toBeInTheDocument();
+      expect(within(profileAlert).getByText(Config.formation.fields.addressCity.label)).toBeInTheDocument();
+      expect(
+        within(profileAlert).getByText(Config.formation.fields.addressZipCode.label)
+      ).toBeInTheDocument();
+    });
+
+    it("displays alert business line 2 is filled then blurred", async () => {
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          industryId: "acupuncture",
+          businessPersona: "STARTING",
+          operatingPhase: OperatingPhaseId.NEEDS_TO_FORM,
+        }),
+        formationData: generateFormationData({
+          formationFormData: generateFormationFormData({
+            ...emptyAddressData,
+          }),
+        }),
+      });
+      renderPage({ business });
+      fillText("Address line2", "Apt");
+
+      clickSave();
+      const profileAlert = screen.getByTestId("profile-error-alert");
+
+      await waitFor(() => {
+        expect(profileAlert).toBeInTheDocument();
+      });
+      expect(within(profileAlert).getByText(Config.formation.fields.addressLine1.label)).toBeInTheDocument();
+      expect(
+        within(profileAlert).queryByText(Config.formation.fields.addressLine2.label)
+      ).not.toBeInTheDocument();
+      expect(
+        within(profileAlert).getByText(Config.formation.fields.addressMunicipality.label)
+      ).toBeInTheDocument();
+      expect(
+        within(profileAlert).getByText(Config.formation.fields.addressZipCode.label)
+      ).toBeInTheDocument();
+    });
+
+    it("displays alert when max character limit for business line 2 is reached", async () => {
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          industryId: "acupuncture",
+          businessPersona: "STARTING",
+          operatingPhase: OperatingPhaseId.NEEDS_TO_FORM,
+        }),
+        formationData: generateFormationData({
+          formationFormData: generateFormationFormData({
+            ...emptyAddressData,
+          }),
+        }),
+      });
+      renderPage({ business });
+      fillText("Address line2", "a".repeat(BUSINESS_ADDRESS_LINE_2_MAX_CHAR + 1));
+
+      clickSave();
+      const profileAlert = screen.getByTestId("profile-error-alert");
+
+      await waitFor(() => {
+        expect(profileAlert).toBeInTheDocument();
+      });
+      expect(within(profileAlert).getByText(Config.formation.fields.addressLine1.label)).toBeInTheDocument();
+      expect(within(profileAlert).getByText(Config.formation.fields.addressLine2.label)).toBeInTheDocument();
+      expect(
+        within(profileAlert).getByText(Config.formation.fields.addressMunicipality.label)
+      ).toBeInTheDocument();
+      expect(
+        within(profileAlert).getByText(Config.formation.fields.addressZipCode.label)
+      ).toBeInTheDocument();
+    });
+
+    it("renders locked profile address fields when business has formed", () => {
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          businessPersona: "STARTING",
+        }),
+        formationData: generateFormationData({
+          completedFilingPayment: true,
+          formationFormData: generateFormationFormData({
+            addressLine1: "123 Testing Road",
+            addressLine2: "",
+            addressMunicipality: generateMunicipality({ displayName: "Allendale" }),
+            addressState: {
+              name: "New Jersey",
+              shortCode: "NJ",
+            },
+            addressZipCode: "07781",
+          }),
+        }),
+      });
+      renderPage({ business });
+
+      expect(screen.getByTestId("locked-profileAddressLine1")).toBeInTheDocument();
+      expect(screen.getByTestId("locked-profileAddressMuniStateZip")).toBeInTheDocument();
+    });
+
+    it("does not render locked profile address fields when business has not been formed", () => {
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          businessPersona: "STARTING",
+        }),
+        formationData: generateFormationData({
+          completedFilingPayment: false,
+          formationFormData: generateFormationFormData({
+            addressLine1: "123 Testing Road",
+            addressLine2: "",
+            addressMunicipality: generateMunicipality({ displayName: "Allendale" }),
+            addressState: {
+              name: "New Jersey",
+              shortCode: "NJ",
+            },
+            addressZipCode: "07781",
+          }),
+        }),
+      });
+      renderPage({ business });
+
+      expect(screen.queryByTestId("locked-profileAddressLine1")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("locked-profileAddressMuniStateZip")).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

As a Poppy user, when accessing my business profile, I should see a section for my business address.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#187003755](https://www.pivotaltracker.com/story/show/187003755).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->
1. Enter the site as a Poppy and select an industry.
2. Go to the business profile.
3. Complete the address fields and click the `Save` button.
4. Continue on to form your business.
5. In Step 2 `(Business)`, open the primary business address section. The address that you entered in the profile will populate here.
6. Before completing formation, change the address in the `Business Step` and go back to the profile. The change will persist.
7. Continue with forming your business.
8. Once formation is complete, the address fields in the profile will be disabled/read-only.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
