### PR TITLE
fix: [#188414550] license data for correct business is updated when multiple businesses exist

### DIFF
--- a/web/src/lib/data-hooks/useUserData.ts
+++ b/web/src/lib/data-hooks/useUserData.ts
@@ -57,9 +57,15 @@ export const useUserData = (): UseUserDataResponse => {
     fetchedUserId.current = data?.user.id;
 
     let licenseDataFromDatabaseDataMoreRecent = false;
-    if (data?.businesses[data.currentBusinessId] && updateQueue?.currentBusiness()) {
+    const currBusinessIdFromUpdateQueue = updateQueue?.current()?.currentBusinessId;
+
+    if (
+      currBusinessIdFromUpdateQueue &&
+      data?.businesses[currBusinessIdFromUpdateQueue] &&
+      updateQueue?.currentBusiness()
+    ) {
       licenseDataFromDatabaseDataMoreRecent = isLicenseDataFromDatabaseDataMoreRecent({
-        businessFromDb: data?.businesses[data.currentBusinessId],
+        businessFromDb: data?.businesses[currBusinessIdFromUpdateQueue],
         businessFromUpdateQueue: updateQueue?.currentBusiness(),
       });
     }
@@ -68,8 +74,16 @@ export const useUserData = (): UseUserDataResponse => {
       setUpdateQueue(new UpdateQueueFactory(data, update));
     } else if (updateQueue?.current() === undefined && data) {
       updateQueue?.queue(data);
-    } else if (licenseDataFromDatabaseDataMoreRecent && updateQueue && data) {
-      const mergedData = modifyCurrentBusiness(updateQueue?.current(), licenseDataModifyingFunction(data));
+    } else if (
+      currBusinessIdFromUpdateQueue &&
+      licenseDataFromDatabaseDataMoreRecent &&
+      updateQueue &&
+      data
+    ) {
+      const mergedData = modifyCurrentBusiness(
+        updateQueue?.current(),
+        licenseDataModifyingFunction(data, currBusinessIdFromUpdateQueue)
+      );
       updateQueue?.queue(mergedData);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/src/lib/utils/licenseStatus.test.ts
+++ b/web/src/lib/utils/licenseStatus.test.ts
@@ -1,5 +1,12 @@
-import { getLicenseStatusResultsFromLicenses } from "@/lib/utils/licenseStatus";
-import { generateLicenseDetails, taskIdLicenseNameMapping } from "@businessnjgovnavigator/shared/";
+import { getLicenseStatusResultsFromLicenses, licenseDataModifyingFunction } from "@/lib/utils/licenseStatus";
+import {
+  generateBusiness,
+  generateLicenseData,
+  generateLicenseDetails,
+  generateUserDataForBusiness,
+  randomElementFromArray,
+  taskIdLicenseNameMapping,
+} from "@businessnjgovnavigator/shared/";
 
 const licenseNames = Object.values(taskIdLicenseNameMapping);
 
@@ -30,6 +37,34 @@ describe("licenseStatus", () => {
           checklistItems: licenseDetails2.checklistItems,
         },
       });
+    });
+  });
+
+  describe("licenseDataModifyingFunction", () => {
+    it("returns a fn that updates the business that was passed in as the argument when invoked", () => {
+      // Used variable names that refer to the specific use case to simplify readability
+      const currBusinessIdFromUpdateQueue = "id 1";
+
+      const businessFromUpdateQueue = generateBusiness({
+        id: currBusinessIdFromUpdateQueue,
+        licenseData: undefined,
+      });
+
+      const licensesFromDb = {
+        [randomElementFromArray(Object.values(taskIdLicenseNameMapping))]: {
+          ...generateLicenseDetails({}),
+        },
+      };
+      const userDataFromDb = generateUserDataForBusiness(
+        generateBusiness({
+          id: currBusinessIdFromUpdateQueue,
+          licenseData: generateLicenseData({ licenses: licensesFromDb }),
+        })
+      );
+      const returnedFn = licenseDataModifyingFunction(userDataFromDb, currBusinessIdFromUpdateQueue);
+
+      const result = returnedFn(businessFromUpdateQueue).licenseData!.licenses;
+      expect(result).toEqual(licensesFromDb);
     });
   });
 });

--- a/web/src/lib/utils/licenseStatus.ts
+++ b/web/src/lib/utils/licenseStatus.ts
@@ -22,9 +22,9 @@ export const getLicenseStatusResultsFromLicenses = (licenses: Licenses): License
   return result;
 };
 
-export const licenseDataModifyingFunction = (dbUserData: UserData) => {
+export const licenseDataModifyingFunction = (dbUserData: UserData, currBusinessId: string) => {
   return (business: Business): Business => {
-    const licenses = dbUserData?.businesses[dbUserData.currentBusinessId]?.licenseData?.licenses || {};
+    const licenses = dbUserData?.businesses[currBusinessId]?.licenseData?.licenses || {};
     const licenseStatusResults = getLicenseStatusResultsFromLicenses(licenses);
 
     return {
@@ -33,7 +33,7 @@ export const licenseDataModifyingFunction = (dbUserData: UserData) => {
         ...getNonLicenseTasks(business),
         ...getLicenseTasksProgress(licenseStatusResults),
       },
-      licenseData: dbUserData?.businesses[dbUserData.currentBusinessId]?.licenseData,
+      licenseData: dbUserData?.businesses[currBusinessId]?.licenseData,
     };
   };
 };


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

https://www.pivotaltracker.com/story/show/188414550

### Approach
Logic was added to ensure the correct business was updated with license data. There can be a discrepancy with the currentBusinessId being one value in the db and another in the queue because the user switched their business. 

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
