### PR TITLE
fix: [#188540248] add check email endpoint to serverless config

### DIFF
--- a/api/src/functions/express/index.ts
+++ b/api/src/functions/express/index.ts
@@ -43,6 +43,13 @@ export default (cognitoArn: string, vpcConfig: FnType["vpc"]): FnType => {
       },
       {
         http: {
+          method: "POST",
+          path: "/api/users/emailCheck",
+          cors: true,
+        },
+      },
+      {
+        http: {
           method: "ANY",
           path: "/{proxy+}",
           authorizer: {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Serverless config change to expose the `/api/users/emailCheck` endpoint. Without this change, I was getting a blanket `401`. We need to be able to call this unauthorized.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188540248](https://www.pivotaltracker.com/story/show/188540248).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->
Validated by deploying to test.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
