### PR TITLE
feat: [#188507862] Automatic Tax Calendar Check

### DIFF
--- a/web/cypress/e2e/auto-tax-filing.spec.ts
+++ b/web/cypress/e2e/auto-tax-filing.spec.ts
@@ -1,0 +1,82 @@
+/* eslint-disable cypress/no-unnecessary-waiting */
+import {
+  clickModalSaveButton,
+  completeBusinessStructureTask,
+  openFormationDateModal,
+  randomPublicFilingLegalStructure,
+  selectDate,
+  selectLocation,
+} from "@businessnjgovnavigator/cypress/support/helpers/helpers";
+import { completeNewBusinessOnboarding } from "@businessnjgovnavigator/cypress/support/helpers/helpers-onboarding";
+import { randomNonHomeBasedIndustry } from "@businessnjgovnavigator/cypress/support/helpers/helpers-select-industries";
+import { onDashboardPage } from "@businessnjgovnavigator/cypress/support/page_objects/dashboardPage";
+import { onProfilePage } from "@businessnjgovnavigator/cypress/support/page_objects/profilePage";
+
+describe("auto tax filing [feature] [all] [group4]", () => {
+  let businessName: string;
+  beforeEach(() => {
+    cy.loginByCognitoApi();
+    businessName = "Cool Business Name";
+  });
+
+  it("automatically registers for Gov2Go and retrieves tax events if business name and tax id are provided", () => {
+    completeNewBusinessOnboarding({ industry: randomNonHomeBasedIndustry() });
+    completeBusinessStructureTask({ legalStructureId: randomPublicFilingLegalStructure() });
+
+    onDashboardPage.getEditProfileLink().should("exist");
+    cy.visit("/profile");
+    cy.get('input[data-testid="businessName"]').type(businessName);
+    onProfilePage.getSaveButton().first().click();
+    openFormationDateModal();
+    selectDate("04/2021");
+    selectLocation("Allendale");
+    clickModalSaveButton();
+
+    onDashboardPage.registerForTaxes();
+    cy.get('input[name="taxId"]').type("123456789098");
+    cy.get("button").contains("Save").click();
+    cy.get(`[data-testid="back-to-dashboard"]`).first().click({ force: true });
+    cy.get('[data-testid="cta-funding-nudge"]').first().click();
+    cy.get('[data-testid="get-tax-access"]').should("not.exist");
+    cy.get('[data-testid="alert-content-container"]').should("exist");
+    onDashboardPage.getTaxFilingCalendar().should("contain", "Your Tax Calendar is pending.");
+    onDashboardPage.getTaxFilingCalendar().get('[data-testid="filings-calendar-as-list"]').should("exist");
+    onDashboardPage.getTaxFilingCalendar().should("contain", "Sales and Use Tax");
+  });
+
+  it("does not automatically register for Gov2Go and retrieve tax filing if missing business name", () => {
+    completeNewBusinessOnboarding({ industry: randomNonHomeBasedIndustry() });
+    completeBusinessStructureTask({ legalStructureId: randomPublicFilingLegalStructure() });
+
+    onDashboardPage.getEditProfileLink().should("exist");
+    openFormationDateModal();
+    selectDate("04/2021");
+    selectLocation("Allendale");
+    clickModalSaveButton();
+
+    onDashboardPage.registerForTaxes();
+    cy.get('input[name="taxId"]').type("123456789098");
+    cy.get("button").contains("Save").click();
+    cy.get(`[data-testid="back-to-dashboard"]`).first().click({ force: true });
+    cy.get('[data-testid="cta-funding-nudge"]').first().click();
+    cy.get('[data-testid="get-tax-access"]').should("exist");
+    cy.get('[data-testid="alert-content-container"]').should("not.exist");
+  });
+
+  it("does not automatically register for Gov2Go and retrieve tax filing if missing tax id", () => {
+    completeNewBusinessOnboarding({ industry: randomNonHomeBasedIndustry() });
+    completeBusinessStructureTask({ legalStructureId: randomPublicFilingLegalStructure() });
+
+    onDashboardPage.getEditProfileLink().should("exist");
+    cy.visit("/profile");
+    cy.get('input[data-testid="businessName"]').type(businessName);
+    onProfilePage.getSaveButton().first().click();
+    openFormationDateModal();
+    selectDate("04/2021");
+    selectLocation("Allendale");
+    clickModalSaveButton();
+    cy.get('[data-testid="cta-funding-nudge"]').first().click();
+    cy.get('[data-testid="get-tax-access"]').should("exist");
+    cy.get('[data-testid="alert-content-container"]').should("not.exist");
+  });
+});

--- a/web/cypress/support/helpers/helpers.ts
+++ b/web/cypress/support/helpers/helpers.ts
@@ -69,6 +69,24 @@ export const clickDeferredSaveButton = () => {
   return cy.get(`button[data-testid="deferred-question-save"]`).first().click();
 };
 
+export const clickModalSaveButton = (): void => {
+  cy.get('[data-testid="modal-button-primary"]').first().click();
+  cy.wait(1000);
+};
+
+export const selectDate = (monthYear: string): void => {
+  cy.chooseDatePicker('[name="dateOfFormation"]', monthYear);
+};
+
+export const selectLocation = (townDisplayName: string): void => {
+  cy.get('[data-testid="municipality"]').type(townDisplayName);
+  cy.get("#municipality-option-0").click({ force: true });
+};
+
+export const openFormationDateModal = (): void => {
+  cy.get('[data-testid="cta-formation-nudge"]').first().click();
+};
+
 //Cypress Mobile Viewport
 export const setMobileViewport = () => {
   cy.viewport(375, 667);

--- a/web/cypress/support/page_objects/dashboardPage.ts
+++ b/web/cypress/support/page_objects/dashboardPage.ts
@@ -41,6 +41,14 @@ export class DashboardPage {
   getHomeBased(radio?: boolean) {
     return cy.get(`input[name="home-based-business"]${radio === undefined ? "" : `[value="${radio}"]`}`);
   }
+
+  getTaxFilingCalendar() {
+    return cy.get('[data-testid="filings-calendar"]');
+  }
+
+  registerForTaxes() {
+    return cy.get('[data-testid="register-for-taxes"]').first().click();
+  }
 }
 
 export const onDashboardPage = new DashboardPage();

--- a/web/src/components/Task.tsx
+++ b/web/src/components/Task.tsx
@@ -49,6 +49,7 @@ export const Task = (props: Props): ReactElement => {
               href={`/tasks/${props.task.urlSlug}`}
               className={`usa-link margin-right-105 ${props.task.required ? "text-bold" : ""}`}
               data-task={props.task.id}
+              data-testid={props.task.id}
             >
               {props.task.name}
             </a>

--- a/web/src/components/dashboard/SectorModal.test.tsx
+++ b/web/src/components/dashboard/SectorModal.test.tsx
@@ -3,7 +3,7 @@ import { getMergedConfig } from "@/contexts/configContext";
 import { useMockBusiness } from "@/test/mock/mockUseUserData";
 import { createPageHelpers, PageHelpers } from "@/test/pages/onboarding/helpers-onboarding";
 import { generateBusiness, generateProfileData } from "@businessnjgovnavigator/shared";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 const submitSectorModal = (): void => {
   fireEvent.click(screen.getByText(Config.dashboardDefaults.sectorModalSaveButton));
@@ -65,7 +65,7 @@ describe("<SectorModal />", () => {
     ).toBeInTheDocument();
   });
 
-  it("calls onContinue prop on successful submit", () => {
+  it("calls onContinue prop on successful submit", async () => {
     const business = generateBusiness({
       profileData: generateProfileData({
         sectorId: undefined,
@@ -78,6 +78,8 @@ describe("<SectorModal />", () => {
     const { page } = renderSectorModal(onContinue);
     page.selectByValue("Sector", "clean-energy");
     submitSectorModal();
-    expect(onContinue).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onContinue).toHaveBeenCalled();
+    });
   });
 });

--- a/web/src/components/dashboard/SectorModal.tsx
+++ b/web/src/components/dashboard/SectorModal.tsx
@@ -43,9 +43,10 @@ export const SectorModal = (props: Props): ReactElement => {
     formContextState.reducer({ type: FieldStateActionKind.RESET });
   };
 
-  FormFuncWrapper(() => {
+  FormFuncWrapper(async () => {
     if (!updateQueue) return;
     updateQueue.queueProfileData(profileData);
+    await updateQueue.update();
     props.onContinue();
   });
 

--- a/web/src/components/dashboard/SidebarCardFundingNudge.tsx
+++ b/web/src/components/dashboard/SidebarCardFundingNudge.tsx
@@ -2,6 +2,7 @@ import { SectorModal } from "@/components/dashboard/SectorModal";
 import { SidebarCardGeneric } from "@/components/dashboard/SidebarCardGeneric";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { QUERIES, routeShallowWithQuery } from "@/lib/domain-logic/routes";
+import { gov2GovTaxFiling } from "@/lib/taxation/helpers";
 import { SidebarCardContent } from "@/lib/types/types";
 import analytics from "@/lib/utils/analytics";
 import { OperatingPhaseId } from "@businessnjgovnavigator/shared/";
@@ -18,12 +19,17 @@ export const SidebarCardFundingNudge = (props: Props): ReactElement => {
   const { updateQueue, business } = useUserData();
 
   const updateToUpAndRunningAndCompleteTaxTask = async (): Promise<void> => {
-    if (!business) return;
-    await updateQueue
-      ?.queueProfileData({
+    if (!updateQueue) return;
+
+    try {
+      await gov2GovTaxFiling({ updateQueue });
+    } finally {
+      updateQueue?.queueProfileData({
         operatingPhase: OperatingPhaseId.UP_AND_RUNNING,
-      })
-      .update();
+      });
+      await updateQueue.update();
+    }
+
     routeShallowWithQuery(router, QUERIES.fromFunding, "true");
   };
 

--- a/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepTwo.test.tsx
+++ b/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepTwo.test.tsx
@@ -5,22 +5,22 @@ import { randomPublicFilingLegalType } from "@/test/factories";
 import { markdownToText, randomElementFromArray } from "@/test/helpers/helpers-utilities";
 import { useMockBusiness } from "@/test/mock/mockUseUserData";
 import {
-  WithStatefulUserData,
   currentBusiness,
   setupStatefulUserDataContext,
   userDataWasNotUpdated,
+  WithStatefulUserData,
 } from "@/test/mock/withStatefulUserData";
 import {
   Business,
+  createEmptyFormationFormData,
   FormationData,
   FormationLegalType,
-  OperatingPhases,
-  UserData,
-  createEmptyFormationFormData,
   generateBusiness,
   generateUserDataForBusiness,
   getCurrentBusiness,
   getCurrentDateISOString,
+  OperatingPhases,
+  UserData,
 } from "@businessnjgovnavigator/shared";
 import {
   generateFormationData,
@@ -103,7 +103,6 @@ describe("<TaxAccessStepTwo />", () => {
         legalStructureId as FormationLegalType
       );
     }
-
     return generateUserDataForBusiness(
       generateBusiness({
         profileData: generateProfileData({
@@ -179,7 +178,6 @@ describe("<TaxAccessStepTwo />", () => {
     it("updates taxId but not businessName on submit", async () => {
       renderComponent(userDataWithPrefilledFields);
       const business = userDataWithPrefilledFields.businesses[userDataWithPrefilledFields.currentBusinessId];
-
       mockApiResponse(userDataWithPrefilledFields, {
         profileData: {
           ...business.profileData,
@@ -201,7 +199,7 @@ describe("<TaxAccessStepTwo />", () => {
         return expect(currentBusiness().profileData.businessName).not.toEqual("zoom");
       });
       expect(currentBusiness().profileData.taxId).toEqual("999888777666");
-      expect(currentBusiness().profileData.encryptedTaxId).toEqual(undefined);
+      expect(currentBusiness().profileData.encryptedTaxId).toEqual("");
     });
 
     it("updates businessName on submit if tax filing is success", async () => {

--- a/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepTwo.tsx
+++ b/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepTwo.tsx
@@ -10,18 +10,17 @@ import { WithErrorBar } from "@/components/WithErrorBar";
 import { FieldStateActionKind } from "@/contexts/formContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { ProfileFormContext } from "@/contexts/profileFormContext";
-import { postTaxFilingsOnboarding } from "@/lib/api-client/apiClient";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { useUpdateTaskProgress } from "@/lib/data-hooks/useUpdateTaskProgress";
 import { useUserData } from "@/lib/data-hooks/useUserData";
+import { gov2GovTaxFiling } from "@/lib/taxation/helpers";
 import { createReducedFieldStates, ProfileFields } from "@/lib/types/types";
 import analytics from "@/lib/utils/analytics";
 import { useMountEffect, useMountEffectWhenDefined } from "@/lib/utils/helpers";
 import {
   Business,
   createEmptyProfileData,
-  getCurrentBusiness,
   LookupLegalStructureById,
   ProfileData,
 } from "@businessnjgovnavigator/shared";
@@ -143,45 +142,19 @@ export const TaxAccessStepTwo = (props: Props): ReactElement => {
 
       setIsLoading(true);
 
-      const encryptedTaxId =
-        profileData.taxId === business.profileData.taxId ? profileData.encryptedTaxId : undefined;
-
       try {
-        let businessNameToSubmitToTaxApi = "";
-
-        if (displayBusinessName()) {
-          businessNameToSubmitToTaxApi = profileData.businessName;
-        }
-        if (displayResponsibleOwnerName()) {
-          businessNameToSubmitToTaxApi = profileData.responsibleOwnerName;
-        }
-
-        const userDataToSet = await postTaxFilingsOnboarding({
-          taxId: profileData.taxId as string,
-          businessName: businessNameToSubmitToTaxApi,
-          encryptedTaxId: encryptedTaxId as string,
-        });
-
-        updateQueue.queue(userDataToSet).queueProfileData({
-          taxId: profileData.taxId,
-          encryptedTaxId: encryptedTaxId,
-        });
-
-        if (getCurrentBusiness(userDataToSet).taxFilingData.state === "SUCCESS") {
-          if (displayBusinessName()) {
-            updateQueue.queueProfileData({
-              businessName: profileData.businessName,
-            });
-          }
-
-          if (displayResponsibleOwnerName()) {
-            updateQueue.queueProfileData({
-              responsibleOwnerName: profileData.responsibleOwnerName,
-            });
-          }
-        }
-
+        await gov2GovTaxFiling({ updateQueue, stagedProfileData: profileData });
         await updateQueue.update();
+        if (profileData.businessName) {
+          updateQueue.queueProfileData({
+            businessName: profileData.businessName,
+          });
+        }
+        if (profileData.responsibleOwnerName) {
+          updateQueue.queueProfileData({
+            responsibleOwnerName: profileData.responsibleOwnerName,
+          });
+        }
       } catch {
         setOnAPIfailed("UNKNOWN");
         setIsLoading(false);

--- a/web/src/lib/taxation/helpers.ts
+++ b/web/src/lib/taxation/helpers.ts
@@ -1,0 +1,57 @@
+import { postTaxFilingsOnboarding } from "@/lib/api-client/apiClient";
+import { UpdateQueue } from "@/lib/types/types";
+import { LookupLegalStructureById } from "@businessnjgovnavigator/shared/legalStructure";
+import { ProfileData } from "@businessnjgovnavigator/shared/profileData";
+
+const displayBusinessName = (profileData: ProfileData): boolean => {
+  const hasBusinessName = LookupLegalStructureById(profileData.legalStructureId).elementsToDisplay.has(
+    "businessName"
+  );
+  const notEmptyString = profileData.businessName !== "";
+  return hasBusinessName && notEmptyString;
+};
+
+const displayResponsibleOwnerName = (profileData: ProfileData): boolean => {
+  const hasResponsibleOwnerName = LookupLegalStructureById(
+    profileData.legalStructureId
+  ).elementsToDisplay.has("responsibleOwnerName");
+  const notEmptyString = profileData.responsibleOwnerName !== "";
+  return hasResponsibleOwnerName && notEmptyString;
+};
+
+interface Props {
+  updateQueue: UpdateQueue;
+  stagedProfileData?: ProfileData;
+}
+
+export const gov2GovTaxFiling = async (props: Props): Promise<void> => {
+  const currentBusiness = props.updateQueue.currentBusiness();
+
+  const updateQueue = props.updateQueue;
+  const profileData = props.stagedProfileData || currentBusiness.profileData;
+  const displayBusinessNameValue = displayBusinessName(profileData);
+  const displayResponsibleOwnerNameValue = displayResponsibleOwnerName(profileData);
+
+  if (!displayBusinessNameValue && !displayResponsibleOwnerNameValue) return;
+  if (!profileData.taxId) return;
+
+  const encryptedTaxIdToSubmitToTaxApi =
+    profileData.taxId === currentBusiness.profileData.taxId && profileData.encryptedTaxId
+      ? profileData.encryptedTaxId
+      : "";
+
+  const businessNameToSubmitToTaxApi = displayBusinessNameValue
+    ? profileData.businessName
+    : profileData.responsibleOwnerName;
+
+  const userDataToSet = await postTaxFilingsOnboarding({
+    taxId: profileData.taxId,
+    businessName: businessNameToSubmitToTaxApi,
+    encryptedTaxId: encryptedTaxIdToSubmitToTaxApi,
+  });
+
+  updateQueue.queue(userDataToSet).queueProfileData({
+    taxId: profileData.taxId,
+    encryptedTaxId: encryptedTaxIdToSubmitToTaxApi,
+  });
+};


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

If a user inputs both the business name and the tax id, it will automatically file for the tax calendar when setting the business status `UP_AND_RUNNING`.

Added a wiremock in order get around the need to access the api. for a working taxid that will return a calendar, use `1234567890\098`

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188507862](https://www.pivotaltracker.com/story/show/188507862).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Create a new business. Add a business name and the tax id `123456789\098` (to satisfy the wiremock) this will return a pending tax calendar.

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
