### PR TITLE
fix: [#188456671] renewal calendar event summary description field is…

### DIFF
--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -3167,7 +3167,7 @@ collections:
           required: true,
           default: "You can renew your license 60 days before it expires and up to 30 days after expiration. If you fail to renew your license at this point, your license will be suspended and you won't be able to provide your licensed services.",
         }
-      - { label: "Summary Description (Optional)", name: "summaryDescriptionMd", widget: "markdown" }
+      - { label: "Summary Description", name: "summaryDescriptionMd", widget: "markdown", required: false }
       - { label: "Below License Status Content", name: "body", widget: "markdown", required: true }
       - {
           label: "Issuing Agency",


### PR DESCRIPTION
… now optional as desired

<!-- Please complete the following sections as necessary. -->

## Description'

super minor, we had a CMS field that should have been optional but was required (as they are required by default)

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188456671](https://www.pivotaltracker.com/story/show/188456671).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

load up CMS locally, see that field is no longer required (it's in the calendar renewals section)

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

The optional part in title is no longer needed as this is automatically added to the label in the CMS when fields are optional

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
