### PR TITLE
chore: [#188640176] update dynamodb download link [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ extension.
   installing via package manager, we suggest installing `corepack` if available
   separately.)
 - [AWS CLI](https://aws.amazon.com/cli/)
-- [JRE/JDK 11.x or newer](https://jdk.java.net/21/) - Install the x64 version –
-  even on macOS – not the arm64 version (Latest OpenJDK version recommended)
-- [Python 3.11](https://www.python.org/downloads/)
+- [JRE/JDK 17.x or newer](https://jdk.java.net/)
+- [Python 3.13](https://www.python.org/downloads/)
 
 **Windows (non-WSL) only**:
 

--- a/api/scripts/dynamodb-local.sh
+++ b/api/scripts/dynamodb-local.sh
@@ -4,7 +4,10 @@ cd "$(git rev-parse --show-toplevel)/api"
 
 set -e
 
-wget -c http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz
+# Reference: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html#DynamoDBLocal.DownloadingAndRunning.title
+# sha256 for verification: https://d1ni2b6xgvw0s0.cloudfront.net/v2.x/dynamodb_local_latest.tar.gz.sha256
+
+wget -c https://d1ni2b6xgvw0s0.cloudfront.net/v2.x/dynamodb_local_latest.tar.gz
 rm -rf .dynamodb
 mkdir .dynamodb
 tar zxvf dynamodb_local_latest.tar.gz -C .dynamodb


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

Update the DynamoDB download link to the new CloudFront distribution URL to support HTTPS downloads and because the AWS folks have asked us to do so nicely.

Update the Readme to reflect the updated Java requirements.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188640176](https://www.pivotaltracker.com/story/show/188640176).
