### PR TITLE
chore(release): 2024.36.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [2024.36.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2024.35.0...v2024.36.0) (2024-12-02)
+
+
+### Features
+
+* [[#188595606](https://github.com/newjersey/navigator.business.nj.gov/issues/188595606)] Electrologist License Status Check, Renewal Events & Reinstatement Quick Actions (MLO) ([b6abf51](https://github.com/newjersey/navigator.business.nj.gov/commit/b6abf5199882cb06347290b19bb5d8e52038cb4f))
+
 # [2024.35.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2024.34.0...v2024.35.0) (2024-11-20)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businessnjgovnavigator/root",
-  "version": "2024.35.0",
+  "version": "2024.36.0",
   "description": "This is the development repository for the work-in-progress business navigator from the New Jersey Office of Innovation. For info on the existing [Business.NJ.gov](https://business.nj.gov) site, please see the [bottom of this document](https://github.com/newjersey/navigator.business.nj.gov#businessnjgov)",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
# [2024.36.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2024.35.0...v2024.36.0) (2024-12-02)

### Features

* [[#188595606](https://github.com/newjersey/navigator.business.nj.gov/issues/188595606)] Electrologist License Status Check, Renewal Events & Reinstatement Quick Actions (MLO) ([b6abf51](https://github.com/newjersey/navigator.business.nj.gov/commit/b6abf5199882cb06347290b19bb5d8e52038cb4f))
