### PR TITLE
feat: [#186316380] correct refocus behavior for formation stepper and errors

### DIFF
--- a/content/src/fieldConfig/business-formation.json
+++ b/content/src/fieldConfig/business-formation.json
@@ -11,6 +11,8 @@
     "general": {
       "helpButtonText": "Help",
       "paymentDisclaimer": "You will be brought to a secure payment platform operated by New Jersey's partner NICUSA Inc. to process your payment.",
+      "ariaContextStepperStateError": "Error",
+      "ariaContextStepperStateIncomplete": "Incomplete",
       "notEntered": "Not Entered",
       "ariaContextWillNeedToProvideBusinessDate": "Provide your business effective date to update the task status",
       "backButtonText": "Cancel",
@@ -18,6 +20,7 @@
       "editButtonText": "Edit",
       "radioNoText": "No",
       "charactersLabel": "characters",
+      "ariaContextStepperLabels": "Formation Stepper Navigation: ${stepName} Step, State: ${stepState}",
       "ariaContextWillLooseCalendarAndCertificationAccess": "You need to confirm your information to update your task status",
       "maximumLengthErrorText": "${field} must be ${maxLen} characters or fewer.",
       "nextButtonText": "Save & Continue",
@@ -28,6 +31,7 @@
       "radioYesText": "Yes",
       "viewMoreButtonText": "Read more",
       "amendmentInfo": "#### Review your information before submitting to the New Jersey Division of Revenue and Enterprise Services.\n If you need to make a change after submitting, you must file an [amendment online.](https://www.njportal.com/dor/businessamendments)",
+      "ariaContextStepperStateComplete": "Complete",
       "viewLessButtonText": "Read less",
       "genericErrorText": "This field requires information."
     },
@@ -247,10 +251,6 @@
         "label": "Registered Agent ID Number",
         "error": "Enter the 4 to 7 digit Registered Agent ID number."
       },
-      "agentOfficeAddressCity": {
-        "label": "Office City",
-        "error": "Enter the agent's city."
-      },
       "corpWatchNotification": {
         "checkboxText": "I want to sign up for CorpWatch Alerts to notify me when any charter document filing is performed for my business."
       },
@@ -438,6 +438,10 @@
       "withdrawals": {
         "label": "Withdrawals",
         "body": "If a general partner withdraws from the partnership, what are the remaining partners rights to contribute to the business? "
+      },
+      "agentOfficeAddressCity": {
+        "label": "Office City",
+        "error": "Enter the agent's city."
       },
       "addressCity": {
         "label": "City",

--- a/web/cypress/support/page_objects/businessFormationPage.ts
+++ b/web/cypress/support/page_objects/businessFormationPage.ts
@@ -172,7 +172,7 @@ class BusinessFormationPage {
     this.getSigner(number).clear().type(name).blur();
   }
   typeContactFirstName(name: string) {
-    this.getContactFirstName().clear().type(name).blur();
+    this.getContactFirstName().focus().clear().type(name).blur();
   }
   typeContactLastName(name: string) {
     this.getContactLastName().clear().type(name).blur();

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -1013,6 +1013,26 @@ collections:
                       name: "ariaContextWillLooseCalendarAndCertificationAccess",
                       widget: "string",
                     }
+                  - {
+                      label: "Aria Context - Stepper Labels",
+                      name: "ariaContextStepperLabels",
+                      widget: "string",
+                    }
+                  - {
+                      label: "Aria Context - Stepper State - Complete",
+                      name: "ariaContextStepperStateComplete",
+                      widget: "string",
+                    }
+                  - {
+                      label: "Aria Context - Stepper State - Error",
+                      name: "ariaContextStepperStateError",
+                      widget: "string",
+                    }
+                  - {
+                      label: "Aria Context - Stepper State - Incomplete",
+                      name: "ariaContextStepperStateIncomplete",
+                      widget: "string",
+                    }
               - label: Nonprofit Provisions
                 name: nonprofitProvisions
                 collapsed: true

--- a/web/src/components/dashboard/AnytimeActionDropdown.tsx
+++ b/web/src/components/dashboard/AnytimeActionDropdown.tsx
@@ -100,9 +100,7 @@ export const AnytimeActionDropdown = (props: Props): ReactElement => {
         {Config.dashboardAnytimeActionDefaults.defaultHeaderText}
       </Heading>
       <HorizontalLine ariaHidden={true} />
-      <span className={"text-bold"}>
-        {Config.dashboardAnytimeActionDefaults.defaultAutocompleteHeaderText}
-      </span>
+      <div className="text-bold">{Config.dashboardAnytimeActionDefaults.defaultAutocompleteHeaderText}</div>
       <span className={isDesktopAndUp ? "flex" : "flex-column"}>
         <Autocomplete
           renderInput={(params): ReactElement => {

--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
@@ -52,6 +52,7 @@ import {
 import { Business } from "@businessnjgovnavigator/shared/userData";
 import * as materialUi from "@mui/material";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 interface MockApiErrorTestData {
   formationFormData: FormationFormData;
@@ -216,11 +217,17 @@ describe("<BusinessFormationPaginator />", () => {
 
     it("switches steps when clicking the stepper", async () => {
       const page = preparePage({ business, displayContent });
-      await page.stepperClickToContactsStep();
-      await page.stepperClickToBusinessStep();
-      await page.stepperClickToReviewStep();
-      await page.stepperClickToBusinessNameStep();
-      await page.stepperClickToBillingStep();
+      await page.stepperClickToContactsStep({ useUserEvent: true });
+      expect(screen.getByTestId("stepper-2")).toHaveFocus();
+      await page.stepperClickToBusinessStep({ useUserEvent: true });
+      expect(screen.getByTestId("stepper-1")).toHaveFocus();
+      await page.stepperClickToReviewStep({ useUserEvent: true });
+
+      expect(screen.getByTestId("stepper-4")).toHaveFocus();
+      await page.stepperClickToBusinessNameStep({ useUserEvent: true });
+      expect(screen.getByTestId("stepper-0")).toHaveFocus();
+      await page.stepperClickToBillingStep({ useUserEvent: true });
+      expect(screen.getByTestId("stepper-3")).toHaveFocus();
       expect(screen.getByTestId("billing-step")).toBeInTheDocument();
     });
 
@@ -2025,7 +2032,6 @@ describe("<BusinessFormationPaginator />", () => {
           expect(screen.getByText("very bad input")).toBeInTheDocument();
           expect(screen.getByText("some field 2")).toBeInTheDocument();
           expect(screen.getByText("must be nj zipcode")).toBeInTheDocument();
-
           await page.stepperClickToBillingStep();
 
           expect(screen.getByText("some field 1")).toBeInTheDocument();
@@ -2278,6 +2284,70 @@ describe("<BusinessFormationPaginator />", () => {
       business = generateBusiness({ profileData, formationData });
       preparePage({ business, displayContent });
       expect(screen.getByTestId("business-name-step")).toBeInTheDocument();
+    });
+  });
+
+  describe("Accessibility Related", () => {
+    it("Moves focus when using arrow keys in Stepper", async () => {
+      const page = preparePage({ business, displayContent });
+      await page.stepperClickToContactsStep({ useUserEvent: true });
+      expect(screen.getByTestId("stepper-2")).toHaveFocus();
+      await userEvent.keyboard("{ArrowRight}");
+      expect(screen.getByTestId("stepper-3")).toHaveFocus();
+    });
+
+    it("Selects a step on keyboard enter press", async () => {
+      const page = preparePage({ business, displayContent });
+      await page.stepperClickToContactsStep({ useUserEvent: true });
+      expect(screen.getByTestId("stepper-2")).toHaveFocus();
+      await userEvent.keyboard("{ArrowRight}");
+      expect(screen.getByTestId("stepper-3")).toHaveFocus();
+      await userEvent.keyboard("{Enter}");
+      expect(screen.getByTestId("billing-step")).toBeInTheDocument();
+    });
+
+    it("has correctly composed aria labels", () => {
+      preparePage({ business, displayContent });
+      expect(screen.getByTestId(`stepper-${LookupStepIndexByName("Name")}`)).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining("Name")
+      );
+      expect(screen.getByTestId(`stepper-${LookupStepIndexByName("Name")}`)).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining(Config.formation.general.ariaContextStepperStateIncomplete)
+      );
+      expect(screen.getByTestId(`stepper-${LookupStepIndexByName("Business")}`)).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining("Business")
+      );
+      expect(screen.getByTestId(`stepper-${LookupStepIndexByName("Business")}`)).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining(Config.formation.general.ariaContextStepperStateIncomplete)
+      );
+      expect(screen.getByTestId(`stepper-${LookupStepIndexByName("Contacts")}`)).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining("Contacts")
+      );
+      expect(screen.getByTestId(`stepper-${LookupStepIndexByName("Contacts")}`)).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining(Config.formation.general.ariaContextStepperStateIncomplete)
+      );
+      expect(screen.getByTestId(`stepper-${LookupStepIndexByName("Billing")}`)).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining("Billing")
+      );
+      expect(screen.getByTestId(`stepper-${LookupStepIndexByName("Billing")}`)).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining(Config.formation.general.ariaContextStepperStateIncomplete)
+      );
+      expect(screen.getByTestId(`stepper-${LookupStepIndexByName("Review")}`)).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining("Review")
+      );
+      expect(screen.getByTestId(`stepper-${LookupStepIndexByName("Review")}`)).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining(Config.formation.general.ariaContextStepperStateIncomplete)
+      );
     });
   });
 });

--- a/web/src/lib/utils/helpers.ts
+++ b/web/src/lib/utils/helpers.ts
@@ -132,23 +132,46 @@ const getNavBarHeight = (): number | undefined => {
 
 export const scrollToTopOfElement = (
   element: HTMLDivElement | null,
-  { waitTime = 100 }: { waitTime?: number }
+  { waitTime = 100, focusElement = false }: { waitTime?: number; focusElement?: boolean }
 ): void => {
+  if (element === null) {
+    return;
+  }
   let y = 0;
 
   if (element) {
     y = window.scrollY + element.getBoundingClientRect().top;
     const navBarHeight = getNavBarHeight();
     if (navBarHeight) {
-      y -= navBarHeight;
+      y -= navBarHeight + 5;
     } else {
       return;
     }
   }
 
   setTimeout(() => {
-    return window.scrollTo({ top: y, behavior: "smooth" });
+    window.scrollTo({ top: y, behavior: "smooth" });
   }, waitTime);
+
+  if (focusElement) {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting && entry.intersectionRatio === 1) {
+            setTimeout(() => {
+              element.focus();
+            }, waitTime);
+            observer.disconnect();
+          }
+        }
+      },
+      {
+        threshold: 1,
+      }
+    );
+
+    observer.observe(element);
+  }
 };
 
 interface AlertProps {

--- a/web/src/styles/base/global.scss
+++ b/web/src/styles/base/global.scss
@@ -30,6 +30,7 @@ ol {
 }
 
 .visually-hidden-centered {
+  // This is a terrrrrrrrible idea for screen reader purposes
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
   height: 1px;
@@ -82,6 +83,12 @@ ol {
 
 .display-only-desktop {
   @media screen and (max-width: $lg) {
+    display: none;
+  }
+}
+
+.display-only-mobile-and-tablet {
+  @media screen and (min-width: $sm) {
     display: none;
   }
 }

--- a/web/src/styles/components/stepper.scss
+++ b/web/src/styles/components/stepper.scss
@@ -78,6 +78,11 @@
     @media (min-width: 40em) {
       padding-bottom: 1rem;
     }
+    @media all and (max-width: $sm) {
+      padding-top: 1rem;
+      margin-top: 0;
+      padding-bottom: 2.5rem;
+    }
   }
 
   /* ----- SEGMENT STYLING (horizontal line connecting steps) ----- */
@@ -86,7 +91,10 @@
     height: 2px !important;
     left: 50%;
     right: -50%;
-    top: 0.125rem;
+    top: 1.7rem;
+    @media all and (max-width: $sm) {
+      top: 1.5rem;
+    }
   }
 
   .usa-step-indicator__segment:after,
@@ -108,7 +116,10 @@
   .usa-step-indicator__segment-label {
     color: $base;
     text-align: center;
-    padding: 0;
+    padding: 1.5rem 0 0 0;
+    @media all and (max-width: $sm) {
+      padding: 0 0 0 0;
+    }
   }
 
   .usa-step-indicator__segment--current .usa-step-indicator__segment-label {
@@ -132,7 +143,7 @@
     width: 1.5rem;
     font-size: 0.88rem;
     padding: calc(0.25rem + 1px);
-    top: calc((1.5rem - 0.5rem) / -2);
+    top: 1rem;
     font-feature-settings: "tnum" 1, "kern" 1;
     background-color: #fff;
     box-shadow: inset 0 0 0 0.25rem #e6e6e6, 0 0 0 0.25rem #fff;
@@ -146,6 +157,10 @@
     z-index: 100;
     margin-left: 1px;
     margin-right: 1px;
+
+    @media all and (max-width: $sm) {
+      top: 0.75;
+    }
   }
 
   .usa-step-indicator__segment::before {
@@ -205,4 +220,11 @@
 .checked-task {
   min-width: 1.125rem;
   min-height: 1.125rem;
+}
+
+.stepper-wrapper {
+  margin-bottom: 0;
+  @media screen and (min-width: $sm) {
+    margin-bottom: 2rem;
+  }
 }

--- a/web/test/helpers/helpers-formation.tsx
+++ b/web/test/helpers/helpers-formation.tsx
@@ -44,6 +44,7 @@ import {
 } from "@businessnjgovnavigator/shared/test";
 import { createTheme, ThemeProvider, useMediaQuery } from "@mui/material";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 const Config = getMergedConfig();
 
@@ -167,6 +168,10 @@ export const setDesktopScreen = (value: boolean): void => {
   });
 };
 
+interface OptionUserEvent {
+  useUserEvent: boolean;
+}
+
 export type FormationPageHelpers = {
   fillText: (label: string, value: string) => void;
   fillAndSubmitBusinessNameStep: (businessName?: string) => Promise<void>;
@@ -179,12 +184,12 @@ export type FormationPageHelpers = {
   submitBillingStep: () => Promise<void>;
   submitReviewStep: () => Promise<void>;
   clickSubmitAndGetError: (business: Business) => Promise<void>;
-  stepperClickToBusinessNameStep: () => Promise<void>;
-  stepperClickToNexusBusinessNameStep: () => Promise<void>;
-  stepperClickToBusinessStep: () => Promise<void>;
-  stepperClickToContactsStep: () => Promise<void>;
-  stepperClickToBillingStep: () => Promise<void>;
-  stepperClickToReviewStep: () => Promise<void>;
+  stepperClickToBusinessNameStep: (eventConfig?: OptionUserEvent) => Promise<void>;
+  stepperClickToNexusBusinessNameStep: (eventConfig?: OptionUserEvent) => Promise<void>;
+  stepperClickToBusinessStep: (eventConfig?: OptionUserEvent) => Promise<void>;
+  stepperClickToContactsStep: (eventConfig?: OptionUserEvent) => Promise<void>;
+  stepperClickToBillingStep: (eventConfig?: OptionUserEvent) => Promise<void>;
+  stepperClickToReviewStep: (eventConfig?: OptionUserEvent) => Promise<void>;
   getStepStateInStepper: (index: number | undefined) => string;
   searchBusinessName: (nameAvailability: Partial<NameAvailability>) => Promise<void>;
   fillAndBlurBusinessName: (businessName?: string) => Promise<void>;
@@ -257,36 +262,46 @@ export const createFormationPageHelpers = (): FormationPageHelpers => {
     });
   };
 
-  const stepperClickToBusinessNameStep = async (): Promise<void> => {
-    fireEvent.click(screen.getByTestId(`stepper-${LookupStepIndexByName("Name")}`));
+  const stepperClickToBusinessNameStep = async (eventConfig?: OptionUserEvent): Promise<void> => {
+    eventConfig?.useUserEvent
+      ? userEvent.click(screen.getByTestId(`stepper-${LookupStepIndexByName("Name")}`))
+      : fireEvent.click(screen.getByTestId(`stepper-${LookupStepIndexByName("Name")}`));
     await waitFor(() => {
       expect(screen.queryByTestId("business-name-step")).toBeInTheDocument();
     });
   };
 
-  const stepperClickToBusinessStep = async (): Promise<void> => {
-    fireEvent.click(screen.getByTestId(`stepper-${LookupStepIndexByName("Business")}`));
+  const stepperClickToBusinessStep = async (eventConfig?: OptionUserEvent): Promise<void> => {
+    eventConfig?.useUserEvent
+      ? userEvent.click(screen.getByTestId(`stepper-${LookupStepIndexByName("Business")}`))
+      : fireEvent.click(screen.getByTestId(`stepper-${LookupStepIndexByName("Business")}`));
     await waitFor(() => {
       expect(screen.queryByTestId("business-step")).toBeInTheDocument();
     });
   };
 
-  const stepperClickToContactsStep = async (): Promise<void> => {
-    fireEvent.click(screen.getByTestId(`stepper-${LookupStepIndexByName("Contacts")}`));
+  const stepperClickToContactsStep = async (eventConfig?: OptionUserEvent): Promise<void> => {
+    eventConfig?.useUserEvent
+      ? userEvent.click(screen.getByTestId(`stepper-${LookupStepIndexByName("Contacts")}`))
+      : fireEvent.click(screen.getByTestId(`stepper-${LookupStepIndexByName("Contacts")}`));
     await waitFor(() => {
       expect(screen.queryByTestId("contacts-step")).toBeInTheDocument();
     });
   };
 
-  const stepperClickToBillingStep = async (): Promise<void> => {
-    fireEvent.click(screen.getByTestId(`stepper-${LookupStepIndexByName("Billing")}`));
+  const stepperClickToBillingStep = async (eventConfig?: OptionUserEvent): Promise<void> => {
+    eventConfig?.useUserEvent
+      ? userEvent.click(screen.getByTestId(`stepper-${LookupStepIndexByName("Billing")}`))
+      : fireEvent.click(screen.getByTestId(`stepper-${LookupStepIndexByName("Billing")}`));
     await waitFor(() => {
       expect(screen.queryByTestId("billing-step")).toBeInTheDocument();
     });
   };
 
-  const stepperClickToReviewStep = async (): Promise<void> => {
-    fireEvent.click(screen.getByTestId(`stepper-${LookupStepIndexByName("Review")}`));
+  const stepperClickToReviewStep = async (eventConfig?: OptionUserEvent): Promise<void> => {
+    eventConfig?.useUserEvent
+      ? userEvent.click(screen.getByTestId(`stepper-${LookupStepIndexByName("Review")}`))
+      : fireEvent.click(screen.getByTestId(`stepper-${LookupStepIndexByName("Review")}`));
     await waitFor(() => {
       expect(screen.queryByTestId("review-step")).toBeInTheDocument();
     });


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

correct refocus behavior for formation stepper (rather than just scrolling to top, also refocuses on that specific tab step), 
(both via the stepper as navigation and the next / previous buttons at the bottom of the page)

page transitions announced when moving between pages with a screen reader (both via the stepper as navigation and the next / previous buttons at the bottom of the page)

Page descriptions enhanced

Page errors announced when pages have errors (page errors also focused when pages have errors and pages are moved too)

Keyboard only accessibility for stepper fixed

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#186316380](https://www.pivotaltracker.com/story/show/186316380).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

All testing begins by going to the formation page while logged in to access the stepper. 
All testing below should happen on Desktop and Mobile

correct refocus behavior for formation stepper
- click on the save and continue and/or back buttons at the bottom of various pages
- see that the new pages scrolls top and selects the newly selected stepper tab
- Navigate page to page clicking on the tab stepper steps themselves
- see that the same refocus behavior occurs

page transitions announced when moving between pages with a screen reader (both via the stepper as navigation and the next / previous buttons at the bottom of the page), Page descriptions enhanced
- with a screen reader
- click on the save and continue and/or back buttons at the bottom of various pages
- hear a description of the new page you're on and that contains all relevant information
- Navigate page to page clicking on the tab stepper steps themselves
- hear a description of the new page you're on and that contains all relevant information

Page errors announced when pages have errors (page errors also focused when pages have errors and pages are moved too)
- go to the review step and submit
- navigate to the prior pages with a screen reader via back and save/continue buttons
- hear the errors announced and see the re-focus behavior as desired
- repeat with navigating by clicking on the stepper 

Keyboard only accessibility for stepper fixed
- tab through the page, 
- you should tab into the stepper's selected step and then directly into content of the panel
- if you are on the selected step and use right and left arrow keys your focus should move between stepper options
- hitting enter on a non-selected tab should move you to that new page and scroll down

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
