### PR TITLE
fix: [#188364329] log user out if no userData found

### DIFF
--- a/api/src/functions/express/app.ts
+++ b/api/src/functions/express/app.ts
@@ -344,7 +344,8 @@ app.use(
     updateSidebarCards,
     updateOperatingPhase,
     AWSEncryptionDecryptionClient,
-    timeStampToBusinessSearch
+    timeStampToBusinessSearch,
+    logger
   )
 );
 

--- a/web/src/lib/api-client/apiClient.ts
+++ b/web/src/lib/api-client/apiClient.ts
@@ -17,11 +17,15 @@ import axios, { AxiosError, AxiosRequestConfig } from "axios";
 
 const apiBaseUrl = process.env.API_BASE_URL || "";
 
-export const getUserData = (id: string): Promise<UserData> => {
-  return get<UserData>(`/users/${id}`).then((userData) => {
-    setPhaseDimension(getCurrentBusiness(userData).profileData.operatingPhase);
-    return userData;
-  });
+export const getUserData = (id: string): Promise<undefined | UserData> => {
+  return get<UserData>(`/users/${id}`)
+    .then((userData) => {
+      setPhaseDimension(getCurrentBusiness(userData).profileData.operatingPhase);
+      return userData;
+    })
+    .catch(() => {
+      return undefined;
+    });
 };
 
 export const postUserData = async (userData: UserData): Promise<UserData> => {

--- a/web/src/lib/auth/signinHelper.ts
+++ b/web/src/lib/auth/signinHelper.ts
@@ -19,7 +19,10 @@ import { Dispatch } from "react";
 import * as session from "./sessionHelper";
 import { triggerSignOut } from "./sessionHelper";
 
-export const onSignIn = async (dispatch: Dispatch<AuthAction>): Promise<void> => {
+export const onSignIn = async (
+  push: (url: string) => Promise<boolean>,
+  dispatch: Dispatch<AuthAction>
+): Promise<void> => {
   const user = await session.getActiveUser();
   dispatch({
     type: "LOGIN",
@@ -27,6 +30,11 @@ export const onSignIn = async (dispatch: Dispatch<AuthAction>): Promise<void> =>
   });
 
   const userData = await api.getUserData(user.id);
+  if (userData === undefined) {
+    // TODO: Maybe include an interstitial that lets the user know why they're being logged out?
+    onSignOut(push, dispatch);
+    return;
+  }
   setRegistrationDimension("Fully Registered");
   setOnLoadDimensions(userData);
 };

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -81,7 +81,7 @@ const App = ({ Component, pageProps }: AppProps): ReactElement => {
   const listener = (data: HubCapsule): void => {
     switch (data.payload.event) {
       case "signIn":
-        onSignIn(dispatch);
+        onSignIn(router.push, dispatch);
         break;
       case "signUp":
         break;


### PR DESCRIPTION
As of 2024-10-16 - this is deployed in the testing site for manual testing.

<!-- Please complete the following sections as necessary. -->

## Description

If a user attempts to log in and there is no user data found, they will be logged out of the My Account app automatically.

### Ticket

This pull request resolves [#188364329](https://www.pivotaltracker.com/story/show/188364329).

### Approach

Added logging on the backend to better capture login events
- userData fetch attempted with email instead of userID
- userData not found
- server error

Added a check in the `onSignIn` function to validate that `userData` exists. If not, trigger log out flow.

### Steps to Test

- Create a new myNJ account
- Attempt to log into the application without completing onboarding
- The application should immediately log you out

Additionally, you should still be able to complete onboarding as a guest, self-reg for myNJ, link an existing myNJ account with your My Account/Navigator userData, and log into an existing account.

### Notes

There will be further work done on this in the near future. This current workflow is not ideal. It is likely that the user will end up in a behavior loop, but this is significantly better than the software loop that users currently experience.

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
