### PR TITLE
feat: [#188057802] updated footer and header to align with NJ gov

### DIFF
--- a/web/src/components/PageFooter.tsx
+++ b/web/src/components/PageFooter.tsx
@@ -16,68 +16,95 @@ export const PageFooter = (): ReactElement => {
         } margin-x-auto padding-y-4 grid-container-widescreen desktop:padding-x-7`}
       >
         <section aria-label="New Jersey Office of Innovation information and services">
-          <div className={`${isLargeScreen ? "" : "flex flex-column flex-align-center"}`}>
-            <a
-              href={Config.footer.linkOne}
-              className="margin-right-1 text-white"
-              target="_blank"
-              rel="noreferrer"
-            >
-              {Config.footer.linkOneText}
-            </a>
-
-            <a
-              href={Config.footer.linkTwo}
-              className="margin-left-1 text-white"
-              target="_blank"
-              rel="noreferrer"
-            >
-              {Config.footer.linkTwoText}
-            </a>
-          </div>
+          <ul
+            className={`${
+              isLargeScreen ? "flex" : "flex flex-column flex-align-center"
+            } footer-social-media-structure`}
+          >
+            <li>
+              <div>
+                <a
+                  href={Config.footer.linkOne}
+                  className="margin-right-1 text-white"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {Config.footer.linkOneText}
+                </a>
+              </div>
+            </li>
+            <li>
+              <div>
+                <a
+                  href={Config.footer.linkTwo}
+                  className="margin-left-1 text-white"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {Config.footer.linkTwoText}
+                </a>
+              </div>
+            </li>
+          </ul>
           <hr className="margin-y-2" />
-          <div className={`${isLargeScreen ? "" : "flex flex-column flex-align-center"}`}>
-            <span className="padding-right-1 text-center">
-              <a
-                href={Config.footer.officeLink}
-                className="text-white"
-                target="_blank"
-                rel="noreferrer noopener"
-                aria-label={Config.footer.madeWithLoveByTheOfficeOfInnovationAriaLabel}
-              >
-                {Config.footer.madeWithText}
-                &nbsp;<Icon className="text-accent-hot">favorite</Icon>&nbsp;
-                {Config.footer.byTheOfficeOfInnovationText}
-              </a>
-            </span>
+          <ul
+            className={`${
+              isLargeScreen ? "flex" : "flex flex-column flex-align-center"
+            } footer-social-media-structure`}
+          >
+            <li className="padding-right-1 text-center">
+              <div>
+                <a
+                  href={Config.footer.officeLink}
+                  className="text-white"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  aria-label={Config.footer.madeWithLoveByTheOfficeOfInnovationAriaLabel}
+                >
+                  {Config.footer.madeWithText}
+                  &nbsp;<Icon className="text-accent-hot">favorite</Icon>&nbsp;
+                  {Config.footer.byTheOfficeOfInnovationText}
+                </a>
+              </div>
+            </li>
 
-            <div className="padding-left-0 desktop:padding-left-1 tablet:display-inline">
-              {Config.footer.creditText}
-              <a href={Config.footer.creditLink} target="_blank" className="text-white" rel="noreferrer">
-                {Config.footer.creditLinkText}
-              </a>
-            </div>
-          </div>
+            <li className="padding-left-0 desktop:padding-left-1 tablet:display-inline">
+              <div>
+                {Config.footer.creditText}
+                <a href={Config.footer.creditLink} target="_blank" className="text-white" rel="noreferrer">
+                  {Config.footer.creditLinkText}
+                </a>
+              </div>
+            </li>
+          </ul>
           {!isLargeScreen && <hr className="margin-y-2" />}
         </section>
 
         <section aria-label="Social media">
           <div className="display-flex flex-column fac">
             <div>{Config.footer.officeExternalText}</div>
-            <div>
-              <a
-                href={Config.footer.gitHubLink}
-                target="_blank"
-                rel="noreferrer"
-                aria-label="GitHub"
-                className="margin-right-105"
-              >
-                <Icon className="footer-social-media-icon margin-top-1">github</Icon>
-              </a>
-              <a href={Config.footer.facebookLink} target="_blank" rel="noreferrer" aria-label="Facebook">
-                <Icon className="footer-social-media-icon margin-top-1">facebook</Icon>
-              </a>
-            </div>
+            <ul className={`footer-social-media-structure flex`}>
+              <li>
+                <div>
+                  <a
+                    href={Config.footer.gitHubLink}
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label="GitHub"
+                    className="margin-right-105"
+                  >
+                    <Icon className="footer-social-media-icon margin-top-1">github</Icon>
+                  </a>
+                </div>
+              </li>
+              <li>
+                <div>
+                  <a href={Config.footer.facebookLink} target="_blank" rel="noreferrer" aria-label="Facebook">
+                    <Icon className="footer-social-media-icon margin-top-1">facebook</Icon>
+                  </a>
+                </div>
+              </li>
+            </ul>
           </div>
         </section>
       </div>

--- a/web/src/components/njwds/Banner.tsx
+++ b/web/src/components/njwds/Banner.tsx
@@ -7,7 +7,12 @@ export const Banner = (): ReactElement => {
         <div className="grid-container-widescreen desktop:padding-x-7">
           <div className="nj-banner__inner margin-y-1 row-desktop-column-mobile fas flex-align-center-desktop-start-mobile space-between">
             <div className="flex fac margin-y-05">
-              <img className="nj-banner__header-seal" src="/vendor/img/nj_state_seal.png" alt="NJ flag" />
+              <img
+                className="nj-banner__header-seal"
+                src="/vendor/img/nj_state_seal.png"
+                alt="NJ flag"
+                role="presentation"
+              />
               <a href="https://nj.gov">Official Site of the State of New Jersey</a>
             </div>
             <div className="flex row-desktop-column-mobile">

--- a/web/src/styles/sections/footer.scss
+++ b/web/src/styles/sections/footer.scss
@@ -7,3 +7,14 @@
 .footer-social-media-icon:hover {
   color: $white;
 }
+
+ul.footer-social-media-structure {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  li {
+    display: inline;
+    margin: 0;
+  }
+}


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

we wanted our header icon to be decorational and ignore and we wanted our footer to read better on NVDA

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188057802](https://www.pivotaltracker.com/story/show/188057802).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

This is basically impossible to test without using NVDA which I believe no dev has. So just make sure the code looks sane and you can visually confirm that it looks the same / operates the same locally

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

Not exactly sure why this works, tried many many things and experimented a lot but didn't really get to a clear reaons

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
