### PR TITLE
feat: [#188507991] License Task CTA Button Updates

### DIFF
--- a/content/src/fieldConfig/config.json
+++ b/content/src/fieldConfig/config.json
@@ -182,7 +182,7 @@
     "issuingAgencyNameText": "NJ Division of Consumer Affairs",
     "deficienciesSubmittedStatusText": "Deficiencies Submitted",
     "deniedPermitStatusText": "Denied",
-    "secondaryCTAFirstLineText": "I Submitted My Application",
+    "secondaryCTAFirstLineText": "Check My Application Status",
     "approvedStatusText": "Approved",
     "address2Label": "Business Address Line 2 (Optional)",
     "address1Label": "Business Address Line 1",

--- a/web/src/components/njwds-extended/cta/CtaContainer.tsx
+++ b/web/src/components/njwds-extended/cta/CtaContainer.tsx
@@ -3,14 +3,13 @@ import { ReactElement, ReactNode } from "react";
 interface Props {
   children: ReactNode;
   noBackgroundColor?: boolean;
+  className?: string;
 }
 
 export const CtaContainer = (props: Props): ReactElement => {
   return (
     <div
-      className={`${
-        props?.noBackgroundColor ? "" : "bg-base-lightest"
-      } margin-x-neg-4 padding-3 margin-top-3 padding-right-4 margin-bottom-neg-4 radius-bottom-lg`}
+      className={`cta-container${props.noBackgroundColor ? " no-background-color " : " "}${props.className}`}
       data-testid="cta-area"
     >
       {props.children}

--- a/web/src/components/tasks/LicenseTask.tsx
+++ b/web/src/components/tasks/LicenseTask.tsx
@@ -1,5 +1,9 @@
 import { NeedsAccountModalWrapper } from "@/components/auth/NeedsAccountModalWrapper";
 import { Content } from "@/components/Content";
+import { CtaContainer } from "@/components/njwds-extended/cta/CtaContainer";
+import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
+import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
+import { Icon } from "@/components/njwds/Icon";
 import { TaskHeader } from "@/components/TaskHeader";
 import { CheckLicenseStatus } from "@/components/tasks/CheckLicenseStatus";
 import { LicenseDetailReceipt } from "@/components/tasks/LicenseDetailReceipt";
@@ -140,9 +144,25 @@ export const LicenseTask = (props: Props): ReactElement => {
                 <Content>{props.task.summaryDescriptionMd || ""}</Content>
                 <Content>{getModifiedTaskContent(roadmap, props.task, "contentMd")}</Content>
               </div>
-              <div className="flex flex-column margin-top-4 margin-bottom-1">
-                <a href={callToActionLink} target="_blank" rel="noreferrer noopener">
-                  <button
+              <CtaContainer className="margin-btm-neg-2">
+                <div className="btn-container">
+                  <SecondaryButton
+                    isColor="primary"
+                    onClick={(): void => {
+                      analytics.event.task_button_i_already_submitted.click.view_status_tab(
+                        "check_status",
+                        "start_application"
+                      );
+                      setTabIndex(STATUS_TAB_INDEX);
+                    }}
+                    dataTestId="cta-secondary"
+                  >
+                    {Config.licenseSearchTask.secondaryCTAFirstLineText}
+                  </SecondaryButton>
+                </div>
+                <div className="btn-container">
+                  <PrimaryButton
+                    isColor="primary"
                     onClick={(): void => {
                       analytics.event.task_primary_call_to_action.click.open_external_website(
                         Config.licenseSearchTask.primaryCTAFirstLineText,
@@ -150,36 +170,13 @@ export const LicenseTask = (props: Props): ReactElement => {
                         "start_application"
                       );
                     }}
-                    className="usa-button width-100 margin-bottom-2"
-                    data-testid="cta-primary"
+                    dataTestId="cta-primary"
                   >
-                    <div className="flex flex-column">
-                      <div>{Config.licenseSearchTask.primaryCTAFirstLineText}</div>
-                      <div className="font-body-3xs margin-top-05">
-                        {Config.licenseSearchTask.primaryCTASecondLineText}
-                      </div>
-                    </div>
-                  </button>
-                </a>
-                <button
-                  onClick={(): void => {
-                    analytics.event.task_button_i_already_submitted.click.view_status_tab(
-                      "check_status",
-                      "start_application"
-                    );
-                    setTabIndex(STATUS_TAB_INDEX);
-                  }}
-                  className="usa-button usa-button--outline width-100"
-                  data-testid="cta-secondary"
-                >
-                  <div className="flex flex-column">
-                    <div>{Config.licenseSearchTask.secondaryCTAFirstLineText}</div>
-                    <div className="font-body-3xs margin-top-05">
-                      {Config.licenseSearchTask.secondaryCTASecondLineText}
-                    </div>
-                  </div>
-                </button>
-              </div>
+                    {Config.licenseSearchTask.primaryCTAFirstLineText}
+                    <Icon iconName="launch" />
+                  </PrimaryButton>
+                </div>
+              </CtaContainer>
             </TabPanel>
             <TabPanel value="1" sx={{ paddingX: 0 }}>
               {hasCompletedSearch && licenseDetails && !searchHasError ? (

--- a/web/src/components/tasks/MultipleDwellingRegistrationTask.tsx
+++ b/web/src/components/tasks/MultipleDwellingRegistrationTask.tsx
@@ -1,8 +1,9 @@
-import { Content } from "@/components/Content";
-import { TaskHeader } from "@/components/TaskHeader";
 import { NeedsAccountModalWrapper } from "@/components/auth/NeedsAccountModalWrapper";
+import { Content } from "@/components/Content";
+import { CtaContainer } from "@/components/njwds-extended/cta/CtaContainer";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
+import { TaskHeader } from "@/components/TaskHeader";
 import { CheckHousingRegistrationStatus } from "@/components/tasks/CheckHousingRegistrationStatus";
 import { HousingRegistrationStatusSummary } from "@/components/tasks/HousingRegistrationStatusSummary";
 import { UnlockedBy } from "@/components/tasks/UnlockedBy";
@@ -124,26 +125,28 @@ export const MultipleDwellingRegistrationTask = (props: Props): ReactElement => 
                 <Content>{props.task.summaryDescriptionMd || ""}</Content>
                 <Content>{getModifiedTaskContent(roadmap, props.task, "contentMd")}</Content>
               </div>
-              <div className="flex flex-column margin-top-4 margin-bottom-1">
-                <PrimaryButton
-                  isColor={"primary"}
-                  onClick={() => {
-                    openInNewTab(callToActionLink);
-                  }}
-                >
-                  <div> {Config.housingRegistrationSearchTask.registrationCallToActionPrimaryText}</div>
-                </PrimaryButton>
-              </div>
-              <div className="flex flex-column">
-                <SecondaryButton
-                  isColor={"primary"}
-                  onClick={() => {
-                    setTabIndex(STATUS_TAB_INDEX);
-                  }}
-                >
-                  <div>{Config.housingRegistrationSearchTask.registrationCallToActionSecondaryText}</div>
-                </SecondaryButton>
-              </div>
+              <CtaContainer className="margin-btm-neg-2">
+                <div className="btn-container">
+                  <SecondaryButton
+                    isColor={"primary"}
+                    onClick={() => {
+                      setTabIndex(STATUS_TAB_INDEX);
+                    }}
+                  >
+                    <div>{Config.housingRegistrationSearchTask.registrationCallToActionSecondaryText}</div>
+                  </SecondaryButton>
+                </div>
+                <div className="btn-container">
+                  <PrimaryButton
+                    isColor={"primary"}
+                    onClick={() => {
+                      openInNewTab(callToActionLink);
+                    }}
+                  >
+                    <div> {Config.housingRegistrationSearchTask.registrationCallToActionPrimaryText}</div>
+                  </PrimaryButton>
+                </div>
+              </CtaContainer>
             </TabPanel>
             <TabPanel value="1" sx={{ paddingX: 0 }}>
               {housingRegistrationLookupSummary ? (

--- a/web/src/components/tasks/RaffleBingoPaginator.tsx
+++ b/web/src/components/tasks/RaffleBingoPaginator.tsx
@@ -130,7 +130,7 @@ export const RaffleBingoPaginator = (props: Props): ReactElement => {
       </div>
 
       <div>
-        <CtaContainer noBackgroundColor={false}>
+        <CtaContainer>
           <ActionBarLayout>
             {!isLastStep(stepIndex) && (
               <PrimaryButton

--- a/web/src/styles/components/cta-container.scss
+++ b/web/src/styles/components/cta-container.scss
@@ -1,0 +1,52 @@
+.cta-container {
+  background-color: $base-lightest;
+  border-bottom-left-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+  display: flex;
+  flex-direction: column-reverse;
+  padding: 1.5rem;
+  margin: 1.5rem -2rem -2rem -2rem;
+
+  @-moz-document url-prefix() {
+    margin: 1.5rem -2rem -2rem -2rem;
+  }
+
+  button {
+    width: 100%;
+  }
+
+  .usa-icon {
+    width: 22px;
+    height: 22px;
+    margin-left: 0.5rem;
+    margin-right: -0.5rem;
+  }
+
+  .btn-container + .btn-container {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.cta-container.no-background-color {
+  background-color: transparent;
+}
+
+.margin-btm-neg-2 {
+  margin-bottom: -3.5rem;
+
+  @-moz-document url-prefix() {
+    margin-bottom: -3.05rem;
+  }
+}
+
+@media screen and (min-width: $sm) {
+  .cta-container {
+    flex-direction: row;
+    justify-content: flex-end;
+
+    .btn-container + .btn-container {
+      margin-left: 1.5rem;
+      margin-bottom: 0;
+    }
+  }
+}

--- a/web/src/styles/main.scss
+++ b/web/src/styles/main.scss
@@ -20,6 +20,7 @@
 @import "components/buttons.scss";
 @import "components/callout.scss";
 @import "components/contextual-info.scss";
+@import "components/cta-container.scss";
 @import "components/stepper.scss";
 @import "components/tables.scss";
 @import "components/tags.scss";


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Update the CTA buttons on the License Task to match the current design. (After speaking with design, I also fixed the CTA buttons on the Multiple Dwelling Registration Task.)

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188507991](https://www.pivotaltracker.com/story/show/188507991).

### Approach

I used this as an excuse to clean up some of CSS and utilize the already existing `CtaContainer`. This will hopefully make it easier to (a) keep styling consistent and (b) address some of the styling issues in Firefox.

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Notes

The spacing for margins and padding are slightly different for FireFox than other browsers (like Chrome). Using `@-moz-document url-prefix()` allows the dev to adjust for those differences.

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
