### PR TITLE
chore: [#187315425] Re-enable code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ with:
 ./scripts/local-feature-tests.sh
 ```
 
+To run all tests with code coverage (locally):
+
+```shell
+yarn test:coverage
+```
+
 Some of the Cypress tests only run in the CI environment. When using the
 `local-feature-tests` script, make sure to have a locally running instance of
 the application.

--- a/jest.coverage.ts
+++ b/jest.coverage.ts
@@ -6,7 +6,7 @@ export default {
   collectCoverage: true,
   collectCoverageFrom: ["**/*.{js,jsx,ts,tsx,cjs,mjs}", "!**/node_modules/**"],
   coverageDirectory: "./coverage",
-  coverageReporters: ["json-summary", "text"],
+  coverageReporters: ["json-summary", "text", "html", "lcov"],
   coveragePathIgnorePatterns: [
     "<rootDir>/.next/",
     "<rootDir>/public/",


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

This PR addresses the need to re-enable and clarify the process for running code coverage locally as part of identifying areas where new unit tests are needed.



## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#187315425](https://www.pivotaltracker.com/story/show/187315425).

### Approach

Changes:
- Updated README.md:
Added instructions for running tests locally with coverage reports, specifying that coverage testing is for local use only and should not be run in CI.
- Updated jest.coverage.ts:
Adjusted coverageReporters settings to ensure the code coverage functionality is correctly configured and ready for use by developers.

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
