### PR TITLE
Add missing displayname to license-tasks

### DIFF
--- a/content/src/roadmaps/license-tasks/cds-healthcare.md
+++ b/content/src/roadmaps/license-tasks/cds-healthcare.md
@@ -1,20 +1,25 @@
 ---
-id: "cds-healthcare"
-webflowId: "66f3197e83af078f435a6ebf"
-urlSlug: "cds-healthcare"
-name: "Apply for Your Controlled Dangerous Substances Registration, if Applicable"
+id: cds-healthcare
+filename: cds-healthcare
+displayname: cds-healthcare
+urlSlug: cds-healthcare
+name: Apply for Your Controlled Dangerous Substances Registration, if Applicable
 webflowName: "Healthcare: Controlled Dangerous Substances Registration"
-filename: "cds-healthcare"
-callToActionLink: "https://www.njconsumeraffairs.gov/dcu/Pages/applications.aspx#"
-callToActionText: "Apply for My CDS Registration"
-agencyId: "nj-consumer-affairs"
-agencyAdditionalContext: "New Jersey Drug Control Unit"
-industryId: "healthcare"
-licenseCertificationClassification: "undefined"
-summaryDescriptionMd: |
-  You need a Controlled Dangerous Substances (CDS) registration if you’re a Medical Doctor, Doctor of Osteopathy, Dentist, Optometrist, Podiatrist, Veterinarian, Physician Assistant, Advanced Practice Nurse, or Certified Nurse Midwife, and you or your business dispense, prescribe, or store any CDS.
+summaryDescriptionMd: >-
+  You need a Controlled Dangerous Substances (CDS) registration if you’re a
+  Medical Doctor, Doctor of Osteopathy, Dentist, Optometrist, Podiatrist,
+  Veterinarian, Physician Assistant, Advanced Practice Nurse, or Certified Nurse
+  Midwife, and you or your business dispense, prescribe, or store any CDS.
+
 
   Use separate forms to register each CDS storage location. Write "branch" at the top.
+industryId: healthcare
+callToActionText: Apply for My CDS Registration
+callToActionLink: https://www.njconsumeraffairs.gov/dcu/Pages/applications.aspx#
+agencyId: nj-consumer-affairs
+agencyAdditionalContext: New Jersey Drug Control Unit
+webflowId: 66f3197e83af078f435a6ebf
+licenseCertificationClassification: undefined
 ---
 
 ## Application Requirements

--- a/content/src/roadmaps/license-tasks/cemetery-branch.md
+++ b/content/src/roadmaps/license-tasks/cemetery-branch.md
@@ -1,19 +1,23 @@
 ---
-notesMd: "* Uncertain on the What if I don't get this license callout. It may be changed to a warning (yellow) instead of conditional (green)"
-id: "cemetery-branch"
-webflowId: "66be3be5b744538ece672248"
-urlSlug: "cemetery-branch"
-name: "Apply for Your Cemetery Salesperson Branch License, if applicable"
-webflowName: "Cemetery: Cemetery Salesperson Branch License "
-filename: "cemetery-branch"
-callToActionLink: "https://www.njconsumeraffairs.gov/cem/Applications/Cemetery-Application-for-Cemetery-Salespersons-Branch-License.pdf"
-callToActionText: "Get My Cemetery Salesperson Branch License"
-agencyId: "nj-consumer-affairs"
-agencyAdditionalContext: "New Jersey Cemetery Board"
-industryId: "cemetery"
-licenseCertificationClassification: "undefined"
+notesMd: "* Uncertain on the What if I don't get this license callout. It may be
+  changed to a warning (yellow) instead of conditional (green)"
 licenseName: ""
-summaryDescriptionMd: "You need a Cemetery Salesperson Branch license to sell at more than one location. You must already have a Cemetery Salesperson license for your main cemetery."
+id: cemetery-branch
+filename: cemetery-branch
+displayname: cemetery-branch
+urlSlug: cemetery-branch
+name: Apply for Your Cemetery Salesperson Branch License, if applicable
+webflowName: "Cemetery: Cemetery Salesperson Branch License "
+summaryDescriptionMd: You need a Cemetery Salesperson Branch license to sell at
+  more than one location. You must already have a Cemetery Salesperson license
+  for your main cemetery.
+industryId: cemetery
+callToActionText: Get My Cemetery Salesperson Branch License
+callToActionLink: https://www.njconsumeraffairs.gov/cem/Applications/Cemetery-Application-for-Cemetery-Salespersons-Branch-License.pdf
+agencyId: nj-consumer-affairs
+agencyAdditionalContext: New Jersey Cemetery Board
+webflowId: 66be3be5b744538ece672248
+licenseCertificationClassification: undefined
 ---
 
 ## Application Requirements

--- a/content/src/roadmaps/license-tasks/cemetery-certificate.md
+++ b/content/src/roadmaps/license-tasks/cemetery-certificate.md
@@ -1,19 +1,23 @@
 ---
-notesMd: "* h2 and h3 still look the same, using h3 per Spencer but ideally we want the h3's to be visually differentiated from the h2. Will need to update this task once this is remedied."
-id: "cemetery-certificate"
-webflowId: "66be3c52407e8f104a12114a"
-urlSlug: "cemetery-certificate"
-name: "Apply for Your Certificate of Authority"
-webflowName: "Cemetery: Certificate of Authority"
-filename: "cemetery-certificate"
-callToActionLink: "https://www.njconsumeraffairs.gov/cem/Applications/Cemetery-Application-and-Information-Sheet-for-Certificate-of-Authority.pdf"
-callToActionText: "Apply for My Certificate of Authority"
-agencyId: "nj-consumer-affairs"
-agencyAdditionalContext: "New Jersey Cemetery Board"
-industryId: "cemetery"
-licenseCertificationClassification: "undefined"
+notesMd: "* h2 and h3 still look the same, using h3 per Spencer but ideally we
+  want the h3's to be visually differentiated from the h2. Will need to update
+  this task once this is remedied."
 licenseName: ""
-summaryDescriptionMd: "To own and operate a cemetery business in New Jersey, you need a Certificate of Authority. Your cemetery business must be a nonprofit."
+id: cemetery-certificate
+filename: cemetery-certificate
+displayname: cemetery-certificate
+urlSlug: cemetery-certificate
+name: Apply for Your Certificate of Authority
+webflowName: "Cemetery: Certificate of Authority"
+summaryDescriptionMd: To own and operate a cemetery business in New Jersey, you
+  need a Certificate of Authority. Your cemetery business must be a nonprofit.
+industryId: cemetery
+callToActionText: Apply for My Certificate of Authority
+callToActionLink: https://www.njconsumeraffairs.gov/cem/Applications/Cemetery-Application-and-Information-Sheet-for-Certificate-of-Authority.pdf
+agencyId: nj-consumer-affairs
+agencyAdditionalContext: New Jersey Cemetery Board
+webflowId: 66be3c52407e8f104a12114a
+licenseCertificationClassification: undefined
 ---
 
 ## Application Requirements

--- a/content/src/roadmaps/license-tasks/landlord-registration.md
+++ b/content/src/roadmaps/license-tasks/landlord-registration.md
@@ -1,13 +1,17 @@
 ---
-id: "landlord-registration"
-webflowId: "66f3198052d588875cacb94c"
-urlSlug: "landlord-registration"
-name: "Register as a Landlord"
+id: landlord-registration
+filename: landlord-registration
+displayname: landlord-registration
+urlSlug: landlord-registration
+name: Register as a Landlord
 webflowName: "Residential Landlord: Landlord Registration"
-filename: "landlord-registration"
-industryId: "residential-landlord"
-licenseCertificationClassification: "undefined"
-summaryDescriptionMd: "Before renting out a **one- or two-unit residential property**, you must register as a landlord with your municipal clerk. You need to register each time you rent out a new property. You also need to give your tenant(s) a copy of the completed application form."
+summaryDescriptionMd: Before renting out a **one- or two-unit residential
+  property**, you must register as a landlord with your municipal clerk. You
+  need to register each time you rent out a new property. You also need to give
+  your tenant(s) a copy of the completed application form.
+industryId: residential-landlord
+webflowId: 66f3198052d588875cacb94c
+licenseCertificationClassification: undefined
 ---
 
 :::note

--- a/content/src/roadmaps/license-tasks/residential-health-care-facility-license.md
+++ b/content/src/roadmaps/license-tasks/residential-health-care-facility-license.md
@@ -1,19 +1,22 @@
 ---
-id: "residential-health-care-facility-license"
-webflowId: "66b375f70b51a2d44273c4df"
-urlSlug: "residential-health-care-facility-license"
-name: "Apply for Your Free-Standing Residential Health Care Facility License"
-webflowName: "Healthcare: Free-Standing Residential Health Care Facility"
-filename: "residential-health-care-facility-license"
-callToActionLink: "https://www.nj.gov/dca/codes/forms/pdf_rooming/RHCF_app.pdf"
-callToActionText: "Apply for My Free-Standing Residential Health Care Facility License"
-agencyId: "nj-community-affairs"
-agencyAdditionalContext: "Bureau of Rooming and Boarding House Standards"
-divisionPhone: "(609) 984-1704"
-industryId: "healthcare"
-licenseCertificationClassification: "undefined"
 licenseName: ""
-summaryDescriptionMd: "You need a license to own and/or operate a new or existing `free-standing residential health care facility|residential-health-care-facility`."
+id: residential-health-care-facility-license
+filename: residential-health-care-facility-license
+displayname: residential-health-care-facility-license
+urlSlug: residential-health-care-facility-license
+name: Apply for Your Free-Standing Residential Health Care Facility License
+webflowName: "Healthcare: Free-Standing Residential Health Care Facility"
+summaryDescriptionMd: You need a license to own and/or operate a new or existing
+  `free-standing residential health care
+  facility|residential-health-care-facility`.
+industryId: healthcare
+callToActionText: Apply for My Free-Standing Residential Health Care Facility License
+callToActionLink: https://www.nj.gov/dca/codes/forms/pdf_rooming/RHCF_app.pdf
+agencyId: nj-community-affairs
+agencyAdditionalContext: Bureau of Rooming and Boarding House Standards
+divisionPhone: (609) 984-1704
+webflowId: 66b375f70b51a2d44273c4df
+licenseCertificationClassification: undefined
 ---
 
 ---
@@ -21,7 +24,7 @@ summaryDescriptionMd: "You need a license to own and/or operate a new or existin
 ## Application Requirements for New Facilities
 
 - Business name
-- `Trade name|alt-name-trade-name`, if applicable
+- `Trade name|alt-name-trade-name` , if applicable
 - `Business structure|business-structure-learn-more`
 - `Employee Identification Number (EIN)|ein`
 - Name and address of your `registered agent|registered-agent`
@@ -31,7 +34,7 @@ summaryDescriptionMd: "You need a license to own and/or operate a new or existin
 - Business name, address, and email of your management company, if applicable
 - Name and address of your parent corporation, if applicable
 - Name of your building owner and a copy of a signed lease, if you are renting the facility
-- Name, title, address, Social Security Number (SSN) or `Tax ID|tax-id`, and percent of ownership for each owner, officer, partner, or stockholder
+- Name, title, address, Social Security Number (SSN) or `Tax ID|tax-id` , and percent of ownership for each owner, officer, partner, or stockholder
 - List of board members, if your business is a nonprofit
 - List of any prior health care application denials or revocations, if applicable
 - List of other licensed health care facilities each principal owns, manages, or operates, if applicable

--- a/content/src/roadmaps/license-tasks/rooming-boarding-house-license.md
+++ b/content/src/roadmaps/license-tasks/rooming-boarding-house-license.md
@@ -1,19 +1,21 @@
 ---
-id: "rooming-boarding-house-license"
-webflowId: "66b375f801e19e1717d32c2d"
-urlSlug: "rooming-boarding-house-license"
-name: "Apply for a Rooming or Boarding House License"
-webflowName: "Lodging: Rooming or Boarding House License"
-filename: "rooming-boarding-house-license"
-callToActionLink: "https://www.nj.gov/dca/codes/forms/pdf_rooming/App_Form_I.pdf"
-callToActionText: "Apply for My Rooming or Boarding House License"
-agencyId: "nj-community-affairs"
-agencyAdditionalContext: "Bureau of Rooming and Boarding House Standards"
-divisionPhone: "(609) 984-1704"
-industryId: "lodging"
-licenseCertificationClassification: "undefined"
 licenseName: ""
-summaryDescriptionMd: "You need a license to own and/or operate a new or existing `rooming or boarding house|rooming-boarding-house`."
+id: rooming-boarding-house-license
+filename: rooming-boarding-house-license
+displayname: rooming-boarding-house-license
+urlSlug: rooming-boarding-house-license
+name: Apply for a Rooming or Boarding House License
+webflowName: "Lodging: Rooming or Boarding House License"
+summaryDescriptionMd: You need a license to own and/or operate a new or existing
+  `rooming or boarding house|rooming-boarding-house`.
+industryId: lodging
+callToActionText: Apply for My Rooming or Boarding House License
+callToActionLink: https://www.nj.gov/dca/codes/forms/pdf_rooming/App_Form_I.pdf
+agencyId: nj-community-affairs
+agencyAdditionalContext: Bureau of Rooming and Boarding House Standards
+divisionPhone: (609) 984-1704
+webflowId: 66b375f801e19e1717d32c2d
+licenseCertificationClassification: undefined
 ---
 
 :::note

--- a/content/src/roadmaps/license-tasks/short-term-rental-registration.md
+++ b/content/src/roadmaps/license-tasks/short-term-rental-registration.md
@@ -1,14 +1,18 @@
 ---
-id: "short-term-rental-registration"
-webflowId: "66f31981c7644d30ef1244e8"
-urlSlug: "short-term-rental-registration"
-name: "Register as a Short-Term Rental, if Your Town Requires It"
+id: short-term-rental-registration
+filename: short-term-rental-registration
+displayname: short-term-rental-registration
+urlSlug: short-term-rental-registration
+name: Register as a Short-Term Rental, if Your Town Requires It
 webflowName: "Residential Landlord: Short-Term Rental Registration"
-filename: "short-term-rental-registration"
-agencyAdditionalContext: "Your Municipality"
-industryId: "residential-landlord"
-licenseCertificationClassification: "undefined"
-summaryDescriptionMd: "If you plan to rent out your property for 60 days or less, you may need to register the property as a short-term rental with your municipal clerk. This requirement also applies to properties rented through websites like Airbnb or Vrbo."
+summaryDescriptionMd: If you plan to rent out your property for 60 days or less,
+  you may need to register the property as a short-term rental with your
+  municipal clerk. This requirement also applies to properties rented through
+  websites like Airbnb or Vrbo.
+industryId: residential-landlord
+agencyAdditionalContext: Your Municipality
+webflowId: 66f31981c7644d30ef1244e8
+licenseCertificationClassification: undefined
 ---
 
 ---


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

The Webflow licenseSync job was incorrectly formatting new license tasks. There is already a fix in place to address this going forward. This change is just to update the impacted files and add the missing `displayname` to the markdown file metadata. 

### Steps to Test

All updated content files should render in the CMS correctly and allow a CMS user to make updates.

### Notes

Running the CMS proxy I have confirmed that all of these files can be updated via the CMS.

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
