### PR TITLE
feat: [#188049417] Bubble investNewark fundings to top of For You column

### DIFF
--- a/web/src/components/dashboard/SidebarCardsContainer.tsx
+++ b/web/src/components/dashboard/SidebarCardsContainer.tsx
@@ -24,14 +24,14 @@ interface Props {
 }
 
 export const SidebarCardsContainer = (props: Props): ReactElement => {
-  const { business } = useUserData();
+  const { business, userData } = useUserData();
 
   const visibleSidebarCards = getVisibleSideBarCards(business, props.sidebarDisplayContent);
   const visibleSortedFundings = getVisibleFundings(
-    sortFundings(filterFundings({ fundings: props.fundings, business: business })),
+    sortFundings(filterFundings({ fundings: props.fundings, business: business }), userData),
     business
   );
-  const hiddenSortedFundings = sortFundings(getHiddenFundings(business, props.fundings));
+  const hiddenSortedFundings = sortFundings(getHiddenFundings(business, props.fundings), userData);
   const visibleSortedCertifications = getVisibleCertifications(
     sortCertifications(filterCertifications({ certifications: props.certifications, business: business })),
     business

--- a/web/src/components/dashboard/SidebarCardsList.test.tsx
+++ b/web/src/components/dashboard/SidebarCardsList.test.tsx
@@ -5,8 +5,8 @@ import analytics from "@/lib/utils/analytics";
 import * as helpers from "@/lib/utils/helpers";
 import { removeMarkdownFormatting } from "@/lib/utils/helpers";
 import { generateCertification, generateFunding, generateSidebarCardContent } from "@/test/factories";
-import { useMockBusiness } from "@/test/mock/mockUseUserData";
-import { OperatingPhaseId, OperatingPhases } from "@businessnjgovnavigator/shared/";
+import { useMockBusiness, useMockUserData } from "@/test/mock/mockUseUserData";
+import { OperatingPhaseId, OperatingPhases, generateUser } from "@businessnjgovnavigator/shared/";
 import { ForeignBusinessTypeId } from "@businessnjgovnavigator/shared/profileData";
 import { generateBusiness, generateProfileData } from "@businessnjgovnavigator/shared/test";
 import * as materialUi from "@mui/material";
@@ -399,6 +399,94 @@ describe("<SidebarCardsList />", () => {
       fireEvent.click(screen.getByTestId("hidden-opportunity-header"));
       fireEvent.click(screen.getByTestId("hidden-opportunity-header"));
       expect(mockHelpers.scrollToTopOfElement).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Funding and Certification Sorting", () => {
+    it("displays certifications above fundings for most users", async () => {
+      useMockUserData({
+        businesses: {
+          "biz-1": generateBusiness({
+            profileData: {
+              ...generateProfileData({
+                operatingPhase: getDisplayFundingOperatingPhase(),
+              }),
+            },
+          }),
+        },
+        user: generateUser({
+          accountCreationSource: "test-source",
+        }),
+      });
+
+      const genericFunding = generateFunding({
+        isNonprofitOnly: false,
+        county: [],
+        sector: [],
+        employeesRequired: undefined,
+        id: "funding-id",
+      });
+      const genericCertification = generateCertification({
+        applicableOwnershipTypes: [],
+        isSbe: false,
+        id: "certification-id",
+      });
+      renderComponent({
+        fundings: [genericFunding],
+        certifications: [genericCertification],
+        displayFundingCards: true,
+        displayCertificationsCards: true,
+      });
+
+      const fundingElement = screen.getByTestId("funding-id");
+      const certificationElement = screen.getByTestId("certification-id");
+
+      expect(fundingElement.compareDocumentPosition(certificationElement)).toBe(
+        Node.DOCUMENT_POSITION_PRECEDING
+      );
+    });
+
+    it("displays fundings above certifications for investNewark users", async () => {
+      useMockUserData({
+        businesses: {
+          "biz-1": generateBusiness({
+            profileData: {
+              ...generateProfileData({
+                operatingPhase: getDisplayFundingOperatingPhase(),
+              }),
+            },
+          }),
+        },
+        user: generateUser({
+          accountCreationSource: "investNewark",
+        }),
+      });
+
+      const genericFunding = generateFunding({
+        isNonprofitOnly: false,
+        county: [],
+        sector: [],
+        employeesRequired: undefined,
+        id: "funding-id",
+      });
+      const genericCertification = generateCertification({
+        applicableOwnershipTypes: [],
+        isSbe: false,
+        id: "certification-id",
+      });
+      renderComponent({
+        fundings: [genericFunding],
+        certifications: [genericCertification],
+        displayFundingCards: true,
+        displayCertificationsCards: true,
+      });
+
+      const fundingElement = screen.getByTestId("funding-id");
+      const certificationElement = screen.getByTestId("certification-id");
+
+      expect(fundingElement.compareDocumentPosition(certificationElement)).toBe(
+        Node.DOCUMENT_POSITION_FOLLOWING
+      );
     });
   });
 });

--- a/web/src/components/dashboard/SidebarCardsList.tsx
+++ b/web/src/components/dashboard/SidebarCardsList.tsx
@@ -5,6 +5,7 @@ import { Heading } from "@/components/njwds-extended/Heading";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { Icon } from "@/components/njwds/Icon";
 import { useConfig } from "@/lib/data-hooks/useConfig";
+import { useUserData } from "@/lib/data-hooks/useUserData";
 import { Certification, Funding, SidebarCardContent } from "@/lib/types/types";
 import analytics from "@/lib/utils/analytics";
 import { openInNewTab, scrollToTopOfElement, templateEval } from "@/lib/utils/helpers";
@@ -26,7 +27,12 @@ export interface SidebarCardsListProps {
 export const SidebarCardsList = (props: SidebarCardsListProps): ReactElement => {
   const [hiddenAccordionIsOpen, setHiddenAccordionIsOpen] = useState<boolean>(false);
   const { Config } = useConfig();
+  const { userData } = useUserData();
   const accordionRef = useRef(null);
+
+  const shouldPrioritizeFundingsOverCertifications =
+    userData?.user.accountCreationSource === "investNewark" ||
+    userData?.user.accountCreationSource === "NJEDA";
 
   const hiddenOpportunitiesCount = (): number => {
     if (props.displayCertificationsCards && props.displayFundingCards) {
@@ -109,12 +115,18 @@ export const SidebarCardsList = (props: SidebarCardsListProps): ReactElement => 
         </div>
       )}
       <div data-testid="visible-opportunities">
+        {shouldPrioritizeFundingsOverCertifications &&
+          props.fundings.map((funding) => {
+            return <OpportunityCard key={funding.id} opportunity={funding} urlPath="funding" />;
+          })}
+
         {renderCertificationsCards &&
           props.certifications.map((cert) => {
             return <OpportunityCard key={cert.id} opportunity={cert} urlPath="certification" />;
           })}
 
         {renderFundingCards &&
+          !shouldPrioritizeFundingsOverCertifications &&
           props.fundings.map((funding) => {
             return <OpportunityCard key={funding.id} opportunity={funding} urlPath="funding" />;
           })}


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Switches the order of fundings and certifications in the For You column if the user signed up through an investNewark link. Also moves fundings from investNewark to the top of the fundings list for those users

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188049417](https://www.pivotaltracker.com/story/show/188049417).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Signup through this link: http://localhost:3000/onboarding?businessMunicipality=Newark&utm_source=investNewark
Sign up as an Oscar or a Poppy that advances to the up and running stage.
You should see fundings over certifications and the two investNewark fundings at the top of the funding list. The sorting of the rest of the list should remain unchanged.

Creating an account through any other means should not see behavior change

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
