### PR TITLE
Domestic-employer updates and starter kits page fix

### DIFF
--- a/content/src/roadmaps/steps-domestic-employer.json
+++ b/content/src/roadmaps/steps-domestic-employer.json
@@ -1,0 +1,11 @@
+{
+  "steps": [
+    {
+      "section": "DOMESTIC_EMPLOYER_SECTION",
+      "stepNumber": 1,
+      "name": "Register as an Employer",
+      "timeEstimate": "",
+      "description": ""
+    }
+  ]
+}

--- a/content/src/roadmaps/steps.json
+++ b/content/src/roadmaps/steps.json
@@ -1,13 +1,6 @@
 {
   "steps": [
     {
-      "section": "DOMESTIC_EMPLOYER_SECTION",
-      "stepNumber": 1,
-      "name": "Register as an Employer",
-      "timeEstimate": "",
-      "description": ""
-    },
-    {
       "section": "PLAN",
       "stepNumber": 1,
       "name": "Plan Your ${OoS} Business",

--- a/web/.dependency-cruiser.js
+++ b/web/.dependency-cruiser.js
@@ -40,6 +40,10 @@ module.exports = {
     },
     {
       from: {},
+      to: { path: "@businessnjgovnavigator/content/roadmaps/steps-domestic-employer.json" },
+    },
+    {
+      from: {},
       to: { path: "@businessnjgovnavigator/content/roadmaps/task-dependencies.json" },
     },
     {

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -1998,7 +1998,34 @@ collections:
               - label: Section
                 name: section
                 widget: select
-                options: ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"]
+                options: ["PLAN", "START"]
+              - label: Time Estimate
+                name: timeEstimate
+                widget: string
+              - label: Description
+                name: description
+                widget: string
+              - label: Number
+                name: stepNumber
+                widget: number
+                min: 0
+                value_type: int
+      - label: "Steps - Domestic Employer"
+        name: "steps-domestic-employer"
+        file: "content/src/roadmaps/steps-domestic-employer.json"
+        fields:
+          - label: steps
+            name: steps
+            widget: list
+            summary: "{{name}}"
+            fields:
+              - label: Name
+                name: name
+                widget: string
+              - label: Section
+                name: section
+                widget: select
+                options: ["DOMESTIC_EMPLOYER_SECTION"]
               - label: Time Estimate
                 name: timeEstimate
                 widget: string
@@ -2025,7 +2052,7 @@ collections:
               - label: Section
                 name: section
                 widget: select
-                options: ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"]
+                options: ["PLAN", "START"]
               - label: Time Estimate
                 name: timeEstimate
                 widget: string

--- a/web/src/components/starter-kits/StepInfo.tsx
+++ b/web/src/components/starter-kits/StepInfo.tsx
@@ -14,7 +14,7 @@ export const StepInfo = (props: { step: Step; taskNames: string[] }): ReactEleme
         {props.step.name.replace("${OoS}", "")}
       </Heading>
       <p>{props.step.description}</p>
-      <strong className="text-base-dark">{`(${props.step.timeEstimate})`}</strong>
+      <strong className="text-base-dark">{props.step.timeEstimate && `(${props.step.timeEstimate})`}</strong>
       <ul className="padding-left-205">
         {props.taskNames.map((taskName) => (
           <li key={taskName}>{taskName}</li>

--- a/web/src/lib/data-hooks/useRoadmap.test.tsx
+++ b/web/src/lib/data-hooks/useRoadmap.test.tsx
@@ -4,12 +4,7 @@ import { Roadmap } from "@/lib/types/types";
 import { generateRoadmap, generateStep, generateTask } from "@/test/factories";
 import { withRoadmap } from "@/test/helpers/helpers-renderers";
 import { useMockBusiness } from "@/test/mock/mockUseUserData";
-import {
-  generateProfileData,
-  getIndustries,
-  OperatingPhases,
-  randomElementFromArray,
-} from "@businessnjgovnavigator/shared";
+import { generateProfileData } from "@businessnjgovnavigator/shared";
 import { SectionType, TaskProgress } from "@businessnjgovnavigator/shared/userData";
 import { render } from "@testing-library/react";
 
@@ -77,83 +72,6 @@ describe("useRoadmap", () => {
     mockBuildUserRoadmap.mockResolvedValue(generateRoadmap({}));
     setupHook();
     expect(mockBuildUserRoadmap).not.toHaveBeenCalled();
-  });
-
-  it("removes 'PLAN' section when business is a Domestic Employer", () => {
-    const roadmap = generateRoadmap({
-      steps: [
-        generateStep({ section: "PLAN", stepNumber: 1 }),
-        generateStep({ section: "PLAN", stepNumber: 2 }),
-        generateStep({ section: "DOMESTIC_EMPLOYER_SECTION", stepNumber: 1 }),
-        generateStep({ section: "DOMESTIC_EMPLOYER_SECTION", stepNumber: 2 }),
-      ],
-      tasks: [
-        generateTask({ stepNumber: 1, id: "task1" }),
-        generateTask({ stepNumber: 1, id: "task2" }),
-        generateTask({ stepNumber: 2, id: "task3" }),
-        generateTask({ stepNumber: 3, id: "task4" }),
-      ],
-    });
-
-    const profileData = generateProfileData({ industryId: "domestic-employer" });
-    useMockBusiness({ profileData, onboardingFormProgress: "COMPLETED" });
-    mockBuildUserRoadmap.mockResolvedValue(generateRoadmap({}));
-    const { sectionNamesInRoadmap } = setupHook(roadmap);
-    expect(sectionNamesInRoadmap).toContain("DOMESTIC_EMPLOYER_SECTION");
-    expect(sectionNamesInRoadmap).not.toContain("PLAN");
-  });
-
-  it("removes 'PLAN' section when business is a Domestic Employer in Guest Mode", () => {
-    const roadmap = generateRoadmap({
-      steps: [
-        generateStep({ section: "PLAN", stepNumber: 1 }),
-        generateStep({ section: "PLAN", stepNumber: 2 }),
-        generateStep({ section: "DOMESTIC_EMPLOYER_SECTION", stepNumber: 1 }),
-        generateStep({ section: "DOMESTIC_EMPLOYER_SECTION", stepNumber: 2 }),
-      ],
-      tasks: [
-        generateTask({ stepNumber: 1, id: "task1" }),
-        generateTask({ stepNumber: 1, id: "task2" }),
-        generateTask({ stepNumber: 2, id: "task3" }),
-        generateTask({ stepNumber: 3, id: "task4" }),
-      ],
-    });
-
-    const guestModePhases = OperatingPhases.filter((operatingPhase) => operatingPhase.id.includes("GUEST"));
-    const profileData = generateProfileData({
-      industryId: "domestic-employer",
-      operatingPhase: randomElementFromArray(guestModePhases).id,
-    });
-    useMockBusiness({ profileData, onboardingFormProgress: "COMPLETED" });
-    mockBuildUserRoadmap.mockResolvedValue(generateRoadmap({}));
-    const { sectionNamesInRoadmap } = setupHook(roadmap);
-    expect(sectionNamesInRoadmap).toContain("DOMESTIC_EMPLOYER_SECTION");
-    expect(sectionNamesInRoadmap).not.toContain("PLAN");
-  });
-
-  it("removes 'DOMESTIC_EMPLOYER_SECTION' section when business is not a Domestic Employer", () => {
-    const roadmap = generateRoadmap({
-      steps: [
-        generateStep({ section: "PLAN", stepNumber: 1 }),
-        generateStep({ section: "PLAN", stepNumber: 2 }),
-        generateStep({ section: "DOMESTIC_EMPLOYER_SECTION", stepNumber: 1 }),
-        generateStep({ section: "DOMESTIC_EMPLOYER_SECTION", stepNumber: 2 }),
-      ],
-      tasks: [
-        generateTask({ stepNumber: 1, id: "task1" }),
-        generateTask({ stepNumber: 1, id: "task2" }),
-        generateTask({ stepNumber: 2, id: "task3" }),
-        generateTask({ stepNumber: 3, id: "task4" }),
-      ],
-    });
-
-    const filteredIndustries = getIndustries().filter((industry) => industry.id !== "domestic-employer");
-    const profileData = generateProfileData({ industryId: randomElementFromArray(filteredIndustries).id });
-    useMockBusiness({ profileData, onboardingFormProgress: "COMPLETED" });
-    mockBuildUserRoadmap.mockResolvedValue(generateRoadmap({}));
-    const { sectionNamesInRoadmap } = setupHook(roadmap);
-    expect(sectionNamesInRoadmap).not.toContain("DOMESTIC_EMPLOYER_SECTION");
-    expect(sectionNamesInRoadmap).toContain("PLAN");
   });
 
   describe("isSectionCompleted", () => {

--- a/web/src/lib/data-hooks/useRoadmap.ts
+++ b/web/src/lib/data-hooks/useRoadmap.ts
@@ -19,26 +19,15 @@ export const useRoadmap = (): UseRoadmapReturnValue => {
   const { roadmap, setRoadmap } = useContext(RoadmapContext);
   const { business } = useUserData();
 
-  const isDomesticEmployer = business?.profileData.industryId === "domestic-employer";
-
   const sectionNamesInRoadmap = useMemo(() => {
     if (!roadmap) {
       return [];
     }
     const { steps } = roadmap;
-    const sections: SectionType[] = steps
-      .filter((step) => {
-        if (step.section === "DOMESTIC_EMPLOYER_SECTION") {
-          return isDomesticEmployer;
-        }
-        if (step.section === "PLAN") {
-          return !isDomesticEmployer;
-        }
-        return true;
-      })
-      .map((step) => step.section);
+    const sections: SectionType[] = steps.map((step) => step.section);
+
     return [...new Set(sections)];
-  }, [roadmap, isDomesticEmployer]);
+  }, [roadmap]);
 
   const rebuildRoadmap = !roadmap || roadmap?.steps.length === 0 || roadmap?.tasks.length === 0;
 

--- a/web/src/lib/roadmap/fixtures/industries/domestic-employer.json
+++ b/web/src/lib/roadmap/fixtures/industries/domestic-employer.json
@@ -1,0 +1,21 @@
+{
+  "displayname": "domestic-employer",
+  "roadmapSteps": [
+    {
+      "step": 1,
+      "weight": 1,
+      "task": "generic-task-1"
+    },
+    {
+      "step": 1,
+      "weight": 2,
+      "task": "generic-task-2"
+    },
+    {
+      "step": 1,
+      "weight": 3,
+      "task": "generic-task-3"
+    }
+  ],
+  "modifications": []
+}

--- a/web/src/lib/roadmap/fixtures/steps-domestic-employer.json
+++ b/web/src/lib/roadmap/fixtures/steps-domestic-employer.json
@@ -1,0 +1,11 @@
+{
+  "steps": [
+    {
+      "section": "DOMESTIC_EMPLOYER_SECTION",
+      "stepNumber": 1,
+      "name": "Register as an Employer",
+      "timeEstimate": "",
+      "description": ""
+    }
+  ]
+}

--- a/web/src/lib/roadmap/roadmapBuilder.test.ts
+++ b/web/src/lib/roadmap/roadmapBuilder.test.ts
@@ -12,6 +12,15 @@ describe("roadmapBuilder", () => {
     expect(roadmap.steps[0].name).toEqual("Foreign Step 1 Name");
   });
 
+  it("uses domestic employer steps when industry is domestic-employer", async () => {
+    const roadmap = await buildRoadmap({
+      industryId: "domestic-employer",
+      addOns: [],
+    });
+
+    expect(roadmap.steps[0].name).toEqual("Register as an Employer");
+  });
+
   it("does not break with empty roadmap", async () => {
     const roadmap = await buildRoadmap({
       industryId: undefined,

--- a/web/src/lib/roadmap/roadmapBuilder.ts
+++ b/web/src/lib/roadmap/roadmapBuilder.ts
@@ -9,7 +9,13 @@ export const buildRoadmap = async ({
   industryId: string | undefined;
   addOns: string[];
 }): Promise<Roadmap> => {
-  const stepImporter: () => Promise<GenericStep[]> = industryId ? importGenericSteps : importForeignSteps;
+  let stepImporter: () => Promise<GenericStep[]>;
+
+  if (industryId) {
+    stepImporter = industryId === "domestic-employer" ? importDomesticEmployerSteps : importGenericSteps;
+  } else {
+    stepImporter = importForeignSteps;
+  }
 
   const results = await stepImporter();
 
@@ -61,6 +67,16 @@ const importRoadmap = async (industryId: string): Promise<IndustryRoadmap> => {
   }
   const industries = await import(`@businessnjgovnavigator/content/roadmaps/industries/${industryId}.json`);
   return industries.default as IndustryRoadmap;
+};
+
+const importDomesticEmployerSteps = async (): Promise<GenericStep[]> => {
+  if (process.env.NODE_ENV === "test") {
+    const steps = await import(`@/lib/roadmap/fixtures/steps-domestic-employer.json`);
+    return steps.steps as GenericStep[];
+  }
+
+  const steps = await import(`@businessnjgovnavigator/content/roadmaps/steps-domestic-employer.json`);
+  return steps.steps as GenericStep[];
 };
 
 const importGenericSteps = async (): Promise<GenericStep[]> => {

--- a/web/src/pages/mgmt/search.tsx
+++ b/web/src/pages/mgmt/search.tsx
@@ -54,6 +54,7 @@ import {
   WebflowLicense,
 } from "@/lib/types/types";
 import NonEssentialQuestions from "@businessnjgovnavigator/content/roadmaps/nonEssentialQuestions.json";
+import DomesticEmployerSteps from "@businessnjgovnavigator/content/roadmaps/steps-domestic-employer.json";
 import ForeignSteps from "@businessnjgovnavigator/content/roadmaps/steps-foreign.json";
 import Steps from "@businessnjgovnavigator/content/roadmaps/steps.json";
 import { getIndustries } from "@businessnjgovnavigator/shared/industry";
@@ -146,10 +147,13 @@ const SearchContentPage = (props: Props): ReactElement => {
     );
 
     const defaultStepsMatches = searchSteps(Steps.steps as Step[], lowercaseTerm, { filename: "Steps" });
+    const domesticEmployerStepsMatches = searchSteps(DomesticEmployerSteps.steps as Step[], lowercaseTerm, {
+      filename: "Steps - Domestic Employer",
+    });
     const foreignStepsMatches = searchSteps(ForeignSteps.steps as Step[], lowercaseTerm, {
       filename: "Steps - Dakota",
     });
-    setStepsMatches([...defaultStepsMatches, ...foreignStepsMatches]);
+    setStepsMatches([...defaultStepsMatches, ...domesticEmployerStepsMatches, ...foreignStepsMatches]);
 
     setNonEssentialQuestionsMatches(
       searchNonEssentialQuestions(


### PR DESCRIPTION
## Description

Resolves an issue with number of roadmap steps being rendered on industry starter kits pages.

### Ticket

This pull request resolves [#188247287](https://www.pivotaltracker.com/story/show/188247287).

### Approach

In #8534 I introduced a new roadmap section for the Domestic Employer industry. Initially I was filtering steps in the `useRoadmap` hook. This work creates a new `steps-domestic-employer.json` file that represents the roadmap sections only to be used for the Domestic Employer industry.

The previous approach caused an issue on the industry starter kits pages where an incorrect number of steps were being rendered for all industries.

**Before:**
![Screenshot 2024-09-13 at 4 34 58 PM](https://github.com/user-attachments/assets/f71fafb7-c515-4c11-bb2f-c86f0356623f)

**After:**
![Screenshot 2024-09-13 at 4 34 30 PM](https://github.com/user-attachments/assets/658a6332-2937-41c9-b287-de45fe7b953a)


### Steps to Test

**Validating Starter Kits**
- Go to any given industry starter kit
- Scroll to the bottom of the page
- Validate that the correct number of steps/sections/roadmap items appear
  - Most importantly, validate that the "Domestic Employer" Step 1 is not prepended

- Go to the domestic employer starter kit
- Confirm only the "Domestic Employer" Step 1 is visible

**Domestic Employer Experience**
See #8534 and #8564 for a more comprehensive set of instructions

### Notes

When I put up #8564 I literally said I should have followed this approach... guess I'm paying for it now.

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
