### PR TITLE
feat: [#186084688] fixed formation heading structure

### DIFF
--- a/web/src/components/tasks/business-formation/billing/BillingStep.tsx
+++ b/web/src/components/tasks/business-formation/billing/BillingStep.tsx
@@ -17,7 +17,9 @@ export const BillingStep = (): ReactElement => {
 
   return (
     <div data-testid="billing-step">
-      <Heading level={3}>{Config.formation.sections.contactInfoHeader}</Heading>
+      <Heading level={2} styleVariant={"h3"}>
+        {Config.formation.sections.contactInfoHeader}
+      </Heading>
       <WithErrorBar
         hasError={doSomeFieldsHaveError(["contactFirstName", "contactLastName"])}
         type="DESKTOP-ONLY"
@@ -64,7 +66,9 @@ export const BillingStep = (): ReactElement => {
         </div>
       </div>
       <hr className="margin-y-3" />
-      <Heading level={3}>{Config.formation.sections.servicesHeader}</Heading>
+      <Heading level={2} styleVariant={"h3"}>
+        {Config.formation.sections.servicesHeader}
+      </Heading>
       <Content>{Config.formation.sections.servicesDescription}</Content>
       <FormationChooseDocuments />
       <PaymentTypeTable />

--- a/web/src/components/tasks/business-formation/billing/FormationChooseNotifications.tsx
+++ b/web/src/components/tasks/business-formation/billing/FormationChooseNotifications.tsx
@@ -31,7 +31,9 @@ export const FormationChooseNotifications = (): ReactElement => {
 
   return (
     <div className="margin-top-3">
-      <Heading level={3}>{Config.formation.sections.notificationsHeader}</Heading>
+      <Heading level={2} styleVariant={"h3"}>
+        {Config.formation.sections.notificationsHeader}
+      </Heading>
       <Content>{Config.formation.sections.notificationsDescription}</Content>
       <FormGroup>
         <FormControlLabel

--- a/web/src/components/tasks/business-formation/business/BusinessNameAndLegalStructure.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessNameAndLegalStructure.tsx
@@ -83,7 +83,7 @@ export const BusinessNameAndLegalStructure = ({ isReviewStep = false }: Props): 
     <>
       <div className="flex space-between margin-bottom-2 flex-align-center">
         <div className="maxw-mobile-lg ">
-          <Heading level={2} styleVariant="h3">
+          <Heading level={isReviewStep ? 3 : 2} styleVariant={"h3"}>
             {Config.formation.sections.businessNameAndStructureHeader}
           </Heading>
         </div>

--- a/web/src/components/tasks/business-formation/contacts/Addresses.tsx
+++ b/web/src/components/tasks/business-formation/contacts/Addresses.tsx
@@ -312,7 +312,7 @@ export const Addresses = <T extends FormationMember | FormationIncorporator>(
         </SnackbarAlert>
       )}
       <div className="margin-bottom-3 members-table" data-testid={`addresses-${props.fieldName}`}>
-        <Heading level={3} style={{ display: "inline" }}>
+        <Heading level={2} styleVariant={"h3"} style={{ display: "inline" }}>
           {props.displayContent.header}
         </Heading>
         {props.displayContent.subheader && (

--- a/web/src/components/tasks/business-formation/contacts/RegisteredAgent.tsx
+++ b/web/src/components/tasks/business-formation/contacts/RegisteredAgent.tsx
@@ -129,7 +129,9 @@ export const RegisteredAgent = (): ReactElement => {
 
   return (
     <>
-      <Heading level={3}>{Config.formation.registeredAgent.label}</Heading>
+      <Heading level={2} styleVariant={"h3"}>
+        {Config.formation.registeredAgent.label}
+      </Heading>
       <Content>{Config.formation.registeredAgent.sectionDescription}</Content>
       <div id="registeredAgent">
         <FormControl fullWidth>

--- a/web/src/components/tasks/business-formation/contacts/Signatures.tsx
+++ b/web/src/components/tasks/business-formation/contacts/Signatures.tsx
@@ -334,7 +334,9 @@ export const Signatures = (): ReactElement => {
   return (
     <>
       <div className="grid-col">
-        <Heading level={3}>{Config.formation.fields.signers.label}</Heading>
+        <Heading level={2} styleVariant={"h3"}>
+          {Config.formation.fields.signers.label}
+        </Heading>
         <Content>{getDescription()}</Content>
         <div className={`grid-row margin-y-2 flex-align-start`}>
           <div className={`grid-col`} data-testid="signers-0">

--- a/web/src/components/tasks/business-formation/name/BusinessNameStep.tsx
+++ b/web/src/components/tasks/business-formation/name/BusinessNameStep.tsx
@@ -63,7 +63,9 @@ export const BusinessNameStep = (): ReactElement => {
   return (
     <div data-testid="business-name-step">
       <form onSubmit={doSearch} className="usa-prose grid-container padding-0">
-        <Heading level={3}>{Config.formation.fields.businessName.header}</Heading>
+        <Heading level={2} styleVariant={"h3"}>
+          {Config.formation.fields.businessName.header}
+        </Heading>
         <Content>{Config.formation.fields.businessName.description}</Content>
         <WithErrorBar hasError={hasError} type="DESKTOP-ONLY">
           <div className="text-bold margin-top-1">{Config.formation.fields.businessName.label}</div>


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Headings in formation jumped from H1 - H3 in some places this is bad and those should go sequentially from H1 - H2

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#186084688](https://www.pivotaltracker.com/story/show/186084688).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Go to the formation pages and go through each step
use a screen reader to navigate by heading (cmd + option + control + H  and cmd + option + control + shift + H)
And see the heading structure doesn't skip and seems logical

Alternatively use a chrome extension to see that the structure is sound
https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh?hl=en-US
Download, then activate, then go to the structure tab


<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

Lots of discussion about when and not using style overrides, but eventually decided that effort could be part of a later ticket and these could continue to use style overrides rather than going through some design work now

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
