### PR TITLE
Fixes to Webflow licenseSync

### DIFF
--- a/web/src/scripts/licenseLoader.mjs
+++ b/web/src/scripts/licenseLoader.mjs
@@ -92,24 +92,25 @@ export const loadNavigatorLicense = (fileName) => {
 export const writeMarkdownString = (license) => {
   return (
     `---\n` +
-    `id: "${license.id}"\n` +
-    `webflowId: "${license.webflowId}"\n` +
-    `urlSlug: "${license.urlSlug}"\n` +
-    `name: "${license.name}"\n` +
-    (license.webflowName ? `webflowName: "${license.webflowName}"\n` : "") +
-    (license.filename ? `filename: "${license.filename}"\n` : "") +
-    (license.callToActionLink ? `callToActionLink: "${license.callToActionLink}"\n` : "") +
-    (license.callToActionText ? `callToActionText: "${license.callToActionText}"\n` : "") +
-    (license.agencyId ? `agencyId: "${license.agencyId}"\n` : "") +
-    (license.agencyAdditionalContext
-      ? `agencyAdditionalContext: "${license.agencyAdditionalContext}"\n`
-      : "") +
-    (license.divisionPhone ? `divisionPhone: "${license.divisionPhone}"\n` : "") +
-    (license.industryId ? `industryId: "${license.industryId}"\n` : "") +
-    (license.webflowType ? `webflowType: "${license.webflowType}"\n` : "") +
-    `licenseCertificationClassification: "${license.licenseCertificationClassification}"\n` +
-    (license.summaryDescriptionMd ? `summaryDescriptionMd: "${license.summaryDescriptionMd}"\n` : "") +
-    `---\n` +
+    `id: ${license.id}\n` +
+    `webflowId: ${license.webflowId}\n` +
+    `urlSlug: ${license.urlSlug}\n` +
+    `name: ${license.name}\n` +
+    `displayname: ${license.displayname}\n${
+      license.webflowName ? `webflowName: ${license.webflowName}\n` : ""
+    }${license.filename ? `filename: ${license.filename}\n` : ""}${
+      license.callToActionLink ? `callToActionLink: ${license.callToActionLink}\n` : ""
+    }${license.callToActionText ? `callToActionText: ${license.callToActionText}\n` : ""}${
+      license.agencyId ? `agencyId: ${license.agencyId}\n` : ""
+    }${
+      license.agencyAdditionalContext ? `agencyAdditionalContext: ${license.agencyAdditionalContext}\n` : ""
+    }${license.divisionPhone ? `divisionPhone: ${license.divisionPhone}\n` : ""}${
+      license.industryId ? `industryId: ${license.industryId}\n` : ""
+    }${
+      license.webflowType ? `webflowType: ${license.webflowType}\n` : ""
+    }licenseCertificationClassification: ${license.licenseCertificationClassification}\n${
+      license.summaryDescriptionMd ? `summaryDescriptionMd: "${license.summaryDescriptionMd}"\n` : ""
+    }---\n` +
     `${license.contentMd}`
   );
 };


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

The Webflow `licenseSync` is currently missing the `displayname` field and is incorrectly writing `summaryDescriptionMd` when writing the `webflowId` to the task Markdown file.

### Ticket

This pull request resolves [#188333470](https://www.pivotaltracker.com/story/show/188333470).

### Steps to Test

1. Create a new license task
2. Run the Webflow license sync
3. Confirm the updated task file renders correctly in the CMS
4. If the new license task is a test file, delete from Webflow

### Notes

This is a response to multiple requests from the content team to fix files that are rendering incorrectly.

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
