### PR TITLE
feat: [#187792208] create industry specific starter kits landing pages

### DIFF
--- a/content/src/fieldConfig/starter-kits.json
+++ b/content/src/fieldConfig/starter-kits.json
@@ -1,12 +1,12 @@
 {
   "starterKits": {
     "hero": {
-      "title": "Your Step-by-Step Business Starter Kit",
+      "title": "Your Step-by-Step ${industry} Business Starter Kit",
       "subtitle": "Our free, step-by-step guide will help you start your business today.",
       "ctaButton": "Start Now"
     },
     "solutions": {
-      "title": "Knowing exactly what your business needs to get started can be difficult.",
+      "title": "Knowing exactly what your ${industry} business needs to get started can be difficult.",
       "subtitle": "Business.NJ.gov provides a free, personalized Starter Kit unique to you and your business needs.",
       "ctaButton": "Get My Starter Kit",
       "card1": {
@@ -23,7 +23,7 @@
       }
     },
     "steps": {
-      "title": "Get Your Business Started in 4 Easy Steps ",
+      "title": "Get Your ${industry} Business Started in ${numberRoadMapSteps} Easy Steps ",
       "ctaButton": "Get My Starter Kit"
     }
   }

--- a/web/src/lib/domain-logic/routes.ts
+++ b/web/src/lib/domain-logic/routes.ts
@@ -11,7 +11,10 @@ export const ROUTES = {
   licenseReinstatement: "/license-reinstatement",
   welcome: "/welcome",
   accountSetup: "/account-setup",
+  starterKits: "/starter-kits",
 };
+
+export const STARTER_KITS_GENERIC_SLUG = "nj-business";
 
 export interface QUERY_PARAMS_VALUES {
   page: number;

--- a/web/src/lib/domain-logic/starterKitsContentModifiers.tsx
+++ b/web/src/lib/domain-logic/starterKitsContentModifiers.tsx
@@ -1,0 +1,21 @@
+import { modifyContent } from "@/lib/domain-logic/modifyContent";
+
+export const insertRoadmapSteps = (content: string, roadMapsStepsLength: string): string => {
+  return modifyContent({
+    content,
+    condition: () => true,
+    modificationMap: {
+      numberRoadMapSteps: roadMapsStepsLength,
+    },
+  });
+};
+
+export const insertIndustryContent = (content: string, industryId: string, industryName: string): string => {
+  return modifyContent({
+    content,
+    condition: () => industryId !== "generic",
+    modificationMap: {
+      industry: industryName,
+    },
+  });
+};

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -120,7 +120,7 @@ const App = ({ Component, pageProps }: AppProps): ReactElement => {
     }
   });
 
-  const isSeoPage = router.pathname.includes("/starter-kits/");
+  const isSeoPage = router.pathname.includes("/starter-kits");
 
   return (
     <>

--- a/web/src/pages/starter-kits/index.tsx
+++ b/web/src/pages/starter-kits/index.tsx
@@ -1,0 +1,31 @@
+import { NavBar } from "@/components/navbar/NavBar";
+import { PageSkeleton } from "@/components/njwds-layout/PageSkeleton";
+import { SingleColumnContainer } from "@/components/njwds/SingleColumnContainer";
+import { PageCircularIndicator } from "@/components/PageCircularIndicator";
+import { ROUTES, STARTER_KITS_GENERIC_SLUG } from "@/lib/domain-logic/routes";
+import { GetServerSideProps } from "next";
+import { ReactElement } from "react";
+
+const StarterKitsRootPage = (): ReactElement => {
+  return (
+    <PageSkeleton landingPage={true}>
+      <NavBar isSeoStarterKit={true} />
+      <main className="desktop:grid-container-widescreen desktop:padding-x-7">
+        <SingleColumnContainer>
+          <PageCircularIndicator />
+        </SingleColumnContainer>
+      </main>
+    </PageSkeleton>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return {
+    redirect: {
+      destination: `${ROUTES.starterKits}/${STARTER_KITS_GENERIC_SLUG}`,
+      permanent: true,
+    },
+  };
+};
+
+export default StarterKitsRootPage;


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

We wanted to genericize our industry starter kits page and make it so that we could have specific ones for each industry

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#187792208](https://www.pivotaltracker.com/story/show/187792208).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Look at the ID's in industry.json
go to 

for example 

http://localhost:3000/starter-kits/generic
or 
http://localhost:3000/starter-kits/cosmetology

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes
I did end up double checking that the code I wrote corresponds to the fields listed by content. 

The industry objects don't have dedicated slug fields but what content wanted corresponding 1 to 1 with the ID field. 

Also their is an acception case for generic here accounted for in the replacement of the token code. I think if it were more than 1 acception I would take a different approach but since its only the generic industry I'm okay with it. 

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
