### PR TITLE
Test migrations against real user data & Add logging to migrations

### DIFF
--- a/api/.dependency-cruiser.js
+++ b/api/.dependency-cruiser.js
@@ -197,6 +197,10 @@ module.exports = {
       from: { path: "src/domain" },
       to: { path: "src/client" },
     },
+    {
+      from: { path: "src/db" },
+      to: { path: "src/libs" },
+    },
   ],
   forbidden: [
     /* rules from the 'recommended' preset: */

--- a/api/jest.config.ts
+++ b/api/jest.config.ts
@@ -17,6 +17,7 @@ export default {
     "@libs/(.*)": "<rootDir>/src/libs/$1",
     "@test/(.*)": "<rootDir>/test/$1",
     "@wiremock/(.*)": "<rootDir>/wiremock/$1",
+    "@scripts/(.*)": "<rootDir>/../scripts/$1",
   },
   globalSetup: "<rootDir>/src/setupTests.ts",
   globalTeardown: "<rootDir>/src/teardownTests.ts",

--- a/api/scripts/migrateAllUserData.ts
+++ b/api/scripts/migrateAllUserData.ts
@@ -1,0 +1,48 @@
+/* eslint-disable no-restricted-imports */
+// Run yarn ts-node migrateAllUserData.ts
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { migrateUserData } from "../src/db/DynamoUserDataClient";
+import { ConsoleLogWriter } from "../src/libs/logWriter";
+
+type User = {
+  email: string;
+  data: unknown;
+  userId: string;
+};
+
+type JsonObject = {
+  Items: User[];
+  Count: number;
+  ScannedCount: number;
+  ConsumedCapacity: unknown;
+  NextToken: string;
+};
+
+const inputDirectory = ""; // Set this to wherever the files are located
+const files: string[] = fs.readdirSync(inputDirectory);
+
+const runMigrations = (users: User[]): void => {
+  for (const user of users) {
+    const logger = ConsoleLogWriter;
+    migrateUserData(user.data, logger);
+    console.log("\n");
+  }
+};
+
+for (const file of files) {
+  if (path.extname(file) === ".json") {
+    const filePath: string = path.join(inputDirectory, file);
+    const fileContent: string = fs.readFileSync(filePath, "utf8");
+    const data: JsonObject = JSON.parse(fileContent);
+
+    const users = data.Items;
+
+    console.log({ filePath });
+    console.log("number of users:", users.length);
+
+    runMigrations(users);
+  }
+}

--- a/api/src/db/DynamoUserDataClient.test.ts
+++ b/api/src/db/DynamoUserDataClient.test.ts
@@ -4,6 +4,7 @@ import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import { DynamoUserDataClient } from "@db/DynamoUserDataClient";
 import { dynamoDbTranslateConfig } from "@db/config/dynamoDbConfig";
 import { UserDataClient } from "@domain/types";
+import { DummyLogWriter, LogWriterType } from "@libs/logWriter";
 import { generateUser, generateUserData } from "@shared/test";
 
 // references jest-dynalite-config values
@@ -20,11 +21,13 @@ describe("DynamoUserDataClient", () => {
 
   let client: DynamoDBDocumentClient;
   let dynamoUserDataClient: UserDataClient;
+  let logger: LogWriterType;
 
   beforeEach(() => {
+    jest.resetAllMocks();
     client = DynamoDBDocumentClient.from(new DynamoDBClient(config), dynamoDbTranslateConfig);
-
-    dynamoUserDataClient = DynamoUserDataClient(client, dbConfig.tableName);
+    logger = DummyLogWriter;
+    dynamoUserDataClient = DynamoUserDataClient(client, dbConfig.tableName, logger);
   });
 
   it("gets inserted items", async () => {

--- a/api/src/db/dynamoUserDataMigration.test.ts
+++ b/api/src/db/dynamoUserDataMigration.test.ts
@@ -5,10 +5,9 @@
 
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { dynamoDbTranslateConfig, DynamoUserDataClient } from "@db/DynamoUserDataClient";
 import { UserDataClient } from "@domain/types";
-
-import { DynamoUserDataClient } from "@db/DynamoUserDataClient";
-import { dynamoDbTranslateConfig } from "@db/config/dynamoDbConfig";
+import { DummyLogWriter, LogWriterType } from "@libs/logWriter";
 import * as sharedUserData from "@shared/userData";
 
 function setupMockSharedUserData(): typeof sharedUserData {
@@ -49,10 +48,12 @@ describe("DynamoUserDataClient Migrations", () => {
 
   let client: DynamoDBDocumentClient;
   let dynamoUserDataClient: UserDataClient;
+  let logger: LogWriterType;
 
   beforeEach(async () => {
     client = DynamoDBDocumentClient.from(new DynamoDBClient(config), dynamoDbTranslateConfig);
-    dynamoUserDataClient = DynamoUserDataClient(client, dbConfig.tableName);
+    logger = DummyLogWriter;
+    dynamoUserDataClient = DynamoUserDataClient(client, dbConfig.tableName, logger);
     await insertOldData();
   });
 

--- a/api/src/functions/encryptTaxId/app.ts
+++ b/api/src/functions/encryptTaxId/app.ts
@@ -1,6 +1,7 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import { dynamoDbTranslateConfig } from "@db/config/dynamoDbConfig";
+import { LogWriter } from "@libs/logWriter";
 import { AWSEncryptionDecryptionFactory } from "src/client/AwsEncryptionDecryptionFactory";
 import { DynamoUserDataClient } from "src/db/DynamoUserDataClient";
 import { encryptTaxIdBatch } from "src/domain/user/encryptTaxIdBatch";
@@ -11,6 +12,8 @@ export default async function handler(): Promise<void> {
   const IS_DOCKER = process.env.IS_DOCKER === "true" || false; // set in docker-compose
   const USERS_TABLE = process.env.USERS_TABLE || "users-table-local";
   const DYNAMO_OFFLINE_PORT = process.env.DYNAMO_PORT || 8000;
+  const STAGE = process.env.STAGE || "local";
+  const logger = LogWriter(`NavigatorWebService/${STAGE}`, "DataMigrationLogs");
 
   let dynamoDb: DynamoDBDocumentClient;
   if (IS_OFFLINE) {
@@ -34,7 +37,7 @@ export default async function handler(): Promise<void> {
     );
   }
 
-  const dbClient = DynamoUserDataClient(dynamoDb, USERS_TABLE);
+  const dbClient = DynamoUserDataClient(dynamoDb, USERS_TABLE, logger);
 
   const AWS_CRYPTO_KEY = process.env.AWS_CRYPTO_KEY || "";
   const AWS_CRYPTO_CONTEXT_STAGE = process.env.AWS_CRYPTO_CONTEXT_STAGE || "";

--- a/api/src/functions/express/app.ts
+++ b/api/src/functions/express/app.ts
@@ -90,6 +90,7 @@ if (IS_OFFLINE) {
 
 const STAGE = process.env.STAGE || "local";
 const logger = LogWriter(`NavigatorWebService/${STAGE}`, "ApiLogs");
+const dataLogger = LogWriter(`NavigatorWebService/${STAGE}`, "DataMigrationLogs");
 
 const LICENSE_STATUS_BASE_URL =
   process.env.LICENSE_STATUS_BASE_URL || `http://${IS_DOCKER ? "wiremock" : "localhost"}:9000`;
@@ -296,7 +297,7 @@ const airtableUserTestingClient = AirtableUserTestingClient(
 );
 
 const USERS_TABLE = process.env.USERS_TABLE || "users-table-local";
-const userDataClient = DynamoUserDataClient(dynamoDb, USERS_TABLE);
+const userDataClient = DynamoUserDataClient(dynamoDb, USERS_TABLE, dataLogger);
 
 const taxFilingInterface = taxFilingsInterfaceFactory(taxFilingClient);
 

--- a/api/src/functions/updateExternalStatus/app.ts
+++ b/api/src/functions/updateExternalStatus/app.ts
@@ -39,7 +39,9 @@ export default async function handler(): Promise<void> {
     );
   }
 
-  const dbClient = DynamoUserDataClient(dynamoDb, USERS_TABLE);
+  const dataLogger = LogWriter(`NavigatorWebService/${STAGE}`, "DataMigrationLogs");
+
+  const dbClient = DynamoUserDataClient(dynamoDb, USERS_TABLE, dataLogger);
   const logger = LogWriter(`NavigatorWebService/${STAGE}`, "ApiLogs");
 
   const GOV_DELIVERY_BASE_URL =

--- a/api/src/libs/logWriter.ts
+++ b/api/src/libs/logWriter.ts
@@ -26,6 +26,26 @@ export const DummyLogWriter: LogWriterType = {
   },
 };
 
+export const ConsoleLogWriter: LogWriterType = {
+  LogError: async (message: string, details?: AxiosError): Promise<void> => {
+    try {
+      console.error(`${message} - ${JSON.stringify(details?.toJSON())}`);
+    } catch (error) {
+      console.error(`Error with LogInfo:${error}`);
+    }
+  },
+  LogInfo: async (message: string): Promise<void> => {
+    try {
+      console.info(message);
+    } catch (error) {
+      console.error(`Error with LogInfo:${error}`);
+    }
+  },
+  GetId: () => {
+    return "";
+  },
+};
+
 export const LogWriter = (groupName: string, logStream: string, region?: string): LogWriterType => {
   const logger = winston.add(
     new WinstonCloudWatch({

--- a/scripts/remove_dynamodb_types.py
+++ b/scripts/remove_dynamodb_types.py
@@ -1,0 +1,61 @@
+import json
+import os
+
+
+# Function to recursively strip DynamoDB types
+def strip_dynamodb_types(data):
+    if isinstance(data, dict):
+        if len(data) == 1 and list(data.keys())[0] in {
+            "S",
+            "N",
+            "BOOL",
+            "M",
+            "L",
+            "SS",
+            "NS",
+            "BS",
+        }:
+            key = list(data.keys())[0]
+            value = data[key]
+            if key == "M":
+                return strip_dynamodb_types(value)
+            elif key == "L":
+                return [strip_dynamodb_types(item) for item in value]
+            else:
+                return value
+        else:
+            return {k: strip_dynamodb_types(v) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [strip_dynamodb_types(item) for item in data]
+    else:
+        return data
+
+
+# Function to process all files in a directory and output cleaned files
+def process_dynamodb_dump(input_dir, output_dir):
+    # Ensure output directory exists
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Iterate through all files in the input directory
+    for filename in os.listdir(input_dir):
+        print(f"Processing {filename}")
+        input_file_path = os.path.join(input_dir, filename)
+        output_file_path = os.path.join(
+            output_dir, f"{filename}.json"
+        )  # Same filename in output directory
+
+        # Read the input file
+        with open(input_file_path, "r") as f:
+            data = json.load(f)
+            # Strip the DynamoDB types
+            cleaned_data = strip_dynamodb_types(data)
+
+        # Write the cleaned data to the corresponding output file
+        with open(output_file_path, "w") as out_f:
+            json.dump(cleaned_data, out_f, indent=4)
+
+
+# Example usage:
+input_directory = ""
+output_directory = ""
+process_dynamodb_dump(input_directory, output_directory)


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
- Added logging to DynamoDB client and associated tests
- Adds scripts to test migrations against a dump of user data

### Ticket

This pull request resolves [#188171973](https://www.pivotaltracker.com/story/show/188171973).

### Approach

- Added log groups in all AWS workspaces [here](https://github.com/newjersey/innovation-terraform/pull/145).
- Created log events in the DynamoDB client to alert for both successful migration upgrade and failure
- Created a script to strip DynamoDB syntax from a dump of user data
- Created a script to upgrade all users in a data dump

We were able to successfully upgrade all users through the current migration version with no errors. 

<img width="721" alt="Screenshot 2024-10-02 at 4 30 52 PM" src="https://github.com/user-attachments/assets/7e5b6b2d-7d9a-494e-bf48-a69f1d7ab3e6">

### Steps to Test

To recreate this locally you would need to get a dump of user data from a given cloud environment. Using the scripts added in this PR, you could then run migrations against all of the data.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
