### PR TITLE
feat: [#186702387] close button revisions, reversion of previous func…

### DIFF
--- a/web/src/components/ModalZeroButton.tsx
+++ b/web/src/components/ModalZeroButton.tsx
@@ -2,7 +2,7 @@ import { Heading } from "@/components/njwds-extended/Heading";
 import { Icon } from "@/components/njwds/Icon";
 import { ContextualInfoContext } from "@/contexts/contextualInfoContext";
 import { Dialog, DialogContent, DialogTitle, IconButton } from "@mui/material";
-import { ReactElement, ReactNode, useContext, useEffect, useRef } from "react";
+import { ReactElement, ReactNode, useContext } from "react";
 
 interface Props {
   isOpen: boolean;
@@ -15,20 +15,6 @@ interface Props {
 export const ModalZeroButton = (props: Props): ReactElement => {
   const { contextualInfo } = useContext(ContextualInfoContext);
 
-  const dialogRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (dialogRef.current) {
-      const firstFocusableElement = dialogRef.current.querySelector<HTMLElement>(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-      );
-      if (firstFocusableElement) {
-        firstFocusableElement.focus();
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dialogRef.current]);
-
   return (
     <Dialog
       fullWidth={false}
@@ -37,7 +23,6 @@ export const ModalZeroButton = (props: Props): ReactElement => {
       onClose={props.close}
       aria-labelledby="dialog-modal"
       disableEnforceFocus={contextualInfo.isVisible}
-      ref={dialogRef}
     >
       <div className="display-flex margin-top-1">
         <DialogTitle


### PR DESCRIPTION
…tionality

<!-- Please complete the following sections as necessary. -->

## Description

This is just reversion of a prior commit that I thought would fix this issue but didn't in reality

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#186702387](https://www.pivotaltracker.com/story/show/186702387).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Navigate to a dialog (home page with it's ) 
![image](https://github.com/user-attachments/assets/5e909dc0-9a83-4005-a726-41ac20f975ee)
Is good and fine. (Since this is a reversion it's just returning to normal functionality)

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

So the point of this story was to get NVDA to stop reading the entire modal contents before, I don't think this would be desirable as the NVDA screen reader is suppose to interact this way with modals from what I can tell. 

I think ideally we're also suppose to focus on the first focusable element when we enter a dialog, MUI has this funcitonlaity built in for it's own components but our buttons aren't MUI underneath and my code workaround from earlier doesn't play nice with NVDA and is kinda confusing, so I'm reverting it. 


<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
