### PR TITLE
chore(release): 2024.30.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [2024.30.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2024.29.0...v2024.30.0) (2024-10-01)
+
+
+### Features
+
+* [[#186702387](https://github.com/newjersey/navigator.business.nj.gov/issues/186702387)] dialog close button isn't part of heading ([0864e3f](https://github.com/newjersey/navigator.business.nj.gov/commit/0864e3fdcf2e6afa6b0684c68049dd389e0a9210))
+
 # [2024.29.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2024.28.0...v2024.29.0) (2024-09-24)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businessnjgovnavigator/root",
-  "version": "2024.29.0",
+  "version": "2024.30.0",
   "description": "This is the development repository for the work-in-progress business navigator from the New Jersey Office of Innovation. For info on the existing [Business.NJ.gov](https://business.nj.gov) site, please see the [bottom of this document](https://github.com/newjersey/navigator.business.nj.gov#businessnjgov)",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
# [2024.30.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2024.29.0...v2024.30.0) (2024-10-01)

### Features

* [[#186702387](https://github.com/newjersey/navigator.business.nj.gov/issues/186702387)] dialog close button isn't part of heading ([0864e3f](https://github.com/newjersey/navigator.business.nj.gov/commit/0864e3fdcf2e6afa6b0684c68049dd389e0a9210))
