### PR TITLE
feat: [#188645454] show me opportunities button analytics

### DIFF
--- a/web/src/components/dashboard/SidebarCardFundingNudge.tsx
+++ b/web/src/components/dashboard/SidebarCardFundingNudge.tsx
@@ -3,6 +3,7 @@ import { SidebarCardGeneric } from "@/components/dashboard/SidebarCardGeneric";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { QUERIES, routeShallowWithQuery } from "@/lib/domain-logic/routes";
 import { SidebarCardContent } from "@/lib/types/types";
+import analytics from "@/lib/utils/analytics";
 import { OperatingPhaseId } from "@businessnjgovnavigator/shared/";
 import { useRouter } from "next/router";
 import { ReactElement, useState } from "react";
@@ -28,6 +29,7 @@ export const SidebarCardFundingNudge = (props: Props): ReactElement => {
 
   const onClick = async (): Promise<void> => {
     if (!business) return;
+    analytics.event.show_me_funding_opportunities.click.show_me_funding_opportunities();
     if (business.profileData.industryId === "generic" || !business.profileData.industryId) {
       setModalOpen(true);
     } else {

--- a/web/src/lib/utils/analytics-legacy.ts
+++ b/web/src/lib/utils/analytics-legacy.ts
@@ -140,7 +140,8 @@ export type LegacyEventCategory =
   | "view_my_violation_note_button_click"
   | "starter_kit_landing_start_now_button"
   | "starter_kit_landing_get_my_starter_kit_button"
-  | "starter_kit_landing_get_my_starter_kit_button_footer";
+  | "starter_kit_landing_get_my_starter_kit_button_footer"
+  | "show_me_funding_opportunities_button";
 
 export type LegacyEventAction =
   | "click"
@@ -267,4 +268,5 @@ export type LegacyEventLabel =
   | "go_to_quick_action_screen"
   | "skip_to_main_content"
   | "go_to_dashboard"
-  | "go_to_business.nj.gov";
+  | "go_to_business.nj.gov"
+  | "show_calendar";

--- a/web/src/lib/utils/analytics.ts
+++ b/web/src/lib/utils/analytics.ts
@@ -216,7 +216,8 @@ type Item =
   | "hidden_opportunities_section"
   | "link_with_myNJ"
   | "landing_page"
-  | "skip_to_main_content";
+  | "skip_to_main_content"
+  | "show_funding_opportunities";
 
 type BooleanResponseOption = "yes" | "no";
 
@@ -2343,6 +2344,20 @@ export default {
             legacy_event_label: "go_to_onboarding",
             event: "call_to_action_clicks",
             clicked_to: "/onboarding",
+          });
+        },
+      },
+    },
+    show_me_funding_opportunities: {
+      click: {
+        show_me_funding_opportunities: () => {
+          eventRunner.track({
+            legacy_event_category: "show_me_funding_opportunities_button",
+            legacy_event_action: "click",
+            legacy_event_label: "show_calendar",
+            event: "link_clicks",
+            click_text: "show_calendar",
+            item: "show_funding_opportunities",
           });
         },
       },


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
This feature adds analytics to the funding nudge so when a user clicks the `Show Me Funding Opportunities` CTA button an analytics events will render.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188645454](https://www.pivotaltracker.com/story/show/188645454).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->
1. Go through onboarding and select an industry.
2. Once you've selected a business structure, return to the dashboard.
3. Click the `Deadlines and Opportunities` CTA button. Complete the required steps within.
4.  Click the `Show Me Funding Opportunities` CTA button. 
5. Inspect the `Network` tab.
6. Once you've found the `collect` request, check the `Payload` for the `event_category (ec)`, `event_action (ea)`, and `event_label (el)`.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
