### PR TITLE
feat: [#188108319] Bubble NJEDA fundings to top of For You column

### DIFF
--- a/web/src/components/dashboard/SidebarCardsContainer.tsx
+++ b/web/src/components/dashboard/SidebarCardsContainer.tsx
@@ -10,7 +10,7 @@ import {
   getVisibleFundings,
   getVisibleSideBarCards,
   sortCertifications,
-  sortFundings,
+  sortFundingsForUser,
 } from "@/lib/domain-logic/sidebarCardsHelpers";
 import { Certification, Funding, SidebarCardContent } from "@/lib/types/types";
 import { LookupOperatingPhaseById } from "@businessnjgovnavigator/shared/";
@@ -28,10 +28,10 @@ export const SidebarCardsContainer = (props: Props): ReactElement => {
 
   const visibleSidebarCards = getVisibleSideBarCards(business, props.sidebarDisplayContent);
   const visibleSortedFundings = getVisibleFundings(
-    sortFundings(filterFundings({ fundings: props.fundings, business: business }), userData),
+    sortFundingsForUser(filterFundings({ fundings: props.fundings, business: business }), userData),
     business
   );
-  const hiddenSortedFundings = sortFundings(getHiddenFundings(business, props.fundings), userData);
+  const hiddenSortedFundings = sortFundingsForUser(getHiddenFundings(business, props.fundings), userData);
   const visibleSortedCertifications = getVisibleCertifications(
     sortCertifications(filterCertifications({ certifications: props.certifications, business: business })),
     business

--- a/web/src/lib/domain-logic/sidebarCardsHelpers.test.ts
+++ b/web/src/lib/domain-logic/sidebarCardsHelpers.test.ts
@@ -8,7 +8,7 @@ import {
   getVisibleFundings,
   getVisibleSideBarCards,
   sortCertifications,
-  sortFundings,
+  sortFundingsForUser,
 } from "@/lib/domain-logic/sidebarCardsHelpers";
 import { SMALL_BUSINESS_MAX_EMPLOYEE_COUNT } from "@/lib/domain-logic/smallBusinessEnterprise";
 import { Certification, Funding, SidebarCardContent } from "@/lib/types/types";
@@ -106,7 +106,7 @@ describe("sidebarCard Helpers", () => {
       const funding5 = generateFunding({ name: "bca", status: "rolling application" });
       const fundings = [funding5, funding2, funding3, funding1, funding4];
 
-      const result = sortFundings(fundings, userData);
+      const result = sortFundingsForUser(fundings, userData);
       expect(result.length).toEqual(5);
       expect(result).toEqual([funding2, funding1, funding3, funding4, funding5]);
     });
@@ -124,7 +124,7 @@ describe("sidebarCard Helpers", () => {
       });
       const fundings = [funding1, funding2];
 
-      const result = sortFundings(fundings);
+      const result = sortFundingsForUser(fundings);
       expect(result.length).toEqual(2);
       expect(result).toEqual([funding1, funding2]);
     });
@@ -163,7 +163,7 @@ describe("sidebarCard Helpers", () => {
         });
         const fundings = [funding5, funding2, funding3, funding1, funding4];
 
-        const result = sortFundings(fundings, userData);
+        const result = sortFundingsForUser(fundings, userData);
         expect(result.length).toEqual(5);
         expect(result).toEqual([funding3, funding5, funding2, funding1, funding4]);
       });
@@ -185,7 +185,7 @@ describe("sidebarCard Helpers", () => {
         });
         const fundings = [funding5, funding2, funding3, funding1, funding4];
 
-        const result = sortFundings(fundings, userData);
+        const result = sortFundingsForUser(fundings, userData);
         expect(result.length).toEqual(5);
         expect(result).toEqual([funding2, funding1, funding3, funding4, funding5]);
       });
@@ -207,7 +207,7 @@ describe("sidebarCard Helpers", () => {
         });
         const fundings = [funding5, funding2, funding3, funding1, funding4];
 
-        const result = sortFundings(fundings, userData);
+        const result = sortFundingsForUser(fundings, userData);
         expect(result.length).toEqual(5);
         expect(result).toEqual([funding2, funding1, funding3, funding4, funding5]);
       });
@@ -233,7 +233,7 @@ describe("sidebarCard Helpers", () => {
         });
         const fundings = [funding5, funding2, funding3, funding1, funding4];
 
-        const result = sortFundings(fundings, userData);
+        const result = sortFundingsForUser(fundings, userData);
         expect(result.length).toEqual(5);
         expect(result).toEqual([funding2, funding1, funding3, funding4, funding5]);
       });

--- a/web/src/lib/domain-logic/sidebarCardsHelpers.ts
+++ b/web/src/lib/domain-logic/sidebarCardsHelpers.ts
@@ -44,7 +44,7 @@ export const getVisibleCertifications = (
     return !business?.preferences.hiddenCertificationIds.includes(it.id);
   });
 };
-export const sortFundings = (fundings: Funding[], userData?: UserData): Funding[] => {
+export const sortFundingsForUser = (fundings: Funding[], userData?: UserData): Funding[] => {
   const initialSorting = fundings.sort((a, b) => {
     const nameA = a.name.toUpperCase(); // ignore upper and lowercase
     const nameB = b.name.toUpperCase();
@@ -52,12 +52,9 @@ export const sortFundings = (fundings: Funding[], userData?: UserData): Funding[
       return -1;
     } else if (FundingStatusOrder[a.status] > FundingStatusOrder[b.status]) {
       return 1;
-    } else if (nameA < nameB) {
-      return -1;
-    } else if (nameA > nameB) {
-      return 1;
     }
-    return 0;
+
+    return nameA.localeCompare(nameB);
   });
   if (userData?.user.accountCreationSource) {
     const agencySource = mapAccountCreationSourceToAgencySource(userData.user.accountCreationSource);
@@ -70,6 +67,8 @@ const mapAccountCreationSourceToAgencySource = (accountCreationSource: string): 
   switch (accountCreationSource) {
     case "investNewark":
       return "invest-newark";
+    case "NJEDA":
+      return "njeda";
     default:
       return "";
   }


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Bubbles NJEDA fundings to top of For You column if user signed up with NJEDA link

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188108319](https://www.pivotaltracker.com/story/show/188108319).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Create an account with this link: http://localhost:3000/onboarding?utm_source=NJEDA
Proceed to being an Operating business
Should see NJEDA fundings above certifications in the For You Column

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation (EX: [Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po)), if necessary
- [x] I have not used any relative imports
- [x] I have checked for and removed instances of unused config from CMS
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see [CMS Additions in Engineering Reference/FAQ](https://docs.google.com/document/d/1X4iWSGmBZdHYZ0jGqkwTR3_yyyqI_TiiJptfc8pi9Po/edit#heading=h.fu5jdsrcqxbh))
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
