### PR TITLE
feat: [#188443179] Unsuccessful Business Address & Zipcode License Check Immediate Error State

### DIFF
--- a/api/src/api/licenseStatusRouter.ts
+++ b/api/src/api/licenseStatusRouter.ts
@@ -1,13 +1,12 @@
 import { getSignedInUserId } from "@api/userRouter";
 import { UpdateLicenseStatus, UserDataClient } from "@domain/types";
-import { LicenseSearchNameAndAddress, LicenseTaskId } from "@shared/license";
+import { LicenseSearchNameAndAddress } from "@shared/license";
 import { UserData } from "@shared/userData";
 import { Router } from "express";
 import { StatusCodes } from "http-status-codes";
 
 type LicenseStatusRequestBody = {
   nameAndAddress: LicenseSearchNameAndAddress;
-  licenseTaskId?: LicenseTaskId;
 };
 
 export const licenseStatusRouterFactory = (
@@ -18,9 +17,9 @@ export const licenseStatusRouterFactory = (
 
   router.post("/license-status", async (req, res) => {
     const userId = getSignedInUserId(req);
-    const { nameAndAddress, licenseTaskId } = req.body as LicenseStatusRequestBody;
+    const { nameAndAddress } = req.body as LicenseStatusRequestBody;
     const userData = await userDataClient.get(userId);
-    updateLicenseStatus(userData, nameAndAddress, licenseTaskId)
+    updateLicenseStatus(userData, nameAndAddress)
       .then(async (userData: UserData) => {
         const updatedUserData = await userDataClient.put(userData);
         res.json(updatedUserData);

--- a/api/src/client/WebserviceLicenseStatusProcessorClient.test.ts
+++ b/api/src/client/WebserviceLicenseStatusProcessorClient.test.ts
@@ -261,7 +261,7 @@ describe("WebserviceLicenseStatusProcessorClient", () => {
         applicationNumber: "12345",
         checklistItem: "Item 1",
         checkoffStatus: "Completed",
-        licenseStatus: "ACTIVE",
+        licenseStatus: "Active",
         issueDate: undefined,
         dateThisStatus: undefined,
         expirationDate: "20210505 000000.000",
@@ -278,6 +278,7 @@ describe("WebserviceLicenseStatusProcessorClient", () => {
     expect(result["Pharmacy-Pharmacy"]?.expirationDateISO).toEqual(
       parseDateWithFormat("20210505", "YYYYMMDD").toISOString()
     );
+    expect(result["Pharmacy-Pharmacy"]?.licenseStatus).toEqual("ACTIVE");
   });
 
   it("does not save the expirationDate if invalid", async () => {
@@ -287,7 +288,7 @@ describe("WebserviceLicenseStatusProcessorClient", () => {
         applicationNumber: "12345",
         checklistItem: "Item 1",
         checkoffStatus: "Completed",
-        licenseStatus: "ACTIVE",
+        licenseStatus: "Active",
         issueDate: undefined,
         dateThisStatus: undefined,
         expirationDate: "20210",
@@ -302,6 +303,7 @@ describe("WebserviceLicenseStatusProcessorClient", () => {
 
     const result = await searchLicenseStatus(nameAndAddress);
     expect(result["Pharmacy-Pharmacy"]?.expirationDateISO).toBeUndefined();
+    expect(result["Pharmacy-Pharmacy"]?.licenseStatus).toEqual("ACTIVE");
   });
 
   it("does not save the expirationDate if undefined", async () => {
@@ -311,7 +313,7 @@ describe("WebserviceLicenseStatusProcessorClient", () => {
         applicationNumber: "12345",
         checklistItem: "Item 1",
         checkoffStatus: "Completed",
-        licenseStatus: "ACTIVE",
+        licenseStatus: "Active",
         issueDate: undefined,
         dateThisStatus: undefined,
         expirationDate: undefined,
@@ -326,6 +328,7 @@ describe("WebserviceLicenseStatusProcessorClient", () => {
 
     const result = await searchLicenseStatus(nameAndAddress);
     expect(result["Pharmacy-Pharmacy"]?.expirationDateISO).toBeUndefined();
+    expect(result["Pharmacy-Pharmacy"]?.licenseStatus).toEqual("ACTIVE");
   });
 
   const queryWithAddress = async (address: string): Promise<LicenseStatusResults> => {
@@ -478,8 +481,8 @@ describe("WebserviceLicenseStatusProcessorClient", () => {
       expect(determineLicenseStatus("Withdrawn")).toBe("WITHDRAWN");
     });
 
-    it("returns UNKNOWN when status is not valid", () => {
-      expect(determineLicenseStatus("fake status")).toBe("UNKNOWN");
+    it("returns UNKNOWN when status is any other status", () => {
+      expect(determineLicenseStatus("FakeStatus")).toBe("UNKNOWN");
     });
   });
 });

--- a/api/src/db/migrations/migrations.ts
+++ b/api/src/db/migrations/migrations.ts
@@ -50,6 +50,7 @@ import { migrate_v141_to_v142 } from "@db/migrations/v142_add_domestic_employer_
 import { migrate_v142_to_v143 } from "@db/migrations/v143_add_property_type_and_rental_unit_count";
 import { migrate_v143_to_v144 } from "@db/migrations/v144_add_raffle_bingo_games";
 import { migrate_v144_to_v145 } from "@db/migrations/v145_add_traveling_circus_or_carnival";
+import { migrate_v145_to_v146 } from "@db/migrations/v146_remove_haserror_field_from_licensedetails";
 import { migrate_v13_to_v14 } from "@db/migrations/v14_add_cleaning_aid_industry";
 import { migrate_v14_to_v15 } from "@db/migrations/v15_add_retail_industry";
 import { migrate_v15_to_v16 } from "@db/migrations/v16_add_user_preferences";
@@ -294,6 +295,7 @@ export const Migrations: MigrationFunction[] = [
   migrate_v142_to_v143,
   migrate_v143_to_v144,
   migrate_v144_to_v145,
+  migrate_v145_to_v146,
 ];
 
 export { generatev144UserData as CURRENT_GENERATOR } from "@db/migrations/v144_add_raffle_bingo_games";

--- a/api/src/db/migrations/v146_remove_haserror_field_from_licensedetails.test.ts
+++ b/api/src/db/migrations/v146_remove_haserror_field_from_licensedetails.test.ts
@@ -1,0 +1,44 @@
+import {
+  generatev145Business,
+  generatev145LicenseDetails,
+  generatev145ProfileData,
+  generatev145UserData,
+} from "@db/migrations/v145_add_traveling_circus_or_carnival";
+import { migrate_v145_to_v146 } from "@db/migrations/v146_remove_haserror_field_from_licensedetails";
+
+describe("v146_remove_haserror_field", () => {
+  it("correctly upgrades a v145 user by removing hasError field from license details", () => {
+    const id = "biz-1";
+    const v145ProfileData = generatev145ProfileData({ industryId: "employment-agency" });
+    const v145Business = generatev145Business({
+      profileData: v145ProfileData,
+      licenseData: {
+        lastUpdatedISO: "some last iso",
+        licenses: {
+          ["Pharmacy-Pharmacy"]: generatev145LicenseDetails({
+            hasError: true,
+          }),
+          ["Accountancy-Firm Registration"]: generatev145LicenseDetails({
+            hasError: false,
+          }),
+        },
+      },
+      id,
+    });
+    const v145User = generatev145UserData({
+      businesses: { "biz-1": v145Business },
+    });
+
+    const fieldToDelete = "hasError";
+
+    const v145Licenses = v145User.businesses[id].licenseData?.licenses;
+    expect(v145Licenses?.["Pharmacy-Pharmacy"]).toHaveProperty(fieldToDelete);
+    expect(v145Licenses?.["Accountancy-Firm Registration"]).toHaveProperty(fieldToDelete);
+
+    const v146User = migrate_v145_to_v146(v145User);
+
+    const v146Licenses = v146User.businesses[id].licenseData?.licenses;
+    expect(v146Licenses?.["Pharmacy-Pharmacy"]).not.toHaveProperty(fieldToDelete);
+    expect(v146Licenses?.["Accountancy-Firm Registration"]).not.toHaveProperty(fieldToDelete);
+  });
+});

--- a/api/src/db/migrations/v146_remove_haserror_field_from_licensedetails.ts
+++ b/api/src/db/migrations/v146_remove_haserror_field_from_licensedetails.ts
@@ -1,146 +1,172 @@
-import { v144Business, v144UserData } from "@db/migrations/v144_add_raffle_bingo_games";
+import {
+  v145Business,
+  v145LicenseName,
+  v145Licenses,
+  v145UserData,
+} from "@db/migrations/v145_add_traveling_circus_or_carnival";
 import { randomInt } from "@shared/intHelpers";
 
-export const migrate_v144_to_v145 = (v144Data: v144UserData): v145UserData => {
+export const migrate_v145_to_v146 = (v145Data: v145UserData): v146UserData => {
   return {
-    ...v144Data,
+    ...v145Data,
     businesses: Object.fromEntries(
-      Object.values(v144Data.businesses)
-        .map((business: v144Business) => migrate_v144Business_to_v145Business(business))
-        .map((currBusiness: v145Business) => [currBusiness.id, currBusiness])
+      Object.values(v145Data.businesses)
+        .map((business: v145Business) => migrate_v145Business_to_v146Business(business))
+        .map((currBusiness: v146Business) => [currBusiness.id, currBusiness])
     ),
-    version: 145,
-  } as v145UserData;
+    version: 146,
+  } as v146UserData;
 };
 
-export const migrate_v144Business_to_v145Business = (business: v144Business): v145Business => {
+export const migrate_v145Business_to_v146Business = (business: v145Business): v146Business => {
+  const newLicenseData = deleteFieldFromInnerObjects(business.licenseData?.licenses);
+
   return {
     ...business,
     profileData: {
       ...business.profileData,
-      travelingCircusOrCarnivalOwningBusiness: undefined,
+      licenseData: {
+        licenses: newLicenseData,
+        ...business.licenseData,
+      },
     },
-  } as v145Business;
+  } as v146Business;
 };
 
-export interface v145IndustrySpecificData {
+export const deleteFieldFromInnerObjects = (
+  v145Licenses: v145Licenses | undefined
+): v146Licenses | undefined => {
+  if (v145Licenses === undefined) {
+    return undefined;
+  }
+
+  for (const licenseName of Object.keys(v145Licenses)) {
+    const licenseDetails = v145Licenses[licenseName as v145LicenseName];
+    if (licenseDetails !== undefined) {
+      delete licenseDetails.hasError;
+    }
+  }
+  return v145Licenses;
+};
+
+export interface v146IndustrySpecificData {
   liquorLicense: boolean;
   requiresCpa: boolean;
   homeBasedBusiness: boolean | undefined;
   providesStaffingService: boolean;
   certifiedInteriorDesigner: boolean;
   realEstateAppraisalManagement: boolean;
-  cannabisLicenseType: v145CannabisLicenseType;
+  cannabisLicenseType: v146CannabisLicenseType;
   cannabisMicrobusiness: boolean | undefined;
   constructionRenovationPlan: boolean | undefined;
-  carService: v145CarServiceType | undefined;
+  carService: v146CarServiceType | undefined;
   interstateTransport: boolean;
   interstateLogistics: boolean | undefined;
   interstateMoving: boolean | undefined;
   isChildcareForSixOrMore: boolean | undefined;
   petCareHousing: boolean | undefined;
   willSellPetCareItems: boolean | undefined;
-  constructionType: v145ConstructionType;
-  residentialConstructionType: v145ResidentialConstructionType;
-  employmentPersonnelServiceType: v145EmploymentAndPersonnelServicesType;
-  employmentPlacementType: v145EmploymentPlacementType;
+  constructionType: v146ConstructionType;
+  residentialConstructionType: v146ResidentialConstructionType;
+  employmentPersonnelServiceType: v146EmploymentAndPersonnelServicesType;
+  employmentPlacementType: v146EmploymentPlacementType;
   carnivalRideOwningBusiness: boolean | undefined;
-  propertyLeaseType: v145PropertyLeaseType;
+  propertyLeaseType: v146PropertyLeaseType;
   hasThreeOrMoreRentalUnits: boolean | undefined;
   travelingCircusOrCarnivalOwningBusiness: boolean | undefined;
 }
 
-export type v145PropertyLeaseType = "SHORT_TERM_RENTAL" | "LONG_TERM_RENTAL" | "BOTH" | undefined;
+export type v146PropertyLeaseType = "SHORT_TERM_RENTAL" | "LONG_TERM_RENTAL" | "BOTH" | undefined;
 
-// ---------------- v145 types ----------------
-type v145TaskProgress = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
-type v145OnboardingFormProgress = "UNSTARTED" | "COMPLETED";
-type v145ABExperience = "ExperienceA" | "ExperienceB";
+// ---------------- v146 types ----------------
+type v146TaskProgress = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+type v146OnboardingFormProgress = "UNSTARTED" | "COMPLETED";
+type v146ABExperience = "ExperienceA" | "ExperienceB";
 
-export interface v145UserData {
-  user: v145BusinessUser;
+export interface v146UserData {
+  user: v146BusinessUser;
   version: number;
   lastUpdatedISO: string;
   dateCreatedISO: string;
   versionWhenCreated: number;
-  businesses: Record<string, v145Business>;
+  businesses: Record<string, v146Business>;
   currentBusinessId: string;
 }
 
-export interface v145Business {
+export interface v146Business {
   id: string;
   dateCreatedISO: string;
   lastUpdatedISO: string;
-  profileData: v145ProfileData;
-  onboardingFormProgress: v145OnboardingFormProgress;
-  taskProgress: Record<string, v145TaskProgress>;
+  profileData: v146ProfileData;
+  onboardingFormProgress: v146OnboardingFormProgress;
+  taskProgress: Record<string, v146TaskProgress>;
   taskItemChecklist: Record<string, boolean>;
-  licenseData: v145LicenseData | undefined;
-  preferences: v145Preferences;
-  taxFilingData: v145TaxFilingData;
-  formationData: v145FormationData;
+  licenseData: v146LicenseData | undefined;
+  preferences: v146Preferences;
+  taxFilingData: v146TaxFilingData;
+  formationData: v146FormationData;
 }
 
-export interface v145ProfileData extends v145IndustrySpecificData {
-  businessPersona: v145BusinessPersona;
+export interface v146ProfileData extends v146IndustrySpecificData {
+  businessPersona: v146BusinessPersona;
   businessName: string;
   responsibleOwnerName: string;
   tradeName: string;
   industryId: string | undefined;
   legalStructureId: string | undefined;
-  municipality: v145Municipality | undefined;
+  municipality: v146Municipality | undefined;
   dateOfFormation: string | undefined;
   entityId: string | undefined;
   employerId: string | undefined;
   taxId: string | undefined;
   encryptedTaxId: string | undefined;
   notes: string;
-  documents: v145ProfileDocuments;
+  documents: v146ProfileDocuments;
   ownershipTypeIds: string[];
   existingEmployees: string | undefined;
   taxPin: string | undefined;
   sectorId: string | undefined;
   naicsCode: string;
-  foreignBusinessTypeIds: v145ForeignBusinessTypeId[];
+  foreignBusinessTypeIds: v146ForeignBusinessTypeId[];
   nexusDbaName: string;
   needsNexusDbaName: boolean;
-  operatingPhase: v145OperatingPhase;
+  operatingPhase: v146OperatingPhase;
   isNonprofitOnboardingRadio: boolean;
   nonEssentialRadioAnswers: Record<string, boolean | undefined>;
   elevatorOwningBusiness: boolean | undefined;
-  communityAffairsAddress?: v145CommunityAffairsAddress;
+  communityAffairsAddress?: v146CommunityAffairsAddress;
   plannedRenovationQuestion: boolean | undefined;
   raffleBingoGames: boolean | undefined;
 }
 
-export type v145CommunityAffairsAddress = {
+export type v146CommunityAffairsAddress = {
   streetAddress1: string;
   streetAddress2?: string;
-  municipality: v145Municipality;
+  municipality: v146Municipality;
 };
 
-type v145BusinessUser = {
+type v146BusinessUser = {
   name?: string;
   email: string;
   id: string;
   receiveNewsletter: boolean;
   userTesting: boolean;
-  externalStatus: v145ExternalStatus;
+  externalStatus: v146ExternalStatus;
   myNJUserKey?: string;
   intercomHash?: string;
-  abExperience: v145ABExperience;
+  abExperience: v146ABExperience;
   accountCreationSource: string;
   contactSharingWithAccountCreationPartner: boolean;
 };
 
-interface v145ProfileDocuments {
+interface v146ProfileDocuments {
   formationDoc: string;
   standingDoc: string;
   certifiedDoc: string;
 }
 
-type v145BusinessPersona = "STARTING" | "OWNING" | "FOREIGN" | undefined;
-type v145OperatingPhase =
+type v146BusinessPersona = "STARTING" | "OWNING" | "FOREIGN" | undefined;
+type v146OperatingPhase =
   | "GUEST_MODE"
   | "NEEDS_TO_FORM"
   | "NEEDS_BUSINESS_STRUCTURE"
@@ -150,18 +176,18 @@ type v145OperatingPhase =
   | "REMOTE_SELLER_WORKER"
   | undefined;
 
-export type v145CannabisLicenseType = "CONDITIONAL" | "ANNUAL" | undefined;
-export type v145CarServiceType = "STANDARD" | "HIGH_CAPACITY" | "BOTH" | undefined;
-export type v145ConstructionType = "RESIDENTIAL" | "COMMERCIAL_OR_INDUSTRIAL" | "BOTH" | undefined;
-export type v145ResidentialConstructionType =
+export type v146CannabisLicenseType = "CONDITIONAL" | "ANNUAL" | undefined;
+export type v146CarServiceType = "STANDARD" | "HIGH_CAPACITY" | "BOTH" | undefined;
+export type v146ConstructionType = "RESIDENTIAL" | "COMMERCIAL_OR_INDUSTRIAL" | "BOTH" | undefined;
+export type v146ResidentialConstructionType =
   | "NEW_HOME_CONSTRUCTION"
   | "HOME_RENOVATIONS"
   | "BOTH"
   | undefined;
-export type v145EmploymentAndPersonnelServicesType = "JOB_SEEKERS" | "EMPLOYERS" | undefined;
-export type v145EmploymentPlacementType = "TEMPORARY" | "PERMANENT" | "BOTH" | undefined;
+export type v146EmploymentAndPersonnelServicesType = "JOB_SEEKERS" | "EMPLOYERS" | undefined;
+export type v146EmploymentPlacementType = "TEMPORARY" | "PERMANENT" | "BOTH" | undefined;
 
-type v145ForeignBusinessTypeId =
+type v146ForeignBusinessTypeId =
   | "employeeOrContractorInNJ"
   | "officeInNJ"
   | "propertyInNJ"
@@ -171,55 +197,54 @@ type v145ForeignBusinessTypeId =
   | "transactionsInNJ"
   | "none";
 
-type v145Municipality = {
+type v146Municipality = {
   name: string;
   displayName: string;
   county: string;
   id: string;
 };
 
-type v145TaxFilingState = "SUCCESS" | "FAILED" | "UNREGISTERED" | "PENDING" | "API_ERROR";
-type v145TaxFilingErrorFields = "businessName" | "formFailure";
+type v146TaxFilingState = "SUCCESS" | "FAILED" | "UNREGISTERED" | "PENDING" | "API_ERROR";
+type v146TaxFilingErrorFields = "businessName" | "formFailure";
 
-type v145TaxFilingData = {
-  state?: v145TaxFilingState;
+type v146TaxFilingData = {
+  state?: v146TaxFilingState;
   lastUpdatedISO?: string;
   registeredISO?: string;
-  errorField?: v145TaxFilingErrorFields;
+  errorField?: v146TaxFilingErrorFields;
   businessName?: string;
-  filings: v145TaxFilingCalendarEvent[];
+  filings: v146TaxFilingCalendarEvent[];
 };
 
-export type v145CalendarEvent = {
+export type v146CalendarEvent = {
   readonly dueDate: string; // YYYY-MM-DD
   readonly calendarEventType: "TAX-FILING" | "LICENSE";
 };
 
-export interface v145TaxFilingCalendarEvent extends v145CalendarEvent {
+export interface v146TaxFilingCalendarEvent extends v146CalendarEvent {
   readonly identifier: string;
   readonly calendarEventType: "TAX-FILING";
 }
 
-export type v145LicenseSearchAddress = {
+export type v146LicenseSearchAddress = {
   addressLine1: string;
   addressLine2: string;
   zipCode: string;
 };
 
-export interface v145LicenseSearchNameAndAddress extends v145LicenseSearchAddress {
+export interface v146LicenseSearchNameAndAddress extends v146LicenseSearchAddress {
   name: string;
 }
 
-type v145LicenseDetails = {
-  nameAndAddress: v145LicenseSearchNameAndAddress;
-  licenseStatus: v145LicenseStatus;
+type v146LicenseDetails = {
+  nameAndAddress: v146LicenseSearchNameAndAddress;
+  licenseStatus: v146LicenseStatus;
   expirationDateISO: string | undefined;
   lastUpdatedISO: string;
-  checklistItems: v145LicenseStatusItem[];
-  hasError?: boolean;
+  checklistItems: v146LicenseStatusItem[];
 };
 
-const v145taskIdLicenseNameMapping = {
+const v146taskIdLicenseNameMapping = {
   "apply-for-shop-license": "Cosmetology and Hairstyling-Shop",
   "appraiser-license": "Real Estate Appraisers-Appraisal Management Company",
   "architect-license": "Architecture-Certificate of Authorization",
@@ -237,19 +262,19 @@ const v145taskIdLicenseNameMapping = {
   "telemarketing-license": "Telemarketers",
 } as const;
 
-type v145LicenseTaskID = keyof typeof v145taskIdLicenseNameMapping;
+type v146LicenseTaskID = keyof typeof v146taskIdLicenseNameMapping;
 
-export type v145LicenseName = (typeof v145taskIdLicenseNameMapping)[v145LicenseTaskID];
+export type v146LicenseName = (typeof v146taskIdLicenseNameMapping)[v146LicenseTaskID];
 
-export type v145Licenses = Partial<Record<v145LicenseName, v145LicenseDetails>>;
+type v146Licenses = Partial<Record<v146LicenseName, v146LicenseDetails>>;
 
-type v145LicenseData = {
+type v146LicenseData = {
   lastUpdatedISO: string;
-  licenses?: v145Licenses;
+  licenses?: v146Licenses;
 };
 
-type v145Preferences = {
-  roadmapOpenSections: v145SectionType[];
+type v146Preferences = {
+  roadmapOpenSections: v146SectionType[];
   roadmapOpenSteps: number[];
   hiddenFundingIds: string[];
   hiddenCertificationIds: string[];
@@ -260,14 +285,14 @@ type v145Preferences = {
   phaseNewlyChanged: boolean;
 };
 
-type v145LicenseStatusItem = {
+type v146LicenseStatusItem = {
   title: string;
-  status: v145CheckoffStatus;
+  status: v146CheckoffStatus;
 };
 
-type v145CheckoffStatus = "ACTIVE" | "PENDING" | "UNKNOWN";
+type v146CheckoffStatus = "ACTIVE" | "PENDING" | "UNKNOWN";
 
-type v145LicenseStatus =
+type v146LicenseStatus =
   | "ACTIVE"
   | "PENDING"
   | "UNKNOWN"
@@ -281,7 +306,7 @@ type v145LicenseStatus =
   | "VOLUNTARY_SURRENDER"
   | "WITHDRAWN";
 
-const v145LicenseStatuses: v145LicenseStatus[] = [
+const v146LicenseStatuses: v146LicenseStatus[] = [
   "ACTIVE",
   "PENDING",
   "UNKNOWN",
@@ -296,31 +321,31 @@ const v145LicenseStatuses: v145LicenseStatus[] = [
   "WITHDRAWN",
 ];
 
-const v145SectionNames = ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"] as const;
-type v145SectionType = (typeof v145SectionNames)[number];
+const v146SectionNames = ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"] as const;
+type v146SectionType = (typeof v146SectionNames)[number];
 
-type v145ExternalStatus = {
-  newsletter?: v145NewsletterResponse;
-  userTesting?: v145UserTestingResponse;
+type v146ExternalStatus = {
+  newsletter?: v146NewsletterResponse;
+  userTesting?: v146UserTestingResponse;
 };
 
-interface v145NewsletterResponse {
+interface v146NewsletterResponse {
   success?: boolean;
-  status: v145NewsletterStatus;
+  status: v146NewsletterStatus;
 }
 
-interface v145UserTestingResponse {
+interface v146UserTestingResponse {
   success?: boolean;
-  status: v145UserTestingStatus;
+  status: v146UserTestingStatus;
 }
 
-type v145NewsletterStatus = (typeof newsletterStatusList)[number];
+type v146NewsletterStatus = (typeof newsletterStatusList)[number];
 
 const externalStatusList = ["SUCCESS", "IN_PROGRESS", "CONNECTION_ERROR"] as const;
 
 const userTestingStatusList = [...externalStatusList] as const;
 
-type v145UserTestingStatus = (typeof userTestingStatusList)[number];
+type v146UserTestingStatus = (typeof userTestingStatusList)[number];
 
 const newsletterStatusList = [
   ...externalStatusList,
@@ -332,7 +357,7 @@ const newsletterStatusList = [
   "QUESTION_WARNING",
 ] as const;
 
-type v145NameAvailabilityStatus =
+type v146NameAvailabilityStatus =
   | "AVAILABLE"
   | "DESIGNATOR_ERROR"
   | "SPECIAL_CHARACTER_ERROR"
@@ -340,31 +365,31 @@ type v145NameAvailabilityStatus =
   | "RESTRICTED_ERROR"
   | undefined;
 
-interface v145NameAvailabilityResponse {
-  status: v145NameAvailabilityStatus;
+interface v146NameAvailabilityResponse {
+  status: v146NameAvailabilityStatus;
   similarNames: string[];
   invalidWord?: string;
 }
 
-interface v145NameAvailability extends v145NameAvailabilityResponse {
+interface v146NameAvailability extends v146NameAvailabilityResponse {
   lastUpdatedTimeStamp: string;
 }
 
-interface v145FormationData {
-  formationFormData: v145FormationFormData;
-  businessNameAvailability: v145NameAvailability | undefined;
-  dbaBusinessNameAvailability: v145NameAvailability | undefined;
-  formationResponse: v145FormationSubmitResponse | undefined;
-  getFilingResponse: v145GetFilingResponse | undefined;
+interface v146FormationData {
+  formationFormData: v146FormationFormData;
+  businessNameAvailability: v146NameAvailability | undefined;
+  dbaBusinessNameAvailability: v146NameAvailability | undefined;
+  formationResponse: v146FormationSubmitResponse | undefined;
+  getFilingResponse: v146GetFilingResponse | undefined;
   completedFilingPayment: boolean;
   lastVisitedPageIndex: number;
 }
 
-type v145InFormInBylaws = "IN_BYLAWS" | "IN_FORM" | undefined;
+type v146InFormInBylaws = "IN_BYLAWS" | "IN_FORM" | undefined;
 
-interface v145FormationFormData extends v145FormationAddress {
+interface v146FormationFormData extends v146FormationAddress {
   readonly businessName: string;
-  readonly businessSuffix: v145BusinessSuffix | undefined;
+  readonly businessSuffix: v146BusinessSuffix | undefined;
   readonly businessTotalStock: string;
   readonly businessStartDate: string; // YYYY-MM-DD
   readonly businessPurpose: string;
@@ -378,13 +403,13 @@ interface v145FormationFormData extends v145FormationAddress {
   readonly canMakeDistribution: boolean | undefined;
   readonly makeDistributionTerms: string;
   readonly hasNonprofitBoardMembers: boolean | undefined;
-  readonly nonprofitBoardMemberQualificationsSpecified: v145InFormInBylaws;
+  readonly nonprofitBoardMemberQualificationsSpecified: v146InFormInBylaws;
   readonly nonprofitBoardMemberQualificationsTerms: string;
-  readonly nonprofitBoardMemberRightsSpecified: v145InFormInBylaws;
+  readonly nonprofitBoardMemberRightsSpecified: v146InFormInBylaws;
   readonly nonprofitBoardMemberRightsTerms: string;
-  readonly nonprofitTrusteesMethodSpecified: v145InFormInBylaws;
+  readonly nonprofitTrusteesMethodSpecified: v146InFormInBylaws;
   readonly nonprofitTrusteesMethodTerms: string;
-  readonly nonprofitAssetDistributionSpecified: v145InFormInBylaws;
+  readonly nonprofitAssetDistributionSpecified: v146InFormInBylaws;
   readonly nonprofitAssetDistributionTerms: string;
   readonly additionalProvisions: string[] | undefined;
   readonly agentNumberOrManual: "NUMBER" | "MANUAL_ENTRY";
@@ -397,10 +422,10 @@ interface v145FormationFormData extends v145FormationAddress {
   readonly agentOfficeAddressZipCode: string;
   readonly agentUseAccountInfo: boolean;
   readonly agentUseBusinessAddress: boolean;
-  readonly members: v145FormationMember[] | undefined;
-  readonly incorporators: v145FormationIncorporator[] | undefined;
-  readonly signers: v145FormationSigner[] | undefined;
-  readonly paymentType: v145PaymentType;
+  readonly members: v146FormationMember[] | undefined;
+  readonly incorporators: v146FormationIncorporator[] | undefined;
+  readonly signers: v146FormationSigner[] | undefined;
+  readonly paymentType: v146PaymentType;
   readonly annualReportNotification: boolean;
   readonly corpWatchNotification: boolean;
   readonly officialFormationDocument: boolean;
@@ -409,39 +434,39 @@ interface v145FormationFormData extends v145FormationAddress {
   readonly contactFirstName: string;
   readonly contactLastName: string;
   readonly contactPhoneNumber: string;
-  readonly foreignStateOfFormation: v145StateObject | undefined;
+  readonly foreignStateOfFormation: v146StateObject | undefined;
   readonly foreignDateOfFormation: string | undefined; // YYYY-MM-DD
-  readonly foreignGoodStandingFile: v145ForeignGoodStandingFileObject | undefined;
+  readonly foreignGoodStandingFile: v146ForeignGoodStandingFileObject | undefined;
   readonly legalType: string;
   readonly willPracticeLaw: boolean | undefined;
   readonly isVeteranNonprofit: boolean | undefined;
 }
 
-type v145ForeignGoodStandingFileObject = {
+type v146ForeignGoodStandingFileObject = {
   Extension: "PDF" | "PNG";
   Content: string;
 };
 
-type v145StateObject = {
+type v146StateObject = {
   shortCode: string;
   name: string;
 };
 
-interface v145FormationAddress {
+interface v146FormationAddress {
   readonly addressLine1: string;
   readonly addressLine2: string;
   readonly addressCity?: string;
-  readonly addressState?: v145StateObject;
-  readonly addressMunicipality?: v145Municipality;
+  readonly addressState?: v146StateObject;
+  readonly addressMunicipality?: v146Municipality;
   readonly addressProvince?: string;
   readonly addressZipCode: string;
   readonly addressCountry: string;
-  readonly businessLocationType: v145FormationBusinessLocationType | undefined;
+  readonly businessLocationType: v146FormationBusinessLocationType | undefined;
 }
 
-type v145FormationBusinessLocationType = "US" | "INTL" | "NJ";
+type v146FormationBusinessLocationType = "US" | "INTL" | "NJ";
 
-type v145SignerTitle =
+type v146SignerTitle =
   | "Authorized Representative"
   | "Authorized Partner"
   | "Incorporator"
@@ -451,19 +476,19 @@ type v145SignerTitle =
   | "Chairman of the Board"
   | "CEO";
 
-interface v145FormationSigner {
+interface v146FormationSigner {
   readonly name: string;
   readonly signature: boolean;
-  readonly title: v145SignerTitle;
+  readonly title: v146SignerTitle;
 }
 
-interface v145FormationIncorporator extends v145FormationSigner, v145FormationAddress {}
+interface v146FormationIncorporator extends v146FormationSigner, v146FormationAddress {}
 
-interface v145FormationMember extends v145FormationAddress {
+interface v146FormationMember extends v146FormationAddress {
   readonly name: string;
 }
 
-type v145PaymentType = "CC" | "ACH" | undefined;
+type v146PaymentType = "CC" | "ACH" | undefined;
 
 const llcBusinessSuffix = [
   "LLC",
@@ -521,24 +546,24 @@ export const AllBusinessSuffixes = [
   ...nonprofitBusinessSuffix,
 ] as const;
 
-type v145BusinessSuffix = (typeof AllBusinessSuffixes)[number];
+type v146BusinessSuffix = (typeof AllBusinessSuffixes)[number];
 
-type v145FormationSubmitResponse = {
+type v146FormationSubmitResponse = {
   success: boolean;
   token: string | undefined;
   formationId: string | undefined;
   redirect: string | undefined;
-  errors: v145FormationSubmitError[];
+  errors: v146FormationSubmitError[];
   lastUpdatedISO: string | undefined;
 };
 
-type v145FormationSubmitError = {
+type v146FormationSubmitError = {
   field: string;
   type: "FIELD" | "UNKNOWN" | "RESPONSE";
   message: string;
 };
 
-type v145GetFilingResponse = {
+type v146GetFilingResponse = {
   success: boolean;
   entityId: string;
   transactionDate: string;
@@ -548,24 +573,24 @@ type v145GetFilingResponse = {
   certifiedDoc: string;
 };
 
-// ---------------- v145 generators ----------------
+// ---------------- v146 generators ----------------
 
-export const generatev145UserData = (overrides: Partial<v145UserData>): v145UserData => {
+export const generatev146UserData = (overrides: Partial<v146UserData>): v146UserData => {
   return {
-    user: generatev145BusinessUser({}),
+    user: generatev146BusinessUser({}),
     version: 140,
     lastUpdatedISO: "",
     dateCreatedISO: "",
     versionWhenCreated: 141,
     businesses: {
-      "123": generatev145Business({ id: "123" }),
+      "123": generatev146Business({ id: "123" }),
     },
     currentBusinessId: "",
     ...overrides,
   };
 };
 
-export const generatev145BusinessUser = (overrides: Partial<v145BusinessUser>): v145BusinessUser => {
+export const generatev146BusinessUser = (overrides: Partial<v146BusinessUser>): v146BusinessUser => {
   return {
     name: `some-name-${randomInt()}`,
     email: `some-email-${randomInt()}@example.com`,
@@ -587,15 +612,15 @@ export const generatev145BusinessUser = (overrides: Partial<v145BusinessUser>): 
   };
 };
 
-export const generatev145Business = (overrides: Partial<v145Business>): v145Business => {
-  const profileData = generatev145ProfileData({});
+export const generatev146Business = (overrides: Partial<v146Business>): v146Business => {
+  const profileData = generatev146ProfileData({});
   return {
     id: `some-id-${randomInt()}`,
     dateCreatedISO: "",
     lastUpdatedISO: "",
     profileData: profileData,
-    preferences: generatev145Preferences({}),
-    formationData: generatev145FormationData({}, profileData.legalStructureId ?? ""),
+    preferences: generatev146Preferences({}),
+    formationData: generatev146FormationData({}, profileData.legalStructureId ?? ""),
     onboardingFormProgress: "UNSTARTED",
     taskProgress: {
       "business-structure": "NOT_STARTED",
@@ -604,16 +629,16 @@ export const generatev145Business = (overrides: Partial<v145Business>): v145Busi
       "general-dvob": false,
     },
     licenseData: undefined,
-    taxFilingData: generatev145TaxFilingData({}),
+    taxFilingData: generatev146TaxFilingData({}),
     ...overrides,
   };
 };
 
-export const generatev145ProfileData = (overrides: Partial<v145ProfileData>): v145ProfileData => {
+export const generatev146ProfileData = (overrides: Partial<v146ProfileData>): v146ProfileData => {
   const id = `some-id-${randomInt()}`;
   const persona = randomInt() % 2 ? "STARTING" : "OWNING";
   return {
-    ...generatev145IndustrySpecificData({}),
+    ...generatev146IndustrySpecificData({}),
     businessPersona: persona,
     businessName: `some-business-name-${randomInt()}`,
     industryId: "restaurant",
@@ -651,9 +676,9 @@ export const generatev145ProfileData = (overrides: Partial<v145ProfileData>): v1
   };
 };
 
-export const generatev145IndustrySpecificData = (
-  overrides: Partial<v145IndustrySpecificData>
-): v145IndustrySpecificData => {
+export const generatev146IndustrySpecificData = (
+  overrides: Partial<v146IndustrySpecificData>
+): v146IndustrySpecificData => {
   return {
     liquorLicense: false,
     requiresCpa: false,
@@ -683,7 +708,7 @@ export const generatev145IndustrySpecificData = (
   };
 };
 
-export const generatev145Preferences = (overrides: Partial<v145Preferences>): v145Preferences => {
+export const generatev146Preferences = (overrides: Partial<v146Preferences>): v146Preferences => {
   return {
     roadmapOpenSections: ["PLAN", "START"],
     roadmapOpenSteps: [],
@@ -698,12 +723,12 @@ export const generatev145Preferences = (overrides: Partial<v145Preferences>): v1
   };
 };
 
-export const generatev145FormationData = (
-  overrides: Partial<v145FormationData>,
+export const generatev146FormationData = (
+  overrides: Partial<v146FormationData>,
   legalStructureId: string
-): v145FormationData => {
+): v146FormationData => {
   return {
-    formationFormData: generatev145FormationFormData({}, legalStructureId),
+    formationFormData: generatev146FormationFormData({}, legalStructureId),
     formationResponse: undefined,
     getFilingResponse: undefined,
     completedFilingPayment: false,
@@ -714,13 +739,13 @@ export const generatev145FormationData = (
   };
 };
 
-export const generatev145FormationFormData = (
-  overrides: Partial<v145FormationFormData>,
+export const generatev146FormationFormData = (
+  overrides: Partial<v146FormationFormData>,
   legalStructureId: string
-): v145FormationFormData => {
+): v146FormationFormData => {
   const isCorp = legalStructureId ? ["s-corporation", "c-corporation"].includes(legalStructureId) : false;
 
-  return <v145FormationFormData>{
+  return <v146FormationFormData>{
     businessName: `some-business-name-${randomInt()}`,
     businessSuffix: "LLC",
     businessTotalStock: isCorp ? randomInt().toString() : "",
@@ -732,7 +757,7 @@ export const generatev145FormationFormData = (
     addressState: { shortCode: "123", name: "new-jersey" },
     addressZipCode: `some-agent-office-zipcode-${randomInt()}`,
     addressCountry: `some-county`,
-    addressMunicipality: generatev145Municipality({}),
+    addressMunicipality: generatev146Municipality({}),
     addressProvince: "",
     withdrawals: `some-withdrawals-text-${randomInt()}`,
     combinedInvestment: `some-combinedInvestment-text-${randomInt()}`,
@@ -764,7 +789,7 @@ export const generatev145FormationFormData = (
     agentUseAccountInfo: !!(randomInt() % 2),
     agentUseBusinessAddress: !!(randomInt() % 2),
     signers: [],
-    members: legalStructureId === "limited-liability-partnership" ? [] : [generatev145FormationMember({})],
+    members: legalStructureId === "limited-liability-partnership" ? [] : [generatev146FormationMember({})],
     incorporators: undefined,
     paymentType: randomInt() % 2 ? "ACH" : "CC",
     annualReportNotification: !!(randomInt() % 2),
@@ -787,7 +812,7 @@ export const generatev145FormationFormData = (
   };
 };
 
-export const generatev145Municipality = (overrides: Partial<v145Municipality>): v145Municipality => {
+export const generatev146Municipality = (overrides: Partial<v146Municipality>): v146Municipality => {
   return {
     displayName: `some-display-name-${randomInt()}`,
     name: `some-name-${randomInt()}`,
@@ -797,7 +822,7 @@ export const generatev145Municipality = (overrides: Partial<v145Municipality>): 
   };
 };
 
-export const generatev145FormationMember = (overrides: Partial<v145FormationMember>): v145FormationMember => {
+export const generatev146FormationMember = (overrides: Partial<v146FormationMember>): v146FormationMember => {
   return {
     name: `some-name`,
     addressLine1: `some-members-address-1-${randomInt()}`,
@@ -811,7 +836,7 @@ export const generatev145FormationMember = (overrides: Partial<v145FormationMemb
   };
 };
 
-export const generatev145TaxFilingData = (overrides: Partial<v145TaxFilingData>): v145TaxFilingData => {
+export const generatev146TaxFilingData = (overrides: Partial<v146TaxFilingData>): v146TaxFilingData => {
   return {
     state: undefined,
     businessName: undefined,
@@ -823,21 +848,20 @@ export const generatev145TaxFilingData = (overrides: Partial<v145TaxFilingData>)
   };
 };
 
-export const generatev145LicenseDetails = (overrides: Partial<v145LicenseDetails>): v145LicenseDetails => {
+export const generatev146LicenseDetails = (overrides: Partial<v146LicenseDetails>): v146LicenseDetails => {
   return {
-    nameAndAddress: generatev145LicenseSearchNameAndAddress({}),
-    licenseStatus: getRandomV145LicenseStatus(),
+    nameAndAddress: generatev146LicenseSearchNameAndAddress({}),
+    licenseStatus: getRandomV146LicenseStatus(),
     expirationDateISO: "some-expiration-iso",
     lastUpdatedISO: "some-last-updated",
-    checklistItems: [generatev145LicenseStatusItem()],
-    hasError: false,
+    checklistItems: [generatev146LicenseStatusItem()],
     ...overrides,
   };
 };
 
-const generatev145LicenseSearchNameAndAddress = (
-  overrides: Partial<v145LicenseSearchNameAndAddress>
-): v145LicenseSearchNameAndAddress => {
+const generatev146LicenseSearchNameAndAddress = (
+  overrides: Partial<v146LicenseSearchNameAndAddress>
+): v146LicenseSearchNameAndAddress => {
   return {
     name: `some-name`,
     addressLine1: `some-members-address-1-${randomInt()}`,
@@ -847,14 +871,14 @@ const generatev145LicenseSearchNameAndAddress = (
   };
 };
 
-const generatev145LicenseStatusItem = (): v145LicenseStatusItem => {
+const generatev146LicenseStatusItem = (): v146LicenseStatusItem => {
   return {
     title: `some-title-${randomInt()}`,
     status: "ACTIVE",
   };
 };
 
-export const getRandomV145LicenseStatus = (): v145LicenseStatus => {
-  const randomIndex = Math.floor(Math.random() * v145LicenseStatuses.length);
-  return v145LicenseStatuses[randomIndex];
+export const getRandomV146LicenseStatus = (): v146LicenseStatus => {
+  const randomIndex = Math.floor(Math.random() * v146LicenseStatuses.length);
+  return v146LicenseStatuses[randomIndex];
 };

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -13,12 +13,7 @@ import {
   HousingRegistrationRequestLookupResponse,
   PropertyInterestType,
 } from "@shared/housing";
-import {
-  enabledLicensesSources,
-  LicenseEntity,
-  LicenseSearchNameAndAddress,
-  LicenseTaskId,
-} from "@shared/license";
+import { enabledLicensesSources, LicenseEntity, LicenseSearchNameAndAddress } from "@shared/license";
 import { ProfileData } from "@shared/profileData";
 import { TaxFilingLookupState, TaxFilingOnboardingState } from "@shared/taxFiling";
 import { Business, UserData } from "@shared/userData";
@@ -136,8 +131,7 @@ export type SearchLicenseStatus = (
 
 export type UpdateLicenseStatus = (
   userData: UserData,
-  nameAndAddress: LicenseSearchNameAndAddress,
-  taskId?: LicenseTaskId
+  nameAndAddress: LicenseSearchNameAndAddress
 ) => Promise<UserData>;
 
 export type FireSafetyInspectionStatus = (address: string) => Promise<FireSafetyInspectionResult[]>;

--- a/api/src/domain/user/updateLicenseStatusFactory.test.ts
+++ b/api/src/domain/user/updateLicenseStatusFactory.test.ts
@@ -262,7 +262,7 @@ describe("updateLicenseStatus", () => {
       );
     });
 
-    it("updates license data of current task to have error license data when webservice receives NO_MATCH_ERROR and rgb also fails", async () => {
+    it("returns empty license object when data of current task to have error license data when webservice receives NO_MATCH_ERROR and rgb also fails", async () => {
       stubWebserviceLicenseStatusSearch.mockRejectedValue(new Error(NO_MATCH_ERROR));
       stubRGBLicenseStatusSearch.mockRejectedValue(new Error("fail"));
 
@@ -271,21 +271,11 @@ describe("updateLicenseStatus", () => {
         licenseData: generateLicenseData({}),
       }));
 
-      const resultUserData = await updateLicenseStatus(userData, nameAndAddress, "pharmacy-license");
+      const resultUserData = await updateLicenseStatus(userData, nameAndAddress);
       const resultCurrentBusiness = getCurrentBusiness(resultUserData);
 
       const resultLicenseData = resultCurrentBusiness.licenseData;
-      const licenseType1Expected = {
-        "Pharmacy-Pharmacy": {
-          licenseStatus: "UNKNOWN",
-          expirationDateISO: undefined,
-          hasError: true,
-
-          checklistItems: [],
-          nameAndAddress,
-          lastUpdatedISO: expectedCurrentDate,
-        },
-      };
+      const licenseType1Expected = {};
 
       expect(resultLicenseData).toEqual({
         lastUpdatedISO: expectedCurrentDate,
@@ -296,7 +286,7 @@ describe("updateLicenseStatus", () => {
     });
 
     it.each([NO_MATCH_ERROR, NO_MAIN_APPS_ERROR, NO_ADDRESS_MATCH_ERROR])(
-      "updates license data of current task to have error license data when rgb receives %s and webservice also fails",
+      "returns empty license task of current task to have error license data when rgb receives %s and webservice also fails",
       async (error) => {
         stubWebserviceLicenseStatusSearch.mockRejectedValue(new Error("fails"));
         stubRGBLicenseStatusSearch.mockRejectedValue(new Error(error));
@@ -306,25 +296,11 @@ describe("updateLicenseStatus", () => {
           licenseData: generateLicenseData({}),
         }));
 
-        const resultUserData = await updateLicenseStatus(
-          userData,
-          nameAndAddress,
-          "home-health-aide-license"
-        );
+        const resultUserData = await updateLicenseStatus(userData, nameAndAddress);
         const resultCurrentBusiness = getCurrentBusiness(resultUserData);
 
         const resultLicenseData = resultCurrentBusiness.licenseData;
-        const licenseType1Expected = {
-          "Health Care Services": {
-            licenseStatus: "UNKNOWN",
-            expirationDateISO: undefined,
-            hasError: true,
-
-            checklistItems: [],
-            nameAndAddress,
-            lastUpdatedISO: expectedCurrentDate,
-          },
-        };
+        const licenseType1Expected = {};
 
         expect(resultLicenseData).toEqual({
           lastUpdatedISO: expectedCurrentDate,

--- a/api/src/domain/user/updateLicenseStatusFactory.ts
+++ b/api/src/domain/user/updateLicenseStatusFactory.ts
@@ -18,8 +18,6 @@ import {
   LicenseName,
   Licenses,
   LicenseSearchNameAndAddress,
-  LicenseTaskId,
-  taskIdLicenseNameMapping,
 } from "@shared/license";
 import { Business, UserData } from "@shared/userData";
 
@@ -28,7 +26,6 @@ const DEBUG_RegulatedBusinessDynamicsLicenseSearch = false; // this variable exi
 const getLicenses = (args: {
   nameAndAddress: LicenseSearchNameAndAddress;
   licenseStatusResult: LicenseStatusResults;
-  taskIdWithError?: LicenseTaskId;
 }): Licenses => {
   const results: Licenses = {};
   for (const key of Object.keys(args.licenseStatusResult) as LicenseName[]) {
@@ -37,20 +34,6 @@ const getLicenses = (args: {
       nameAndAddress: args.nameAndAddress,
       lastUpdatedISO: getCurrentDateISOString(),
     } as LicenseDetails;
-  }
-  const licenseRelatedToCurrentTask = args.taskIdWithError
-    ? taskIdLicenseNameMapping[args.taskIdWithError]
-    : undefined;
-
-  if (licenseRelatedToCurrentTask && !(licenseRelatedToCurrentTask in results)) {
-    results[licenseRelatedToCurrentTask] = {
-      nameAndAddress: args.nameAndAddress,
-      licenseStatus: "UNKNOWN",
-      expirationDateISO: undefined,
-      lastUpdatedISO: getCurrentDateISOString(),
-      checklistItems: [],
-      hasError: true,
-    };
   }
 
   return results;
@@ -61,7 +44,6 @@ const updateLicenseStatusAndLicenseTask = (
   args: {
     nameAndAddress: LicenseSearchNameAndAddress;
     licenseStatusResult: LicenseStatusResults;
-    taskIdWithError?: LicenseTaskId;
   }
 ): UserData => {
   // TODO: In a future state we need to account for existing license data with address that does not match search query
@@ -84,11 +66,7 @@ export const updateLicenseStatusFactory = (
   webserviceLicenseStatusSearch: SearchLicenseStatus,
   rgbLicenseStatusSearch: SearchLicenseStatus
 ): UpdateLicenseStatus => {
-  return async (
-    userData: UserData,
-    nameAndAddress: LicenseSearchNameAndAddress,
-    taskId?: LicenseTaskId
-  ): Promise<UserData> => {
+  return async (userData: UserData, nameAndAddress: LicenseSearchNameAndAddress): Promise<UserData> => {
     const webserviceLicenseStatusPromise = webserviceLicenseStatusSearch(nameAndAddress);
     const rgbLicenseStatusPromise = rgbLicenseStatusSearch(nameAndAddress);
     return Promise.allSettled([webserviceLicenseStatusPromise, rgbLicenseStatusPromise])
@@ -111,25 +89,15 @@ export const updateLicenseStatusFactory = (
           });
         }
 
-        if (webserviceHasError && rgbHasError) {
-          if (webserviceHasInvalidMatch || rgbHasInvalidMatch) {
-            return updateLicenseStatusAndLicenseTask(userData, {
-              nameAndAddress: nameAndAddress,
-              licenseStatusResult: {},
-              taskIdWithError: taskId,
-            });
-          }
-
-          if (!webserviceHasInvalidMatch && !rgbHasInvalidMatch) {
-            const webserviceErrorMessage = webserviceLicenseStatusResults.reason;
-            const rgbErrorMessage = rgbLicenseStatusResults.reason;
-            throw new Error(
-              JSON.stringify({
-                webserviceErrorMessage,
-                rgbErrorMessage,
-              })
-            );
-          }
+        if (!webserviceHasInvalidMatch && !rgbHasInvalidMatch && webserviceHasError && rgbHasError) {
+          const webserviceErrorMessage = webserviceLicenseStatusResults.reason;
+          const rgbErrorMessage = rgbLicenseStatusResults.reason;
+          throw new Error(
+            JSON.stringify({
+              webserviceErrorMessage,
+              rgbErrorMessage,
+            })
+          );
         }
 
         let results: LicenseStatusResults = {};
@@ -151,7 +119,6 @@ export const updateLicenseStatusFactory = (
             }
           }
         }
-
         return updateLicenseStatusAndLicenseTask(userData, {
           nameAndAddress: nameAndAddress,
           licenseStatusResult: results,

--- a/shared/src/license.ts
+++ b/shared/src/license.ts
@@ -69,7 +69,6 @@ export type LicenseDetails = {
   expirationDateISO: string | undefined;
   lastUpdatedISO: string;
   checklistItems: LicenseStatusItem[];
-  hasError?: boolean;
 };
 
 export const enabledLicensesSources = {

--- a/shared/src/userData.ts
+++ b/shared/src/userData.ts
@@ -29,7 +29,7 @@ export interface Business {
   readonly formationData: FormationData;
 }
 
-export const CURRENT_VERSION = 145;
+export const CURRENT_VERSION = 146;
 
 export const createEmptyBusiness = (id?: string): Business => {
   return {

--- a/web/src/lib/api-client/apiClient.test.ts
+++ b/web/src/lib/api-client/apiClient.test.ts
@@ -1,7 +1,4 @@
 import { generateInputFile } from "@/test/factories";
-import { taskIdLicenseNameMapping } from "@businessnjgovnavigator/shared/";
-import { randomElementFromArray } from "@businessnjgovnavigator/shared/arrayHelpers";
-import { LicenseTaskId } from "@businessnjgovnavigator/shared/license";
 import {
   generateLicenseSearchNameAndAddress,
   generateTaxIdAndBusinessName,
@@ -58,27 +55,13 @@ describe("apiClient", () => {
     });
   });
 
-  it("posts license status without licenseTaskId specified", async () => {
+  it("posts license status", async () => {
     mockAxios.post.mockResolvedValue({ data: {} });
     const nameAndAddress = generateLicenseSearchNameAndAddress({});
     await checkLicenseStatus(nameAndAddress);
     expect(mockAxios.post).toHaveBeenCalledWith(
       "/api/license-status",
-      { nameAndAddress, licenseTaskId: undefined },
-      {
-        headers: { Authorization: "Bearer some-token" },
-      }
-    );
-  });
-
-  it("posts license status with licenseTaskId specified", async () => {
-    mockAxios.post.mockResolvedValue({ data: {} });
-    const nameAndAddress = generateLicenseSearchNameAndAddress({});
-    const licenseTaskId = randomElementFromArray(Object.keys(taskIdLicenseNameMapping));
-    await checkLicenseStatus(nameAndAddress, licenseTaskId as LicenseTaskId);
-    expect(mockAxios.post).toHaveBeenCalledWith(
-      "/api/license-status",
-      { nameAndAddress, licenseTaskId },
+      { nameAndAddress },
       {
         headers: { Authorization: "Bearer some-token" },
       }

--- a/web/src/lib/api-client/apiClient.ts
+++ b/web/src/lib/api-client/apiClient.ts
@@ -1,7 +1,7 @@
 import { getCurrentToken } from "@/lib/auth/sessionHelper";
 import { SelfRegResponse } from "@/lib/types/types";
 import { phaseChangeAnalytics, setPhaseDimension } from "@/lib/utils/analytics-helpers";
-import { getCurrentBusiness, LicenseTaskId } from "@businessnjgovnavigator/shared";
+import { getCurrentBusiness } from "@businessnjgovnavigator/shared";
 import {
   InputFile,
   LicenseSearchNameAndAddress,
@@ -31,12 +31,8 @@ export const postUserData = async (userData: UserData): Promise<UserData> => {
   });
 };
 
-export const checkLicenseStatus = (
-  nameAndAddress: LicenseSearchNameAndAddress,
-  licenseTaskId?: LicenseTaskId
-): Promise<UserData> => {
-  console.log(`apiClient -  ${licenseTaskId}`);
-  return post(`/license-status`, { nameAndAddress, licenseTaskId });
+export const checkLicenseStatus = (nameAndAddress: LicenseSearchNameAndAddress): Promise<UserData> => {
+  return post(`/license-status`, { nameAndAddress });
 };
 
 export const checkElevatorRegistrationStatus = (


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
User Story
As a user that has conducted a license status check search, I want to be informed that no license has been found immediately when viewing the task and the error message persists until the information is updated.

Acceptance Criteria
Given a license search have been conducted
and the check did not find a license
when viewing the license task
then the 'License could not be found..." warning is rendered in the task
and the error persists

dev note: the license status of UNKNOWN is used to trigger the alert, the status changes should be handled in the backend
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188443179](https://www.pivotaltracker.com/story/show/188443179).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
