### PR TITLE
feat: [#188283234] Enable contextual info in non essential questions

### DIFF
--- a/content/src/roadmaps/nonEssentialQuestions.json
+++ b/content/src/roadmaps/nonEssentialQuestions.json
@@ -47,7 +47,7 @@
     },
     {
       "id": "freestanding-residential-health-care-license",
-      "questionText": "Do you plan to own and/or operate a free-standing residential health care facility?",
+      "questionText": "Do you plan to own and/or operate a `free-standing residential health care facility?|residential-health-care-facility`",
       "addOn": "healthcare-freestanding-facility-license"
     },
     {

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -1988,7 +1988,7 @@ collections:
                 widget: string
               - label: Question
                 name: questionText
-                widget: string
+                widget: markdown
               - label: Add On
                 name: addOn
                 widget: "relation"

--- a/web/src/components/data-fields/non-essential-questions/NonEssentialQuestion.tsx
+++ b/web/src/components/data-fields/non-essential-questions/NonEssentialQuestion.tsx
@@ -1,3 +1,4 @@
+import { Content } from "@/components/Content";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { getNonEssentialQuestionText } from "@/lib/domain-logic/getNonEssentialQuestionText";
@@ -28,7 +29,9 @@ export const NonEssentialQuestion = (props: Props): ReactElement => {
       {nonEssentialQuestionText && (
         <>
           <div className={"margin-top-2"}>
-            <span className={"text-bold"}>{nonEssentialQuestionText}</span>
+            <div className={"text-bold"}>
+              <Content>{nonEssentialQuestionText}</Content>
+            </div>
             <span className={"margin-left-05"}>
               {Config.profileDefaults.fields.nonEssentialQuestions.default.optionalText}
             </span>


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
Enables embedding contextual links within non-essential questions

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188283234](https://www.pivotaltracker.com/story/show/188283234).

### Approach
Converts non-essential question to Content.

This format `text|contextual-info-text` will be displayed in the CMS as a string, not as a contextual text. Right now this only affects a single NEQ but we might need a follow-up ticket so it properly displays in the CMS

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

1. Create new Poppy in health care industry
2. Go to profile to see non-essential question

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
