### PR TITLE
feat: [#186324885] agent information checkbox missing proper notifica…

### DIFF
--- a/content/src/fieldConfig/business-formation.json
+++ b/content/src/fieldConfig/business-formation.json
@@ -6,7 +6,11 @@
       "radioButtonNumberText": "Enter Your Registered Agent ID Number",
       "radioButtonManualText": "Manually Identify Your Registered Agent",
       "sameAddressCheckbox": "The address is the same as the business location.",
-      "sameContactCheckbox": "The agent information is the same as the account holder."
+      "sameContactCheckbox": "The agent information is the same as the account holder.",
+      "noteTitle": "Note: ",
+      "noteBody": "By checking this box, the account holder information will be applied to the 'Registered Agent Name' and 'Registered Agent Email' fields. These fields will be locked.",
+      "checkboxUnCheckedScreenReaderAnnouncement": "The Registered Agent Name and Registered Agent Email fields are now filled with the account holder information and locked",
+      "checkboxCheckedScreenReaderAnnouncement": "The Registered Agent Name and Registered Agent Email fields are now editable"
     },
     "general": {
       "helpButtonText": "Help",

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -894,6 +894,18 @@ collections:
                       name: "sameContactCheckbox",
                       widget: "string",
                     }
+                  - { label: "Note Title", name: "noteTitle", widget: "string" }
+                  - { label: "Note Body", name: "noteBody", widget: "markdown" }
+                  - {
+                      label: "Checkbox Unchecked Screen Reader Announcement",
+                      name: "checkboxUnCheckedScreenReaderAnnouncement",
+                      widget: "string",
+                    }
+                  - {
+                      label: "Checkbox Checked Screen Reader Announcement",
+                      name: "checkboxCheckedScreenReaderAnnouncement",
+                      widget: "string",
+                    }
               - label: Sections
                 name: sections
                 collapsed: true

--- a/web/src/components/GenericTextField.tsx
+++ b/web/src/components/GenericTextField.tsx
@@ -45,6 +45,7 @@ export interface GenericTextFieldProps<T = FieldErrorType> extends FormContextFi
   allowMasking?: boolean;
   inputProps?: OutlinedInputProps;
   type?: HTMLInputTypeAttribute;
+  readOnly?: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, react/display-name
@@ -163,10 +164,18 @@ export const GenericTextField = forwardRef(
           {...fieldOptions}
           sx={{ width: 1, ...fieldOptions?.sx }}
           inputProps={{
+            readOnly: props.readOnly,
+            "aria-readonly": props.readOnly,
+            className: `${props.readOnly ? "bg-base-lightest" : ""}`,
             ...fieldOptions?.inputProps,
             "aria-label": props.ariaLabel ?? camelCaseToSentence(props.fieldName),
           }}
-          InputProps={props.inputProps}
+          InputProps={{
+            readOnly: props.readOnly,
+            "aria-readonly": props.readOnly,
+            className: `${props.readOnly ? "bg-base-lightest" : ""}`,
+            ...props.inputProps,
+          }}
           type={props.type}
           onFocus={props.onFocus}
         />

--- a/web/src/components/njwds-extended/HorizontalStepper.tsx
+++ b/web/src/components/njwds-extended/HorizontalStepper.tsx
@@ -166,7 +166,7 @@ export const HorizontalStepper = (props: Props): ReactElement => {
       content,
       condition: () => true,
       modificationMap: {
-        stepName: stepName,
+        stepName,
       },
     });
   };
@@ -176,7 +176,7 @@ export const HorizontalStepper = (props: Props): ReactElement => {
       content,
       condition: () => true,
       modificationMap: {
-        stepState: stepState,
+        stepState,
       },
     });
   };

--- a/web/src/components/tasks/business-formation/BusinessFormationTextField.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationTextField.tsx
@@ -11,6 +11,7 @@ export interface Props extends Omit<GenericTextFieldProps, "value" | "fieldName"
   label?: string;
   secondaryLabel?: string;
   errorBarType: "ALWAYS" | "MOBILE-ONLY" | "DESKTOP-ONLY" | "NEVER";
+  readOnly?: boolean;
 }
 
 export const BusinessFormationTextField = ({ className, ...props }: Props): ReactElement => {
@@ -40,6 +41,7 @@ export const BusinessFormationTextField = ({ className, ...props }: Props): Reac
         value={state.formationFormData[props.fieldName]}
         onValidation={onValidation}
         {...props}
+        readOnly={props.readOnly}
         handleChange={handleChange}
         error={hasError}
       />

--- a/web/src/components/tasks/business-formation/contacts/RegisteredAgent.test.tsx
+++ b/web/src/components/tasks/business-formation/contacts/RegisteredAgent.test.tsx
@@ -109,15 +109,15 @@ describe("Formation - Registered Agent Field", () => {
 
     expect(page.getInputElementByLabel("Agent name").value).toEqual("Original Name");
     expect(page.getInputElementByLabel("Agent email").value).toEqual("original@example.com");
-    expect(page.getInputElementByLabel("Agent name").disabled).toEqual(false);
-    expect(page.getInputElementByLabel("Agent email").disabled).toEqual(false);
+    expect(page.getInputElementByLabel("Agent name").readOnly).toEqual(false);
+    expect(page.getInputElementByLabel("Agent email").readOnly).toEqual(false);
 
     page.selectCheckbox(Config.formation.registeredAgent.sameContactCheckbox);
 
     expect(page.getInputElementByLabel("Agent name").value).toEqual("New Name");
     expect(page.getInputElementByLabel("Agent email").value).toEqual("new@example.com");
-    expect(page.getInputElementByLabel("Agent name").disabled).toEqual(true);
-    expect(page.getInputElementByLabel("Agent email").disabled).toEqual(true);
+    expect(page.getInputElementByLabel("Agent name").readOnly).toEqual(true);
+    expect(page.getInputElementByLabel("Agent email").readOnly).toEqual(true);
   });
 
   it("un-disables but leaves values for agent name and email when user unchecks", async () => {

--- a/web/src/components/tasks/business-formation/contacts/RegisteredAgent.tsx
+++ b/web/src/components/tasks/business-formation/contacts/RegisteredAgent.tsx
@@ -1,3 +1,4 @@
+import { Callout } from "@/components/Callout";
 import { Content } from "@/components/Content";
 import { ModifiedContent } from "@/components/ModifiedContent";
 import { Heading } from "@/components/njwds-extended/Heading";
@@ -127,6 +128,18 @@ export const RegisteredAgent = (): ReactElement => {
     }
   };
 
+  const getAriaLiveRegion = (): ReactElement | undefined => {
+    const interactedWithAgentCheckbox =
+      state.interactedFields.includes("agentEmail") && state.interactedFields.includes("agentName");
+    if (interactedWithAgentCheckbox && !state.formationFormData.agentUseAccountInfo) {
+      return <div>{`${Config.formation.registeredAgent.checkboxCheckedScreenReaderAnnouncement}`}</div>;
+    }
+
+    if (interactedWithAgentCheckbox && state.formationFormData.agentUseAccountInfo) {
+      return <div>{`${Config.formation.registeredAgent.checkboxUnCheckedScreenReaderAnnouncement}`}</div>;
+    }
+  };
+
   return (
     <>
       <Heading level={2} styleVariant={"h3"}>
@@ -177,6 +190,25 @@ export const RegisteredAgent = (): ReactElement => {
 
           {state.formationFormData.agentNumberOrManual === "MANUAL_ENTRY" && (
             <div data-testid="agent-name">
+              <div
+                aria-hidden={
+                  state.interactedFields.includes("agentEmail") &&
+                  state.interactedFields.includes("agentName")
+                    ? "true"
+                    : "false"
+                }
+              >
+                <Callout
+                  calloutType="note"
+                  headerText={Config.formation.registeredAgent.noteTitle}
+                  showHeader={true}
+                >
+                  {Config.formation.registeredAgent.noteBody}
+                </Callout>
+              </div>
+              <div aria-live="polite" className="screen-reader-only">
+                {getAriaLiveRegion()}
+              </div>
               <div className="margin-top-3 margin-bottom-1">
                 <FormControlLabel
                   label={Config.formation.registeredAgent.sameContactCheckbox}
@@ -185,10 +217,12 @@ export const RegisteredAgent = (): ReactElement => {
                       checked={state.formationFormData.agentUseAccountInfo}
                       onChange={toggleUseAccountInfo}
                       id="same-agent-info-as-account-checkbox"
+                      inputProps={{ "aria-controls": "agent-name-id agent-email-id" }}
                     />
                   }
                 />
               </div>
+
               <WithErrorBar hasError={doSomeFieldsHaveError(["agentName", "agentEmail"])} type="DESKTOP-ONLY">
                 <div className="grid-row grid-gap-1 margin-bottom-2">
                   <div className="grid-col-12 tablet:grid-col-6">
@@ -199,7 +233,9 @@ export const RegisteredAgent = (): ReactElement => {
                         validationText={getFieldErrorLabel("agentName")}
                         errorBarType="MOBILE-ONLY"
                         fieldName="agentName"
-                        disabled={shouldBeDisabled("agentName", "ACCOUNT")}
+                        readOnly={shouldBeDisabled("agentName", "ACCOUNT")}
+                        type="text"
+                        inputProps={{ id: "agent-name-id" }}
                       />
                     </FormationField>
                   </div>
@@ -211,7 +247,9 @@ export const RegisteredAgent = (): ReactElement => {
                         errorBarType="MOBILE-ONLY"
                         required={true}
                         validationText={getFieldErrorLabel("agentEmail")}
-                        disabled={shouldBeDisabled("agentEmail", "ACCOUNT")}
+                        readOnly={shouldBeDisabled("agentEmail", "ACCOUNT")}
+                        type="text"
+                        inputProps={{ id: "agent-email-id" }}
                       />
                     </FormationField>
                   </div>

--- a/web/src/styles/base/background-colors.scss
+++ b/web/src/styles/base/background-colors.scss
@@ -10,6 +10,10 @@
   background-color: $base-light !important;
 }
 
+.bg-base-lightest {
+  background-color: $base-lightest !important;
+}
+
 .bg-base-lightest-hover:hover {
   background-color: $base-lightest !important;
 }


### PR DESCRIPTION
…tion

<!-- Please complete the following sections as necessary. -->

## Description

We have a checkbox on step 3 of formation that locks some fields and pre populates them. This isn't announced and should be instead moving forward. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#186324885](https://www.pivotaltracker.com/story/show/186324885).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Go to step 3 of formation, turn on screen reader
cmd + F5

Navigate to the checkbox, 

Check it, 

See that it announces additional context regarding what happened

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

This was a whole mess and a half. 

We wanted to announce the change and I was super on the fence about just trying to have context visible on the page be enough vs announcing and leaving that aria live region on the page to then later be discovered and having that aria-live region disappear after a few seconds so as to not confuse a screen reader user when they returned. 

I went with the second option and I think in our case it is quite clear but I still don't love it and am not 100% confident I've made best decision. 

At a minimum I did do research, and consulted a number of people so I think I've done the best I could with the context available to me at the moment. 

(The change text is discoverable and divides the UX of the page for screen reader users in that their note block changes to be the alert message whereas a sighted user doesn't have this experience, I think this is reasonable and clear if not a little less than idea in that it's a bit complex and dividing UX is not a great practice. )

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
