### PR TITLE
Updates to Domestic Employer experience based on SME feedback

### DIFF
--- a/api/src/client/ApiFormationHealth.ts
+++ b/api/src/client/ApiFormationHealth.ts
@@ -29,7 +29,7 @@ export const ApiFormationHealth: UserData = {
       taskItemChecklist: {},
       licenseData: undefined,
       preferences: {
-        roadmapOpenSections: ["PLAN", "START"],
+        roadmapOpenSections: ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"],
         roadmapOpenSteps: [18013808],
         hiddenFundingIds: [],
         hiddenCertificationIds: [],

--- a/api/src/db/migrations/migrations.ts
+++ b/api/src/db/migrations/migrations.ts
@@ -46,6 +46,7 @@ import { migrate_v138_to_v139 } from "@db/migrations/v139_own_carnival_rides";
 import { migrate_v12_to_v13 } from "@db/migrations/v13_add_construction_renovation_plan";
 import { migrate_v139_to_v140 } from "@db/migrations/v140_modify_home_health_industry";
 import { migrate_v140_to_v141 } from "@db/migrations/v141_sync_migrated_and_newly_created_users";
+import { migrate_v141_to_v142 } from "@db/migrations/v142_add_domestic_employer_roadmap_section";
 import { migrate_v13_to_v14 } from "@db/migrations/v14_add_cleaning_aid_industry";
 import { migrate_v14_to_v15 } from "@db/migrations/v15_add_retail_industry";
 import { migrate_v15_to_v16 } from "@db/migrations/v16_add_user_preferences";
@@ -286,6 +287,7 @@ export const Migrations: MigrationFunction[] = [
   migrate_v138_to_v139,
   migrate_v139_to_v140,
   migrate_v140_to_v141,
+  migrate_v141_to_v142,
 ];
 
-export { generatev141UserData as CURRENT_GENERATOR } from "@db/migrations/v141_sync_migrated_and_newly_created_users";
+export { generatev142UserData as CURRENT_GENERATOR } from "@db/migrations/v142_add_domestic_employer_roadmap_section";

--- a/api/src/db/migrations/v142_add_domestic_employer_roadmap_section.ts
+++ b/api/src/db/migrations/v142_add_domestic_employer_roadmap_section.ts
@@ -1,0 +1,802 @@
+import { v141Business, v141UserData } from "@db/migrations/v141_sync_migrated_and_newly_created_users";
+import { randomInt } from "@shared/intHelpers";
+
+export const migrate_v141_to_v142 = (v141Data: v141UserData): v142UserData => {
+  return {
+    ...v141Data,
+    businesses: Object.fromEntries(
+      Object.values(v141Data.businesses)
+        .map((business: v141Business) => migrate_v141Business_to_v142Business(business))
+        .map((currBusiness: v142Business) => [currBusiness.id, currBusiness])
+    ),
+    version: 142,
+  } as v142UserData;
+};
+
+export const migrate_v141Business_to_v142Business = (business: v141Business): v142Business => {
+  // @ts-expect-error this field exists for user data migrated from earlier than v108
+  delete business.formationData.businessNameSearch;
+
+  return {
+    ...business,
+    preferences: {
+      ...business.preferences,
+      roadmapOpenSections: [...business.preferences.roadmapOpenSections, "DOMESTIC_EMPLOYER_SECTION"],
+    },
+  } as v142Business;
+};
+
+// ---------------- v142 types ----------------
+type v142TaskProgress = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+type v142OnboardingFormProgress = "UNSTARTED" | "COMPLETED";
+type v142ABExperience = "ExperienceA" | "ExperienceB";
+
+export interface v142UserData {
+  user: v142BusinessUser;
+  version: number;
+  lastUpdatedISO: string;
+  dateCreatedISO: string;
+  versionWhenCreated: number;
+  businesses: Record<string, v142Business>;
+  currentBusinessId: string;
+}
+
+export interface v142Business {
+  id: string;
+  dateCreatedISO: string;
+  lastUpdatedISO: string;
+  profileData: v142ProfileData;
+  onboardingFormProgress: v142OnboardingFormProgress;
+  taskProgress: Record<string, v142TaskProgress>;
+  taskItemChecklist: Record<string, boolean>;
+  licenseData: v142LicenseData | undefined;
+  preferences: v142Preferences;
+  taxFilingData: v142TaxFilingData;
+  formationData: v142FormationData;
+}
+
+export interface v142ProfileData extends v142IndustrySpecificData {
+  businessPersona: v142BusinessPersona;
+  businessName: string;
+  responsibleOwnerName: string;
+  tradeName: string;
+  industryId: string | undefined;
+  legalStructureId: string | undefined;
+  municipality: v142Municipality | undefined;
+  dateOfFormation: string | undefined;
+  entityId: string | undefined;
+  employerId: string | undefined;
+  taxId: string | undefined;
+  encryptedTaxId: string | undefined;
+  notes: string;
+  documents: v142ProfileDocuments;
+  ownershipTypeIds: string[];
+  existingEmployees: string | undefined;
+  taxPin: string | undefined;
+  sectorId: string | undefined;
+  naicsCode: string;
+  foreignBusinessTypeIds: v142ForeignBusinessTypeId[];
+  nexusDbaName: string;
+  needsNexusDbaName: boolean;
+  operatingPhase: v142OperatingPhase;
+  isNonprofitOnboardingRadio: boolean;
+  nonEssentialRadioAnswers: Record<string, boolean | undefined>;
+  elevatorOwningBusiness: boolean | undefined;
+  communityAffairsAddress?: v142CommunityAffairsAddress;
+  plannedRenovationQuestion: boolean | undefined;
+}
+
+export interface v142IndustrySpecificData {
+  liquorLicense: boolean;
+  requiresCpa: boolean;
+  homeBasedBusiness: boolean | undefined;
+  providesStaffingService: boolean;
+  certifiedInteriorDesigner: boolean;
+  realEstateAppraisalManagement: boolean;
+  cannabisLicenseType: v142CannabisLicenseType;
+  cannabisMicrobusiness: boolean | undefined;
+  constructionRenovationPlan: boolean | undefined;
+  carService: v142CarServiceType | undefined;
+  interstateTransport: boolean;
+  interstateLogistics: boolean | undefined;
+  interstateMoving: boolean | undefined;
+  isChildcareForSixOrMore: boolean | undefined;
+  petCareHousing: boolean | undefined;
+  willSellPetCareItems: boolean | undefined;
+  constructionType: v142ConstructionType;
+  residentialConstructionType: v142ResidentialConstructionType;
+  employmentPersonnelServiceType: v142EmploymentAndPersonnelServicesType;
+  employmentPlacementType: v142EmploymentPlacementType;
+  carnivalRideOwningBusiness: boolean | undefined;
+}
+
+export type v142CommunityAffairsAddress = {
+  streetAddress1: string;
+  streetAddress2?: string;
+  municipality: v142Municipality;
+};
+
+type v142BusinessUser = {
+  name?: string;
+  email: string;
+  id: string;
+  receiveNewsletter: boolean;
+  userTesting: boolean;
+  externalStatus: v142ExternalStatus;
+  myNJUserKey?: string;
+  intercomHash?: string;
+  abExperience: v142ABExperience;
+  accountCreationSource: string;
+  contactSharingWithAccountCreationPartner: boolean;
+};
+
+interface v142ProfileDocuments {
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+}
+
+type v142BusinessPersona = "STARTING" | "OWNING" | "FOREIGN" | undefined;
+type v142OperatingPhase =
+  | "GUEST_MODE"
+  | "NEEDS_TO_FORM"
+  | "NEEDS_BUSINESS_STRUCTURE"
+  | "FORMED"
+  | "UP_AND_RUNNING"
+  | "UP_AND_RUNNING_OWNING"
+  | "REMOTE_SELLER_WORKER"
+  | undefined;
+
+export type v142CannabisLicenseType = "CONDITIONAL" | "ANNUAL" | undefined;
+export type v142CarServiceType = "STANDARD" | "HIGH_CAPACITY" | "BOTH" | undefined;
+export type v142ConstructionType = "RESIDENTIAL" | "COMMERCIAL_OR_INDUSTRIAL" | "BOTH" | undefined;
+export type v142ResidentialConstructionType =
+  | "NEW_HOME_CONSTRUCTION"
+  | "HOME_RENOVATIONS"
+  | "BOTH"
+  | undefined;
+export type v142EmploymentAndPersonnelServicesType = "JOB_SEEKERS" | "EMPLOYERS" | undefined;
+export type v142EmploymentPlacementType = "TEMPORARY" | "PERMANENT" | "BOTH" | undefined;
+
+type v142ForeignBusinessTypeId =
+  | "employeeOrContractorInNJ"
+  | "officeInNJ"
+  | "propertyInNJ"
+  | "companyOperatedVehiclesInNJ"
+  | "employeesInNJ"
+  | "revenueInNJ"
+  | "transactionsInNJ"
+  | "none";
+
+type v142Municipality = {
+  name: string;
+  displayName: string;
+  county: string;
+  id: string;
+};
+
+type v142TaxFilingState = "SUCCESS" | "FAILED" | "UNREGISTERED" | "PENDING" | "API_ERROR";
+type v142TaxFilingErrorFields = "businessName" | "formFailure";
+
+type v142TaxFilingData = {
+  state?: v142TaxFilingState;
+  lastUpdatedISO?: string;
+  registeredISO?: string;
+  errorField?: v142TaxFilingErrorFields;
+  businessName?: string;
+  filings: v142TaxFilingCalendarEvent[];
+};
+
+export type v142CalendarEvent = {
+  readonly dueDate: string; // YYYY-MM-DD
+  readonly calendarEventType: "TAX-FILING" | "LICENSE";
+};
+
+export interface v142TaxFilingCalendarEvent extends v142CalendarEvent {
+  readonly identifier: string;
+  readonly calendarEventType: "TAX-FILING";
+}
+
+export type v142LicenseSearchAddress = {
+  addressLine1: string;
+  addressLine2: string;
+  zipCode: string;
+};
+
+export interface v142LicenseSearchNameAndAddress extends v142LicenseSearchAddress {
+  name: string;
+}
+
+type v142LicenseDetails = {
+  nameAndAddress: v142LicenseSearchNameAndAddress;
+  licenseStatus: v142LicenseStatus;
+  expirationDateISO: string | undefined;
+  lastUpdatedISO: string;
+  checklistItems: v142LicenseStatusItem[];
+  hasError?: boolean;
+};
+
+const v142taskIdLicenseNameMapping = {
+  "apply-for-shop-license": "Cosmetology and Hairstyling-Shop",
+  "appraiser-license": "Real Estate Appraisers-Appraisal Management Company",
+  "architect-license": "Architecture-Certificate of Authorization",
+  "health-club-registration": "Health Club Services",
+  "home-health-aide-license": "Health Care Services",
+  "hvac-license": "HVACR-HVACR CE Sponsor",
+  "landscape-architect-license": "Landscape Architecture-Certificate of Authorization",
+  "license-massage-therapy": "Massage and Bodywork Therapy-Massage and Bodywork Employer",
+  "moving-company-license": "Public Movers and Warehousemen-Public Mover and Warehouseman",
+  "pharmacy-license": "Pharmacy-Pharmacy",
+  "public-accountant-license": "Accountancy-Firm Registration",
+  "register-accounting-firm": "Accountancy-Firm Registration",
+  "register-consumer-affairs": "Home Improvement Contractors-Home Improvement Contractor",
+  "ticket-broker-reseller-registration": "Ticket Brokers",
+  "telemarketing-license": "Telemarketers",
+} as const;
+
+type v142LicenseTaskID = keyof typeof v142taskIdLicenseNameMapping;
+
+export type v142LicenseName = (typeof v142taskIdLicenseNameMapping)[v142LicenseTaskID];
+
+type v142Licenses = Partial<Record<v142LicenseName, v142LicenseDetails>>;
+
+type v142LicenseData = {
+  lastUpdatedISO: string;
+  licenses?: v142Licenses;
+};
+
+type v142Preferences = {
+  roadmapOpenSections: v142SectionType[];
+  roadmapOpenSteps: number[];
+  hiddenFundingIds: string[];
+  hiddenCertificationIds: string[];
+  visibleSidebarCards: string[];
+  isCalendarFullView: boolean;
+  returnToLink: string;
+  isHideableRoadmapOpen: boolean;
+  phaseNewlyChanged: boolean;
+};
+
+type v142LicenseStatusItem = {
+  title: string;
+  status: v142CheckoffStatus;
+};
+
+type v142CheckoffStatus = "ACTIVE" | "PENDING" | "UNKNOWN";
+
+type v142LicenseStatus =
+  | "ACTIVE"
+  | "PENDING"
+  | "UNKNOWN"
+  | "EXPIRED"
+  | "BARRED"
+  | "OUT_OF_BUSINESS"
+  | "REINSTATEMENT_PENDING"
+  | "CLOSED"
+  | "DELETED"
+  | "DENIED"
+  | "VOLUNTARY_SURRENDER"
+  | "WITHDRAWN";
+
+const v142SectionNames = ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"] as const;
+type v142SectionType = (typeof v142SectionNames)[number];
+
+type v142ExternalStatus = {
+  newsletter?: v142NewsletterResponse;
+  userTesting?: v142UserTestingResponse;
+};
+
+interface v142NewsletterResponse {
+  success?: boolean;
+  status: v142NewsletterStatus;
+}
+
+interface v142UserTestingResponse {
+  success?: boolean;
+  status: v142UserTestingStatus;
+}
+
+type v142NewsletterStatus = (typeof newsletterStatusList)[number];
+
+const externalStatusList = ["SUCCESS", "IN_PROGRESS", "CONNECTION_ERROR"] as const;
+
+const userTestingStatusList = [...externalStatusList] as const;
+
+type v142UserTestingStatus = (typeof userTestingStatusList)[number];
+
+const newsletterStatusList = [
+  ...externalStatusList,
+  "EMAIL_ERROR",
+  "TOPIC_ERROR",
+  "RESPONSE_WARNING",
+  "RESPONSE_ERROR",
+  "RESPONSE_FAIL",
+  "QUESTION_WARNING",
+] as const;
+
+type v142NameAvailabilityStatus =
+  | "AVAILABLE"
+  | "DESIGNATOR_ERROR"
+  | "SPECIAL_CHARACTER_ERROR"
+  | "UNAVAILABLE"
+  | "RESTRICTED_ERROR"
+  | undefined;
+
+interface v142NameAvailabilityResponse {
+  status: v142NameAvailabilityStatus;
+  similarNames: string[];
+  invalidWord?: string;
+}
+
+interface v142NameAvailability extends v142NameAvailabilityResponse {
+  lastUpdatedTimeStamp: string;
+}
+
+interface v142FormationData {
+  formationFormData: v142FormationFormData;
+  businessNameAvailability: v142NameAvailability | undefined;
+  dbaBusinessNameAvailability: v142NameAvailability | undefined;
+  formationResponse: v142FormationSubmitResponse | undefined;
+  getFilingResponse: v142GetFilingResponse | undefined;
+  completedFilingPayment: boolean;
+  lastVisitedPageIndex: number;
+}
+
+type v142InFormInBylaws = "IN_BYLAWS" | "IN_FORM" | undefined;
+
+interface v142FormationFormData extends v142FormationAddress {
+  readonly businessName: string;
+  readonly businessSuffix: v142BusinessSuffix | undefined;
+  readonly businessTotalStock: string;
+  readonly businessStartDate: string; // YYYY-MM-DD
+  readonly businessPurpose: string;
+  readonly withdrawals: string;
+  readonly combinedInvestment: string;
+  readonly dissolution: string;
+  readonly canCreateLimitedPartner: boolean | undefined;
+  readonly createLimitedPartnerTerms: string;
+  readonly canGetDistribution: boolean | undefined;
+  readonly getDistributionTerms: string;
+  readonly canMakeDistribution: boolean | undefined;
+  readonly makeDistributionTerms: string;
+  readonly hasNonprofitBoardMembers: boolean | undefined;
+  readonly nonprofitBoardMemberQualificationsSpecified: v142InFormInBylaws;
+  readonly nonprofitBoardMemberQualificationsTerms: string;
+  readonly nonprofitBoardMemberRightsSpecified: v142InFormInBylaws;
+  readonly nonprofitBoardMemberRightsTerms: string;
+  readonly nonprofitTrusteesMethodSpecified: v142InFormInBylaws;
+  readonly nonprofitTrusteesMethodTerms: string;
+  readonly nonprofitAssetDistributionSpecified: v142InFormInBylaws;
+  readonly nonprofitAssetDistributionTerms: string;
+  readonly additionalProvisions: string[] | undefined;
+  readonly agentNumberOrManual: "NUMBER" | "MANUAL_ENTRY";
+  readonly agentNumber: string;
+  readonly agentName: string;
+  readonly agentEmail: string;
+  readonly agentOfficeAddressLine1: string;
+  readonly agentOfficeAddressLine2: string;
+  readonly agentOfficeAddressCity: string;
+  readonly agentOfficeAddressZipCode: string;
+  readonly agentUseAccountInfo: boolean;
+  readonly agentUseBusinessAddress: boolean;
+  readonly members: v142FormationMember[] | undefined;
+  readonly incorporators: v142FormationIncorporator[] | undefined;
+  readonly signers: v142FormationSigner[] | undefined;
+  readonly paymentType: v142PaymentType;
+  readonly annualReportNotification: boolean;
+  readonly corpWatchNotification: boolean;
+  readonly officialFormationDocument: boolean;
+  readonly certificateOfStanding: boolean;
+  readonly certifiedCopyOfFormationDocument: boolean;
+  readonly contactFirstName: string;
+  readonly contactLastName: string;
+  readonly contactPhoneNumber: string;
+  readonly foreignStateOfFormation: v142StateObject | undefined;
+  readonly foreignDateOfFormation: string | undefined; // YYYY-MM-DD
+  readonly foreignGoodStandingFile: v142ForeignGoodStandingFileObject | undefined;
+  readonly legalType: string;
+  readonly willPracticeLaw: boolean | undefined;
+  readonly isVeteranNonprofit: boolean | undefined;
+}
+
+type v142ForeignGoodStandingFileObject = {
+  Extension: "PDF" | "PNG";
+  Content: string;
+};
+
+type v142StateObject = {
+  shortCode: string;
+  name: string;
+};
+
+interface v142FormationAddress {
+  readonly addressLine1: string;
+  readonly addressLine2: string;
+  readonly addressCity?: string;
+  readonly addressState?: v142StateObject;
+  readonly addressMunicipality?: v142Municipality;
+  readonly addressProvince?: string;
+  readonly addressZipCode: string;
+  readonly addressCountry: string;
+  readonly businessLocationType: v142FormationBusinessLocationType | undefined;
+}
+
+type v142FormationBusinessLocationType = "US" | "INTL" | "NJ";
+
+type v142SignerTitle =
+  | "Authorized Representative"
+  | "Authorized Partner"
+  | "Incorporator"
+  | "General Partner"
+  | "President"
+  | "Vice-President"
+  | "Chairman of the Board"
+  | "CEO";
+
+interface v142FormationSigner {
+  readonly name: string;
+  readonly signature: boolean;
+  readonly title: v142SignerTitle;
+}
+
+interface v142FormationIncorporator extends v142FormationSigner, v142FormationAddress {}
+
+interface v142FormationMember extends v142FormationAddress {
+  readonly name: string;
+}
+
+type v142PaymentType = "CC" | "ACH" | undefined;
+
+const llcBusinessSuffix = [
+  "LLC",
+  "L.L.C.",
+  "LTD LIABILITY CO",
+  "LTD LIABILITY CO.",
+  "LTD LIABILITY COMPANY",
+  "LIMITED LIABILITY CO",
+  "LIMITED LIABILITY CO.",
+  "LIMITED LIABILITY COMPANY",
+] as const;
+
+const llpBusinessSuffix = [
+  "Limited Liability Partnership",
+  "LLP",
+  "L.L.P.",
+  "Registered Limited Liability Partnership",
+  "RLLP",
+  "R.L.L.P.",
+] as const;
+
+export const lpBusinessSuffix = ["LIMITED PARTNERSHIP", "LP", "L.P."] as const;
+
+const corpBusinessSuffix = [
+  "Corporation",
+  "Incorporated",
+  "Company",
+  "LTD",
+  "CO",
+  "CO.",
+  "CORP",
+  "CORP.",
+  "INC",
+  "INC.",
+] as const;
+
+export const nonprofitBusinessSuffix = [
+  "A NJ NONPROFIT CORPORATION",
+  "CORPORATION",
+  "INCORPORATED",
+  "CORP",
+  "CORP.",
+  "INC",
+  "INC.",
+] as const;
+
+const foreignCorpBusinessSuffix = [...corpBusinessSuffix, "P.C.", "P.A."] as const;
+
+export const AllBusinessSuffixes = [
+  ...llcBusinessSuffix,
+  ...llpBusinessSuffix,
+  ...lpBusinessSuffix,
+  ...corpBusinessSuffix,
+  ...foreignCorpBusinessSuffix,
+  ...nonprofitBusinessSuffix,
+] as const;
+
+type v142BusinessSuffix = (typeof AllBusinessSuffixes)[number];
+
+type v142FormationSubmitResponse = {
+  success: boolean;
+  token: string | undefined;
+  formationId: string | undefined;
+  redirect: string | undefined;
+  errors: v142FormationSubmitError[];
+  lastUpdatedISO: string | undefined;
+};
+
+type v142FormationSubmitError = {
+  field: string;
+  type: "FIELD" | "UNKNOWN" | "RESPONSE";
+  message: string;
+};
+
+type v142GetFilingResponse = {
+  success: boolean;
+  entityId: string;
+  transactionDate: string;
+  confirmationNumber: string;
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+};
+
+// ---------------- v142 generators ----------------
+
+export const generatev142UserData = (overrides: Partial<v142UserData>): v142UserData => {
+  return {
+    user: generatev142BusinessUser({}),
+    version: 140,
+    lastUpdatedISO: "",
+    dateCreatedISO: "",
+    versionWhenCreated: 141,
+    businesses: {
+      "123": generatev142Business({ id: "123" }),
+    },
+    currentBusinessId: "",
+    ...overrides,
+  };
+};
+
+export const generatev142BusinessUser = (overrides: Partial<v142BusinessUser>): v142BusinessUser => {
+  return {
+    name: `some-name-${randomInt()}`,
+    email: `some-email-${randomInt()}@example.com`,
+    id: `some-id-${randomInt()}`,
+    receiveNewsletter: false,
+    userTesting: false,
+    externalStatus: {
+      userTesting: {
+        success: true,
+        status: "SUCCESS",
+      },
+    },
+    myNJUserKey: undefined,
+    intercomHash: undefined,
+    abExperience: "ExperienceA",
+    accountCreationSource: `some-source-${randomInt()}`,
+    contactSharingWithAccountCreationPartner: false,
+    ...overrides,
+  };
+};
+
+export const generatev142Business = (overrides: Partial<v142Business>): v142Business => {
+  const profileData = generatev142ProfileData({});
+  return {
+    id: `some-id-${randomInt()}`,
+    dateCreatedISO: "",
+    lastUpdatedISO: "",
+    profileData: profileData,
+    preferences: generatev142Preferences({}),
+    formationData: generatev142FormationData({}, profileData.legalStructureId ?? ""),
+    onboardingFormProgress: "UNSTARTED",
+    taskProgress: {
+      "business-structure": "NOT_STARTED",
+    },
+    taskItemChecklist: {
+      "general-dvob": false,
+    },
+    licenseData: undefined,
+    taxFilingData: generatev142TaxFilingData({}),
+    ...overrides,
+  };
+};
+
+export const generatev142ProfileData = (overrides: Partial<v142ProfileData>): v142ProfileData => {
+  const id = `some-id-${randomInt()}`;
+  const persona = randomInt() % 2 ? "STARTING" : "OWNING";
+  return {
+    ...generatev142IndustrySpecificData({}),
+    businessPersona: persona,
+    businessName: `some-business-name-${randomInt()}`,
+    industryId: "restaurant",
+    legalStructureId: "limited-liability-partnership",
+    dateOfFormation: undefined,
+    entityId: randomInt(10).toString(),
+    employerId: randomInt(9).toString(),
+    taxId: randomInt() % 2 ? randomInt(9).toString() : randomInt(12).toString(),
+    encryptedTaxId: `some-encrypted-value`,
+    notes: `some-notes-${randomInt()}`,
+    existingEmployees: randomInt(7).toString(),
+    naicsCode: randomInt(6).toString(),
+    isNonprofitOnboardingRadio: false,
+    nexusDbaName: "undefined",
+    needsNexusDbaName: true,
+    operatingPhase: "NEEDS_TO_FORM",
+    ownershipTypeIds: [],
+    documents: {
+      certifiedDoc: `${id}/certifiedDoc-${randomInt()}.pdf`,
+      formationDoc: `${id}/formationDoc-${randomInt()}.pdf`,
+      standingDoc: `${id}/standingDoc-${randomInt()}.pdf`,
+    },
+    taxPin: randomInt(4).toString(),
+    sectorId: undefined,
+    foreignBusinessTypeIds: [],
+    municipality: undefined,
+    responsibleOwnerName: `some-owner-name-${randomInt()}`,
+    tradeName: `some-trade-name-${randomInt()}`,
+    elevatorOwningBusiness: undefined,
+    nonEssentialRadioAnswers: {},
+    plannedRenovationQuestion: undefined,
+    communityAffairsAddress: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev142IndustrySpecificData = (
+  overrides: Partial<v142IndustrySpecificData>
+): v142IndustrySpecificData => {
+  return {
+    liquorLicense: false,
+    requiresCpa: false,
+    homeBasedBusiness: false,
+    cannabisLicenseType: undefined,
+    cannabisMicrobusiness: undefined,
+    constructionRenovationPlan: undefined,
+    providesStaffingService: false,
+    certifiedInteriorDesigner: false,
+    realEstateAppraisalManagement: false,
+    carService: undefined,
+    interstateTransport: false,
+    isChildcareForSixOrMore: undefined,
+    willSellPetCareItems: undefined,
+    petCareHousing: undefined,
+    interstateLogistics: undefined,
+    interstateMoving: undefined,
+    constructionType: undefined,
+    residentialConstructionType: undefined,
+    employmentPersonnelServiceType: undefined,
+    employmentPlacementType: undefined,
+    carnivalRideOwningBusiness: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev142Preferences = (overrides: Partial<v142Preferences>): v142Preferences => {
+  return {
+    roadmapOpenSections: ["PLAN", "START"],
+    roadmapOpenSteps: [],
+    hiddenCertificationIds: [],
+    hiddenFundingIds: [],
+    visibleSidebarCards: [],
+    returnToLink: "",
+    isCalendarFullView: true,
+    isHideableRoadmapOpen: false,
+    phaseNewlyChanged: false,
+    ...overrides,
+  };
+};
+
+export const generatev142FormationData = (
+  overrides: Partial<v142FormationData>,
+  legalStructureId: string
+): v142FormationData => {
+  return {
+    formationFormData: generatev142FormationFormData({}, legalStructureId),
+    formationResponse: undefined,
+    getFilingResponse: undefined,
+    completedFilingPayment: false,
+    businessNameAvailability: undefined,
+    lastVisitedPageIndex: 0,
+    dbaBusinessNameAvailability: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev142FormationFormData = (
+  overrides: Partial<v142FormationFormData>,
+  legalStructureId: string
+): v142FormationFormData => {
+  const isCorp = legalStructureId ? ["s-corporation", "c-corporation"].includes(legalStructureId) : false;
+
+  return <v142FormationFormData>{
+    businessName: `some-business-name-${randomInt()}`,
+    businessSuffix: "LLC",
+    businessTotalStock: isCorp ? randomInt().toString() : "",
+    businessStartDate: new Date(Date.now()).toISOString().split("T")[0],
+    businessPurpose: `some-purpose-${randomInt()}`,
+    addressLine1: `some-members-address-1-${randomInt()}`,
+    addressLine2: `some-members-address-2-${randomInt()}`,
+    addressCity: `some-members-address-city-${randomInt()}`,
+    addressState: { shortCode: "123", name: "new-jersey" },
+    addressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    addressCountry: `some-county`,
+    addressMunicipality: generatev142Municipality({}),
+    addressProvince: "",
+    withdrawals: `some-withdrawals-text-${randomInt()}`,
+    combinedInvestment: `some-combinedInvestment-text-${randomInt()}`,
+    dissolution: `some-dissolution-text-${randomInt()}`,
+    canCreateLimitedPartner: !!(randomInt() % 2),
+    createLimitedPartnerTerms: `some-createLimitedPartnerTerms-text-${randomInt()}`,
+    canGetDistribution: !!(randomInt() % 2),
+    getDistributionTerms: `some-getDistributionTerms-text-${randomInt()}`,
+    canMakeDistribution: !!(randomInt() % 2),
+    makeDistributionTerms: `make-getDistributionTerms-text-${randomInt()}`,
+    hasNonprofitBoardMembers: true,
+    nonprofitBoardMemberQualificationsSpecified: "IN_BYLAWS",
+    nonprofitBoardMemberQualificationsTerms: "",
+    nonprofitBoardMemberRightsSpecified: "IN_BYLAWS",
+    nonprofitBoardMemberRightsTerms: "",
+    nonprofitTrusteesMethodSpecified: "IN_BYLAWS",
+    nonprofitTrusteesMethodTerms: "",
+    nonprofitAssetDistributionSpecified: "IN_BYLAWS",
+    nonprofitAssetDistributionTerms: "",
+    provisions: [],
+    agentNumberOrManual: randomInt() % 2 ? "NUMBER" : "MANUAL_ENTRY",
+    agentNumber: `some-agent-number-${randomInt()}`,
+    agentName: `some-agent-name-${randomInt()}`,
+    agentEmail: `some-agent-email-${randomInt()}`,
+    agentOfficeAddressLine1: `some-agent-office-address-1-${randomInt()}`,
+    agentOfficeAddressLine2: `some-agent-office-address-2-${randomInt()}`,
+    agentOfficeAddressCity: `some-agent-office-address-city-${randomInt()}`,
+    agentOfficeAddressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    agentUseAccountInfo: !!(randomInt() % 2),
+    agentUseBusinessAddress: !!(randomInt() % 2),
+    signers: [],
+    members: legalStructureId === "limited-liability-partnership" ? [] : [generatev142FormationMember({})],
+    incorporators: undefined,
+    paymentType: randomInt() % 2 ? "ACH" : "CC",
+    annualReportNotification: !!(randomInt() % 2),
+    corpWatchNotification: !!(randomInt() % 2),
+    officialFormationDocument: !!(randomInt() % 2),
+    certificateOfStanding: !!(randomInt() % 2),
+    certifiedCopyOfFormationDocument: !!(randomInt() % 2),
+    contactFirstName: `some-contact-first-name-${randomInt()}`,
+    contactLastName: `some-contact-last-name-${randomInt()}`,
+    contactPhoneNumber: `some-contact-phone-number-${randomInt()}`,
+    foreignStateOfFormation: undefined,
+    foreignDateOfFormation: undefined,
+    foreignGoodStandingFile: undefined,
+    willPracticeLaw: false,
+    isVeteranNonprofit: false,
+    legalType: "",
+    additionalProvisions: undefined,
+    businessLocationType: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev142Municipality = (overrides: Partial<v142Municipality>): v142Municipality => {
+  return {
+    displayName: `some-display-name-${randomInt()}`,
+    name: `some-name-${randomInt()}`,
+    county: `some-county-${randomInt()}`,
+    id: `some-id-${randomInt()}`,
+    ...overrides,
+  };
+};
+
+export const generatev142FormationMember = (overrides: Partial<v142FormationMember>): v142FormationMember => {
+  return {
+    name: `some-name`,
+    addressLine1: `some-members-address-1-${randomInt()}`,
+    addressLine2: `some-members-address-2-${randomInt()}`,
+    addressCity: `some-members-address-city-${randomInt()}`,
+    addressState: { shortCode: "123", name: "new-jersey" },
+    addressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    addressCountry: `some-county`,
+    businessLocationType: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev142TaxFilingData = (overrides: Partial<v142TaxFilingData>): v142TaxFilingData => {
+  return {
+    state: undefined,
+    businessName: undefined,
+    errorField: undefined,
+    lastUpdatedISO: undefined,
+    registeredISO: undefined,
+    filings: [],
+    ...overrides,
+  };
+};

--- a/content/src/fieldConfig/config.json
+++ b/content/src/fieldConfig/config.json
@@ -13,7 +13,8 @@
   },
   "sectionHeaders": {
     "PLAN": "Plan",
-    "START": "Start"
+    "START": "Start",
+    "DOMESTIC_EMPLOYER_SECTION": "Register"
   },
   "taskProgressCard": {
     "optionalTasksSingular": "${numTasks} optional task",

--- a/content/src/fieldConfig/dashboard-defaults.json
+++ b/content/src/fieldConfig/dashboard-defaults.json
@@ -9,7 +9,8 @@
     "genericToProfileButtonText": "Business Profile"
   },
   "dashboardRoadmapHeaderDefaults": {
-    "RoadmapTasksHeaderText": "Business Tasks"
+    "RoadmapTasksHeaderText": "Business Tasks",
+    "DomesticEmployerRoadmapTasksHeaderText": "Tasks"
   },
   "dashboardAnytimeActionDefaults": {
     "defaultHeaderText": "Manage My Business",

--- a/content/src/roadmaps/steps.json
+++ b/content/src/roadmaps/steps.json
@@ -1,6 +1,13 @@
 {
   "steps": [
     {
+      "section": "DOMESTIC_EMPLOYER_SECTION",
+      "stepNumber": 1,
+      "name": "Register as an Employer",
+      "timeEstimate": "",
+      "description": ""
+    },
+    {
       "section": "PLAN",
       "stepNumber": 1,
       "name": "Plan Your ${OoS} Business",

--- a/shared/src/userData.ts
+++ b/shared/src/userData.ts
@@ -29,7 +29,7 @@ export interface Business {
   readonly formationData: FormationData;
 }
 
-export const CURRENT_VERSION = 141;
+export const CURRENT_VERSION = 142;
 
 export const createEmptyBusiness = (id?: string): Business => {
   return {
@@ -42,7 +42,7 @@ export const createEmptyBusiness = (id?: string): Business => {
     taskItemChecklist: {},
     licenseData: undefined,
     preferences: {
-      roadmapOpenSections: ["PLAN", "START"],
+      roadmapOpenSections: ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"],
       roadmapOpenSteps: [],
       hiddenCertificationIds: [],
       hiddenFundingIds: [],
@@ -86,7 +86,7 @@ export const createEmptyUserData = (user: BusinessUser): UserData => {
   };
 };
 
-export const sectionNames = ["PLAN", "START"] as const;
+export const sectionNames = ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"] as const;
 export type SectionType = (typeof sectionNames)[number];
 
 export type TaskProgress = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -1998,7 +1998,7 @@ collections:
               - label: Section
                 name: section
                 widget: select
-                options: ["PLAN", "START"]
+                options: ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"]
               - label: Time Estimate
                 name: timeEstimate
                 widget: string
@@ -2025,7 +2025,7 @@ collections:
               - label: Section
                 name: section
                 widget: select
-                options: ["PLAN", "START"]
+                options: ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"]
               - label: Time Estimate
                 name: timeEstimate
                 widget: string
@@ -3210,6 +3210,11 @@ collections:
             widget: object
             fields:
               - { label: Roadmap Tasks Header Text, name: RoadmapTasksHeaderText, widget: string }
+              - {
+                  label: Roadmap Tasks Header Text (Domestic Employer only),
+                  name: DomesticEmployerRoadmapTasksHeaderText,
+                  widget: string,
+                }
           - label: Dashboard Anytime Action Defaults
             name: dashboardAnytimeActionDefaults
             collapsed: false
@@ -4161,6 +4166,7 @@ collections:
             fields:
               - { label: Plan Label, name: PLAN, widget: string }
               - { label: Start Label, name: START, widget: string }
+              - { label: Domestic Employer Roadmap Section, name: DOMESTIC_EMPLOYER_SECTION, widget: string }
           - label: Self Registration
             name: selfRegistration
             collapsed: true

--- a/web/src/components/Step.tsx
+++ b/web/src/components/Step.tsx
@@ -38,7 +38,7 @@ export const Step = (props: Props): ReactElement => {
               >
                 <ModifiedContent>{props.step.name}</ModifiedContent>
               </span>
-              <span className="text-base">({props.step.timeEstimate})</span>
+              {props.step.timeEstimate && <span className="text-base">({props.step.timeEstimate})</span>}
             </div>
           </div>
         </div>

--- a/web/src/components/dashboard/DashboardOnDesktop.test.tsx
+++ b/web/src/components/dashboard/DashboardOnDesktop.test.tsx
@@ -63,6 +63,7 @@ const operatingPhasesThatDontDisplayHideableRoadmapTasks = OperatingPhases.filte
 }).map((obj) => obj.id);
 
 const operatingPhasesThatDisplayHideableRoadmapTasks = OperatingPhases.filter((obj) => {
+  if (obj.id === OperatingPhaseId.DOMESTIC_EMPLOYER) return false;
   return obj.displayHideableRoadmapTasks;
 }).map((obj) => obj.id);
 
@@ -253,8 +254,26 @@ describe("<DashboardOnDesktop />", () => {
       expect(
         screen.getByText(Config.dashboardRoadmapHeaderDefaults.RoadmapTasksHeaderText)
       ).toBeInTheDocument();
+      expect(
+        screen.queryByText(Config.dashboardRoadmapHeaderDefaults.DomesticEmployerRoadmapTasksHeaderText)
+      ).not.toBeInTheDocument();
     }
   );
+
+  it("renders HideableTasks for DOMESTIC_EMPLOYER OperatingPhase with alternate heading", () => {
+    useMockBusiness({
+      profileData: generateProfileData({ operatingPhase: OperatingPhaseId.DOMESTIC_EMPLOYER }),
+      onboardingFormProgress: "COMPLETED",
+    });
+    renderDashboardComponent({});
+
+    expect(
+      screen.queryByText(Config.dashboardRoadmapHeaderDefaults.RoadmapTasksHeaderText)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(Config.dashboardRoadmapHeaderDefaults.DomesticEmployerRoadmapTasksHeaderText)
+    ).toBeInTheDocument();
+  });
 
   describe("deferred onboarding question", () => {
     describe.each(operatingPhasesNotDisplayingHomeBasedPrompt)(

--- a/web/src/components/dashboard/DashboardOnDesktop.tsx
+++ b/web/src/components/dashboard/DashboardOnDesktop.tsx
@@ -6,9 +6,9 @@ import { ElevatorViolationsCard } from "@/components/dashboard/ElevatorViolation
 import { HideableTasks } from "@/components/dashboard/HideableTasks";
 import { Roadmap } from "@/components/dashboard/Roadmap";
 import { SidebarCardsContainer } from "@/components/dashboard/SidebarCardsContainer";
+import { getRoadmapHeadingText } from "@/components/dashboard/helpers";
 import { FilingsCalendar } from "@/components/filings-calendar/FilingsCalendar";
 import { Heading } from "@/components/njwds-extended/Heading";
-import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { isHomeBasedBusinessApplicable } from "@/lib/domain-logic/isHomeBasedBusinessApplicable";
 import { QUERIES, routeShallowWithQuery } from "@/lib/domain-logic/routes";
@@ -42,7 +42,6 @@ export const DashboardOnDesktop = (props: Props): ReactElement => {
   const { business } = useUserData();
   const router = useRouter();
   const operatingPhase = LookupOperatingPhaseById(business?.profileData.operatingPhase);
-  const { Config } = useConfig();
   const deferredHomeBasedOnSaveButtonClick = (): void =>
     routeShallowWithQuery(router, QUERIES.deferredQuestionAnswered, "true");
 
@@ -80,9 +79,7 @@ export const DashboardOnDesktop = (props: Props): ReactElement => {
                 {operatingPhase.displayRoadmapTasks && (
                   <>
                     <hr className="margin-bottom-3" />
-                    <Heading level={2}>
-                      {Config.dashboardRoadmapHeaderDefaults.RoadmapTasksHeaderText}
-                    </Heading>
+                    <Heading level={2}>{getRoadmapHeadingText(operatingPhase)}</Heading>
                     <Roadmap />
                   </>
                 )}

--- a/web/src/components/dashboard/DashboardOnMobile.test.tsx
+++ b/web/src/components/dashboard/DashboardOnMobile.test.tsx
@@ -76,6 +76,7 @@ const operatingPhasesThatDontDisplayHideableRoadmapTasks = OperatingPhases.filte
 }).map((obj) => obj.id);
 
 const operatingPhasesThatDisplayHideableRoadmapTasks = OperatingPhases.filter((obj) => {
+  if (obj.id === OperatingPhaseId.DOMESTIC_EMPLOYER) return false;
   return obj.displayHideableRoadmapTasks;
 }).map((obj) => obj.id);
 
@@ -266,8 +267,33 @@ describe("<DashboardOnMobile />", () => {
       expect(
         screen.getByText(Config.dashboardRoadmapHeaderDefaults.RoadmapTasksHeaderText)
       ).toBeInTheDocument();
+      expect(
+        screen.queryAllByRole("heading", {
+          level: 2,
+          name: Config.dashboardRoadmapHeaderDefaults.DomesticEmployerRoadmapTasksHeaderText,
+        }).length
+      ).toEqual(0);
     }
   );
+
+  it("renders HideableTasks for DOMESTIC_EMPLOYER OperatingPhase with alternate heading", () => {
+    useMockBusiness({
+      profileData: generateProfileData({ operatingPhase: OperatingPhaseId.DOMESTIC_EMPLOYER }),
+      onboardingFormProgress: "COMPLETED",
+    });
+    renderDashboardComponent({});
+
+    expect(
+      screen.queryByText(Config.dashboardRoadmapHeaderDefaults.RoadmapTasksHeaderText)
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: Config.dashboardRoadmapHeaderDefaults.DomesticEmployerRoadmapTasksHeaderText,
+      })
+    ).toBeInTheDocument();
+  });
 
   describe("deferred onboarding question", () => {
     describe.each(operatingPhasesNotDisplayingHomeBasedPrompt)(

--- a/web/src/components/dashboard/DashboardOnMobile.tsx
+++ b/web/src/components/dashboard/DashboardOnMobile.tsx
@@ -7,9 +7,9 @@ import { HideableTasks } from "@/components/dashboard/HideableTasks";
 import { Roadmap } from "@/components/dashboard/Roadmap";
 import { SidebarCardsContainer } from "@/components/dashboard/SidebarCardsContainer";
 import TwoTabDashboardLayout from "@/components/dashboard/TwoTabDashboardLayout";
+import { getRoadmapHeadingText } from "@/components/dashboard/helpers";
 import { FilingsCalendar } from "@/components/filings-calendar/FilingsCalendar";
 import { Heading } from "@/components/njwds-extended/Heading";
-import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { isHomeBasedBusinessApplicable } from "@/lib/domain-logic/isHomeBasedBusinessApplicable";
 import { QUERIES, routeShallowWithQuery } from "@/lib/domain-logic/routes";
@@ -43,7 +43,6 @@ export const DashboardOnMobile = (props: Props): ReactElement => {
   const { business } = useUserData();
   const router = useRouter();
   const operatingPhase = LookupOperatingPhaseById(business?.profileData.operatingPhase);
-  const { Config } = useConfig();
 
   const deferredHomeBasedOnSaveButtonClick = (): void =>
     routeShallowWithQuery(router, QUERIES.deferredQuestionAnswered, "true");
@@ -78,7 +77,7 @@ export const DashboardOnMobile = (props: Props): ReactElement => {
               {operatingPhase.displayRoadmapTasks && (
                 <>
                   <hr className="margin-bottom-3" />
-                  <Heading level={2}>{Config.dashboardRoadmapHeaderDefaults.RoadmapTasksHeaderText}</Heading>
+                  <Heading level={2}>{getRoadmapHeadingText(operatingPhase)}</Heading>
                   <Roadmap />
                 </>
               )}

--- a/web/src/components/dashboard/helpers.ts
+++ b/web/src/components/dashboard/helpers.ts
@@ -1,0 +1,14 @@
+import { getMergedConfig } from "@/contexts/configContext";
+import {
+  OperatingPhase,
+  OperatingPhaseId,
+  UnknownOperatingPhase,
+} from "@businessnjgovnavigator/shared/operatingPhase";
+
+const Config = getMergedConfig();
+
+export const getRoadmapHeadingText = (operatingPhase: OperatingPhase | UnknownOperatingPhase): string => {
+  return operatingPhase.id === OperatingPhaseId.DOMESTIC_EMPLOYER
+    ? Config.dashboardRoadmapHeaderDefaults.DomesticEmployerRoadmapTasksHeaderText
+    : Config.dashboardRoadmapHeaderDefaults.RoadmapTasksHeaderText;
+};

--- a/web/src/lib/data-hooks/useRoadmap.ts
+++ b/web/src/lib/data-hooks/useRoadmap.ts
@@ -3,6 +3,7 @@ import { useUserData } from "@/lib/data-hooks/useUserData";
 import { buildUserRoadmap } from "@/lib/roadmap/buildUserRoadmap";
 import { Roadmap, Task } from "@/lib/types/types";
 import { useMountEffectWhenDefined } from "@/lib/utils/helpers";
+import { OperatingPhaseId } from "@businessnjgovnavigator/shared/operatingPhase";
 import { SectionType, TaskProgress, sectionNames } from "@businessnjgovnavigator/shared/userData";
 import { useContext, useMemo } from "react";
 
@@ -19,17 +20,26 @@ export const useRoadmap = (): UseRoadmapReturnValue => {
   const { roadmap, setRoadmap } = useContext(RoadmapContext);
   const { business } = useUserData();
 
+  const isDomesticEmployer = business?.profileData.operatingPhase === OperatingPhaseId.DOMESTIC_EMPLOYER;
+
   const sectionNamesInRoadmap = useMemo(() => {
     if (!roadmap) {
       return [];
     }
     const { steps } = roadmap;
-    const sections: SectionType[] = [];
-    for (const step of steps) {
-      sections.push(step.section);
-    }
+    const sections: SectionType[] = steps
+      .filter((step) => {
+        if (step.section === "DOMESTIC_EMPLOYER_SECTION") {
+          return isDomesticEmployer;
+        }
+        if (step.section === "PLAN") {
+          return !isDomesticEmployer;
+        }
+        return true;
+      })
+      .map((step) => step.section);
     return [...new Set(sections)];
-  }, [roadmap]);
+  }, [roadmap, isDomesticEmployer]);
 
   const rebuildRoadmap = !roadmap || roadmap?.steps.length === 0 || roadmap?.tasks.length === 0;
 


### PR DESCRIPTION
## Description

SMEs reviewing the Domestic Employer industry experience requested some specific changes to the roadmap.
<img width="601" alt="Screenshot 2024-08-30 at 3 55 42 PM" src="https://github.com/user-attachments/assets/633090ee-2642-4112-b5eb-0bb1dfd6a39e">

### Ticket

This pull request resolves [#188193453](https://www.pivotaltracker.com/story/show/188193453).

### Approach

These changes largely use the "Domestic Employer" operating phase to determine what content to render. To handle the roadmap section copy changes I created a new section to be conditionally shown only for Domestic Employers.

### Steps to Test

Create a business of industry "Domestic Employer". After completing onboarding all of the changes should be immediately visible on the roadmap.

Be sure to test both desktop and mobile, as well as the mini-roadmap.

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
