### PR TITLE
feat: [#188595628] Dakota Corporations Formation Task - Certificate of Good Standing Error Prevention - Business Designator Copy

### DIFF
--- a/content/src/fieldConfig/business-formation.json
+++ b/content/src/fieldConfig/business-formation.json
@@ -284,6 +284,7 @@
       "businessSuffix": {
         "label": "Business Designator",
         "labelContextualInfo": "business-designator",
+        "labelSecondaryTextForeignCorporation": "(Must match Certificate of Good Standing)",
         "error": "Select a business designator.",
         "optionsUpdatedSnackbarAlert": "Your Business Designator list has been updated. Make your selection from the dropdown menu."
       },

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -298,6 +298,11 @@ collections:
                           value_field: "{{filename}}",
                           display_fields: ["{{displayname}}"],
                         }
+                      - {
+                          label: "Secondary Text Foreign Corporation",
+                          name: "labelSecondaryTextForeignCorporation",
+                          widget: "string",
+                        }
                       - { label: "Inline error", name: "error", widget: "string" }
                       - {
                           label: "Options Updated Snackbar Message",

--- a/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
@@ -489,77 +489,91 @@ describe("Formation - BusinessStep", () => {
       });
     }
 
-    describe("Business Designator Options based on Will Practice Law Answer", () => {
-      it.each(corpLegalStructures)(
-        "Shows PA and PC options for Business Designator when Will You Practice Law is Yes",
-        async (legalStructureId) => {
-          await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, { willPracticeLaw: true });
+    describe("Business Designator", () => {
+      describe("Business Designator secondary label foreign corporation", () => {
+        it.each(corpLegalStructures)(
+          `Shows secondary label foreign corporation when persona is foreign and legal structure is %s`,
+          async (legalStructureId) => {
+            await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, {});
+            expect(
+              screen.getByText(Config.formation.fields.businessSuffix.labelSecondaryTextForeignCorporation)
+            ).toBeInTheDocument();
+          }
+        );
+      });
 
-          expect(screen.queryByText("P.C.")).not.toBeInTheDocument();
-          expect(screen.queryByText("P.A.")).not.toBeInTheDocument();
+      describe("Business Designator Options based on Will Practice Law Answer", () => {
+        it.each(corpLegalStructures)(
+          "Shows PA and PC options for Business Designator when Will You Practice Law is Yes",
+          async (legalStructureId) => {
+            await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, { willPracticeLaw: true });
 
-          await userEvent.click(screen.getByTestId("business-suffix-main"));
-          expect(screen.getByText("P.C.")).toBeInTheDocument();
-          expect(screen.getByText("P.A.")).toBeInTheDocument();
-        }
-      );
+            expect(screen.queryByText("P.C.")).not.toBeInTheDocument();
+            expect(screen.queryByText("P.A.")).not.toBeInTheDocument();
 
-      it.each(corpLegalStructures)(
-        "Does not show PA and PC options for Business Designator when Will You Practice Law is No",
-        async (legalStructureId) => {
-          await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, { willPracticeLaw: false });
-          expect(screen.queryByText("P.C.")).not.toBeInTheDocument();
-          expect(screen.queryByText("P.A.")).not.toBeInTheDocument();
+            await userEvent.click(screen.getByTestId("business-suffix-main"));
+            expect(screen.getByText("P.C.")).toBeInTheDocument();
+            expect(screen.getByText("P.A.")).toBeInTheDocument();
+          }
+        );
 
-          await userEvent.click(screen.getByTestId("business-suffix-main"));
+        it.each(corpLegalStructures)(
+          "Does not show PA and PC options for Business Designator when Will You Practice Law is No",
+          async (legalStructureId) => {
+            await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, { willPracticeLaw: false });
+            expect(screen.queryByText("P.C.")).not.toBeInTheDocument();
+            expect(screen.queryByText("P.A.")).not.toBeInTheDocument();
 
-          expect(screen.queryByText("P.C.")).not.toBeInTheDocument();
-          expect(screen.queryByText("P.A.")).not.toBeInTheDocument();
-        }
-      );
+            await userEvent.click(screen.getByTestId("business-suffix-main"));
 
-      it.each(corpLegalStructures)(
-        "Does not show PA and PC options for Business Designator when Will You Practice Law is Undefined",
-        async (legalStructureId) => {
-          await getPageHelper(
-            { businessPersona: "FOREIGN", legalStructureId },
-            { willPracticeLaw: undefined }
-          );
-          expect(screen.queryByText("P.C.")).not.toBeInTheDocument();
-          expect(screen.queryByText("P.A.")).not.toBeInTheDocument();
+            expect(screen.queryByText("P.C.")).not.toBeInTheDocument();
+            expect(screen.queryByText("P.A.")).not.toBeInTheDocument();
+          }
+        );
 
-          await userEvent.click(screen.getByTestId("business-suffix-main"));
+        it.each(corpLegalStructures)(
+          "Does not show PA and PC options for Business Designator when Will You Practice Law is Undefined",
+          async (legalStructureId) => {
+            await getPageHelper(
+              { businessPersona: "FOREIGN", legalStructureId },
+              { willPracticeLaw: undefined }
+            );
+            expect(screen.queryByText("P.C.")).not.toBeInTheDocument();
+            expect(screen.queryByText("P.A.")).not.toBeInTheDocument();
 
-          expect(screen.queryByText("P.C.")).not.toBeInTheDocument();
-          expect(screen.queryByText("P.A.")).not.toBeInTheDocument();
-        }
-      );
+            await userEvent.click(screen.getByTestId("business-suffix-main"));
 
-      it.each(corpLegalStructures)(
-        "Displays an Alert when selecting an option for the Will you practice law question to tell the user Business Designator options have changed",
-        async (legalStructureId) => {
-          await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, {});
-          expect(
-            screen.queryByText(Config.formation.fields.businessSuffix.optionsUpdatedSnackbarAlert)
-          ).not.toBeInTheDocument();
-          fireEvent.click(screen.getByTestId("willPracticeLaw-true"));
-          expect(
-            screen.getByText(Config.formation.fields.businessSuffix.optionsUpdatedSnackbarAlert)
-          ).toBeInTheDocument();
-        }
-      );
+            expect(screen.queryByText("P.C.")).not.toBeInTheDocument();
+            expect(screen.queryByText("P.A.")).not.toBeInTheDocument();
+          }
+        );
 
-      it.each(corpLegalStructures)(
-        "clears Business Designator if Will you practice law question is changed and Business designator is selected",
-        async (legalStructureId) => {
-          await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, { willPracticeLaw: true });
-          await userEvent.click(screen.getByTestId("business-suffix-main"));
-          await userEvent.click(screen.getByText("P.C."));
-          expect(screen.getByTestId("business-suffix-main")).toHaveTextContent("P.C.");
-          fireEvent.click(screen.getByTestId("willPracticeLaw-false"));
-          expect(screen.getByTestId("business-suffix-main")).toBeEmptyDOMElement();
-        }
-      );
+        it.each(corpLegalStructures)(
+          "Displays an Alert when selecting an option for the Will you practice law question to tell the user Business Designator options have changed",
+          async (legalStructureId) => {
+            await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, {});
+            expect(
+              screen.queryByText(Config.formation.fields.businessSuffix.optionsUpdatedSnackbarAlert)
+            ).not.toBeInTheDocument();
+            fireEvent.click(screen.getByTestId("willPracticeLaw-true"));
+            expect(
+              screen.getByText(Config.formation.fields.businessSuffix.optionsUpdatedSnackbarAlert)
+            ).toBeInTheDocument();
+          }
+        );
+
+        it.each(corpLegalStructures)(
+          "clears Business Designator if Will you practice law question is changed and Business designator is selected",
+          async (legalStructureId) => {
+            await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, { willPracticeLaw: true });
+            await userEvent.click(screen.getByTestId("business-suffix-main"));
+            await userEvent.click(screen.getByText("P.C."));
+            expect(screen.getByTestId("business-suffix-main")).toHaveTextContent("P.C.");
+            fireEvent.click(screen.getByTestId("willPracticeLaw-false"));
+            expect(screen.getByTestId("business-suffix-main")).toBeEmptyDOMElement();
+          }
+        );
+      });
     });
   });
 

--- a/web/src/components/tasks/business-formation/business/FormationDate.tsx
+++ b/web/src/components/tasks/business-formation/business/FormationDate.tsx
@@ -8,6 +8,7 @@ import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormationErrors } from "@/lib/data-hooks/useFormationErrors";
 import { camelCaseToSentence } from "@/lib/utils/cases-helpers";
+import { isForeignCorporation } from "@/lib/utils/helpers";
 import {
   DateObject,
   advancedDateLibrary,
@@ -30,22 +31,25 @@ export const FormationDate = (props: Props): ReactElement => {
   const { state, setFormationFormData, setFieldsInteracted } = useContext(BusinessFormationContext);
   const { doesFieldHaveError } = useFormationErrors();
   const dateFormat = "MM/DD/YYYY";
+  const floatClass = isForeignCorporation(state.formationFormData.legalType) ? "float-none" : "float-left";
 
   const contentProps = useMemo(
     () => ({
       businessStartDate: {
         label: (
-          <>
-            <strong>
-              <ContextualInfoButton
-                text={Config.formation.fields.businessStartDate.label}
-                id={Config.formation.fields.businessStartDate.labelContextualInfo}
-              />
-            </strong>
-            <span className="margin-left-05">
-              {Config.formation.fields.businessStartDate.labelSecondaryText}
-            </span>
-          </>
+          <div>
+            <div className={`${floatClass}`}>
+              <strong>
+                <ContextualInfoButton
+                  text={Config.formation.fields.businessStartDate.label}
+                  id={Config.formation.fields.businessStartDate.labelContextualInfo}
+                />
+              </strong>
+            </div>
+            <div className={`${floatClass}`}>
+              <span>{Config.formation.fields.foreignDateOfFormation.labelSecondaryText}</span>
+            </div>
+          </div>
         ),
         helperText: getBusinessStartDateHelperText(state.formationFormData.legalType),
       },

--- a/web/src/components/tasks/business-formation/business/SuffixDropdown.tsx
+++ b/web/src/components/tasks/business-formation/business/SuffixDropdown.tsx
@@ -3,6 +3,7 @@ import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormationErrors } from "@/lib/data-hooks/useFormationErrors";
 import { camelCaseToSentence } from "@/lib/utils/cases-helpers";
+import { isForeignCorporation } from "@/lib/utils/helpers";
 import {
   BusinessSuffix,
   BusinessSuffixMap,
@@ -53,13 +54,18 @@ export const SuffixDropdown = (): ReactElement => {
 
   return (
     <>
-      <div className="flex">
-        <strong>
-          <ContextualInfoButton
-            text={Config.formation.fields.businessSuffix.label}
-            id={Config.formation.fields.businessSuffix.labelContextualInfo}
-          />
-        </strong>
+      <div>
+        <div>
+          <strong>
+            <ContextualInfoButton
+              text={Config.formation.fields.businessSuffix.label}
+              id={Config.formation.fields.businessSuffix.labelContextualInfo}
+            />
+          </strong>
+        </div>
+        {isForeignCorporation(state.formationFormData.legalType) && (
+          <div>{Config.formation.fields.businessSuffix.labelSecondaryTextForeignCorporation}</div>
+        )}
       </div>
       <FormControl fullWidth error={doesFieldHaveError(FIELD)}>
         <InputLabel id="business-suffix-label" className="visibility-hidden">


### PR DESCRIPTION
Dakota Corporations Formation Task - Certificate of Good Standing Error Prevention - Business Designator Copy

<!-- Please complete the following sections as necessary. -->

## Description
Dakota Corporations Formation Task - Certificate of Good Standing Error Prevention - Business Designator Copy
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188595628](https://www.pivotaltracker.com/story/show/188595628).

### Approach
When I am a Dakota Coporation  and I am forming a business I want to see the new copy of "Must Match Certificate of Good standing" to be under the Business Designator label and the "mm/dd/yy" to be under the effective date.  To do this I used a Grid component with the direction of the grid based on if it is a dakota corporation, it uses a column direction.  If it is anything else it will be a row direction.  This fix is implemented in the Suffix dropdown and the formation date component that was using a Fragment instead.

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
