### PR TITLE
fix: [#188599283] Have vacant building question appear for signed in owning users

### DIFF
--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -329,7 +329,7 @@ const ProfilePage = (props: Props): ReactElement => {
     if (!business) return false;
     return (
       (profileData.industryId === "real-estate-investor" || profileData.sectorId === "real-estate") &&
-      (profileData.operatingPhase === "UP_AND_RUNNING" || profileData.operatingPhase === "GUEST_MODE_OWNING")
+      (profileData.operatingPhase === "UP_AND_RUNNING" || profileData.businessPersona === "OWNING")
     );
   };
 
@@ -567,18 +567,6 @@ const ProfilePage = (props: Props): ReactElement => {
           <NonEssentialQuestionsSection />
         </ProfileField>
 
-        <ProfileField
-          fieldName="vacantPropertyOwner"
-          isVisible={displayVacantBuildingOwnerQuestion()}
-          hideHeader={true}
-          boldAltDescription={true}
-          boldDescription={true}
-        >
-          <span className={"margin-left-05"}>
-            {Config.profileDefaults.fields.nonEssentialQuestions.default.optionalText}
-          </span>
-          <RadioQuestion<boolean> fieldName={"vacantPropertyOwner"} choices={[true, false]} />
-        </ProfileField>
         <ProfileField
           fieldName="sectorId"
           isVisible={profileData.industryId === "generic" || !!props.CMS_ONLY_fakeBusiness}

--- a/web/test/pages/profile/profile-owning.test.tsx
+++ b/web/test/pages/profile/profile-owning.test.tsx
@@ -748,6 +748,63 @@ describe("profile - owning existing business", () => {
 
       expect(screen.queryByTestId("elevatorOwningBusiness-radio-group")).not.toBeInTheDocument();
     });
+
+    it("shows vacant building question for real estate up and running poppies", async () => {
+      const business = generateBusinessForProfile({
+        profileData: generateOwningProfileData({
+          industryId: "real-estate-investor",
+          operatingPhase: OperatingPhaseId.UP_AND_RUNNING,
+          businessPersona: "STARTING",
+          homeBasedBusiness: false,
+        }),
+        formationData: generateFormationData({
+          formationFormData: generateFormationFormData({
+            ...emptyAddressData,
+          }),
+        }),
+      });
+      renderPage({ business });
+
+      expect(screen.getByTestId("vacantPropertyOwner-radio-group")).toBeInTheDocument();
+    });
+
+    it("shows vacant building question for owning guest mode users", async () => {
+      const business = generateBusinessForProfile({
+        profileData: generateOwningProfileData({
+          industryId: "real-estate-investor",
+          operatingPhase: OperatingPhaseId.GUEST_MODE_OWNING,
+          businessPersona: "OWNING",
+          homeBasedBusiness: false,
+        }),
+        formationData: generateFormationData({
+          formationFormData: generateFormationFormData({
+            ...emptyAddressData,
+          }),
+        }),
+      });
+      renderPage({ business });
+
+      expect(screen.getByTestId("vacantPropertyOwner-radio-group")).toBeInTheDocument();
+    });
+
+    it("shows vacant building question for owning signed in users", async () => {
+      const business = generateBusinessForProfile({
+        profileData: generateOwningProfileData({
+          industryId: "real-estate-investor",
+          operatingPhase: OperatingPhaseId.UP_AND_RUNNING_OWNING,
+          businessPersona: "OWNING",
+          homeBasedBusiness: false,
+        }),
+        formationData: generateFormationData({
+          formationFormData: generateFormationFormData({
+            ...emptyAddressData,
+          }),
+        }),
+      });
+      renderPage({ business });
+
+      expect(screen.getByTestId("vacantPropertyOwner-radio-group")).toBeInTheDocument();
+    });
   });
 
   const getSectorIDValue = (): string => {


### PR DESCRIPTION

<!-- Please complete the following sections as necessary. -->

## Description
Adds in criteria for the vacant building non essential question to appear to logged in users owning, removed the question from the starting profile because it is now impossible for it to render there

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188599283](https://www.pivotaltracker.com/story/show/188599283).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
1. Create an Oscar user while signed into MyNJ in the real estate industry sector
2. You  should see the non-essential question in the profile

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
