### PR TITLE
feat: [#188414641] business address pre-populates from profile for license task

### DIFF
--- a/web/cypress/support/helpers/factories.ts
+++ b/web/cypress/support/helpers/factories.ts
@@ -3,9 +3,8 @@ import {
   randomFormationLegalType,
 } from "@businessnjgovnavigator/cypress/support/helpers/helpers";
 import {
-  arrayOfCountriesObjects as countries,
-  arrayOfStateObjects as states,
   BusinessSignerTypeMap,
+  arrayOfCountriesObjects as countries,
   FormationAddress,
   FormationLegalType,
   FormationMember,
@@ -13,6 +12,7 @@ import {
   Municipality,
   randomInt,
   randomIntFromInterval,
+  arrayOfStateObjects as states,
 } from "@businessnjgovnavigator/shared/";
 
 export const generateMunicipality = (overrides: Partial<Municipality>): Municipality => {

--- a/web/src/components/tasks/CheckLicenseStatus.tsx
+++ b/web/src/components/tasks/CheckLicenseStatus.tsx
@@ -74,6 +74,9 @@ export const CheckLicenseStatus = (props: Props): ReactElement => {
         return {
           ...prevValues,
           name: business.profileData.businessName,
+          addressLine1: business.formationData.formationFormData.addressLine1,
+          addressLine2: business.formationData.formationFormData.addressLine2 || "",
+          zipCode: business.formationData.formationFormData.addressZipCode,
         };
       });
     }

--- a/web/src/components/tasks/LicenseTask.test.tsx
+++ b/web/src/components/tasks/LicenseTask.test.tsx
@@ -171,8 +171,8 @@ describe("<LicenseTask />", () => {
   });
 
   describe("on second tab (search tab)", () => {
-    describe("auto fill address values", () => {
-      it("auto fills name and address values from license details in user data", async () => {
+    describe("auto-fill address values", () => {
+      it("auto-fills name and address values from license details in user data", async () => {
         useMockBusiness({
           licenseData: generateLicenseData(
             {},
@@ -260,13 +260,18 @@ describe("<LicenseTask />", () => {
         expect(getValue("zipcode")).toEqual("12345");
       });
 
-      it("auto fills business name from profile data when no licenseData and formation response is not successful", async () => {
+      it("auto-fills business name from profile data when no licenseData and formation response is not successful", async () => {
         useMockBusiness({
           profileData: generateProfileData({
             businessName: "Applebees",
           }),
           licenseData: undefined,
           formationData: generateFormationData({
+            formationFormData: generateFormationFormData({
+              addressLine1: "123 Honeybee Lane",
+              addressLine2: "Suite BB",
+              addressZipCode: "12345",
+            }),
             formationResponse: generateFormationSubmitResponse({
               success: false,
             }),
@@ -278,12 +283,12 @@ describe("<LicenseTask />", () => {
         await waitFor(() => {
           expect(getValue("business-name")).toEqual("Applebees");
         });
-        expect(getValue("address-1")).toEqual("");
-        expect(getValue("address-2")).toEqual("");
-        expect(getValue("zipcode")).toEqual("");
+        expect(getValue("address-1")).toEqual("123 Honeybee Lane");
+        expect(getValue("address-2")).toEqual("Suite BB");
+        expect(getValue("zipcode")).toEqual("12345");
       });
 
-      it("auto fills business name from profile data when lastUpdatedISO in licenseData is empty and name and address fields are empty and formation response is not successful", async () => {
+      it("auto-fills business name from profile data when lastUpdatedISO in licenseData is empty and formation response is not successful", async () => {
         useMockBusiness({
           profileData: generateProfileData({
             businessName: "Applebees",
@@ -298,6 +303,11 @@ describe("<LicenseTask />", () => {
             }
           ),
           formationData: generateFormationData({
+            formationFormData: generateFormationFormData({
+              addressLine1: "123 Honeybee Lane",
+              addressLine2: "Suite BB",
+              addressZipCode: "12345",
+            }),
             formationResponse: generateFormationSubmitResponse({
               success: false,
             }),
@@ -309,9 +319,9 @@ describe("<LicenseTask />", () => {
         await waitFor(() => {
           expect(getValue("business-name")).toEqual("Applebees");
         });
-        expect(getValue("address-1")).toEqual("");
-        expect(getValue("address-2")).toEqual("");
-        expect(getValue("zipcode")).toEqual("");
+        expect(getValue("address-1")).toEqual("123 Honeybee Lane");
+        expect(getValue("address-2")).toEqual("Suite BB");
+        expect(getValue("zipcode")).toEqual("12345");
       });
     });
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
As a user who has added my address in my profile, when viewing the  license task, my name and address pre-populate.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188414641](https://www.pivotaltracker.com/story/show/188414641).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->
1. Enter the application as a `Poppy` and an industry with a license task (i.e Cosmetology). 
2. Got to the profile and enter a business name and address. 
3. On the dashboard, click into the industry (i.e. Cosmetology) license task.
4. The business name and address entered in the profile will persist.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
