### PR TITLE
feat: [#186084688] callout alerts are now aria groups

### DIFF
--- a/content/src/mappings/callout-alerts.json
+++ b/content/src/mappings/callout-alerts.json
@@ -1,0 +1,10 @@
+{
+  "calloutAlerts": {
+    "calloutAlertGroupTitle": "${alertVariant}",
+    "info": "informational",
+    "success": "success",
+    "error": "error",
+    "warning": "warning",
+    "note": "note"
+  }
+}

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -5690,6 +5690,29 @@ collections:
               - { label: "Error Description 2", name: "errorDescriptionPt2", widget: "markdown" }
               - { label: "Chat with Expert", name: "errorChatWithExpert", widget: "markdown" }
 
+  - name: "component-accessibility"
+    label: "Component Accessibility"
+    delete: false
+    create: false
+    files:
+      - label: "Callout Alerts"
+        name: "callout-alerts"
+        file: "content/src/mappings/callout-alerts.json"
+        editor:
+          preview: true
+        fields:
+          - label: "Callout Alerts"
+            name: calloutAlerts
+            collapsed: false
+            widget: object
+            fields:
+              - { label: "Callout Alert Group Title", name: "calloutAlertGroupTitle", widget: "string" }
+              - { label: "Info (Blue)", name: "info", widget: "string" }
+              - { label: "Success (Green)", name: "success", widget: "string" }
+              - { label: "Error (Red)", name: "error", widget: "string" }
+              - { label: "Warning (Yellow)", name: "warning", widget: "string" }
+              - { label: "Note (Gray)", name: "note", widget: "string" }
+
   - name: "global-error-messages"
     label: "Global Error Messages"
     delete: false

--- a/web/src/components/njwds-extended/SnackbarAlert.tsx
+++ b/web/src/components/njwds-extended/SnackbarAlert.tsx
@@ -39,6 +39,7 @@ export const SnackbarAlert = (props: Props): ReactElement => {
             noIcon={props.noIcon}
             rounded
             dataTestid={props.dataTestid}
+            noAlertRole
           >
             <div>{props.children}</div>
           </Alert>

--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
@@ -599,9 +599,11 @@ describe("<BusinessFormationPaginator />", () => {
         await page.submitReviewStep();
 
         await page.stepperClickToContactsStep();
-        expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.errorBanner.errorOnStep);
-        expect(screen.queryByRole("alert")).not.toHaveTextContent(Config.formation.fields.members.label);
-        expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.fields.trustees.label);
+        expect(screen.getByTestId("alert-error")).toHaveTextContent(Config.formation.errorBanner.errorOnStep);
+        expect(screen.queryByTestId("alert-error")).not.toHaveTextContent(
+          Config.formation.fields.members.label
+        );
+        expect(screen.getByTestId("alert-error")).toHaveTextContent(Config.formation.fields.trustees.label);
       });
 
       it.each(corpLegalStructures)(
@@ -622,9 +624,15 @@ describe("<BusinessFormationPaginator />", () => {
 
           await page.stepperClickToContactsStep();
 
-          expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.errorBanner.errorOnStep);
-          expect(screen.queryByRole("alert")).not.toHaveTextContent(Config.formation.fields.members.label);
-          expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.fields.directors.label);
+          expect(screen.getByTestId("alert-error")).toHaveTextContent(
+            Config.formation.errorBanner.errorOnStep
+          );
+          expect(screen.queryByTestId("alert-error")).not.toHaveTextContent(
+            Config.formation.fields.members.label
+          );
+          expect(screen.getByTestId("alert-error")).toHaveTextContent(
+            Config.formation.fields.directors.label
+          );
         }
       );
     });
@@ -1377,12 +1385,14 @@ describe("<BusinessFormationPaginator />", () => {
             if (formationStepName === "Contacts") await page.stepperClickToContactsStep();
             if (formationStepName === "Billing") await page.stepperClickToBillingStep();
 
-            expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.errorBanner.errorOnStep);
-            expect(screen.getByRole("alert")).toHaveTextContent(
+            expect(screen.getByTestId("alert-error")).toHaveTextContent(
+              Config.formation.errorBanner.errorOnStep
+            );
+            expect(screen.getByTestId("alert-error")).toHaveTextContent(
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               (Config.formation.fields as any)[fieldName as string].label
             );
-            expect(screen.getByRole("alert")).toHaveTextContent("very bad input");
+            expect(screen.getByTestId("alert-error")).toHaveTextContent("very bad input");
           });
 
           it.each([
@@ -1428,9 +1438,9 @@ describe("<BusinessFormationPaginator />", () => {
             if (formationStepName === "Business") await page.stepperClickToBusinessStep();
             if (formationStepName === "Contacts") await page.stepperClickToContactsStep();
             if (formationStepName === "Billing") await page.stepperClickToBillingStep();
-            expect(screen.getByRole("alert")).toBeInTheDocument();
+            expect(screen.getByTestId("alert-error")).toBeInTheDocument();
             page.fillText(fieldLabel as string as string, newTextInput as string);
-            expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+            expect(screen.queryByTestId("alert-error")).not.toBeInTheDocument();
             expect(screen.queryByText(Config.formation.errorBanner.errorOnStep)).not.toBeInTheDocument();
             expect(page.getStepStateInStepper(LookupStepIndexByName(formationStepName))).toEqual(
               "COMPLETE-ACTIVE"
@@ -1458,9 +1468,9 @@ describe("<BusinessFormationPaginator />", () => {
               if (formationStepName === "Business") await page.stepperClickToBusinessStep();
               if (formationStepName === "Contacts") await page.stepperClickToContactsStep();
               if (formationStepName === "Billing") await page.stepperClickToBillingStep();
-              expect(screen.getByRole("alert")).toBeInTheDocument();
+              expect(screen.getByTestId("alert-error")).toBeInTheDocument();
               fireEvent.click(screen.getByTestId(radioBtnTestId as string));
-              expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+              expect(screen.queryByTestId("alert-error")).not.toBeInTheDocument();
               expect(screen.queryByText(Config.formation.errorBanner.errorOnStep)).not.toBeInTheDocument();
               expect(page.getStepStateInStepper(LookupStepIndexByName(formationStepName))).toEqual(
                 "COMPLETE-ACTIVE"
@@ -1491,12 +1501,12 @@ describe("<BusinessFormationPaginator />", () => {
               await page.stepperClickToReviewStep();
               await page.clickSubmit();
               if (formationStepName === "Business") await page.stepperClickToBusinessStep();
-              expect(screen.getByRole("alert")).toBeInTheDocument();
+              expect(screen.getByTestId("alert-error")).toBeInTheDocument();
 
               page.selectByText(dropDownLabel as string, dropDownValue as string);
               fireEvent.focusOut(screen.getAllByLabelText(dropDownLabel as string)[0]);
 
-              expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+              expect(screen.queryByTestId("alert-error")).not.toBeInTheDocument();
               expect(screen.queryByText(Config.formation.errorBanner.errorOnStep)).not.toBeInTheDocument();
               expect(page.getStepStateInStepper(LookupStepIndexByName(formationStepName))).toEqual(
                 "COMPLETE-ACTIVE"
@@ -1527,14 +1537,14 @@ describe("<BusinessFormationPaginator />", () => {
               await page.stepperClickToReviewStep();
               await page.clickSubmit();
               if (formationStepName === "Business") await page.stepperClickToBusinessStep();
-              expect(screen.getByRole("alert")).toBeInTheDocument();
+              expect(screen.getByTestId("alert-error")).toBeInTheDocument();
 
               page.selectDate(
                 newDate as DateObject,
                 datePickerFieldType as "Business start date" | "Foreign date of formation"
               );
 
-              expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+              expect(screen.queryByTestId("alert-error")).not.toBeInTheDocument();
               expect(screen.queryByText(Config.formation.errorBanner.errorOnStep)).not.toBeInTheDocument();
               expect(page.getStepStateInStepper(LookupStepIndexByName(formationStepName))).toEqual(
                 "COMPLETE-ACTIVE"
@@ -1960,12 +1970,14 @@ describe("<BusinessFormationPaginator />", () => {
             if (formationStepName === "Business") await page.stepperClickToBusinessStep();
             if (formationStepName === "Contacts") await page.stepperClickToContactsStep();
             if (formationStepName === "Billing") await page.stepperClickToBillingStep();
-            expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.errorBanner.errorOnStep);
-            expect(screen.getByRole("alert")).toHaveTextContent(
+            expect(screen.getByTestId("alert-error")).toHaveTextContent(
+              Config.formation.errorBanner.errorOnStep
+            );
+            expect(screen.getByTestId("alert-error")).toHaveTextContent(
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               (Config.formation.fields as any)[fieldName as string].label
             );
-            expect(screen.getByRole("alert")).toHaveTextContent("very bad input");
+            expect(screen.getByTestId("alert-error")).toHaveTextContent("very bad input");
           });
 
           it.each([
@@ -2001,11 +2013,11 @@ describe("<BusinessFormationPaginator />", () => {
             if (formationStepName === "Business") await page.stepperClickToBusinessStep();
             if (formationStepName === "Contacts") await page.stepperClickToContactsStep();
             if (formationStepName === "Billing") await page.stepperClickToBillingStep();
-            expect(screen.getByRole("alert")).toBeInTheDocument();
+            expect(screen.getByTestId("alert-error")).toBeInTheDocument();
 
             page.fillText(fieldLabel as string as string, newTextInput as string);
             await waitFor(() => {
-              expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+              expect(screen.queryByTestId("alert-error")).not.toBeInTheDocument();
             });
             expect(screen.queryByText(Config.formation.errorBanner.errorOnStep)).not.toBeInTheDocument();
             expect(page.getStepStateInStepper(LookupStepIndexByName(formationStepName))).toEqual(

--- a/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
@@ -992,20 +992,22 @@ describe("Formation - BusinessStep", () => {
     it("displays Business Suffix error label when Business Suffix is undefined", async () => {
       const page = await getPageHelper({}, { businessSuffix: undefined });
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.fields.businessSuffix.label);
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
+        Config.formation.fields.businessSuffix.label
+      );
     });
 
     it("displays Withdrawals error label when Withdrawals is empty", async () => {
       const page = await getPageHelper({ legalStructureId: "limited-partnership" }, { withdrawals: "" });
       await attemptApiSubmission(page);
       expect(screen.getByText(Config.formation.general.genericErrorText)).toBeInTheDocument();
-      expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.fields.withdrawals.label);
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(Config.formation.fields.withdrawals.label);
     });
 
     it("displays Dissolution error label when Dissolution is empty", async () => {
       const page = await getPageHelper({ legalStructureId: "limited-partnership" }, { dissolution: "" });
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.fields.dissolution.label);
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(Config.formation.fields.dissolution.label);
     });
 
     it("displays Combined Investment error label when Combined Investment is empty", async () => {
@@ -1014,7 +1016,9 @@ describe("Formation - BusinessStep", () => {
         { combinedInvestment: "" }
       );
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.fields.combinedInvestment.label);
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
+        Config.formation.fields.combinedInvestment.label
+      );
     });
 
     it("displays error label when Partnership Rights can create Limited Partner is undefined", async () => {
@@ -1036,7 +1040,7 @@ describe("Formation - BusinessStep", () => {
       );
       fireEvent.click(screen.getByTestId("canCreateLimitedPartner-true"));
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
         Config.formation.fields.createLimitedPartnerTerms.label
       );
     });
@@ -1059,7 +1063,7 @@ describe("Formation - BusinessStep", () => {
       );
       fireEvent.click(screen.getByTestId("canMakeDistribution-true"));
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
         Config.formation.fields.makeDistributionTerms.label
       );
     });
@@ -1082,13 +1086,17 @@ describe("Formation - BusinessStep", () => {
       );
       fireEvent.click(screen.getByTestId("canGetDistribution-true"));
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.fields.getDistributionTerms.label);
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
+        Config.formation.fields.getDistributionTerms.label
+      );
     });
 
     it("displays error label when Total Shares is empty", async () => {
       const page = await getPageHelper({ legalStructureId: "c-corporation" }, { businessTotalStock: "" });
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.fields.businessTotalStock.label);
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
+        Config.formation.fields.businessTotalStock.label
+      );
       expect(screen.getByText(Config.formation.fields.businessTotalStock.error)).toBeInTheDocument();
     });
 
@@ -1098,7 +1106,7 @@ describe("Formation - BusinessStep", () => {
         { foreignDateOfFormation: undefined }
       );
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
         Config.formation.fields.foreignDateOfFormation.label
       );
       expect(screen.getByText(Config.formation.fields.foreignDateOfFormation.error)).toBeInTheDocument();
@@ -1110,7 +1118,7 @@ describe("Formation - BusinessStep", () => {
         { foreignStateOfFormation: undefined }
       );
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
         Config.formation.fields.foreignStateOfFormation.label
       );
       expect(screen.getByText(Config.formation.fields.foreignStateOfFormation.error)).toBeInTheDocument();
@@ -1119,13 +1127,15 @@ describe("Formation - BusinessStep", () => {
     it("displays error label when Address line1 is empty", async () => {
       const page = await getPageHelper({ businessPersona: "FOREIGN" }, { addressLine1: "" });
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.fields.addressLine1.label);
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(Config.formation.fields.addressLine1.label);
     });
 
     it("displays error label when Address zip code is empty", async () => {
       const page = await getPageHelper({ businessPersona: "FOREIGN" }, { addressZipCode: "" });
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.fields.addressZipCode.label);
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
+        Config.formation.fields.addressZipCode.label
+      );
     });
 
     it("displays error label when Address province is undefined", async () => {
@@ -1134,7 +1144,9 @@ describe("Formation - BusinessStep", () => {
         { addressProvince: undefined, businessLocationType: "INTL" }
       );
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.fields.addressProvince.label);
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
+        Config.formation.fields.addressProvince.label
+      );
     });
 
     it("displays error label when Address country is undefined", async () => {
@@ -1143,7 +1155,9 @@ describe("Formation - BusinessStep", () => {
         { addressCountry: undefined, businessLocationType: "INTL" }
       );
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.fields.addressCountry.label);
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
+        Config.formation.fields.addressCountry.label
+      );
     });
 
     it("displays error label when Address city is undefined", async () => {
@@ -1152,7 +1166,7 @@ describe("Formation - BusinessStep", () => {
         { addressCity: undefined, businessLocationType: "INTL" }
       );
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.fields.addressCity.label);
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(Config.formation.fields.addressCity.label);
     });
 
     it("displays error label when Address state is undefined", async () => {
@@ -1161,13 +1175,15 @@ describe("Formation - BusinessStep", () => {
         { addressState: undefined, businessLocationType: "US" }
       );
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.fields.addressState.label);
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(Config.formation.fields.addressState.label);
     });
 
     it("displays error label when isVeteranNonprofit is undefined", async () => {
       const page = await getPageHelper({ legalStructureId: "nonprofit" }, { isVeteranNonprofit: undefined });
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(Config.formation.fields.isVeteranNonprofit.label);
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
+        Config.formation.fields.isVeteranNonprofit.label
+      );
       expect(screen.getByText(Config.formation.fields.isVeteranNonprofit.error)).toBeInTheDocument();
     });
 
@@ -1177,7 +1193,7 @@ describe("Formation - BusinessStep", () => {
         { hasNonprofitBoardMembers: undefined, legalType: "nonprofit" }
       );
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
         Config.formation.fields.hasNonprofitBoardMembers.label
       );
       expect(screen.getByText(Config.formation.general.genericErrorText)).toBeInTheDocument();
@@ -1193,7 +1209,7 @@ describe("Formation - BusinessStep", () => {
         }
       );
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
         Config.formation.fields.nonprofitBoardMemberQualificationsSpecified.label
       );
       expect(screen.getByText(Config.formation.general.genericErrorText)).toBeInTheDocument();
@@ -1210,7 +1226,7 @@ describe("Formation - BusinessStep", () => {
         }
       );
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
         Config.formation.fields.nonprofitBoardMemberQualificationsTerms.label
       );
       expect(screen.getByText(Config.formation.general.genericErrorText)).toBeInTheDocument();
@@ -1226,7 +1242,7 @@ describe("Formation - BusinessStep", () => {
         }
       );
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
         Config.formation.fields.nonprofitBoardMemberRightsSpecified.label
       );
       expect(screen.getByText(Config.formation.general.genericErrorText)).toBeInTheDocument();
@@ -1243,7 +1259,7 @@ describe("Formation - BusinessStep", () => {
         }
       );
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
         Config.formation.fields.nonprofitBoardMemberRightsSpecified.label
       );
       expect(screen.getByText(Config.formation.general.genericErrorText)).toBeInTheDocument();
@@ -1259,7 +1275,7 @@ describe("Formation - BusinessStep", () => {
         }
       );
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
         Config.formation.fields.nonprofitTrusteesMethodSpecified.label
       );
       expect(screen.getByText(Config.formation.general.genericErrorText)).toBeInTheDocument();
@@ -1276,7 +1292,7 @@ describe("Formation - BusinessStep", () => {
         }
       );
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
         Config.formation.fields.nonprofitTrusteesMethodTerms.label
       );
       expect(screen.getByText(Config.formation.general.genericErrorText)).toBeInTheDocument();
@@ -1292,7 +1308,7 @@ describe("Formation - BusinessStep", () => {
         }
       );
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
         Config.formation.fields.nonprofitAssetDistributionSpecified.label
       );
       expect(screen.getByText(Config.formation.general.genericErrorText)).toBeInTheDocument();
@@ -1309,7 +1325,7 @@ describe("Formation - BusinessStep", () => {
         }
       );
       await attemptApiSubmission(page);
-      expect(screen.getByRole("alert")).toHaveTextContent(
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
         Config.formation.fields.nonprofitAssetDistributionTerms.label
       );
       expect(screen.getByText(Config.formation.general.genericErrorText)).toBeInTheDocument();

--- a/web/src/components/tasks/business-formation/business/MainBusinessAddressNj.test.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusinessAddressNj.test.tsx
@@ -136,7 +136,7 @@ describe("<MainBusinessAddressNj />", () => {
       });
       await attemptApiSubmission(page);
 
-      expect(screen.getByRole("alert")).toHaveTextContent(
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (Config.formation.fields as any)[field].label
       );

--- a/web/src/contexts/configContext.ts
+++ b/web/src/contexts/configContext.ts
@@ -32,6 +32,7 @@ import * as Profile from "@businessnjgovnavigator/content/fieldConfig/profile.js
 import * as StarterKits from "@businessnjgovnavigator/content/fieldConfig/starter-kits.json";
 import * as TaxAccess from "@businessnjgovnavigator/content/fieldConfig/tax-access-modal.json";
 import * as Tax from "@businessnjgovnavigator/content/fieldConfig/tax.json";
+import * as CalloutAlerts from "@businessnjgovnavigator/content/mappings/callout-alerts.json";
 import * as PageMetadata from "@businessnjgovnavigator/content/page-metadata/page-metadata.json";
 
 import { merge } from "lodash";
@@ -76,7 +77,8 @@ const merged = JSON.parse(
       ElevatorRegistration,
       StarterKits,
       HousingRegistrationSearchTask,
-      anytimeActionReinstatementAndLicenseCalendarEventStatusDefaults
+      anytimeActionReinstatementAndLicenseCalendarEventStatusDefaults,
+      CalloutAlerts
     )
   )
 );
@@ -117,7 +119,8 @@ export type ConfigType = typeof ConfigOriginal &
   typeof PageMetadata &
   typeof StarterKits &
   typeof HousingRegistrationSearchTask &
-  typeof anytimeActionReinstatementAndLicenseCalendarEventStatusDefaults;
+  typeof anytimeActionReinstatementAndLicenseCalendarEventStatusDefaults &
+  typeof CalloutAlerts;
 
 export const getMergedConfig = (): ConfigType => {
   return merge(
@@ -154,7 +157,8 @@ export const getMergedConfig = (): ConfigType => {
     ElevatorRegistration,
     StarterKits,
     HousingRegistrationSearchTask,
-    anytimeActionReinstatementAndLicenseCalendarEventStatusDefaults
+    anytimeActionReinstatementAndLicenseCalendarEventStatusDefaults,
+    CalloutAlerts
   );
 };
 

--- a/web/src/lib/search/cmsCollections.ts
+++ b/web/src/lib/search/cmsCollections.ts
@@ -77,6 +77,7 @@ export const cmsCollections = [
       "404 Page",
       "Global Error Messages",
       "Navigation Config",
+      "Component Accessibility",
     ],
   },
 ];


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Bascially we wanted the callout inline alerts to be grouped from the perspective of a screen reader

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#186084688](https://www.pivotaltracker.com/story/show/186084688).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Go to a page with an inline calllout, theres one on step 2 of formation under one of the optional parts below, you do have to open it via the link on the right

<img width="1234" alt="image" src="https://github.com/user-attachments/assets/a2d839f4-53a8-4a13-93fc-60b0cc823374">

use a screen reader to navigate through it and see that it has structure relative to the screen reader

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

Made a mapping for content such that they can modify these overrides and text completely. 

Also removed the role from this component it's parent handles this already

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
