### PR TITLE
chore: [#188081219] add trim to nospace and write-once-read-only widgets

### DIFF
--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -42,10 +42,10 @@ collections:
       - { label: "Summary Description", name: "summaryDescriptionMd", widget: "markdown" }
       - { label: "Content", name: "body", widget: "markdown" }
       - { label: "Url Slug", name: "urlSlug", widget: "nospace" }
-      - { label: "Filename", name: "filename", widget: "write-once-read-only" }
+      - { label: "Filename", name: "filename", widget: "write-once-read-only-no-space" }
       - { label: "Display Name", name: "displayname", widget: "nospace" }
       - { label: "Name", name: "name", widget: "string" }
-      - { label: "Id", name: "id", widget: "write-once-read-only" }
+      - { label: "Id", name: "id", widget: "write-once-read-only-no-space" }
       - { label: "Call To Action Link", name: "callToActionLink", widget: "string", required: false }
       - { label: "Call To Action Text", name: "callToActionText", widget: "string", required: false }
       - label: Agency
@@ -1171,7 +1171,7 @@ collections:
         }
       - { label: "Summary Description", name: "summaryDescriptionMd", widget: "markdown" }
       - { label: "Content", name: "body", widget: "markdown" }
-      - { label: "Url Slug / Filename", name: "urlSlug", widget: "write-once-read-only" }
+      - { label: "Url Slug / Filename", name: "urlSlug", widget: "write-once-read-only-no-space" }
       - { label: "Name", name: "name", widget: "string" }
       - { label: "Id", name: "id", widget: "string" }
       - { label: "Call To Action Link", name: "callToActionLink", widget: "string", required: false }
@@ -1217,7 +1217,7 @@ collections:
           hint: "This appears only in My Account, in the For You column, max char is 150 including spaces, plain text only",
         }
       - { label: "Content", name: "body", widget: "markdown" }
-      - { label: "Url Slug / Filename", name: "urlSlug", widget: "write-once-read-only" }
+      - { label: "Url Slug / Filename", name: "urlSlug", widget: "write-once-read-only-no-space" }
       - { label: "Name", name: "name", widget: "string" }
       - { label: "Id", name: "id", widget: "string" }
       - { label: "Call To Action Link", name: "callToActionLink", widget: "string", required: false }
@@ -1266,7 +1266,7 @@ collections:
       - {
           label: "File Name",
           name: "filename",
-          widget: "write-once-read-only",
+          widget: "write-once-read-only-no-space",
           hint: "This is the name of the file in the code only. Lowercase, no spaces, add hyphens between words",
         }
       - {
@@ -1290,7 +1290,7 @@ collections:
       - {
           label: "Id",
           name: "id",
-          widget: "write-once-read-only",
+          widget: "write-once-read-only-no-space",
           hint: "Lowercase, no spaces, add hyphens between words",
         }
       - {
@@ -1480,7 +1480,7 @@ collections:
       - {
           label: "File Name",
           name: "filename",
-          widget: "write-once-read-only",
+          widget: "write-once-read-only-no-space",
           hint: "This is the name of the file in the code only. Lowercase, no spaces, add hyphens between words",
         }
       - {
@@ -1504,7 +1504,7 @@ collections:
       - {
           label: "Id",
           name: "id",
-          widget: "write-once-read-only",
+          widget: "write-once-read-only-no-space",
           hint: "Lowercase, no spaces, add hyphens between words",
         }
       - {
@@ -1725,7 +1725,7 @@ collections:
         required: false
       - label: Id / Filename
         name: id
-        widget: write-once-read-only
+        widget: write-once-read-only-no-space
       - label: "Display Name"
         name: "displayname"
         widget: "string"
@@ -1876,7 +1876,7 @@ collections:
     fields:
       - label: Filename
         name: id
-        widget: write-once-read-only
+        widget: write-once-read-only-no-space
       - label: Displayname
         name: displayname
         widget: string
@@ -2290,13 +2290,13 @@ collections:
       - { label: "Summary Description", name: "summaryDescriptionMd", widget: "markdown" }
       - { label: "Content", name: "body", widget: "markdown" }
       - { label: "Url Slug", name: "urlSlug", widget: "nospace" }
-      - { label: "Filename", name: "filename", widget: "write-once-read-only" }
+      - { label: "Filename", name: "filename", widget: "write-once-read-only-no-space" }
       - { label: "Display Name", name: "displayname", widget: "nospace" }
       - { label: "Name", name: "name", widget: "string" }
       - {
           label: "Id",
           name: "id",
-          widget: "write-once-read-only",
+          widget: "write-once-read-only-no-space",
           required: true,
           hint: "This is should be the same as the filename.",
         }
@@ -2358,14 +2358,14 @@ collections:
       - {
           label: "Id",
           name: "id",
-          widget: "write-once-read-only",
+          widget: "write-once-read-only-no-space",
           required: true,
           hint: "This is should be the same as the filename.",
         }
       - {
           label: "Filename",
           name: "filename",
-          widget: "write-once-read-only",
+          widget: "write-once-read-only-no-space",
           hint: "This is the name of the file in the code only.",
         }
       - {
@@ -2456,7 +2456,7 @@ collections:
       preview: true
     fields:
       - { label: "Internal Notes", name: "notesMd", widget: "markdown", required: false }
-      - { label: "Filename", name: "filename", widget: "write-once-read-only" }
+      - { label: "Filename", name: "filename", widget: "write-once-read-only-no-space" }
       - { label: "Display Name", name: "displayname", widget: "nospace" }
       - { label: "Url Slug", name: "urlSlug", widget: "nospace" }
       - { label: "Title (Navigator)", name: "name", widget: "string", required: false }
@@ -2825,9 +2825,9 @@ collections:
     fields:
       - { label: "Internal Notes", name: "notesMd", widget: "markdown", required: false }
       - { label: "Name", name: "name", widget: "string", required: false }
-      - { label: "ID", name: "id", widget: "write-once-read-only" }
+      - { label: "ID", name: "id", widget: "write-once-read-only-no-space" }
       - { label: "Webflow Name", name: "webflowName", widget: "string", required: false }
-      - { label: "File name", name: "filename", widget: "write-once-read-only" }
+      - { label: "File name", name: "filename", widget: "write-once-read-only-no-space" }
       - { label: "Call to Action Link", name: "callToActionLink", widget: "string", required: false }
       - { label: "Call to Action Text", name: "callToActionText", widget: "string", required: false }
       - { label: "Agency ID", name: "agencyId", widget: "string", required: false }
@@ -3104,7 +3104,7 @@ collections:
       preview: true
     fields:
       - { label: "Internal Notes", name: "notesMd", widget: "markdown", required: false }
-      - { label: "Url Slug / Filename", name: "urlSlug", widget: "write-once-read-only" }
+      - { label: "Url Slug / Filename", name: "urlSlug", widget: "write-once-read-only-no-space" }
       - { label: "Name", name: "name", widget: "string" }
       - { label: "Extension", name: "extension", widget: "boolean", required: false }
       - { label: "Summary Description", name: "summaryDescriptionMd", widget: "markdown" }
@@ -3414,7 +3414,11 @@ collections:
       preview: true
     fields:
       - { label: "Internal Notes", name: "notesMd", widget: "markdown", required: false }
-      - { label: "Filename (disabled after file creation)", name: "filename", widget: "write-once-read-only" }
+      - {
+          label: "Filename (disabled after file creation)",
+          name: "filename",
+          widget: "write-once-read-only-no-space",
+        }
       - { label: "Name/Title", name: "name", widget: "string" }
       - {
           label: "Apply to all - overrides industry and sector dropdown",
@@ -3473,7 +3477,11 @@ collections:
       preview: true
     fields:
       - { label: "Internal Notes", name: "notesMd", widget: "markdown", required: false }
-      - { label: "Filename (disabled after file creation)", name: "filename", widget: "write-once-read-only" }
+      - {
+          label: "Filename (disabled after file creation)",
+          name: "filename",
+          widget: "write-once-read-only-no-space",
+        }
       - { label: "Name/Title", name: "name", widget: "string" }
       - {
           label: "Apply to all - overrides industry and sector dropdown",
@@ -3532,7 +3540,11 @@ collections:
       preview: false
     fields:
       - { label: "Internal Notes", name: "notesMd", widget: "markdown", required: false }
-      - { label: "Filename (disabled after file creation)", name: "filename", widget: "write-once-read-only" }
+      - {
+          label: "Filename (disabled after file creation)",
+          name: "filename",
+          widget: "write-once-read-only-no-space",
+        }
       - { label: "Name/Title", name: "name", widget: "string" }
       - {
           label: "Apply to all - overrides industry and sector dropdown",
@@ -5511,7 +5523,7 @@ collections:
       - { label: "Internal Notes", name: "notesMd", widget: "markdown", required: false }
       - { label: "Header", name: "header", widget: "string" }
       - { label: "Content", name: "body", widget: "markdown" }
-      - { label: "Filename", name: "slug", widget: "write-once-read-only" }
+      - { label: "Filename", name: "slug", widget: "write-once-read-only-no-space" }
       - { label: "Display Name", name: "displayname", widget: "nospace" }
 
   - name: "page-not-found-error"

--- a/web/src/lib/cms/fields/nospacefield.tsx
+++ b/web/src/lib/cms/fields/nospacefield.tsx
@@ -53,7 +53,7 @@ class NoSpaceControl extends Component<NoSpaceProps, NoSpaceState> {
 
   handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     this.setState({ _sel: e.target.selectionStart });
-    this.props.onChange(e.target.value);
+    this.props.onChange(e.target.value.trim());
   };
 
   render(): ReactElement {

--- a/web/src/lib/cms/fields/writeoncereadonlynospacefield.tsx
+++ b/web/src/lib/cms/fields/writeoncereadonlynospacefield.tsx
@@ -1,6 +1,6 @@
 import React, { Component, createRef, ReactElement } from "react";
 
-type WriteOnceReadOnlyProps = {
+type WriteOnceReadOnlyNoSpaceProps = {
   onChange: (e: string) => void;
   entry?: object;
   forID?: string;
@@ -10,16 +10,19 @@ type WriteOnceReadOnlyProps = {
   setActiveStyle: () => void;
   setInactiveStyle: () => void;
 };
-type WriteOnceReadOnlyState = {
+type WriteOnceReadOnlyNoSpaceState = {
   entry_object: object;
   value: string;
   _sel: number | null;
 };
 
-class WriteOnceReadOnlyControl extends Component<WriteOnceReadOnlyProps, WriteOnceReadOnlyState> {
+class WriteOnceReadOnlyNoSpaceControl extends Component<
+  WriteOnceReadOnlyNoSpaceProps,
+  WriteOnceReadOnlyNoSpaceState
+> {
   private el = createRef<HTMLInputElement>();
 
-  constructor(props: WriteOnceReadOnlyProps) {
+  constructor(props: WriteOnceReadOnlyNoSpaceProps) {
     super(props);
     const entry_object = JSON.parse(JSON.stringify(this.props.entry));
     this.state = {
@@ -49,7 +52,7 @@ class WriteOnceReadOnlyControl extends Component<WriteOnceReadOnlyProps, WriteOn
 
   handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     this.setState({ _sel: e.target.selectionStart });
-    this.props.onChange(e.target.value);
+    this.props.onChange(e.target.value.trim());
   };
 
   render(): ReactElement {
@@ -70,4 +73,4 @@ class WriteOnceReadOnlyControl extends Component<WriteOnceReadOnlyProps, WriteOn
   }
 }
 
-export { WriteOnceReadOnlyControl };
+export { WriteOnceReadOnlyNoSpaceControl };

--- a/web/src/pages/mgmt/cms.tsx
+++ b/web/src/pages/mgmt/cms.tsx
@@ -5,7 +5,7 @@ import IconWidgetEditor from "@/lib/cms/editors/icon";
 import AlertEditor from "@/lib/cms/editors/infoAlert";
 import Note from "@/lib/cms/editors/note";
 import { NoSpaceControl } from "@/lib/cms/fields/nospacefield";
-import { WriteOnceReadOnlyControl } from "@/lib/cms/fields/writeoncereadonlyfield";
+import { WriteOnceReadOnlyNoSpaceControl } from "@/lib/cms/fields/writeoncereadonlynospacefield";
 import { applyTheme } from "@/lib/cms/helpers/applyTheme";
 import CannabisEligibilityModalPreview from "@/lib/cms/previews/CannabisEligibilityModalPreview";
 import CannabisLicensePreview from "@/lib/cms/previews/CannabisLicensePreview";
@@ -63,7 +63,7 @@ const CMS = dynamic(
       // @ts-expect-error: No type definition available
       CMS.init({ CMS_CONFIG });
       // @ts-expect-error: No type definition available
-      CMS.registerWidget("write-once-read-only", WriteOnceReadOnlyControl);
+      CMS.registerWidget("write-once-read-only-no-space", WriteOnceReadOnlyNoSpaceControl);
       // @ts-expect-error: No type definition available
       CMS.registerWidget("nospace", NoSpaceControl);
       // @ts-expect-error: No type definition available


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

https://www.pivotaltracker.com/story/show/188081219

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
Add trim() to the nospace and the write once widgets. Note: the write once widget name was updated to state no spaces can be added.

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
