### PR TITLE
Cleanup migration generators

### DIFF
--- a/api/src/db/migrations/migrations.test.ts
+++ b/api/src/db/migrations/migrations.test.ts
@@ -151,6 +151,11 @@ describe("migrations", () => {
       expect(Migrations.length).toEqual(CURRENT_VERSION);
     });
 
+    it("ensures that the CURRENT_GENERATOR matches the CURRENT_VERSION of user data", () => {
+      const currentUser = CURRENT_GENERATOR({});
+      expect(currentUser.version).toBe(CURRENT_VERSION);
+    });
+
     it("ensures that a user who has been fully migrated has the same fields as a newly generated user on the current version", () => {
       const currentUser = CURRENT_GENERATOR({});
       let migratedUser: unknown = generateV0UserData({});

--- a/api/src/db/migrations/v102_rename_tax_registration_nudge.ts
+++ b/api/src/db/migrations/v102_rename_tax_registration_nudge.ts
@@ -587,7 +587,7 @@ export const generateV102FormationData = (
 export const generateV102UserData = (overrides: Partial<v102UserData>): v102UserData => {
   const profileData = generateV102ProfileData({});
   return {
-    version: 101,
+    version: 102,
     user: generateV102User({}),
     profileData: generateV102ProfileData({}),
     formProgress: "UNSTARTED",

--- a/api/src/db/migrations/v103_change_tax_calendar_view_default.ts
+++ b/api/src/db/migrations/v103_change_tax_calendar_view_default.ts
@@ -581,7 +581,7 @@ export const generateV103FormationData = (
 export const generateV103UserData = (overrides: Partial<v103UserData>): v103UserData => {
   const profileData = generateV103ProfileData({});
   return {
-    version: 102,
+    version: 103,
     user: generateV103User({}),
     profileData: generateV103ProfileData({}),
     formProgress: "UNSTARTED",

--- a/api/src/db/migrations/v104_add_needs_nexus_dba_name_field.ts
+++ b/api/src/db/migrations/v104_add_needs_nexus_dba_name_field.ts
@@ -581,7 +581,7 @@ export const generateV104FormationData = (
 export const generateV104UserData = (overrides: Partial<v104UserData>): v104UserData => {
   const profileData = generateV104ProfileData({});
   return {
-    version: 102,
+    version: 104,
     user: generateV104User({}),
     profileData: generateV104ProfileData({}),
     formProgress: "UNSTARTED",

--- a/api/src/db/migrations/v105_add_pet_care_essential_question.ts
+++ b/api/src/db/migrations/v105_add_pet_care_essential_question.ts
@@ -568,7 +568,7 @@ export const generateV105FormationData = (
 export const generateV105UserData = (overrides: Partial<v105UserData>): v105UserData => {
   const profileData = generateV105ProfileData({});
   return {
-    version: 102,
+    version: 105,
     user: generateV105User({}),
     profileData: generateV105ProfileData({}),
     formProgress: "UNSTARTED",

--- a/api/src/db/migrations/v106_add_pet_care_housing_essential_question.ts
+++ b/api/src/db/migrations/v106_add_pet_care_housing_essential_question.ts
@@ -570,7 +570,7 @@ export const generateV106FormationData = (
 export const generateV106UserData = (overrides: Partial<v106UserData>): v106UserData => {
   const profileData = generateV106ProfileData({});
   return {
-    version: 102,
+    version: 106,
     user: generateV106User({}),
     profileData: generateV106ProfileData({}),
     formProgress: "UNSTARTED",

--- a/api/src/db/migrations/v108_add_business_name_search_to_formation_data.ts
+++ b/api/src/db/migrations/v108_add_business_name_search_to_formation_data.ts
@@ -594,7 +594,7 @@ export const generateV108FormationData = (
 export const generateV108UserData = (overrides: Partial<v108UserData>): v108UserData => {
   const profileData = generateV108ProfileData({});
   return {
-    version: 102,
+    version: 108,
     user: generateV108User({}),
     profileData: generateV108ProfileData({}),
     formProgress: "UNSTARTED",

--- a/api/src/db/migrations/v117_add_onboarding_nonprofit.ts
+++ b/api/src/db/migrations/v117_add_onboarding_nonprofit.ts
@@ -604,7 +604,7 @@ export const generateV117FormationData = (
 export const generateV117UserData = (overrides: Partial<v117UserData>): v117UserData => {
   const profileData = generateV117ProfileData({});
   return {
-    version: 102,
+    version: 117,
     dateCreatedISO: undefined,
     versionWhenCreated: -1,
     user: generateV117User({}),

--- a/api/src/db/migrations/v122_remove_welcome_and_welcomeupandrunning_sidecards.ts
+++ b/api/src/db/migrations/v122_remove_welcome_and_welcomeupandrunning_sidecards.ts
@@ -470,7 +470,7 @@ type v122GetFilingResponse = {
 export const generateV122UserData = (overrides: Partial<v122UserData>): v122UserData => {
   return {
     user: generateV122BusinessUser({}),
-    version: 121,
+    version: 122,
     lastUpdatedISO: "",
     dateCreatedISO: "",
     versionWhenCreated: -1,

--- a/api/src/db/migrations/v123_remove_account_creation_sidecards.ts
+++ b/api/src/db/migrations/v123_remove_account_creation_sidecards.ts
@@ -473,7 +473,7 @@ type v123GetFilingResponse = {
 export const generateV123UserData = (overrides: Partial<v123UserData>): v123UserData => {
   return {
     user: generateV123BusinessUser({}),
-    version: 121,
+    version: 123,
     lastUpdatedISO: "",
     dateCreatedISO: "",
     versionWhenCreated: -1,

--- a/api/src/db/migrations/v135_use_interstate_logistics_and_transport_fields.ts
+++ b/api/src/db/migrations/v135_use_interstate_logistics_and_transport_fields.ts
@@ -505,7 +505,7 @@ type v135GetFilingResponse = {
 export const generatev135UserData = (overrides: Partial<v135UserData>): v135UserData => {
   return {
     user: generatev135BusinessUser({}),
-    version: 134,
+    version: 135,
     lastUpdatedISO: "",
     dateCreatedISO: "",
     versionWhenCreated: -1,

--- a/api/src/db/migrations/v136_add_user_account_creation_source.ts
+++ b/api/src/db/migrations/v136_add_user_account_creation_source.ts
@@ -492,7 +492,7 @@ type v136GetFilingResponse = {
 export const generatev136UserData = (overrides: Partial<v136UserData>): v136UserData => {
   return {
     user: generatev136BusinessUser({}),
-    version: 134,
+    version: 136,
     lastUpdatedISO: "",
     dateCreatedISO: "",
     versionWhenCreated: -1,

--- a/api/src/db/migrations/v137_add_employment_placement_personal_types.ts
+++ b/api/src/db/migrations/v137_add_employment_placement_personal_types.ts
@@ -509,7 +509,7 @@ type v137GetFilingResponse = {
 export const generatev137UserData = (overrides: Partial<v137UserData>): v137UserData => {
   return {
     user: generatev137BusinessUser({}),
-    version: 134,
+    version: 137,
     lastUpdatedISO: "",
     dateCreatedISO: "",
     versionWhenCreated: -1,

--- a/api/src/db/migrations/v138_multi_license_support.ts
+++ b/api/src/db/migrations/v138_multi_license_support.ts
@@ -775,7 +775,7 @@ type v138GetFilingResponse = {
 export const generatev138UserData = (overrides: Partial<v138UserData>): v138UserData => {
   return {
     user: generatev138BusinessUser({}),
-    version: 134,
+    version: 138,
     lastUpdatedISO: "",
     dateCreatedISO: "",
     versionWhenCreated: -1,

--- a/api/src/db/migrations/v139_own_carnival_rides.ts
+++ b/api/src/db/migrations/v139_own_carnival_rides.ts
@@ -531,7 +531,7 @@ type v139GetFilingResponse = {
 export const generatev139UserData = (overrides: Partial<v139UserData>): v139UserData => {
   return {
     user: generatev139BusinessUser({}),
-    version: 134,
+    version: 139,
     lastUpdatedISO: "",
     dateCreatedISO: "",
     versionWhenCreated: -1,

--- a/api/src/db/migrations/v141_sync_migrated_and_newly_created_users.ts
+++ b/api/src/db/migrations/v141_sync_migrated_and_newly_created_users.ts
@@ -562,10 +562,10 @@ type v141GetFilingResponse = {
 export const generatev141UserData = (overrides: Partial<v141UserData>): v141UserData => {
   return {
     user: generatev141BusinessUser({}),
-    version: 140,
+    version: 141,
     lastUpdatedISO: "",
     dateCreatedISO: "",
-    versionWhenCreated: 141,
+    versionWhenCreated: -1,
     businesses: {
       "123": generatev141Business({ id: "123" }),
     },

--- a/api/src/db/migrations/v142_add_domestic_employer_roadmap_section.ts
+++ b/api/src/db/migrations/v142_add_domestic_employer_roadmap_section.ts
@@ -535,10 +535,10 @@ type v142GetFilingResponse = {
 export const generatev142UserData = (overrides: Partial<v142UserData>): v142UserData => {
   return {
     user: generatev142BusinessUser({}),
-    version: 140,
+    version: 142,
     lastUpdatedISO: "",
     dateCreatedISO: "",
-    versionWhenCreated: 141,
+    versionWhenCreated: -1,
     businesses: {
       "123": generatev142Business({ id: "123" }),
     },

--- a/api/src/db/migrations/v143_add_property_type_and_rental_unit_count.ts
+++ b/api/src/db/migrations/v143_add_property_type_and_rental_unit_count.ts
@@ -537,10 +537,10 @@ type v143GetFilingResponse = {
 export const generatev143UserData = (overrides: Partial<v143UserData>): v143UserData => {
   return {
     user: generatev143BusinessUser({}),
-    version: 140,
+    version: 143,
     lastUpdatedISO: "",
     dateCreatedISO: "",
-    versionWhenCreated: 141,
+    versionWhenCreated: -1,
     businesses: {
       "123": generatev143Business({ id: "123" }),
     },

--- a/api/src/db/migrations/v144_add_raffle_bingo_games.ts
+++ b/api/src/db/migrations/v144_add_raffle_bingo_games.ts
@@ -537,10 +537,10 @@ type v144GetFilingResponse = {
 export const generatev144UserData = (overrides: Partial<v144UserData>): v144UserData => {
   return {
     user: generatev144BusinessUser({}),
-    version: 140,
+    version: 144,
     lastUpdatedISO: "",
     dateCreatedISO: "",
-    versionWhenCreated: 141,
+    versionWhenCreated: -1,
     businesses: {
       "123": generatev144Business({ id: "123" }),
     },

--- a/api/src/db/migrations/v145_add_traveling_circus_or_carnival.ts
+++ b/api/src/db/migrations/v145_add_traveling_circus_or_carnival.ts
@@ -553,10 +553,10 @@ type v145GetFilingResponse = {
 export const generatev145UserData = (overrides: Partial<v145UserData>): v145UserData => {
   return {
     user: generatev145BusinessUser({}),
-    version: 140,
+    version: 145,
     lastUpdatedISO: "",
     dateCreatedISO: "",
-    versionWhenCreated: 141,
+    versionWhenCreated: -1,
     businesses: {
       "123": generatev145Business({ id: "123" }),
     },

--- a/api/src/db/migrations/v146_remove_haserror_field_from_licensedetails.ts
+++ b/api/src/db/migrations/v146_remove_haserror_field_from_licensedetails.ts
@@ -578,10 +578,10 @@ type v146GetFilingResponse = {
 export const generatev146UserData = (overrides: Partial<v146UserData>): v146UserData => {
   return {
     user: generatev146BusinessUser({}),
-    version: 140,
+    version: 146,
     lastUpdatedISO: "",
     dateCreatedISO: "",
-    versionWhenCreated: 141,
+    versionWhenCreated: -1,
     businesses: {
       "123": generatev146Business({ id: "123" }),
     },

--- a/api/src/db/migrations/v147_remove_nonprofit_onboarding_field.ts
+++ b/api/src/db/migrations/v147_remove_nonprofit_onboarding_field.ts
@@ -551,10 +551,10 @@ type v147GetFilingResponse = {
 export const generatev147UserData = (overrides: Partial<v147UserData>): v147UserData => {
   return {
     user: generatev147BusinessUser({}),
-    version: 140,
+    version: 147,
     lastUpdatedISO: "",
     dateCreatedISO: "",
-    versionWhenCreated: 141,
+    versionWhenCreated: -1,
     businesses: {
       "123": generatev147Business({ id: "123" }),
     },

--- a/api/src/db/migrations/v148_add_vacant_building_field.ts
+++ b/api/src/db/migrations/v148_add_vacant_building_field.ts
@@ -552,10 +552,10 @@ type v148GetFilingResponse = {
 export const generatev148UserData = (overrides: Partial<v148UserData>): v148UserData => {
   return {
     user: generatev148BusinessUser({}),
-    version: 140,
+    version: 148,
     lastUpdatedISO: "",
     dateCreatedISO: "",
-    versionWhenCreated: 141,
+    versionWhenCreated: -1,
     businesses: {
       "123": generatev148Business({ id: "123" }),
     },

--- a/api/src/db/migrations/v95_added_new_tax_calendar_state.ts
+++ b/api/src/db/migrations/v95_added_new_tax_calendar_state.ts
@@ -465,7 +465,7 @@ export const v95TaxFilingDataGenerator = (overrides: Partial<v95TaxFilingData>):
 
 export const v95UserDataGenerator = (overrides: Partial<v95UserData>): v95UserData => {
   return {
-    version: 92,
+    version: 95,
     user: generatev95User({}),
     profileData: generatev95ProfileData({}),
     formProgress: "UNSTARTED",


### PR DESCRIPTION
## Description

Modified a number of the migration generators to reference the correct version number, and added a test to assert that the global var `CURRENT_GENERATOR` is actually looking at the current generator function.

### Steps to Test

All tests associated with migration information should still pass. There's no manual check needed for this.

### Notes

Initially wanted to add a test for the `CURRENT_GENERATOR` because updating this value was being overlooked in migration upgrades. Modified the rest of the files just for accuracy. Nothing about this was actually breaking functionality.

This is just cleanup.

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
