### PR TITLE
chore: [#187578804] enhance log, make function accessible in prod

### DIFF
--- a/api/serverless.ts
+++ b/api/serverless.ts
@@ -303,28 +303,23 @@ serverlessConfiguration.functions = {
         }
       : undefined
   ),
+  migrateUsersVersion: migrateUsersVersion(
+    env.CI
+      ? {
+          securityGroupIds: ["${self:custom.config.infrastructure.SECURITY_GROUP}"],
+          subnetIds: [
+            "${self:custom.config.infrastructure.SUBNET_01}",
+            "${self:custom.config.infrastructure.SUBNET_02}",
+          ],
+        }
+      : undefined
+  ),
 };
 
 if (stage !== contentEnv && stage !== testEnv) {
   serverlessConfiguration.functions = {
     ...serverlessConfiguration.functions,
     healthCheck: healthCheck(
-      env.CI
-        ? {
-            securityGroupIds: ["${self:custom.config.infrastructure.SECURITY_GROUP}"],
-            subnetIds: [
-              "${self:custom.config.infrastructure.SUBNET_01}",
-              "${self:custom.config.infrastructure.SUBNET_02}",
-            ],
-          }
-        : undefined
-    ),
-  };
-}
-if (stage === testEnv || stage === devEnv || stage === "local") {
-  serverlessConfiguration.functions = {
-    ...serverlessConfiguration.functions,
-    migrateUsersVersion: migrateUsersVersion(
       env.CI
         ? {
             securityGroupIds: ["${self:custom.config.infrastructure.SECURITY_GROUP}"],

--- a/api/src/libs/migrateUserVersion.ts
+++ b/api/src/libs/migrateUserVersion.ts
@@ -36,7 +36,10 @@ export const migrateUserVersion = (
       });
     })
     .catch((error) => {
-      logger.LogError(`Migration failed: ${error instanceof Error ? error.message : "Unknown error"}`);
+      const errorMessage = `MigrateUserVersions Failed: ${
+        error instanceof Error ? error.message : "Unknown error"
+      }`;
+      logger.LogError(errorMessage);
       return { success: false, error: error instanceof Error ? error.message : "Unknown error" };
     });
 };


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
This PR enhances the logging mechanism in the migrateUserVersion function, providing detailed logs for both successful migrations and errors. Additionally, the function is made accessible in the production and staging environments to facilitate smoother migrations and debugging.
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#187578804](https://www.pivotaltracker.com/story/show/187578804).

### Approach
- Improved logging for successful migrations and error handling.
- Updated the function access to be available in both production and staging environments.


<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
