### PR TITLE
feat: [#186702387] close button revisions

### DIFF
--- a/web/src/components/ModalOneButton.tsx
+++ b/web/src/components/ModalOneButton.tsx
@@ -36,7 +36,6 @@ export const ModalOneButton = (props: Props): ReactElement => {
       close={props.close}
       title={props.title}
       unpaddedChildren={buttonNode}
-      uncloseable={props.uncloseable}
     >
       {props.children}
     </ModalZeroButton>

--- a/web/src/components/ModalZeroButton.tsx
+++ b/web/src/components/ModalZeroButton.tsx
@@ -2,7 +2,7 @@ import { Heading } from "@/components/njwds-extended/Heading";
 import { Icon } from "@/components/njwds/Icon";
 import { ContextualInfoContext } from "@/contexts/contextualInfoContext";
 import { Dialog, DialogContent, DialogTitle, IconButton } from "@mui/material";
-import { ReactElement, ReactNode, useContext } from "react";
+import { ReactElement, ReactNode, useContext, useEffect, useRef } from "react";
 
 interface Props {
   isOpen: boolean;
@@ -10,11 +10,25 @@ interface Props {
   title: string;
   children: ReactNode;
   unpaddedChildren?: ReactNode;
-  uncloseable?: boolean;
 }
 
 export const ModalZeroButton = (props: Props): ReactElement => {
   const { contextualInfo } = useContext(ContextualInfoContext);
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (dialogRef.current) {
+      const firstFocusableElement = dialogRef.current.querySelector<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (firstFocusableElement) {
+        firstFocusableElement.focus();
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dialogRef.current]);
+
   return (
     <Dialog
       fullWidth={false}
@@ -23,6 +37,7 @@ export const ModalZeroButton = (props: Props): ReactElement => {
       onClose={props.close}
       aria-labelledby="dialog-modal"
       disableEnforceFocus={contextualInfo.isVisible}
+      ref={dialogRef}
     >
       <div className="display-flex margin-top-1">
         <DialogTitle
@@ -33,18 +48,16 @@ export const ModalZeroButton = (props: Props): ReactElement => {
             {props.title}
           </Heading>
         </DialogTitle>
-        {!props.uncloseable && (
-          <IconButton
-            aria-label="close"
-            className="margin-left-auto margin-3"
-            onClick={props.close}
-            sx={{
-              color: "#757575",
-            }}
-          >
-            <Icon className="usa-icon--size-4">close</Icon>
-          </IconButton>
-        )}
+        <IconButton
+          aria-label="close"
+          className="margin-left-auto margin-3"
+          onClick={props.close}
+          sx={{
+            color: "#757575",
+          }}
+        >
+          <Icon className="usa-icon--size-4">close</Icon>
+        </IconButton>
       </div>
       <DialogContent sx={{ padding: 0 }} dividers>
         <div className="padding-x-4 margin-bottom-4 margin-top-2" data-testid="modal-body">


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

We were having some screen reader NVDA specific issues with the dialogs reading all its content when you go into it, rather than letting you move through it after a brief summary. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#186702387](https://www.pivotaltracker.com/story/show/186702387).

### Approach

Lots of research

turns out that a modals that has a form is suppose to be this way, but a modal with only text content or like confirm or cancel modals are suppose to be read all at once without prompting. 

The pattern desired is to auto focus on the first clickable element (the close button), which will also read out a brief description of the modal and title as such. 

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

1. login and go to formation step 3 contacts
2. turn on your screen reader
3. if you click add member, a modal will popup
4. You should be focused on the close button and it should be noted that you're in a dialog with a title of add members
5. The screen reader should not continue reading all the modal contents at that point

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
