### PR TITLE
feat: [#186702387] dialog close button isn't part of heading

### DIFF
--- a/web/src/components/ModalZeroButton.tsx
+++ b/web/src/components/ModalZeroButton.tsx
@@ -21,17 +21,22 @@ export const ModalZeroButton = (props: Props): ReactElement => {
       maxWidth="sm"
       open={props.isOpen}
       onClose={props.close}
-      aria-labelledby="modal"
+      aria-labelledby="dialog-modal"
       disableEnforceFocus={contextualInfo.isVisible}
     >
-      <DialogTitle id="modal" className="display-flex flex-row flex-align-center margin-top-1 break-word">
-        <Heading level={0} styleVariant="h2" className="padding-x-1 margin-0-override">
-          {props.title}
-        </Heading>
+      <div className="display-flex margin-top-1">
+        <DialogTitle
+          id="dialog-modal"
+          className="display-flex flex-row flex-align-center break-word flex-fill"
+        >
+          <Heading level={0} styleVariant="h2" className="padding-x-1 margin-0-override">
+            {props.title}
+          </Heading>
+        </DialogTitle>
         {!props.uncloseable && (
           <IconButton
             aria-label="close"
-            className="margin-left-auto"
+            className="margin-left-auto margin-3"
             onClick={props.close}
             sx={{
               color: "#757575",
@@ -40,7 +45,7 @@ export const ModalZeroButton = (props: Props): ReactElement => {
             <Icon className="usa-icon--size-4">close</Icon>
           </IconButton>
         )}
-      </DialogTitle>
+      </div>
       <DialogContent sx={{ padding: 0 }} dividers>
         <div className="padding-x-4 margin-bottom-4 margin-top-2" data-testid="modal-body">
           {props.children}


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

We had a few situations where the modals had their close buttons as part of the header and were announced as part of a header (also unelectable by screen readers)

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#186702387](https://www.pivotaltracker.com/story/show/186702387).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

1. Go to formation step 3 contacts
2. turn on your screen reader (cmd + F5)
4. navigate to any of the add trustee, members or signers buttons (via control + option + right arrow)
5. Select this button using (enter)
6. This will trigger a modal to open
7.  (via control + option + right arrow) navigate through the dialog seeing that the header and close button are now distinct
8. Make sure no other random style changes happened

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

For some reason this element is wrapped in a group before it's diaglog, I investigated this quite a bit, as the MUI examples on their site for all their various supported versions (inlcuding ours at v15) don't have this issue. 

When I copied over their example verbatum though I ran into this issues, not sure exactly how that could happen but I'm punting on it for now. 

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
