### PR TITLE
feat: [#188109500] Update error message when no license results are f…

### DIFF
--- a/api/src/api/licenseStatusRouter.test.ts
+++ b/api/src/api/licenseStatusRouter.test.ts
@@ -74,14 +74,14 @@ describe("licenseStatusRouter", () => {
     stubUpdateLicenseStatus.mockResolvedValue(userData);
 
     const nameAndAddress = generateLicenseSearchNameAndAddress({});
-    const licenseTaskID = "some-task-id";
+    const licenseTaskId = "some-id";
     stubUserDataClient.get.mockResolvedValue(userData);
-    const response = await request(app).post(`/license-status`).send({ nameAndAddress, licenseTaskID });
+    const response = await request(app).post(`/license-status`).send({ nameAndAddress, licenseTaskId });
     expect(response.status).toEqual(StatusCodes.OK);
     expect(stubUserDataClient.get).toHaveBeenCalledWith("some-id");
     expect(stubUserDataClient.put).toHaveBeenCalledWith(userData);
     expect(response.body).toEqual(userData);
-    expect(stubUpdateLicenseStatus).toHaveBeenCalledWith(userData, nameAndAddress, licenseTaskID);
+    expect(stubUpdateLicenseStatus).toHaveBeenCalledWith(userData, nameAndAddress, licenseTaskId);
   });
 
   it("returns INTERNAL SERVER ERROR if license search errors", async () => {

--- a/api/src/api/licenseStatusRouter.ts
+++ b/api/src/api/licenseStatusRouter.ts
@@ -1,13 +1,13 @@
 import { getSignedInUserId } from "@api/userRouter";
 import { UpdateLicenseStatus, UserDataClient } from "@domain/types";
-import { LicenseSearchNameAndAddress, LicenseTaskID } from "@shared/license";
+import { LicenseSearchNameAndAddress, LicenseTaskId } from "@shared/license";
 import { UserData } from "@shared/userData";
 import { Router } from "express";
 import { StatusCodes } from "http-status-codes";
 
 type LicenseStatusRequestBody = {
   nameAndAddress: LicenseSearchNameAndAddress;
-  licenseTaskID?: LicenseTaskID;
+  licenseTaskId?: LicenseTaskId;
 };
 
 export const licenseStatusRouterFactory = (
@@ -18,9 +18,9 @@ export const licenseStatusRouterFactory = (
 
   router.post("/license-status", async (req, res) => {
     const userId = getSignedInUserId(req);
-    const { nameAndAddress, licenseTaskID } = req.body as LicenseStatusRequestBody;
+    const { nameAndAddress, licenseTaskId } = req.body as LicenseStatusRequestBody;
     const userData = await userDataClient.get(userId);
-    updateLicenseStatus(userData, nameAndAddress, licenseTaskID)
+    updateLicenseStatus(userData, nameAndAddress, licenseTaskId)
       .then(async (userData: UserData) => {
         const updatedUserData = await userDataClient.put(userData);
         res.json(updatedUserData);

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -16,7 +16,7 @@ import {
   enabledLicensesSources,
   LicenseEntity,
   LicenseSearchNameAndAddress,
-  LicenseTaskID,
+  LicenseTaskId,
 } from "@shared/license";
 import { ProfileData } from "@shared/profileData";
 import { TaxFilingCalendarEvent, TaxFilingLookupState, TaxFilingOnboardingState } from "@shared/taxFiling";
@@ -135,7 +135,7 @@ export type SearchLicenseStatus = (
 export type UpdateLicenseStatus = (
   userData: UserData,
   nameAndAddress: LicenseSearchNameAndAddress,
-  taskId?: LicenseTaskID
+  taskId?: LicenseTaskId
 ) => Promise<UserData>;
 
 export type FireSafetyInspectionStatus = (address: string) => Promise<FireSafetyInspectionResult[]>;

--- a/api/src/domain/user/updateLicenseStatusFactory.test.ts
+++ b/api/src/domain/user/updateLicenseStatusFactory.test.ts
@@ -246,8 +246,8 @@ describe("updateLicenseStatus", () => {
 
   describe("error handling", () => {
     it("throws error when both webservice and rgb api call fails", async () => {
-      stubWebserviceLicenseStatusSearch.mockRejectedValue("fail");
-      stubRGBLicenseStatusSearch.mockRejectedValue("fail");
+      stubWebserviceLicenseStatusSearch.mockRejectedValue(new Error("fail"));
+      stubRGBLicenseStatusSearch.mockRejectedValue(new Error("fail"));
 
       userData = modifyCurrentBusiness(userData, (business) => ({
         ...business,
@@ -256,15 +256,15 @@ describe("updateLicenseStatus", () => {
 
       await expect(updateLicenseStatus(userData, nameAndAddress)).rejects.toThrow(
         JSON.stringify({
-          webserviceErrorMessage: "fail",
-          rgbErrorMessage: "fail",
+          webserviceErrorMessage: new Error("fail"),
+          rgbErrorMessage: new Error("fail"),
         })
       );
     });
 
     it("updates license data of current task to have error license data when webservice receives NO_MATCH_ERROR and rgb also fails", async () => {
-      stubWebserviceLicenseStatusSearch.mockRejectedValue(NO_MATCH_ERROR);
-      stubRGBLicenseStatusSearch.mockRejectedValue("fail");
+      stubWebserviceLicenseStatusSearch.mockRejectedValue(new Error(NO_MATCH_ERROR));
+      stubRGBLicenseStatusSearch.mockRejectedValue(new Error("fail"));
 
       userData = modifyCurrentBusiness(userData, (business) => ({
         ...business,
@@ -298,8 +298,8 @@ describe("updateLicenseStatus", () => {
     it.each([NO_MATCH_ERROR, NO_MAIN_APPS_ERROR, NO_ADDRESS_MATCH_ERROR])(
       "updates license data of current task to have error license data when rgb receives %s and webservice also fails",
       async (error) => {
-        stubWebserviceLicenseStatusSearch.mockRejectedValue("fails");
-        stubRGBLicenseStatusSearch.mockRejectedValue(error);
+        stubWebserviceLicenseStatusSearch.mockRejectedValue(new Error("fails"));
+        stubRGBLicenseStatusSearch.mockRejectedValue(new Error(error));
 
         userData = modifyCurrentBusiness(userData, (business) => ({
           ...business,

--- a/api/src/domain/user/updateLicenseStatusFactory.ts
+++ b/api/src/domain/user/updateLicenseStatusFactory.ts
@@ -13,7 +13,7 @@ import {
   LicenseName,
   Licenses,
   LicenseSearchNameAndAddress,
-  LicenseTaskID,
+  LicenseTaskId,
   taskIdLicenseNameMapping,
 } from "@shared/license";
 import { modifyCurrentBusiness } from "@shared/test";
@@ -42,7 +42,7 @@ const getLicenseTasksProgress = (licenseStatusResult: LicenseStatusResults): Rec
 const getLicenses = (args: {
   nameAndAddress: LicenseSearchNameAndAddress;
   licenseStatusResult: LicenseStatusResults;
-  taskIdWithError?: LicenseTaskID;
+  taskIdWithError?: LicenseTaskId;
 }): Licenses => {
   const results: Licenses = {};
   for (const key of Object.keys(args.licenseStatusResult) as LicenseName[]) {
@@ -52,7 +52,6 @@ const getLicenses = (args: {
       lastUpdatedISO: getCurrentDateISOString(),
     } as LicenseDetails;
   }
-
   const licenseRelatedToCurrentTask = args.taskIdWithError
     ? taskIdLicenseNameMapping[args.taskIdWithError]
     : undefined;
@@ -76,7 +75,7 @@ const update = (
   args: {
     nameAndAddress: LicenseSearchNameAndAddress;
     licenseStatusResult: LicenseStatusResults;
-    taskIdWithError?: LicenseTaskID;
+    taskIdWithError?: LicenseTaskId;
   }
 ): UserData => {
   // TODO: In a future state we need to account for existing license data with address that does not match search query
@@ -108,21 +107,20 @@ export const updateLicenseStatusFactory = (
   return async (
     userData: UserData,
     nameAndAddress: LicenseSearchNameAndAddress,
-    taskId?: LicenseTaskID
+    taskId?: LicenseTaskId
   ): Promise<UserData> => {
     const webserviceLicenseStatusPromise = webserviceLicenseStatusSearch(nameAndAddress);
     const rgbLicenseStatusPromise = rgbLicenseStatusSearch(nameAndAddress);
-
     return Promise.allSettled([webserviceLicenseStatusPromise, rgbLicenseStatusPromise])
       .then(([webserviceLicenseStatusResults, rgbLicenseStatusResults]) => {
         const webserviceHasError = webserviceLicenseStatusResults.status === "rejected";
         const webserviceHasInvalidMatch =
-          webserviceHasError && [NO_MATCH_ERROR].includes(webserviceLicenseStatusResults.reason);
+          webserviceHasError && [NO_MATCH_ERROR].includes(webserviceLicenseStatusResults.reason.message);
         const rgbHasError = rgbLicenseStatusResults.status === "rejected";
         const rgbHasInvalidMatch =
           rgbHasError &&
           [NO_ADDRESS_MATCH_ERROR, NO_MATCH_ERROR, NO_MAIN_APPS_ERROR].includes(
-            rgbLicenseStatusResults.reason
+            rgbLicenseStatusResults.reason.message
           );
 
         if (DEBUG_RegulatedBusinessDynamicsLicenseSearch) {

--- a/content/src/fieldConfig/config.json
+++ b/content/src/fieldConfig/config.json
@@ -157,7 +157,7 @@
     "primaryCTASecondLineText": "with the Division of Consumer Affairs",
     "stateLabel": "State",
     "checklistCompletedStatusText": "Checklist Completed",
-    "errorTextNotFound": "We cannot find your application. Please check the information you've entered.",
+    "errorTextNotFound": "License could not be found. Please try again or contact your licensing agency for more information.",
     "submitText": "Submit",
     "closedPermitStatusText": "Closed",
     "zipCodeLabel": "ZIP Code",
@@ -249,7 +249,7 @@
     "similarUnavailableNamesText": "Here are similar business names that are already taken:",
     "availableText": "It looks like \"${name}\" might be available, but you should do an official name check using the button below.",
     "errorTextBadInput": "Sorry, that isn't a valid company name. Try a more specific name.",
-    "errorTextSearchFailed": "Sorry, something went wrong. Please try again later.",
+    "errorTextSearchFailed": "Unable to complete check. Please try again later.",
     "unavailableText": "Sorry, \"${name}\" isn't available. Try another name."
   },
   "footer": {

--- a/shared/src/license.ts
+++ b/shared/src/license.ts
@@ -106,9 +106,9 @@ export const LicenseNameTaskIdMapping = Object.fromEntries(
   Object.entries(taskIdLicenseNameMapping).map(([key, value]) => [value, key])
 );
 
-export type LicenseTaskID = keyof typeof taskIdLicenseNameMapping;
+export type LicenseTaskId = keyof typeof taskIdLicenseNameMapping;
 
-export type LicenseName = (typeof taskIdLicenseNameMapping)[LicenseTaskID];
+export type LicenseName = (typeof taskIdLicenseNameMapping)[LicenseTaskId];
 
 export type Licenses = Partial<Record<LicenseName, LicenseDetails>>;
 

--- a/web/src/components/tasks/CheckLicenseStatus.tsx
+++ b/web/src/components/tasks/CheckLicenseStatus.tsx
@@ -8,7 +8,7 @@ import { useMountEffectWhenDefined } from "@/lib/utils/helpers";
 import {
   createEmptyLicenseSearchNameAndAddress,
   LicenseSearchNameAndAddress,
-  LicenseTaskID,
+  LicenseTaskId,
   taskIdLicenseNameMapping,
 } from "@businessnjgovnavigator/shared/";
 import { TextField } from "@mui/material";
@@ -31,7 +31,7 @@ interface Props {
   onSubmit: (nameAndAddress: LicenseSearchNameAndAddress) => void;
   error: LicenseSearchError | undefined;
   isLoading: boolean;
-  licenseTaskId: LicenseTaskID;
+  licenseTaskId: LicenseTaskId;
 }
 
 const Config = getMergedConfig();
@@ -101,12 +101,19 @@ export const CheckLicenseStatus = (props: Props): ReactElement => {
   const getErrorAlert = (): ReactElement => {
     if (!props.error) {
       return <></>;
+    } else if (props.error === "NOT_FOUND") {
+      return (
+        <Alert dataTestid={`error-alert-${props.error}`} variant="warning">
+          {LicenseSearchErrorLookup[props.error]}
+        </Alert>
+      );
+    } else {
+      return (
+        <Alert dataTestid={`error-alert-${props.error}`} variant="error">
+          {LicenseSearchErrorLookup[props.error]}
+        </Alert>
+      );
     }
-    return (
-      <Alert dataTestid={`error-alert-${props.error}`} variant="error">
-        {LicenseSearchErrorLookup[props.error]}
-      </Alert>
-    );
   };
 
   return (

--- a/web/src/components/tasks/LicenseDetailReceipt.tsx
+++ b/web/src/components/tasks/LicenseDetailReceipt.tsx
@@ -9,7 +9,7 @@ import analytics from "@/lib/utils/analytics";
 import {
   LicenseDetails,
   LicenseStatusItem,
-  LicenseTaskID,
+  LicenseTaskId,
   taskIdLicenseNameMapping,
 } from "@businessnjgovnavigator/shared/";
 import type { ReactElement } from "react";
@@ -17,7 +17,7 @@ import type { ReactElement } from "react";
 interface Props {
   licenseDetails: LicenseDetails;
   onEdit: () => void;
-  licenseTaskId: LicenseTaskID;
+  licenseTaskId: LicenseTaskId;
 }
 
 const Config = getMergedConfig();

--- a/web/src/components/tasks/LicenseTask.tsx
+++ b/web/src/components/tasks/LicenseTask.tsx
@@ -14,7 +14,7 @@ import { getModifiedTaskContent } from "@/lib/utils/roadmap-helpers";
 import {
   LicenseDetails,
   LicenseSearchNameAndAddress,
-  LicenseTaskID,
+  LicenseTaskId,
   taskIdLicenseNameMapping,
   UserData,
 } from "@businessnjgovnavigator/shared/";
@@ -83,15 +83,15 @@ export const LicenseTask = (props: Props): ReactElement => {
 
     setIsLoading(true);
     api
-      .checkLicenseStatus(nameAndAddress, props.task.id as LicenseTaskID)
+      .checkLicenseStatus(nameAndAddress, props.task.id as LicenseTaskId)
       .then((result: UserData) => {
         const resultLicenseData =
           result.businesses[result.currentBusinessId]?.licenseData?.licenses?.[licenseNameForTask];
 
         if (!resultLicenseData) return;
         analytics.event.task_address_form.response.success_application_found();
-
         setLicenseDetails(resultLicenseData);
+
         if (resultLicenseData.licenseStatus === "UNKNOWN") {
           analytics.event.task_address_form.response.fail_application_not_found();
           setError("NOT_FOUND");

--- a/web/src/lib/api-client/apiClient.test.ts
+++ b/web/src/lib/api-client/apiClient.test.ts
@@ -1,7 +1,7 @@
 import { generateInputFile } from "@/test/factories";
 import { taskIdLicenseNameMapping } from "@businessnjgovnavigator/shared/";
 import { randomElementFromArray } from "@businessnjgovnavigator/shared/arrayHelpers";
-import { LicenseTaskID } from "@businessnjgovnavigator/shared/license";
+import { LicenseTaskId } from "@businessnjgovnavigator/shared/license";
 import {
   generateLicenseSearchNameAndAddress,
   generateTaxIdAndBusinessName,
@@ -75,7 +75,7 @@ describe("apiClient", () => {
     mockAxios.post.mockResolvedValue({ data: {} });
     const nameAndAddress = generateLicenseSearchNameAndAddress({});
     const licenseTaskId = randomElementFromArray(Object.keys(taskIdLicenseNameMapping));
-    await checkLicenseStatus(nameAndAddress, licenseTaskId as LicenseTaskID);
+    await checkLicenseStatus(nameAndAddress, licenseTaskId as LicenseTaskId);
     expect(mockAxios.post).toHaveBeenCalledWith(
       "/api/license-status",
       { nameAndAddress, licenseTaskId },

--- a/web/src/lib/api-client/apiClient.ts
+++ b/web/src/lib/api-client/apiClient.ts
@@ -1,7 +1,7 @@
 import { getCurrentToken } from "@/lib/auth/sessionHelper";
 import { SelfRegResponse } from "@/lib/types/types";
 import { phaseChangeAnalytics, setPhaseDimension } from "@/lib/utils/analytics-helpers";
-import { getCurrentBusiness, LicenseTaskID } from "@businessnjgovnavigator/shared";
+import { getCurrentBusiness, LicenseTaskId } from "@businessnjgovnavigator/shared";
 import {
   InputFile,
   LicenseSearchNameAndAddress,
@@ -33,8 +33,9 @@ export const postUserData = async (userData: UserData): Promise<UserData> => {
 
 export const checkLicenseStatus = (
   nameAndAddress: LicenseSearchNameAndAddress,
-  licenseTaskId?: LicenseTaskID
+  licenseTaskId?: LicenseTaskId
 ): Promise<UserData> => {
+  console.log(`apiClient -  ${licenseTaskId}`);
   return post(`/license-status`, { nameAndAddress, licenseTaskId });
 };
 

--- a/web/src/lib/types/types.ts
+++ b/web/src/lib/types/types.ts
@@ -14,7 +14,7 @@ import {
   FormationSigner,
   IndustrySpecificData,
   LicenseName,
-  LicenseTaskID,
+  LicenseTaskId,
   Preferences,
   ProfileData,
   SectionType,
@@ -364,7 +364,7 @@ export interface Task {
 }
 
 export interface TaskWithLicenseTaskId extends Task {
-  id: LicenseTaskID;
+  id: LicenseTaskId;
   licenseName?: LicenseName;
 }
 

--- a/web/src/pages/mgmt/modifyBusiness.tsx
+++ b/web/src/pages/mgmt/modifyBusiness.tsx
@@ -12,7 +12,7 @@ import {
   getCurrentDate,
   LicenseStatus,
   licenseStatuses,
-  LicenseTaskID,
+  LicenseTaskId,
   taskIdLicenseNameMapping,
   TaskProgress,
 } from "@businessnjgovnavigator/shared/index";
@@ -94,11 +94,11 @@ const ModifyBusinessPage = (): ReactElement => {
                     variant="outlined"
                     onChange={(event) => {
                       setTaskId(event.target.value);
-                      setLicenseName(taskIdLicenseNameMapping[event.target.value as LicenseTaskID]);
+                      setLicenseName(taskIdLicenseNameMapping[event.target.value as LicenseTaskId]);
                     }}
                   >
                     {licenseSearchEnabledTaskIds.map((taskId) => {
-                      const licenseTaskId = taskIdLicenseNameMapping[taskId as LicenseTaskID];
+                      const licenseTaskId = taskIdLicenseNameMapping[taskId as LicenseTaskId];
                       return (
                         <MenuItem key={`${licenseTaskId}-${taskId}`} value={taskId}>
                           {licenseTaskId} ({taskId} task)

--- a/web/test/factories.ts
+++ b/web/test/factories.ts
@@ -39,7 +39,7 @@ import {
   InputFile,
   LegalStructure,
   LegalStructures,
-  LicenseTaskID,
+  LicenseTaskId,
   NameAvailability,
   OperatingPhaseId,
   OperatingPhases,
@@ -137,7 +137,7 @@ export const generateTask = (overrides: Partial<Task>): Task => {
 };
 
 export const generateLicenseTask = (overrides: Partial<TaskWithLicenseTaskId>): TaskWithLicenseTaskId => {
-  const licenseTaskId = randomElementFromArray(Object.keys(taskIdLicenseNameMapping)) as LicenseTaskID;
+  const licenseTaskId = randomElementFromArray(Object.keys(taskIdLicenseNameMapping)) as LicenseTaskId;
   return {
     ...generateTask({}),
     id: licenseTaskId,


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
Acceptance Criteria
Given I have entered in a business name and address into the license status check task
and there is a problem with the system integration
when attempting to check my license status
then I am presented with the existing red alert "Unable to check, please try again later" error (see design for latest copy)

Given I have entered in a business name and address into the license status check task
when no licenses are found
then a message is displayed indicating that no license was found, instead of the saying "License could not be found..." (see design for latest copy)
and the alert uses the new yellow alert design

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188109500](https://www.pivotaltracker.com/story/show/188109500).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
