### PR TITLE
Add filtering logic into industry.ts to remove disabled industries

### DIFF
--- a/shared/jest.config.ts
+++ b/shared/jest.config.ts
@@ -1,5 +1,9 @@
 import sharedConfig from "../jest.shared";
 
+process.env = Object.assign(process.env, {
+  SHOW_DISABLED_INDUSTRIES: "false",
+});
+
 /** @type {import('jest').Config} */
 export default {
   ...sharedConfig,

--- a/shared/src/industry.test.ts
+++ b/shared/src/industry.test.ts
@@ -1,23 +1,107 @@
-import { Industries, isIndustryIdGeneric, LookupIndustryById } from "./industry";
+import { orderBy } from "lodash";
+import industryJson from "../../content/lib/industry.json";
+import { getIndustries, Industry, isIndustryIdGeneric, LookupIndustryById } from "./industry";
 
 describe("Industry Tests", () => {
   it("has industry records", () => {
-    expect(Industries.length).toBeGreaterThan(0);
+    expect(getIndustries().length).toBeGreaterThan(0);
   });
 
-  for (const index of Industries) {
-    it(`${index.id} has an id`, () => {
-      expect(index.id.length).toBeGreaterThan(0);
+  describe.each(getIndustries())("$name", (industry) => {
+    it("has an id", () => {
+      expect(industry.id.length).toBeGreaterThan(0);
     });
 
-    it(`${index.id} has a name`, () => {
-      expect(index.name.length).toBeGreaterThan(0);
+    it("has a name", () => {
+      expect(industry.name.length).toBeGreaterThan(0);
     });
 
-    it(`${index.id} has a description`, () => {
-      expect(index.description.length).toBeGreaterThan(0);
+    it("has a description", () => {
+      expect(industry.description.length).toBeGreaterThan(0);
     });
-  }
+  });
+
+  it("getIndustries returns industries in order by name", () => {
+    const orderdIndustries = orderBy(
+      industryJson.industries as Industry[],
+      [isIndustryIdGeneric, "name"],
+      ["desc", "asc"]
+    ).filter((x: Industry) => {
+      return x.isEnabled;
+    });
+
+    expect(getIndustries()).toEqual(orderdIndustries);
+  });
+
+  describe("when SHOW_DISABLED_INDUSTRIES is 'false'", () => {
+    const originalEnvironment = process.env;
+
+    beforeEach(() => {
+      jest.resetModules();
+      process.env = {
+        ...originalEnvironment,
+        SHOW_DISABLED_INDUSTRIES: "false",
+      };
+    });
+
+    afterEach(() => {
+      jest.resetModules();
+      process.env = {
+        ...originalEnvironment,
+      };
+    });
+
+    it("getIndustries only contains 'enabled' industries", () => {
+      const filteredOrderdIndustries = orderBy(
+        industryJson.industries as Industry[],
+        [isIndustryIdGeneric, "name"],
+        ["desc", "asc"]
+      ).filter((x: Industry) => {
+        return x.isEnabled;
+      });
+
+      expect(getIndustries()).toEqual(filteredOrderdIndustries);
+    });
+  });
+
+  describe("when SHOW_DISABLED_INDUSTRIES is 'true'", () => {
+    const originalEnvironment = process.env;
+
+    beforeEach(() => {
+      jest.resetModules();
+      process.env = {
+        ...originalEnvironment,
+        SHOW_DISABLED_INDUSTRIES: "true",
+      };
+    });
+
+    afterEach(() => {
+      jest.resetModules();
+      process.env = {
+        ...originalEnvironment,
+      };
+    });
+
+    it("getIndustries contains all industries", () => {
+      const orderdIndustries = orderBy(
+        industryJson.industries as Industry[],
+        [isIndustryIdGeneric, "name"],
+        ["desc", "asc"]
+      );
+
+      expect(getIndustries()).toEqual(orderdIndustries);
+    });
+  });
+
+  it("getIndustries returns all industries when overrideShowDisabledIndustries is true", () => {
+    const orderdIndustries = orderBy(
+      industryJson.industries as Industry[],
+      [isIndustryIdGeneric, "name"],
+      ["desc", "asc"]
+    );
+
+    expect(getIndustries({ overrideShowDisabledIndustries: true })).toEqual(orderdIndustries);
+  });
 
   describe("Lookup By Id", () => {
     it("returns empty object when invalid id is supplied", () => {

--- a/shared/src/industry.ts
+++ b/shared/src/industry.ts
@@ -1,3 +1,4 @@
+import { orderBy } from "lodash";
 import industryJson from "../../content/lib/industry.json";
 
 export interface Industry {
@@ -50,7 +51,7 @@ export interface TaskModification {
 
 export const LookupIndustryById = (id: string | undefined): Industry => {
   return (
-    Industries.find((x) => {
+    getIndustries().find((x) => {
       return x.id === id;
     }) ?? {
       id: "",
@@ -81,8 +82,18 @@ export const LookupIndustryById = (id: string | undefined): Industry => {
   );
 };
 
-export const Industries: Industry[] = industryJson.industries;
-
 export const isIndustryIdGeneric = (industry: Industry): boolean => {
   return industry.id === "generic";
 };
+
+// eslint-disable-next-line unicorn/prevent-abbreviations
+export const getIndustries = (props?: { overrideShowDisabledIndustries?: boolean }): Industry[] =>
+  orderBy(industryJson.industries as Industry[], [isIndustryIdGeneric, "name"], ["desc", "asc"]).filter(
+    (x) => {
+      return (
+        x.isEnabled ||
+        props?.overrideShowDisabledIndustries ||
+        process.env.SHOW_DISABLED_INDUSTRIES === "true"
+      );
+    }
+  );

--- a/shared/src/test/factories.ts
+++ b/shared/src/test/factories.ts
@@ -12,7 +12,7 @@ import {
   PublicFilingLegalType,
   publicFilingLegalTypes,
 } from "../formationData";
-import { Industries, Industry } from "../industry";
+import { getIndustries, Industry } from "../industry";
 import { randomInt } from "../intHelpers";
 import { LegalStructure, LegalStructures } from "../legalStructure";
 import {
@@ -200,12 +200,9 @@ export const generateUser = (overrides: Partial<BusinessUser>): BusinessUser => 
   };
 };
 
-export const randomFilteredIndustry = (
-  function_: (industry: Industry) => boolean,
-  { isEnabled = true }
-): Industry => {
-  const filteredIndustries = Industries.filter((x: Industry) => {
-    return function_(x) && x.isEnabled === isEnabled;
+export const filterRandomIndustry = (function_: (industry: Industry) => boolean): Industry => {
+  const filteredIndustries = getIndustries().filter((x: Industry) => {
+    return function_(x);
   });
   const randomIndex = Math.floor(Math.random() * filteredIndustries.length);
   return filteredIndustries[randomIndex];
@@ -215,7 +212,7 @@ export const randomIndustry = (canHavePermanentLocation = false): Industry => {
   const filter = (x: Industry): boolean => {
     return x.canHavePermanentLocation === canHavePermanentLocation;
   };
-  return randomFilteredIndustry(filter, { isEnabled: true });
+  return filterRandomIndustry(filter);
 };
 
 export const generateIndustrySpecificData = (

--- a/web/cypress/e2e/group_1_onboarding/onboarding-as-foreign-business.spec.ts
+++ b/web/cypress/e2e/group_1_onboarding/onboarding-as-foreign-business.spec.ts
@@ -11,14 +11,14 @@ import {
 } from "@businessnjgovnavigator/cypress/support/page_objects/onboardingPageNew";
 import {
   CarServiceType,
-  Industries,
   Industry,
   ResidentialConstructionType,
   carServiceOptions,
+  getIndustries,
   randomInt,
 } from "@businessnjgovnavigator/shared";
 
-const enabledIndustries = Industries.filter((element: Industry) => {
+const enabledIndustries = getIndustries().filter((element: Industry) => {
   return element.isEnabled && element.id !== "domestic-employer";
 });
 

--- a/web/cypress/e2e/group_1_onboarding/onboarding-as-starting-business.spec.ts
+++ b/web/cypress/e2e/group_1_onboarding/onboarding-as-starting-business.spec.ts
@@ -1,8 +1,7 @@
 import {
   carServiceOptions,
   CarServiceType,
-  Industries,
-  Industry,
+  getIndustries,
   randomInt,
   ResidentialConstructionType,
 } from "@businessnjgovnavigator/shared";
@@ -13,9 +12,7 @@ import {
 } from "../../support/helpers/helpers";
 import { onOnboardingPageStartingBusiness } from "../../support/page_objects/onboardingPageNew";
 
-const enabledIndustries = Industries.filter((element: Industry) => {
-  return element.isEnabled;
-});
+const industries = getIndustries();
 
 describe("Onboarding for all industries when starting a business [feature] [all] [group1]", () => {
   describe("Desktop", () => {
@@ -23,7 +20,7 @@ describe("Onboarding for all industries when starting a business [feature] [all]
       cy.loginByCognitoApi();
     });
 
-    for (const industry of enabledIndustries) {
+    for (const industry of industries) {
       it(`Onboarding for ${industry.name}`, () => {
         cy.url().should("include", "onboarding?page=1");
         onOnboardingPageStartingBusiness.selectBusinessPersonaRadio("STARTING");

--- a/web/cypress/support/helpers/helpers-onboarding.ts
+++ b/web/cypress/support/helpers/helpers-onboarding.ts
@@ -6,10 +6,10 @@ import {
   Registration,
   StartingOnboardingData,
 } from "@businessnjgovnavigator/cypress/support/types";
-import { Industries, Industry } from "@businessnjgovnavigator/shared/lib/shared/src/industry";
+import { getIndustries, Industry } from "@businessnjgovnavigator/shared/lib/shared/src/industry";
 import { randomInt } from "@businessnjgovnavigator/shared/lib/shared/src/intHelpers";
 import { carServiceOptions } from "@businessnjgovnavigator/shared/lib/shared/src/profileData";
-import { LookupSectorTypeById, arrayOfSectors } from "@businessnjgovnavigator/shared/lib/shared/src/sector";
+import { arrayOfSectors, LookupSectorTypeById } from "@businessnjgovnavigator/shared/lib/shared/src/sector";
 
 export const completeNewBusinessOnboarding = ({
   industry = undefined,
@@ -26,7 +26,7 @@ export const completeNewBusinessOnboarding = ({
   petCareHousing = undefined,
 }: Partial<StartingOnboardingData> & Partial<Registration>): void => {
   if (industry === undefined) {
-    industry = randomElementFromArray(Industries.filter((x) => x.isEnabled) as Industry[]) as Industry;
+    industry = randomElementFromArray(getIndustries()) as Industry;
   }
 
   if (carService === undefined) {
@@ -279,7 +279,7 @@ export const completeForeignNexusBusinessOnboarding = ({
   cy.url().should("include", `onboarding?page=3`);
 
   if (industry === undefined) {
-    industry = randomElementFromArray(Industries.filter((x) => x.isEnabled) as Industry[]) as Industry;
+    industry = randomElementFromArray(getIndustries()) as Industry;
   }
 
   onOnboardingPage.selectIndustry((industry as Industry).id);

--- a/web/cypress/support/helpers/helpers-select-industries.ts
+++ b/web/cypress/support/helpers/helpers-select-industries.ts
@@ -1,13 +1,13 @@
 import { randomElementFromArray } from "@businessnjgovnavigator/cypress/support/helpers/helpers";
-import { Industries, Industry } from "@businessnjgovnavigator/shared/lib/shared/src/industry";
+import { getIndustries, Industry } from "@businessnjgovnavigator/shared/lib/shared/src/industry";
 
-export const homeBasedIndustries = Industries.filter((industry) => {
+export const homeBasedIndustries = getIndustries().filter((industry) => {
   return industry.industryOnboardingQuestions.canBeHomeBased && industry.canHavePermanentLocation;
 });
-export const liquorLicenseIndustries = Industries.filter((industry) => {
+export const liquorLicenseIndustries = getIndustries().filter((industry) => {
   return industry.industryOnboardingQuestions.isLiquorLicenseApplicable;
 });
-export const industriesNotHomeBasedOrLiquorLicense = Industries.filter((industry) => {
+export const industriesNotHomeBasedOrLiquorLicense = getIndustries().filter((industry) => {
   return (
     !industry.industryOnboardingQuestions.canBeHomeBased &&
     industry.canHavePermanentLocation &&

--- a/web/src/components/CannabisLocationAlert.test.tsx
+++ b/web/src/components/CannabisLocationAlert.test.tsx
@@ -3,10 +3,10 @@ import { getMergedConfig } from "@/contexts/configContext";
 import { WithStatefulUserData } from "@/test/mock/withStatefulUserData";
 import { Industry } from "@businessnjgovnavigator/shared/industry";
 import {
+  filterRandomIndustry,
   generateBusiness,
   generateProfileData,
   generateUserDataForBusiness,
-  randomFilteredIndustry,
 } from "@businessnjgovnavigator/shared/test";
 import { render, screen } from "@testing-library/react";
 
@@ -35,7 +35,7 @@ describe("<CannabisLocationAlert />", () => {
 
   it("is NOT displayed for non-cannabis businesses", () => {
     const filter = (industry: Industry): boolean => industry.id !== "cannabis";
-    const industry = randomFilteredIndustry(filter, { isEnabled: true });
+    const industry = filterRandomIndustry(filter);
 
     renderWithBusiness(industry.id);
     expect(screen.queryByText(Config.profileDefaults.default.cannabisLocationAlert)).not.toBeInTheDocument();

--- a/web/src/components/data-fields/Industry.test.tsx
+++ b/web/src/components/data-fields/Industry.test.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/test/factories";
 import { useMockBusiness } from "@/test/mock/mockUseUserData";
 import { WithStatefulProfileData, currentProfileData } from "@/test/mock/withStatefulProfileData";
-import { generateProfileData, randomFilteredIndustry, randomIndustry } from "@businessnjgovnavigator/shared";
+import { filterRandomIndustry, generateProfileData, randomIndustry } from "@businessnjgovnavigator/shared";
 import {
   ProfileData,
   createEmptyProfileData,
@@ -94,7 +94,7 @@ describe("<Industry />", () => {
       return eq.fieldName !== "residentialConstructionType" && eq.fieldName !== "employmentPlacementType";
     });
     nonConditionalEssentialQuestions.map((el) => {
-      const validIndustryId = randomFilteredIndustry(el.isQuestionApplicableToIndustry, { isEnabled: true });
+      const validIndustryId = filterRandomIndustry(el.isQuestionApplicableToIndustry);
       const nonValidIndustryId = randomNegativeFilteredIndustry(el.isQuestionApplicableToIndustry);
 
       businessPersonas.map((persona) => {

--- a/web/src/components/data-fields/IndustryDropdown.tsx
+++ b/web/src/components/data-fields/IndustryDropdown.tsx
@@ -14,14 +14,12 @@ import { templateEval } from "@/lib/utils/helpers";
 import { splitAndBoldSearchText } from "@/lib/utils/splitAndBoldSearchText";
 import {
   CannabisLicenseType,
-  Industries,
   Industry,
   LookupIndustryById,
-  isIndustryIdGeneric,
+  getIndustries,
 } from "@businessnjgovnavigator/shared";
 import { nexusLocationInNewJersey } from "@businessnjgovnavigator/shared/domain-logic/nexusLocationInNewJersey";
 import { Autocomplete, FilterOptionsState, TextField, createFilterOptions } from "@mui/material";
-import { orderBy } from "lodash";
 import { ChangeEvent, FocusEvent, ReactElement, useContext, useState } from "react";
 
 interface Props {
@@ -44,13 +42,7 @@ export const IndustryDropdown = (props: Props): ReactElement => {
       fieldName: "industryId",
     });
 
-  const IndustriesOrdered: Industry[] = orderBy(
-    Industries,
-    [isIndustryIdGeneric, "name"],
-    ["desc", "asc"]
-  ).filter((x) => {
-    return x.isEnabled || process.env.SHOW_DISABLED_INDUSTRIES === "true";
-  });
+  const Industries = getIndustries();
 
   const onIndustryIdChange = (industryId: string | undefined): void => {
     let cannabisLicenseType = undefined;
@@ -118,7 +110,7 @@ export const IndustryDropdown = (props: Props): ReactElement => {
 
   return (
     <Autocomplete
-      options={IndustriesOrdered}
+      options={Industries}
       filterOptions={getFilterOptions}
       groupBy={(): string => {
         return "DEFAULT-GROUP";

--- a/web/src/lib/roadmap/buildUserRoadmap.test.ts
+++ b/web/src/lib/roadmap/buildUserRoadmap.test.ts
@@ -5,10 +5,10 @@ import * as roadmapBuilderModule from "@/lib/roadmap/roadmapBuilder";
 import { generateRoadmap, generateTask } from "@/test/factories";
 import { getLastCalledWith } from "@/test/helpers/helpers-utilities";
 import {
-  Industries,
   generateMunicipality,
   generateMunicipalityDetail,
   generateProfileData,
+  getIndustries,
 } from "@businessnjgovnavigator/shared";
 import * as fetchMunicipalityById from "@businessnjgovnavigator/shared/domain-logic/fetchMunicipalityById";
 import {
@@ -263,7 +263,7 @@ describe("buildUserRoadmap", () => {
   });
 
   describe("industry", () => {
-    for (const industry of Industries.filter((x) => {
+    for (const industry of getIndustries().filter((x) => {
       return x.id !== "generic";
     })) {
       it(`adds ${industry.name} industry and modifications`, async () => {
@@ -271,7 +271,7 @@ describe("buildUserRoadmap", () => {
           generateStartingProfile({ industryId: industry.id, certifiedInteriorDesigner: true })
         );
         const lastCalledWith = getLastCalledWith(mockRoadmapBuilder)[0];
-        const shouldNotContainIndustries = Industries.filter((it) => {
+        const shouldNotContainIndustries = getIndustries().filter((it) => {
           return it.id !== industry.id;
         });
         expect(lastCalledWith.industryId).toBe(industry.id);
@@ -283,7 +283,7 @@ describe("buildUserRoadmap", () => {
 
     describe("on-boarding modifications", () => {
       describe("staffing service", () => {
-        for (const industry of Industries.filter((x) => {
+        for (const industry of getIndustries().filter((x) => {
           return x.industryOnboardingQuestions.isProvidesStaffingServicesApplicable;
         })) {
           it(`set industry to employment-agency if ${industry.name} with staffing service`, async () => {

--- a/web/src/lib/utils/analytics-helpers.test.ts
+++ b/web/src/lib/utils/analytics-helpers.test.ts
@@ -1,13 +1,13 @@
 import analytics from "@/lib/utils/analytics";
 import { randomElementFromArray } from "@/test/helpers/helpers-utilities";
-import { generateProfileData, Industries } from "@businessnjgovnavigator/shared/";
+import { generateProfileData, getIndustries } from "@businessnjgovnavigator/shared/";
 import { sendOnboardingOnSubmitEvents } from "./analytics-helpers";
 
 jest.mock("@/lib/utils/analytics");
 
 const mockAnalytic = analytics as jest.Mocked<typeof analytics>;
 
-const liquorLicenseApplicableIndustries = Industries.filter((industry) => {
+const liquorLicenseApplicableIndustries = getIndustries().filter((industry) => {
   return industry.industryOnboardingQuestions.isLiquorLicenseApplicable === true;
 });
 

--- a/web/src/lib/utils/starterKits.ts
+++ b/web/src/lib/utils/starterKits.ts
@@ -1,4 +1,4 @@
-import { Industries } from "@businessnjgovnavigator/shared/industry";
+import { getIndustries } from "@businessnjgovnavigator/shared/industry";
 
 export const STARTER_KITS_GENERIC_SLUG = "nj-business";
 
@@ -9,7 +9,7 @@ export type StarterKitsUrl = {
 };
 
 export const getAllStarterKitUrls = (): PathParameters<StarterKitsUrl>[] => {
-  return Industries.filter((industry) => industry.isEnabled).map((industry) => {
+  return getIndustries().map((industry) => {
     if (industry.id === "generic") {
       return {
         params: {

--- a/web/src/pages/mgmt/search.tsx
+++ b/web/src/pages/mgmt/search.tsx
@@ -56,7 +56,7 @@ import {
 import NonEssentialQuestions from "@businessnjgovnavigator/content/roadmaps/nonEssentialQuestions.json";
 import ForeignSteps from "@businessnjgovnavigator/content/roadmaps/steps-foreign.json";
 import Steps from "@businessnjgovnavigator/content/roadmaps/steps.json";
-import { Industries } from "@businessnjgovnavigator/shared";
+import { getIndustries } from "@businessnjgovnavigator/shared/industry";
 import { TextField } from "@mui/material";
 import { GetStaticPropsResult } from "next";
 import { NextSeo } from "next-seo";
@@ -136,7 +136,9 @@ const SearchContentPage = (props: Props): ReactElement => {
     setCertMatches(searchCertifications(props.certifications, lowercaseTerm));
     setCertArchiveMatches(searchCertifications(props.archivedCertifications, lowercaseTerm));
     setFundingMatches(searchFundings(props.fundings, lowercaseTerm));
-    setIndustryMatches(searchIndustries(Industries, lowercaseTerm));
+    setIndustryMatches(
+      searchIndustries(getIndustries({ overrideShowDisabledIndustries: true }), lowercaseTerm)
+    );
     setAnytimeActionLinkMatches(searchAnytimeActionLinks(props.anytimeActionLinks, lowercaseTerm));
     setAnytimeActionTaskMatches(searchAnytimeActionTasks(props.anytimeActionTasks, lowercaseTerm));
     setAnytimeActionLicenseReinstatementMatches(

--- a/web/test/factories.ts
+++ b/web/test/factories.ts
@@ -61,7 +61,7 @@ import {
 } from "@businessnjgovnavigator/shared/";
 import { FormationData } from "@businessnjgovnavigator/shared/formationData";
 import { BusinessPersona } from "@businessnjgovnavigator/shared/profileData";
-import { randomFilteredIndustry, randomIndustry, randomSector } from "@businessnjgovnavigator/shared/test";
+import { filterRandomIndustry, randomIndustry, randomSector } from "@businessnjgovnavigator/shared/test";
 
 export const generateSectionType = (): SectionType => {
   const num = randomInt();
@@ -501,26 +501,23 @@ export const randomOwnershipType = (): OwnershipType => {
 };
 
 export const randomNegativeFilteredIndustry = (func: (industry: Industry) => boolean): Industry => {
-  return randomFilteredIndustry(
-    (industry: Industry) => {
-      return !func(industry);
-    },
-    { isEnabled: true }
-  );
+  return filterRandomIndustry((industry: Industry) => {
+    return !func(industry);
+  });
 };
 
 export const randomHomeBasedIndustry = (): string => {
   const filter = (it: Industry): boolean => {
     return !!it.industryOnboardingQuestions.canBeHomeBased;
   };
-  return randomFilteredIndustry(filter, { isEnabled: true }).id;
+  return filterRandomIndustry(filter).id;
 };
 
 export const randomNonHomeBasedIndustry = (): string => {
   const filter = (it: Industry): boolean => {
     return !it.industryOnboardingQuestions.canBeHomeBased && it.canHavePermanentLocation;
   };
-  return randomFilteredIndustry(filter, { isEnabled: true }).id;
+  return filterRandomIndustry(filter).id;
 };
 
 export const generateBusinessPersona = (): Exclude<BusinessPersona, undefined> => {

--- a/web/test/pages/onboarding/helpers-onboarding.tsx
+++ b/web/test/pages/onboarding/helpers-onboarding.tsx
@@ -15,7 +15,6 @@ import { WithStatefulUserData, currentBusiness } from "@/test/mock/withStatefulU
 import {
   BusinessPersona,
   DateObject,
-  Industries,
   Municipality,
   UserData,
   businessStructureTaskId,
@@ -26,6 +25,7 @@ import {
   generateProfileData,
   generateUser,
   generateUserDataForBusiness,
+  getIndustries,
   industrySpecificDataChoices,
 } from "@businessnjgovnavigator/shared/";
 import { ThemeProvider, createTheme } from "@mui/material";
@@ -329,11 +329,11 @@ export const mockSuccessfulApiSignups = (): void => {
   });
 };
 
-export const industriesWithSingleEssentialQuestion = Industries.filter((industry) => {
+export const industriesWithSingleEssentialQuestion = getIndustries().filter((industry) => {
   return hasEssentialQuestion(industry.id) && industry.isEnabled && industry.id !== "employment-agency";
 });
 
-export const industriesWithOutEssentialQuestion = Industries.filter((industry) => {
+export const industriesWithOutEssentialQuestion = getIndustries().filter((industry) => {
   return !hasEssentialQuestion(industry.id) && industry.isEnabled;
 });
 

--- a/web/test/pages/profile/profile-shared.test.tsx
+++ b/web/test/pages/profile/profile-shared.test.tsx
@@ -33,9 +33,9 @@ import {
   randomInt,
 } from "@businessnjgovnavigator/shared";
 import {
+  filterRandomIndustry,
   generateFormationData,
   generateTaxFilingData,
-  randomFilteredIndustry,
 } from "@businessnjgovnavigator/shared/test";
 
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
@@ -621,7 +621,7 @@ describe("profile - shared", () => {
       "should NOT display a warning alert for non-cannabis businesses when %s",
       async (businessPersona: BusinessPersona) => {
         const filter = (industry: Industry): boolean => industry.id !== "cannabis";
-        const industry = randomFilteredIndustry(filter, { isEnabled: true });
+        const industry = filterRandomIndustry(filter);
 
         renderPage({
           business: generateBusinessForProfile({


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Currently, we are filtering disabled industries every instance we try to access the full list. This PR adds the filtering to remove industries where `{isEnabled: false}` in `industry.ts`. This is based on the env variable `SHOW_DISABLED_INDUSTRIES` and includes an override for testing purposes and the CMS search page.

### Ticket

This pull request resolves [#188117285](https://www.pivotaltracker.com/story/show/188117285).

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
