### PR TITLE
chore: [#188283471] fix filters out licenses unrelated to user indust…

### DIFF
--- a/web/src/components/dashboard/AnytimeActionDropdown.test.tsx
+++ b/web/src/components/dashboard/AnytimeActionDropdown.test.tsx
@@ -221,12 +221,13 @@ describe("<AnytimeActionDropdown />", () => {
     });
 
     it("filters out licenses unrelated to user industry", () => {
-      const licenseName = randomElementFromArray(Object.values(taskIdLicenseNameMapping));
+      const validLicenseName = Object.values(taskIdLicenseNameMapping)[0];
+      const invalidLicenseName = Object.values(taskIdLicenseNameMapping)[1];
 
       useMockBusiness({
         licenseData: generateLicenseData({
           licenses: {
-            [licenseName]: generateLicenseDetails({
+            [validLicenseName]: generateLicenseDetails({
               licenseStatus: "EXPIRED",
             }),
           },
@@ -235,12 +236,13 @@ describe("<AnytimeActionDropdown />", () => {
 
       anytimeActionLicense = [
         generateAnytimeActionLicenseReinstatement({
-          licenseName,
+          licenseName: validLicenseName,
           name: "hvac-contractor-reinstatement",
           urlSlug: "some-url",
           filename: "some-filename-license",
         }),
         generateAnytimeActionLicenseReinstatement({
+          licenseName: invalidLicenseName,
           name: "cannabis-license-reinstatement",
           urlSlug: "some-url",
           filename: "some-filename-license-zzz",


### PR DESCRIPTION
…ry flakey test

<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

https://www.pivotaltracker.com/story/show/188283471

### Approach
The licenseName field must be selected from a list `Object.values(taskIdLicenseNameMapping)`. The `generateAnytimeActionLicenseReinstatement` function randomly selects a value for the licenseName field. A flakey test can occur when both generate functions randomly select the same value. I added logic to prevent this.

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
