### PR TITLE
Remove tests from CI pipeline for testing site branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -918,6 +918,7 @@ workflows:
           filters:
             branches:
               ignore:
+                - accessibility-testing-repo
                 - /^release-.*/
                 - /^staging-.*/
                 - /^cms/.*/
@@ -931,6 +932,7 @@ workflows:
           filters:
             branches:
               ignore:
+                - accessibility-testing-repo
                 - content-repo
                 - /^release-.*/
                 - /^staging-.*/
@@ -948,6 +950,7 @@ workflows:
             branches:
               ignore:
                 - main
+                - accessibility-testing-repo
                 - content-repo
                 - /^release-.*/
                 - /^staging-.*/
@@ -965,6 +968,7 @@ workflows:
             branches:
               ignore:
                 - main
+                - accessibility-testing-repo
                 - content-repo
                 - /^release-.*/
                 - /^staging-.*/
@@ -982,6 +986,7 @@ workflows:
             branches:
               ignore:
                 - main
+                - accessibility-testing-repo
                 - content-repo
                 - /^release-.*/
                 - /^staging-.*/
@@ -999,6 +1004,7 @@ workflows:
             branches:
               ignore:
                 - main
+                - accessibility-testing-repo
                 - content-repo
                 - /^release-.*/
                 - /^staging-.*/
@@ -1016,6 +1022,7 @@ workflows:
             branches:
               ignore:
                 - main
+                - accessibility-testing-repo
                 - content-repo
                 - /^release-.*/
                 - /^staging-.*/


### PR DESCRIPTION
## Description

Remove the tests from the CI pipeline that deploys the testing site. This is unnecessary and just runs up the CI bill.

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
