### PR TITLE
fix: [#188496271] Fix flakey License Task Test

### DIFF
--- a/web/src/components/tasks/LicenseTask.test.tsx
+++ b/web/src/components/tasks/LicenseTask.test.tsx
@@ -515,6 +515,13 @@ describe("<LicenseTask />", () => {
               }),
             }
           ),
+          formationData: generateFormationData({
+            formationFormData: generateFormationFormData({
+              addressLine1: "",
+              addressLine2: "",
+              addressZipCode: "",
+            }),
+          }),
         });
         renderTask();
         fireEvent.click(screen.getByText(Config.licenseSearchTask.tab2Text));


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

A flaky test in the LicenseTask tests would fail part of the time due to `useMockBusiness` generating a business that could not pass the test.

In this case, the test was looking for an missing information error. Sometimes the business generated wouldn't have any of that missing information.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188496271](https://www.pivotaltracker.com/story/show/188496271).

### Approach

I added:

```
formationData: generateFormationData({
  formationFormData: generateFormationFormData({
    addressLine1: "",
    addressLine2: "",
    addressZipCode: "",
  }),
}),
```

to `useMockBusiness` to ensure that there will always be missing information to trigger the error for the test.

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

Run `yarn test LicenseTask` multiple times.
Make sure it passes every time (would recommend at least 3-5 times)

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
