### PR TITLE
feat: [#188150760] Post-formation Business Address Profile Locked & E…

### DIFF
--- a/content/src/fieldConfig/profile.json
+++ b/content/src/fieldConfig/profile.json
@@ -441,7 +441,8 @@
       "profileErrorAlert": "Complete ${fieldText} to access your dashboard:",
       "cannabisLocationAlert": "Check if your local government allows a cannabis license.",
       "certificationDocFileTitle": "Certified Copy of Formation",
-      "profileTabInfoTitle": "Business Information"
+      "profileTabInfoTitle": "Business Information",
+      "profileAddressNotProvided" : "Address not provided"
     }
   }
 }

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -5483,6 +5483,7 @@ collections:
                   - { label: Save Button Text, name: saveButtonText, widget: string }
                   - { label: Back Button Text, name: backButtonText, widget: string }
                   - { label: Info Tab Title, name: profileTabInfoTitle, widget: string }
+                  - { label: Address Not Provided Text, name: profileAddressNotProvided, widget: string }
                   - {
                       label: Note for Businesses Formed Outside Navigator,
                       name: noteForBusinessesFormedOutsideNavigator,

--- a/web/src/components/profile/ProfileAddressLockedFields.test.tsx
+++ b/web/src/components/profile/ProfileAddressLockedFields.test.tsx
@@ -3,7 +3,18 @@ import { generateAddress } from "@/test/factories";
 import { WithStatefulAddressData } from "@/test/mock/withStatefulAddressData";
 import { Address, emptyAddressData, Municipality } from "@businessnjgovnavigator/shared/";
 import { generateMunicipality } from "@businessnjgovnavigator/shared/test";
+import * as materialUi from "@mui/material";
+import { createTheme, ThemeProvider } from "@mui/material";
 import { render, screen, within } from "@testing-library/react";
+
+jest.mock("@mui/material", () => mockMaterialUI());
+
+function mockMaterialUI(): typeof materialUi {
+  return {
+    ...jest.requireActual("@mui/material"),
+    useMediaQuery: jest.fn(),
+  };
+}
 
 describe("ProfileAddressLockedFields", () => {
   const renderComponent = ({
@@ -14,12 +25,14 @@ describe("ProfileAddressLockedFields", () => {
     municipalities?: Municipality[];
   }): void => {
     render(
-      <WithStatefulAddressData
-        initialData={address || emptyAddressData}
-        municipalities={municipalities || [generateMunicipality({})]}
-      >
-        <ProfileAddressLockedFields />
-      </WithStatefulAddressData>
+      <ThemeProvider theme={createTheme()}>
+        <WithStatefulAddressData
+          initialData={address || emptyAddressData}
+          municipalities={municipalities || [generateMunicipality({})]}
+        >
+          <ProfileAddressLockedFields />
+        </WithStatefulAddressData>
+      </ThemeProvider>
     );
   };
 
@@ -33,6 +46,7 @@ describe("ProfileAddressLockedFields", () => {
     });
     renderComponent({ address });
 
+    expect(screen.getByTestId("locked-profileBusinessAddressTooltip")).toBeInTheDocument();
     const addressLine1 = screen.getByTestId("locked-profileAddressLine1");
     expect(within(addressLine1).getByText("1111 Home Alone")).toBeInTheDocument();
     const addressMuniStateZip = screen.getByTestId("locked-profileAddressMuniStateZip");
@@ -50,6 +64,7 @@ describe("ProfileAddressLockedFields", () => {
     });
     renderComponent({ address });
 
+    expect(screen.getByTestId("locked-profileBusinessAddressTooltip")).toBeInTheDocument();
     const addressLine1 = screen.getByTestId("locked-profileAddressLine1");
     expect(within(addressLine1).getByText("1111 Home Alone")).toBeInTheDocument();
     const addressLine2 = screen.getByTestId("locked-profileAddressLine2");
@@ -68,6 +83,8 @@ describe("ProfileAddressLockedFields", () => {
     });
     renderComponent({ address });
 
+    expect(screen.getByTestId("locked-profileBusinessAddressTooltip")).toBeInTheDocument();
+    expect(screen.getByTestId("locked-profileAddressNotProvided")).toBeInTheDocument();
     expect(screen.queryByTestId("locked-profileAddressLine1")).not.toBeInTheDocument();
     expect(screen.queryByTestId("locked-profileAddressLine2")).not.toBeInTheDocument();
     expect(screen.queryByTestId("locked-profileAddressMuniStateZip")).not.toBeInTheDocument();

--- a/web/src/components/profile/ProfileAddressLockedFields.tsx
+++ b/web/src/components/profile/ProfileAddressLockedFields.tsx
@@ -1,3 +1,5 @@
+import { ArrowTooltip } from "@/components/ArrowTooltip";
+import { Icon } from "@/components/njwds/Icon";
 import { AddressContext } from "@/contexts/addressContext";
 import { getMergedConfig } from "@/contexts/configContext";
 import { ReactElement, useContext } from "react";
@@ -8,24 +10,40 @@ export const ProfileAddressLockedFields = (): ReactElement => {
   const Config = getMergedConfig();
   return (
     <div className="margin-top-4 margin-bottom-4" data-testid={"locked-profileAddressFields"}>
-      <div className="text-bold margin-bottom-05">
-        {Config.profileDefaults.fields.businessAddress.default.header}
+      <div className="flex flex-row fac margin-bottom-05">
+        <div className="text-bold">{Config.profileDefaults.fields.businessAddress.default.header}</div>
+        <div className="margin-left-1">
+          <ArrowTooltip
+            title={Config.profileDefaults.default.lockedFieldTooltipText}
+            data-testid="locked-profileBusinessAddressTooltip"
+          >
+            <div className="fdr fac font-body-lg">
+              <Icon>help_outline</Icon>
+            </div>
+          </ArrowTooltip>
+        </div>
       </div>
 
       {state.addressData.addressLine1 &&
-        state.addressData.addressMunicipality &&
-        state.addressData.addressState &&
-        state.addressData.addressZipCode && (
-          <>
-            <div data-testid={"locked-profileAddressLine1"}>{state.addressData.addressLine1}</div>
-            {state.addressData.addressLine2 && (
-              <div data-testid={"locked-profileAddressLine2"}>{state.addressData.addressLine2}</div>
-            )}
-            <div
-              data-testid={"locked-profileAddressMuniStateZip"}
-            >{`${state.addressData.addressMunicipality?.displayName}, ${state.addressData.addressState?.shortCode} ${state.addressData.addressZipCode}`}</div>
-          </>
-        )}
+      state.addressData.addressMunicipality &&
+      state.addressData.addressState &&
+      state.addressData.addressZipCode ? (
+        <>
+          <div data-testid={"locked-profileAddressLine1"}>{state.addressData.addressLine1}</div>
+          {state.addressData.addressLine2 && (
+            <div data-testid={"locked-profileAddressLine2"}>{state.addressData.addressLine2}</div>
+          )}
+          <div
+            data-testid={"locked-profileAddressMuniStateZip"}
+          >{`${state.addressData.addressMunicipality?.displayName}, ${state.addressData.addressState?.shortCode} ${state.addressData.addressZipCode}`}</div>
+        </>
+      ) : (
+        <>
+          <div data-testid="locked-profileAddressNotProvided">
+            {Config.profileDefaults.default.profileAddressNotProvided}
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/web/src/components/profile/ProfileNewJerseyAddress.test.tsx
+++ b/web/src/components/profile/ProfileNewJerseyAddress.test.tsx
@@ -12,11 +12,21 @@ import {
   Municipality,
 } from "@businessnjgovnavigator/shared/";
 import { generateMunicipality } from "@businessnjgovnavigator/shared/test";
+import * as materialUi from "@mui/material";
+import { createTheme, ThemeProvider } from "@mui/material";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 
 const Config = getMergedConfig();
 
 jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
+jest.mock("@mui/material", () => mockMaterialUI());
+
+function mockMaterialUI(): typeof materialUi {
+  return {
+    ...jest.requireActual("@mui/material"),
+    useMediaQuery: jest.fn(),
+  };
+}
 
 describe("<ProfileNewJerseyAddress  />", () => {
   beforeEach(() => {
@@ -25,12 +35,14 @@ describe("<ProfileNewJerseyAddress  />", () => {
 
   const renderComponent = ({ municipalities }: { municipalities?: Municipality[] }): void => {
     render(
-      <WithStatefulAddressData
-        initialData={emptyAddressData}
-        municipalities={municipalities || [generateMunicipality({})]}
-      >
-        <ProfileNewJerseyAddress />
-      </WithStatefulAddressData>
+      <ThemeProvider theme={createTheme()}>
+        <WithStatefulAddressData
+          initialData={emptyAddressData}
+          municipalities={municipalities || [generateMunicipality({})]}
+        >
+          <ProfileNewJerseyAddress />
+        </WithStatefulAddressData>
+      </ThemeProvider>
     );
   };
 


### PR DESCRIPTION
…mpty State

<!-- Please complete the following sections as necessary. -->

## Description

User Story
As a user that has formed through Business.NJ.gov, when viewing my business information in my profile I want to be aware that my address is locked and no longer editable, and if I didn't provide an address during formation I want to be informed of this uneditable field so that I can understand why I can't update my business information in my account.

Acceptance Criteria
Formed with Address
Given I have already formed my business through Business.NJ.gov
when accessing my profile
then I want to see the existing 'locked' tool-tip next to my Business Address Section

Formed without Address
Given I have already formed my business through the Business.NJ.gov
and I did not have an address
when accessing my profile
then I want to see a 'locked' tool-tip next to my Business Address Section that further explains why the field is actually empty
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188150760](https://www.pivotaltracker.com/story/show/188150760).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
