### PR TITLE
feat: [#188682553] add certificate of good standing to Dakota NP

### DIFF
--- a/content/src/roadmaps/add-ons/nonprofit-and-corp-foreign.json
+++ b/content/src/roadmaps/add-ons/nonprofit-and-corp-foreign.json
@@ -1,6 +1,6 @@
 {
-  "displayname": "scorp-ccorp-foreign",
-  "filename": "scorp-ccorp-foreign",
+  "displayname": "nonprofit-and-corp-foreign",
+  "filename": "nonprofit-and-corp-foreign",
   "roadmapSteps": [
     {
       "step": 2,

--- a/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
@@ -491,7 +491,7 @@ describe("Formation - BusinessStep", () => {
 
     describe("Business Designator", () => {
       describe("Business Designator secondary label foreign corporation", () => {
-        it.each(corpLegalStructures)(
+        it.each(["c-corporation", "s-corporation", "nonprofit"])(
           `Shows secondary label foreign corporation when persona is foreign and legal structure is %s`,
           async (legalStructureId) => {
             await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, {});

--- a/web/src/components/tasks/business-formation/business/FormationDate.tsx
+++ b/web/src/components/tasks/business-formation/business/FormationDate.tsx
@@ -8,7 +8,7 @@ import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormationErrors } from "@/lib/data-hooks/useFormationErrors";
 import { camelCaseToSentence } from "@/lib/utils/cases-helpers";
-import { isForeignCorporation } from "@/lib/utils/helpers";
+import { isForeignCorporationOrNonprofit } from "@/lib/utils/helpers";
 import {
   DateObject,
   advancedDateLibrary,
@@ -31,7 +31,9 @@ export const FormationDate = (props: Props): ReactElement => {
   const { state, setFormationFormData, setFieldsInteracted } = useContext(BusinessFormationContext);
   const { doesFieldHaveError } = useFormationErrors();
   const dateFormat = "MM/DD/YYYY";
-  const floatClass = isForeignCorporation(state.formationFormData.legalType) ? "float-none" : "float-left";
+  const floatClass = isForeignCorporationOrNonprofit(state.formationFormData.legalType)
+    ? "float-none"
+    : "float-left";
 
   const contentProps = useMemo(
     () => ({

--- a/web/src/components/tasks/business-formation/business/SuffixDropdown.tsx
+++ b/web/src/components/tasks/business-formation/business/SuffixDropdown.tsx
@@ -3,7 +3,7 @@ import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormationErrors } from "@/lib/data-hooks/useFormationErrors";
 import { camelCaseToSentence } from "@/lib/utils/cases-helpers";
-import { isForeignCorporation } from "@/lib/utils/helpers";
+import { isForeignCorporationOrNonprofit } from "@/lib/utils/helpers";
 import {
   BusinessSuffix,
   BusinessSuffixMap,
@@ -63,7 +63,7 @@ export const SuffixDropdown = (): ReactElement => {
             />
           </strong>
         </div>
-        {isForeignCorporation(state.formationFormData.legalType) && (
+        {isForeignCorporationOrNonprofit(state.formationFormData.legalType) && (
           <div>{Config.formation.fields.businessSuffix.labelSecondaryTextForeignCorporation}</div>
         )}
       </div>

--- a/web/src/lib/roadmap/buildUserRoadmap.test.ts
+++ b/web/src/lib/roadmap/buildUserRoadmap.test.ts
@@ -149,12 +149,15 @@ describe("buildUserRoadmap", () => {
       expect(roadmap.tasks).toHaveLength(0);
     });
 
-    it("adds scorp-ccorp-foreign for S-Corp/C-Corp legal structures", async () => {
+    it("adds nonprofit-and-corp-foreign for S-Corp/C-Corp/foreign nonprofit legal structures", async () => {
       await buildUserRoadmap(createEmptyNexusProfile({ legalStructureId: "s-corporation" }));
-      expect(getLastCalledWith(mockRoadmapBuilder)[0].addOns).toContain("scorp-ccorp-foreign");
+      expect(getLastCalledWith(mockRoadmapBuilder)[0].addOns).toContain("nonprofit-and-corp-foreign");
 
       await buildUserRoadmap(createEmptyNexusProfile({ legalStructureId: "c-corporation" }));
-      expect(getLastCalledWith(mockRoadmapBuilder)[0].addOns).toContain("scorp-ccorp-foreign");
+      expect(getLastCalledWith(mockRoadmapBuilder)[0].addOns).toContain("nonprofit-and-corp-foreign");
+
+      await buildUserRoadmap(createEmptyNexusProfile({ legalStructureId: "nonprofit" }));
+      expect(getLastCalledWith(mockRoadmapBuilder)[0].addOns).toContain("nonprofit-and-corp-foreign");
     });
   });
 

--- a/web/src/lib/roadmap/buildUserRoadmap.ts
+++ b/web/src/lib/roadmap/buildUserRoadmap.ts
@@ -268,9 +268,10 @@ const getLegalStructureAddOns = (profileData: ProfileData): string[] => {
     }
     if (
       profileData.legalStructureId === "s-corporation" ||
-      profileData.legalStructureId === "c-corporation"
+      profileData.legalStructureId === "c-corporation" ||
+      profileData.legalStructureId === "nonprofit"
     ) {
-      addOns.push("scorp-ccorp-foreign");
+      addOns.push("nonprofit-and-corp-foreign");
     }
   } else {
     if (LookupLegalStructureById(profileData.legalStructureId).requiresPublicFiling) {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
This feature adds the certificate of good standing to the non-profit roadmap for the Dakota persona.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188682553](https://www.pivotaltracker.com/story/show/188682553).



<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

1. Onboard as a Dakota business.
2. Select non-profit as your business structure.
3. The certificate of good standing task will appear as the first step in Step 2 of your roadmap. 
4.  Access the `Check Available Names` task and  in Step 2 of the paginator, you will see the Business Designator helper text, (Must match Certificate of Good Standing).



<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
