### PR TITLE
Automatically select biz structure for dev skip-onboarding

### DIFF
--- a/web/src/components/onboarding/DevOnlySkipOnboardingButton.tsx
+++ b/web/src/components/onboarding/DevOnlySkipOnboardingButton.tsx
@@ -1,5 +1,7 @@
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
+import { useUserData } from "@/lib/data-hooks/useUserData";
+import { businessStructureTaskId } from "@businessnjgovnavigator/shared/";
 import { emptyProfileData } from "@businessnjgovnavigator/shared/profileData";
 import { ReactElement, useContext } from "react";
 
@@ -10,15 +12,21 @@ interface Props {
 
 export const DevOnlySkipOnboardingButton = (props: Props): ReactElement => {
   const { state, setProfileData } = useContext(ProfileDataContext);
+  const { updateQueue } = useUserData();
 
   const devOnlySkipOnboarding = (): void => {
     setProfileData({
       ...emptyProfileData,
       businessPersona: "STARTING",
       industryId: "generic",
+      legalStructureId: "c-corporation",
     });
     props.setPage({ current: 2, previous: 1 });
     props.routeToPage(2);
+    updateQueue?.queueTaskProgress({
+      [businessStructureTaskId]: "COMPLETED",
+    });
+    updateQueue?.update();
   };
 
   if (state.page === 1 && process.env.NODE_ENV === "development") {


### PR DESCRIPTION
## Description

Given the point of the "Skip" button in the onboarding flow is supposed to help us get to our work faster, @FarazA22 added this in the #8193 work. This will automatically select C-corp as the biz structure when you use the "Skip" button in the onboarding flow.

Removed from that PR as feedback from @somabadri 

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [X] I have not used any relative imports
- [X] I have checked for and removed instances of unused config from CMS
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
