### PR TITLE
release 20240917

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2024.28.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v2024.28.0...v2024.28.1) (2024-09-20)
+
+
+### Bug Fixes
+
+* redeploy as account instead of navigator ([8af3600](https://github.com/newjersey/navigator.business.nj.gov/commit/8af3600386b5db647dca8abf06ac620200eff4a1))
+
 # [2024.28.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2024.27.0...v2024.28.0) (2024-09-18)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businessnjgovnavigator/root",
-  "version": "2024.28.0",
+  "version": "2024.28.1",
   "description": "This is the development repository for the work-in-progress business navigator from the New Jersey Office of Innovation. For info on the existing [Business.NJ.gov](https://business.nj.gov) site, please see the [bottom of this document](https://github.com/newjersey/navigator.business.nj.gov#businessnjgov)",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
- **fix: redeploy as account instead of navigator**
- **chore(release): 2024.28.1 [skip ci]**
