### PR TITLE
feat: [#188540268] Implement new login navigation pattern

### DIFF
--- a/content/src/fieldConfig/check-account-email-page.json
+++ b/content/src/fieldConfig/check-account-email-page.json
@@ -1,0 +1,15 @@
+{
+  "checkAccountEmailPage": {
+    "defaultErrorMessage": "An error has occurred. Please try again later.",
+    "invalidEmailError": "Please enter a valid email address.",
+    "needHelpText": "Need help?",
+    "inputLabel": "Email",
+    "intercomChatText": "Chat with us",
+    "header": "Log in to Business.NJ.gov",
+    "noAccountText": "Don’t have an account?",
+    "linkAccountLinkText": "Sign up and link your myNewJersey account",
+    "inputButton": "Next",
+    "serviceNotAvailableError": "Service unavailable. Please try again later.",
+    "emailNotFoundError": "No account found. Try a different email address."
+  }
+}

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -6010,6 +6010,38 @@ collections:
               - { label: "Error Description 2", name: "errorDescriptionPt2", widget: "markdown" }
               - { label: "Chat with Expert", name: "errorChatWithExpert", widget: "markdown" }
 
+  - name: "check-account-email-page"
+    label: "Check Account Email Page"
+    delete: false
+    create: false
+    files:
+      - label: "Check Account Email Page Text"
+        name: "check-account-email-page"
+        file: "content/src/fieldConfig/check-account-email-page.json"
+        editor:
+          preview: true
+        fields:
+          - label: "Check Account Email Page Text"
+            name: checkAccountEmailPage
+            collapsed: false
+            widget: object
+            fields:
+              - { label: "Header", name: "header", widget: "string" }
+              - { label: "Input label", name: "inputLabel", widget: "string" }
+              - { label: "Invalid Email text", name: "invalidEmailError", widget: "string" }
+              - { label: "Email Not Found Error Text", name: "emailNotFoundError", widget: "string" }
+              - {
+                  label: "Service Unavailable Error Text",
+                  name: "serviceNotAvailableError",
+                  widget: "string",
+                }
+              - { label: "Default Error Message Text", name: "defaultErrorMessage", widget: "string" }
+              - { label: "Input button", name: "inputButton", widget: "string" }
+              - { label: "No Account Text", name: "noAccountText", widget: "string" }
+              - { label: "Link Account Link Text", name: "linkAccountLinkText", widget: "string" }
+              - { label: "Need help text", name: "needHelpText", widget: "string" }
+              - { label: "Intercom chat text", name: "intercomChatText", widget: "string" }
+
   - name: "component-accessibility"
     label: "Component Accessibility"
     delete: false

--- a/web/src/components/GenericTextField.tsx
+++ b/web/src/components/GenericTextField.tsx
@@ -28,6 +28,7 @@ export interface GenericTextFieldProps<T = FieldErrorType> extends FormContextFi
   valueFilter?: (value: string) => string;
   handleChange?: (value: string) => void | ((value: ChangeEvent<HTMLInputElement>) => void);
   onChange?: (value: string) => void | ((value: ChangeEvent<HTMLInputElement>) => void);
+  onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
   onFocus?: () => void;
   error?: boolean;
   validationText?: string;
@@ -178,6 +179,7 @@ export const GenericTextField = forwardRef(
           }}
           type={props.type}
           onFocus={props.onFocus}
+          onKeyDown={props.onKeyDown}
         />
 
         <div aria-live="polite" className="screen-reader-only">

--- a/web/src/components/LoginEmailCheck.test.tsx
+++ b/web/src/components/LoginEmailCheck.test.tsx
@@ -1,0 +1,99 @@
+import { LoginEmailCheck } from "@/components/LoginEmailCheck";
+import { getMergedConfig } from "@/contexts/configContext";
+import * as api from "@/lib/api-client/apiClient";
+import { triggerSignIn } from "@/lib/auth/sessionHelper";
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const Config = getMergedConfig();
+
+jest.mock("@/lib/api-client/apiClient", () => ({ postUserEmailCheck: jest.fn() }));
+jest.mock("@/lib/auth/sessionHelper", () => ({
+  triggerSignIn: jest.fn(),
+}));
+const mockApi = api as jest.Mocked<typeof api>;
+
+describe("<LoginEmailCheck />", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("calls triggerSignIn when a matching user is found", async () => {
+    const email = "test@example.com";
+    mockApi.postUserEmailCheck.mockReturnValue(Promise.resolve({ email, found: true }));
+    render(<LoginEmailCheck />);
+
+    const emailField = screen.getByLabelText("Email");
+    fireEvent.change(emailField, { target: { value: email } });
+    const submitButton = screen.getByRole("button", { name: Config.checkAccountEmailPage.inputButton });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(triggerSignIn).toHaveBeenCalled();
+    });
+  });
+
+  it("displays an error when a matching user is not found", async () => {
+    const email = "test@example.com";
+    mockApi.postUserEmailCheck.mockReturnValue(Promise.reject(404));
+    render(<LoginEmailCheck />);
+
+    const emailField = screen.getByLabelText("Email");
+    fireEvent.change(emailField, { target: { value: email } });
+    const submitButton = screen.getByRole("button", { name: Config.checkAccountEmailPage.inputButton });
+    fireEvent.click(submitButton);
+
+    expect(await screen.findByText(Config.checkAccountEmailPage.emailNotFoundError)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(triggerSignIn).not.toHaveBeenCalled();
+    });
+  });
+
+  it("displays an error when an invalid email address is entered", async () => {
+    const invalidEmail = "what is an email, even?";
+    render(<LoginEmailCheck />);
+
+    const emailField = screen.getByLabelText("Email");
+    fireEvent.change(emailField, { target: { value: invalidEmail } });
+    const submitButton = screen.getByRole("button", { name: Config.checkAccountEmailPage.inputButton });
+    fireEvent.click(submitButton);
+
+    expect(await screen.findByText(Config.checkAccountEmailPage.invalidEmailError)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(triggerSignIn).not.toHaveBeenCalled();
+    });
+  });
+
+  it("displays a default error message if an unknown error occurs", async () => {
+    render(<LoginEmailCheck />);
+    const email = "test@example.com";
+    // Doesn't matter what status code we use here, as long as it's not
+    // one that we currently account for in our error handling.
+    mockApi.postUserEmailCheck.mockReturnValue(Promise.reject(418));
+
+    const emailField = screen.getByLabelText("Email");
+    fireEvent.change(emailField, { target: { value: email } });
+    const submitButton = screen.getByRole("button", { name: Config.checkAccountEmailPage.inputButton });
+    fireEvent.click(submitButton);
+
+    expect(await screen.findByText(Config.checkAccountEmailPage.defaultErrorMessage)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(triggerSignIn).not.toHaveBeenCalled();
+    });
+  });
+
+  it("submits the form when the user presses enter", async () => {
+    const email = "test@example.com";
+    mockApi.postUserEmailCheck.mockReturnValue(Promise.resolve({ email, found: true }));
+
+    render(<LoginEmailCheck />);
+
+    const emailField = screen.getByLabelText("Email");
+    fireEvent.change(emailField, { target: { value: email } });
+    fireEvent.keyDown(emailField, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(triggerSignIn).toHaveBeenCalled();
+    });
+  });
+});

--- a/web/src/components/LoginEmailCheck.tsx
+++ b/web/src/components/LoginEmailCheck.tsx
@@ -1,0 +1,110 @@
+import { GenericTextField } from "@/components/GenericTextField";
+import { WithErrorBar } from "@/components/WithErrorBar";
+import { Heading } from "@/components/njwds-extended/Heading";
+import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
+import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
+import { postUserEmailCheck } from "@/lib/api-client/apiClient";
+import { triggerSignIn } from "@/lib/auth/sessionHelper";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { ROUTES } from "@/lib/domain-logic/routes";
+import analytics from "@/lib/utils/analytics";
+import { validateEmail } from "@/lib/utils/helpers";
+import { InputLabel } from "@mui/material";
+import Link from "next/link";
+
+import { useState, type ReactElement } from "react";
+
+export const LoginEmailCheck = (): ReactElement => {
+  const [email, setEmail] = useState<string>("");
+  const [emailError, setEmailError] = useState<string>("");
+
+  const handleSubmit = (email: string): void => {
+    const isValidEmail = validateEmail(email);
+
+    if (isValidEmail) {
+      checkEmailExists(email);
+    } else {
+      setEmailError(Config.checkAccountEmailPage.invalidEmailError);
+    }
+  };
+
+  const checkEmailExists = async (email: string): Promise<void> => {
+    try {
+      const response = await postUserEmailCheck(email);
+      if (response.found) {
+        setEmailError("");
+        triggerSignIn();
+        analytics.event.check_account_next_button.submit.go_to_myNJ_login();
+      }
+    } catch (error) {
+      if (error === 404) {
+        setEmailError(Config.checkAccountEmailPage.emailNotFoundError);
+      } else if (error === 500) {
+        setEmailError(Config.checkAccountEmailPage.serviceNotAvailableError);
+      } else {
+        setEmailError(Config.checkAccountEmailPage.defaultErrorMessage);
+      }
+    }
+  };
+
+  const { Config } = useConfig();
+
+  const handleTextInputChange = (value: string): void => {
+    setEmail(value);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (event.key === "Enter") {
+      const email = (event.target as HTMLInputElement).value;
+      handleSubmit(email);
+    }
+  };
+
+  return (
+    <div className="email-check-card padding-5 desktop:margin-x-2 radius-md">
+      <Heading level={1} styleVariant="h2">
+        {Config.checkAccountEmailPage.header}
+      </Heading>
+
+      <WithErrorBar hasError={Boolean(emailError)} type="ALWAYS">
+        <InputLabel htmlFor="email">Email</InputLabel>
+        <GenericTextField
+          inputWidth="default"
+          fieldName="email"
+          value={email}
+          handleChange={handleTextInputChange}
+          error={Boolean(emailError)}
+          validationText={emailError}
+          onKeyDown={(e) => handleKeyDown(e)}
+        />
+      </WithErrorBar>
+
+      <PrimaryButton
+        isFullWidthOnDesktop
+        isColor="primary"
+        isSubmitButton
+        onClick={() => handleSubmit(email)}
+      >
+        {Config.checkAccountEmailPage.inputButton}
+      </PrimaryButton>
+
+      <hr className="margin-y-3" />
+      <p className="link-account-text">
+        <span className="margin-right-05">{Config.checkAccountEmailPage.noAccountText}</span>
+        <Link href={ROUTES.onboarding}>{Config.checkAccountEmailPage.linkAccountLinkText}</Link>
+      </p>
+
+      <div className="display-flex flex-align-end">
+        <p>{Config.checkAccountEmailPage.needHelpText}</p>
+        <UnStyledButton
+          isUnderline
+          isIntercomEnabled
+          onClick={analytics.event.check_account_help_button.click.open_live_chat}
+          className="margin-left-05"
+        >
+          {Config.checkAccountEmailPage.intercomChatText}
+        </UnStyledButton>
+      </div>
+    </div>
+  );
+};

--- a/web/src/components/auth/NeedsAccountModal.test.tsx
+++ b/web/src/components/auth/NeedsAccountModal.test.tsx
@@ -1,7 +1,6 @@
 import { NeedsAccountModal } from "@/components/auth/NeedsAccountModal";
 import { getMergedConfig } from "@/contexts/configContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
-import * as session from "@/lib/auth/sessionHelper";
 import { ROUTES } from "@/lib/domain-logic/routes";
 import { withNeedsAccountContext } from "@/test/helpers/helpers-renderers";
 import { markdownToText } from "@/test/helpers/helpers-utilities";
@@ -14,9 +13,6 @@ const Config = getMergedConfig();
 jest.mock("@/lib/api-client/apiClient", () => ({ postSelfReg: jest.fn() }));
 jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
 jest.mock("next/router", () => ({ useRouter: jest.fn() }));
-jest.mock("@/lib/auth/sessionHelper", () => ({ triggerSignIn: jest.fn() }));
-
-const mockSession = session as jest.Mocked<typeof session>;
 
 describe("<NeedsAccount Modal />", () => {
   beforeEach(() => {
@@ -72,6 +68,6 @@ describe("<NeedsAccount Modal />", () => {
   it("goes to myNJ when Log-in link is clicked", () => {
     setupHookWithAuth(IsAuthenticated.FALSE);
     fireEvent.click(screen.getByText(markdownToText(Config.selfRegistration.needsAccountModalSubText)));
-    expect(mockSession.triggerSignIn).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith(ROUTES.login);
   });
 });

--- a/web/src/components/auth/NeedsAccountModal.tsx
+++ b/web/src/components/auth/NeedsAccountModal.tsx
@@ -3,7 +3,6 @@ import { ModalZeroButton } from "@/components/ModalZeroButton";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
-import { triggerSignIn } from "@/lib/auth/sessionHelper";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { QUERIES, ROUTES } from "@/lib/domain-logic/routes";
@@ -60,7 +59,7 @@ export const NeedsAccountModal = (): ReactElement => {
             <Content
               onClick={(): void => {
                 analytics.event.guest_modal.click.go_to_myNJ_login();
-                triggerSignIn();
+                router.push(ROUTES.login);
               }}
             >
               {Config.selfRegistration.needsAccountModalSubText}

--- a/web/src/components/auth/RegistrationStatusSnackbar.test.tsx
+++ b/web/src/components/auth/RegistrationStatusSnackbar.test.tsx
@@ -14,7 +14,6 @@ const Config = getMergedConfig();
 jest.mock("next/router", () => ({ useRouter: jest.fn() }));
 jest.mock("@/lib/api-client/apiClient", () => ({ postSelfReg: jest.fn() }));
 jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
-jest.mock("@/lib/auth/sessionHelper", () => ({ triggerSignIn: jest.fn() }));
 
 describe("<RegistrationStatusSnackbar />", () => {
   beforeEach(() => {

--- a/web/src/components/navbar/NavBar.tsx
+++ b/web/src/components/navbar/NavBar.tsx
@@ -9,6 +9,7 @@ import { ReactElement, useContext, useEffect, useMemo, useState } from "react";
 
 type Props = {
   landingPage?: boolean;
+  isLoginPage?: boolean;
   isSeoStarterKit?: boolean;
   task?: Task;
   showSidebar?: boolean;
@@ -55,6 +56,7 @@ export const NavBar = (props: Props): ReactElement => {
         <NavBarDesktop
           isSeoStarterKit={props.isSeoStarterKit}
           isLanding={props.landingPage}
+          isLoginPage={props.isLoginPage}
           logoOnlyType={props.logoOnly}
           previousBusinessId={props.previousBusinessId}
           currentlyOnboarding={currentlyOnboarding()}
@@ -65,11 +67,12 @@ export const NavBar = (props: Props): ReactElement => {
       <div className="display-inline desktop:display-none">
         <NavBarMobile
           isSeoStarterKit={props.isSeoStarterKit}
+          isLanding={props.landingPage}
+          isLoginPage={props.isLoginPage}
           scrolled={scrolled}
           task={props.task}
           showSidebar={props.showSidebar}
           hideMiniRoadmap={props.hideMiniRoadmap}
-          isLanding={props.landingPage}
           previousBusinessId={props.previousBusinessId}
           logoOnlyType={props.logoOnly}
           currentlyOnboarding={currentlyOnboarding()}

--- a/web/src/components/navbar/NavBarLoginButton.test.tsx
+++ b/web/src/components/navbar/NavBarLoginButton.test.tsx
@@ -1,43 +1,21 @@
 import { NavBarLoginButton } from "@/components/navbar/NavBarLoginButton";
 import { getMergedConfig } from "@/contexts/configContext";
-import { triggerSignIn } from "@/lib/auth/sessionHelper";
-import analytics from "@/lib/utils/analytics";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ROUTES } from "@/lib/domain-logic/routes";
+import { mockPush, useMockRouter } from "@/test/mock/mockRouter";
+import { fireEvent, render, screen } from "@testing-library/react";
 
-jest.mock("@/lib/auth/sessionHelper", () => ({
-  triggerSignIn: jest.fn(),
-}));
-jest.mock("@/lib/utils/analytics", () => setupMockAnalytics());
-
-function setupMockAnalytics(): typeof analytics {
-  return {
-    ...jest.requireActual("@/lib/utils/analytics").default,
-    event: {
-      ...jest.requireActual("@/lib/utils/analytics").default.event,
-      landing_page_navbar_log_in: {
-        click: {
-          go_to_myNJ_login: jest.fn(),
-        },
-      },
-    },
-  };
-}
-const mockAnalytics = analytics as jest.Mocked<typeof analytics>;
+jest.mock("next/router", () => ({ useRouter: jest.fn() }));
 
 describe("NavBarLoginButton", () => {
-  const Config = getMergedConfig();
-
-  it("triggers analytics on click", async () => {
-    render(<NavBarLoginButton />);
-    fireEvent.click(screen.getByText(Config.navigationDefaults.logInButton));
-    await waitFor(() => {
-      expect(mockAnalytics.event.landing_page_navbar_log_in.click.go_to_myNJ_login).toHaveBeenCalled();
-    });
+  beforeEach(() => {
+    useMockRouter({});
   });
+
+  const Config = getMergedConfig();
 
   it("triggers signin action on click", () => {
     render(<NavBarLoginButton />);
     fireEvent.click(screen.getByText(Config.navigationDefaults.logInButton));
-    expect(triggerSignIn).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith(ROUTES.login);
   });
 });

--- a/web/src/components/navbar/NavBarLoginButton.tsx
+++ b/web/src/components/navbar/NavBarLoginButton.tsx
@@ -1,18 +1,18 @@
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
-import { triggerSignIn } from "@/lib/auth/sessionHelper";
 import { useConfig } from "@/lib/data-hooks/useConfig";
-import analytics from "@/lib/utils/analytics";
+import { ROUTES } from "@/lib/domain-logic/routes";
+import { useRouter } from "next/router";
 import { ReactElement } from "react";
 
 export const NavBarLoginButton = (): ReactElement => {
   const { Config } = useConfig();
+  const router = useRouter();
   return (
     <span className="margin-right-2">
       <UnStyledButton
         dataTestid="login-button"
         onClick={(): void => {
-          triggerSignIn();
-          analytics.event.landing_page_navbar_log_in.click.go_to_myNJ_login();
+          router.push(ROUTES.login);
         }}
       >
         {Config.navigationDefaults.logInButton}

--- a/web/src/components/navbar/desktop/NavBarDesktop.test.tsx
+++ b/web/src/components/navbar/desktop/NavBarDesktop.test.tsx
@@ -92,7 +92,6 @@ describe("<NavBarDesktop />", () => {
       render(<NavBarDesktop isLanding={false} currentlyOnboarding={true} isAuthenticated={false} />);
 
       quickLinksDoNotExist();
-      expect(screen.getByText(Config.navigationDefaults.logInButton)).toBeInTheDocument();
       expect(screen.getByTestId("nav-bar-desktop-dropdown-button")).toBeInTheDocument();
     });
   });

--- a/web/src/components/navbar/desktop/NavBarDesktop.tsx
+++ b/web/src/components/navbar/desktop/NavBarDesktop.tsx
@@ -26,6 +26,7 @@ import React, { ReactElement, useEffect, useRef, useState } from "react";
 interface Props {
   previousBusinessId?: string | undefined;
   isLanding: boolean | undefined;
+  isLoginPage?: boolean;
   isSeoStarterKit?: boolean;
   logoOnlyType?: "NAVIGATOR_LOGO" | "NAVIGATOR_MYNJ_LOGO" | undefined;
   currentlyOnboarding: boolean | undefined;
@@ -68,6 +69,12 @@ export const NavBarDesktop = (props: Props): ReactElement => {
   if (props.logoOnlyType) {
     // loading/redirect/ethan onboarding
     return <NavBarLogoOnlyDesktop logoType={props.logoOnlyType} />;
+  } else if (props.isLoginPage) {
+    return (
+      <NavBarDesktopWrapper CMS_ONLY_disableSticky={props.CMS_PREVIEW_ONLY_SHOW_MENU}>
+        <NavBarDesktopHomeLogo previousBusinessId={props.previousBusinessId} isLoginPage />
+      </NavBarDesktopWrapper>
+    );
   } else if (props.isSeoStarterKit) {
     // starter kits page for SEO
     return (
@@ -107,7 +114,6 @@ export const NavBarDesktop = (props: Props): ReactElement => {
       <NavBarDesktopWrapper CMS_ONLY_disableSticky={props.CMS_PREVIEW_ONLY_SHOW_MENU}>
         <NavBarDesktopHomeLogo previousBusinessId={props.previousBusinessId} />
         <div className={"display-flex flex-row flex-align-center"}>
-          <NavBarLoginButton />
           <NavBarDesktopDropDown
             disabled={true}
             anchorRef={anchorRef}

--- a/web/src/components/navbar/desktop/NavBarDesktopHomeLogo.tsx
+++ b/web/src/components/navbar/desktop/NavBarDesktopHomeLogo.tsx
@@ -6,6 +6,7 @@ import { ReactElement } from "react";
 
 interface Props {
   previousBusinessId?: string;
+  isLoginPage?: boolean;
 }
 
 export const NavBarDesktopHomeLogo = (props: Props): ReactElement => {
@@ -17,10 +18,14 @@ export const NavBarDesktopHomeLogo = (props: Props): ReactElement => {
       <div className="margin-x-105">
         <NavBarVerticalLine />
       </div>
-      <NavBarDashboardLink
-        linkText={Config.navigationDefaults.navBarMyAccountText}
-        previousBusinessId={props.previousBusinessId}
-      />
+      {props.isLoginPage ? (
+        <span className="my-acccount-login-text">My Account</span>
+      ) : (
+        <NavBarDashboardLink
+          linkText={Config.navigationDefaults.navBarMyAccountText}
+          previousBusinessId={props.previousBusinessId}
+        />
+      )}
     </div>
   );
 };

--- a/web/src/components/navbar/mobile/NavBarMobile.tsx
+++ b/web/src/components/navbar/mobile/NavBarMobile.tsx
@@ -29,6 +29,7 @@ interface Props {
   showSidebar?: boolean;
   isSeoStarterKit?: boolean;
   isLanding?: boolean;
+  isLoginPage?: boolean;
   previousBusinessId?: string | undefined;
   logoOnlyType?: "NAVIGATOR_LOGO" | "NAVIGATOR_MYNJ_LOGO" | undefined;
   currentlyOnboarding: boolean;
@@ -64,6 +65,18 @@ export const NavBarMobile = (props: Props): ReactElement => {
   if (props.logoOnlyType) {
     return (
       <NavBarLogoOnlyMobile scrolled={scrolled} showMyNjLogo={props.logoOnlyType === "NAVIGATOR_MYNJ_LOGO"} />
+    );
+  } else if (props.isLoginPage) {
+    return (
+      <NavBarMobileWrapper scrolled={scrolled}>
+        <NavBarMobileHomeLogo
+          isLoginPage
+          scrolled={props.scrolled}
+          showSidebar={props.showSidebar}
+          previousBusinessId={props.previousBusinessId}
+          businessNavBarTitle={navBarBusinessTitle}
+        />
+      </NavBarMobileWrapper>
     );
   } else if (props.isSeoStarterKit) {
     return (

--- a/web/src/components/navbar/mobile/NavBarMobileAccountSlideOutMenu.test.tsx
+++ b/web/src/components/navbar/mobile/NavBarMobileAccountSlideOutMenu.test.tsx
@@ -3,9 +3,6 @@ import analytics from "@/lib/utils/analytics";
 import { MenuItem } from "@mui/material";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-jest.mock("@/lib/auth/sessionHelper", () => ({
-  triggerSignIn: jest.fn(),
-}));
 jest.mock("@/lib/utils/analytics", () => setupMockAnalytics());
 
 function setupMockAnalytics(): typeof analytics {

--- a/web/src/components/navbar/mobile/NavBarMobileHomeLogo.tsx
+++ b/web/src/components/navbar/mobile/NavBarMobileHomeLogo.tsx
@@ -5,6 +5,7 @@ import { useConfig } from "@/lib/data-hooks/useConfig";
 import { ReactElement } from "react";
 
 interface Props {
+  isLoginPage?: boolean;
   scrolled: boolean;
   showSidebar: boolean | undefined;
   previousBusinessId: string | undefined;
@@ -24,13 +25,17 @@ export const NavBarMobileHomeLogo = (props: Props): ReactElement => {
           <NavBarVerticalLine />
         </div>
         <div>
-          <NavBarDashboardLink
-            className={props.showSidebar ? "truncate-long-business-names_NavBarMobile" : ""}
-            linkText={
-              props.showSidebar ? props.businessNavBarTitle : Config.navigationDefaults.navBarMyAccountText
-            }
-            previousBusinessId={props.previousBusinessId}
-          />
+          {props.isLoginPage ? (
+            <span className="my-acccount-login-text font-body-sm">My Account</span>
+          ) : (
+            <NavBarDashboardLink
+              className={props.showSidebar ? "truncate-long-business-names_NavBarMobile" : ""}
+              linkText={
+                props.showSidebar ? props.businessNavBarTitle : Config.navigationDefaults.navBarMyAccountText
+              }
+              previousBusinessId={props.previousBusinessId}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/web/src/components/navbar/mobile/NavBarMobileQuickLinksSlideOutMenu.test.tsx
+++ b/web/src/components/navbar/mobile/NavBarMobileQuickLinksSlideOutMenu.test.tsx
@@ -3,9 +3,6 @@ import { getMergedConfig } from "@/contexts/configContext";
 import analytics from "@/lib/utils/analytics";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-jest.mock("@/lib/auth/sessionHelper", () => ({
-  triggerSignIn: jest.fn(),
-}));
 jest.mock("@/lib/utils/analytics", () => setupMockAnalytics());
 
 function setupMockAnalytics(): typeof analytics {

--- a/web/src/components/navbar/shared-submenu-components.test.tsx
+++ b/web/src/components/navbar/shared-submenu-components.test.tsx
@@ -14,7 +14,6 @@ import {
   Updates,
 } from "@/components/navbar/shared-submenu-components";
 import { getMergedConfig } from "@/contexts/configContext";
-import { triggerSignIn } from "@/lib/auth/sessionHelper";
 import { onSignOut } from "@/lib/auth/signinHelper";
 import { ROUTES } from "@/lib/domain-logic/routes";
 import analytics from "@/lib/utils/analytics";
@@ -34,9 +33,6 @@ jest.mock("@/lib/auth/signinHelper", () => {
     onSignOut: jest.fn(),
   };
 });
-jest.mock("@/lib/auth/sessionHelper", () => ({
-  triggerSignIn: jest.fn(),
-}));
 jest.mock("next/router", () => ({ useRouter: jest.fn() }));
 jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
 jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
@@ -48,9 +44,6 @@ jest.mock(
       children
 );
 
-jest.mock("@/lib/auth/sessionHelper", () => ({
-  triggerSignIn: jest.fn(),
-}));
 jest.mock("@/lib/utils/analytics", () => setupMockAnalytics());
 
 function setupMockAnalytics(): typeof analytics {
@@ -107,7 +100,7 @@ describe("shared-submenu-components", () => {
     render(<LoginMenuItem />);
     expect(screen.getByText(Config.navigationDefaults.logInButton)).toBeInTheDocument();
     fireEvent.click(screen.getByText(Config.navigationDefaults.logInButton));
-    expect(triggerSignIn).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith(ROUTES.login);
   });
 
   it("renders LogoutMenuItem and it navigates correclty onClick", () => {

--- a/web/src/components/navbar/shared-submenu-components.tsx
+++ b/web/src/components/navbar/shared-submenu-components.tsx
@@ -1,7 +1,6 @@
 import { ButtonIcon } from "@/components/ButtonIcon";
 import { NavMenuItem } from "@/components/navbar/NavMenuItem";
 import { AuthContext } from "@/contexts/authContext";
-import { triggerSignIn } from "@/lib/auth/sessionHelper";
 import { onSignOut } from "@/lib/auth/signinHelper";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
@@ -18,10 +17,11 @@ import { ReactElement, useContext } from "react";
 
 export const LoginMenuItem = (): ReactElement => {
   const { Config } = useConfig();
+  const router = useRouter();
   return NavMenuItem({
     onClick: (): void => {
       analytics.event.landing_page_navbar_log_in.click.go_to_myNJ_login();
-      triggerSignIn();
+      router.push(ROUTES.login);
     },
     icon: <ButtonIcon svgFilename="login" sizePx="25px" />,
     itemText: Config.navigationDefaults.logInButton,

--- a/web/src/components/njwds-layout/PageSkeleton.tsx
+++ b/web/src/components/njwds-layout/PageSkeleton.tsx
@@ -10,6 +10,7 @@ import React, { ReactElement } from "react";
 interface Props {
   children: React.ReactNode;
   landingPage?: boolean;
+  isLoginPage?: boolean;
   showNavBar?: boolean;
   task?: Task;
   showSidebar?: boolean;
@@ -29,6 +30,7 @@ export const PageSkeleton = (props: Props): ReactElement => {
         {props.showNavBar && (
           <NavBar
             landingPage={props.landingPage}
+            isLoginPage={props.isLoginPage}
             task={props.task}
             showSidebar={props.showSidebar}
             hideMiniRoadmap={props.hideMiniRoadmap}

--- a/web/src/components/tasks/LicenseTask.test.tsx
+++ b/web/src/components/tasks/LicenseTask.test.tsx
@@ -482,7 +482,6 @@ describe("<LicenseTask />", () => {
             },
           })
         );
-        console.log(JSON.stringify(userData));
         mockApi.checkLicenseStatus.mockResolvedValue(userData);
         fireEvent.submit(screen.getByTestId("check-status-submit"));
         await waitFor(() => {

--- a/web/src/contexts/configContext.ts
+++ b/web/src/contexts/configContext.ts
@@ -10,6 +10,7 @@ import * as CannabisLicenseEligibilityModal from "@businessnjgovnavigator/conten
 import * as CannabisLicenseTab1 from "@businessnjgovnavigator/content/fieldConfig/cannabis-license-tab1.json";
 import * as CannabisPriorityStatusTab1 from "@businessnjgovnavigator/content/fieldConfig/cannabis-priority-status-tab1.json";
 import * as CannabisPriorityStatusTab2 from "@businessnjgovnavigator/content/fieldConfig/cannabis-priority-status-tab2.json";
+import * as CheckAccountEmailPage from "@businessnjgovnavigator/content/fieldConfig/check-account-email-page.json";
 import * as ConfigOriginal from "@businessnjgovnavigator/content/fieldConfig/config.json";
 import * as DashboardCalendar from "@businessnjgovnavigator/content/fieldConfig/dashboard-calendar.json";
 import * as DashboardDefaults from "@businessnjgovnavigator/content/fieldConfig/dashboard-defaults.json";
@@ -80,7 +81,8 @@ const merged = JSON.parse(
       HousingRegistrationSearchTask,
       anytimeActionReinstatementAndLicenseCalendarEventStatusDefaults,
       CalloutAlerts,
-      WasteQuestionnairePage
+      WasteQuestionnairePage,
+      CheckAccountEmailPage
     )
   )
 );
@@ -123,6 +125,7 @@ export type ConfigType = typeof ConfigOriginal &
   typeof HousingRegistrationSearchTask &
   typeof anytimeActionReinstatementAndLicenseCalendarEventStatusDefaults &
   typeof CalloutAlerts &
+  typeof CheckAccountEmailPage &
   typeof WasteQuestionnairePage;
 
 export const getMergedConfig = (): ConfigType => {
@@ -162,7 +165,8 @@ export const getMergedConfig = (): ConfigType => {
     HousingRegistrationSearchTask,
     anytimeActionReinstatementAndLicenseCalendarEventStatusDefaults,
     CalloutAlerts,
-    WasteQuestionnairePage
+    WasteQuestionnairePage,
+    CheckAccountEmailPage
   );
 };
 

--- a/web/src/lib/api-client/apiClient.test.ts
+++ b/web/src/lib/api-client/apiClient.test.ts
@@ -15,6 +15,7 @@ import {
   postTaxFilingsLookup,
   postTaxFilingsOnboarding,
   postUserData,
+  postUserEmailCheck,
 } from "./apiClient";
 
 jest.mock("axios");
@@ -53,6 +54,14 @@ describe("apiClient", () => {
     expect(mockAxios.get).toHaveBeenCalledWith("/api/some/url", {
       headers: { Authorization: "Bearer some-token" },
     });
+  });
+
+  it("posts email check", async () => {
+    const email = "someone@example.com";
+    mockAxios.post.mockResolvedValue({ data: { email, found: true } });
+    const response = await postUserEmailCheck(email);
+    expect(response).toEqual({ email, found: true });
+    expect(mockAxios.post).toHaveBeenCalledWith("/api/users/emailCheck", { email }, {});
   });
 
   it("posts license status", async () => {

--- a/web/src/lib/api-client/apiClient.ts
+++ b/web/src/lib/api-client/apiClient.ts
@@ -31,6 +31,14 @@ export const postUserData = async (userData: UserData): Promise<UserData> => {
   });
 };
 
+type EmailCheckResponse = {
+  email: string;
+  found: boolean;
+};
+export const postUserEmailCheck = async (email: string): Promise<EmailCheckResponse> => {
+  return post("/users/emailCheck", { email }, false);
+};
+
 export const checkLicenseStatus = (nameAndAddress: LicenseSearchNameAndAddress): Promise<UserData> => {
   return post(`/license-status`, { nameAndAddress });
 };

--- a/web/src/lib/domain-logic/routes.ts
+++ b/web/src/lib/domain-logic/routes.ts
@@ -12,6 +12,7 @@ export const ROUTES = {
   welcome: "/welcome",
   accountSetup: "/account-setup",
   starterKits: "/starter-kits",
+  login: "/login",
 };
 
 export interface QUERY_PARAMS_VALUES {

--- a/web/src/lib/search/cmsCollections.ts
+++ b/web/src/lib/search/cmsCollections.ts
@@ -76,6 +76,7 @@ export const cmsCollections = [
       "Profile Page",
       "Contextual Information",
       "404 Page",
+      "Check Account Email Page",
       "Component Accessibility",
       "Global Error Messages",
       "Navigation Config",

--- a/web/src/lib/utils/analytics-legacy.ts
+++ b/web/src/lib/utils/analytics-legacy.ts
@@ -141,7 +141,10 @@ export type LegacyEventCategory =
   | "starter_kit_landing_start_now_button"
   | "starter_kit_landing_get_my_starter_kit_button"
   | "starter_kit_landing_get_my_starter_kit_button_footer"
-  | "show_me_funding_opportunities_button";
+  | "show_me_funding_opportunities_button"
+  | "check_account_help_button"
+  | "check_account_log_in"
+  | "link_your_myNJ_account_link";
 
 export type LegacyEventAction =
   | "click"

--- a/web/src/lib/utils/analytics.ts
+++ b/web/src/lib/utils/analytics.ts
@@ -106,7 +106,8 @@ type Clicked =
   | "go_to_NavigatorAccount_setup"
   | "log_out"
   | "unlinked_myNJ_account"
-  | "get_unlinked_myNJ_account_modal";
+  | "get_unlinked_myNJ_account_modal"
+  | "link_your_myNJ_account";
 
 type OnSiteSection =
   | "landing_page"
@@ -217,7 +218,9 @@ type Item =
   | "link_with_myNJ"
   | "landing_page"
   | "skip_to_main_content"
-  | "show_funding_opportunities";
+  | "show_funding_opportunities"
+  | "check_account_log_in"
+  | "link_your_myNJ_account_link";
 
 type BooleanResponseOption = "yes" | "no";
 
@@ -2358,6 +2361,49 @@ export default {
             event: "link_clicks",
             click_text: "show_calendar",
             item: "show_funding_opportunities",
+          });
+        },
+      },
+    },
+    check_account_help_button: {
+      click: {
+        open_live_chat: () => {
+          eventRunner.track({
+            event: "link_clicks",
+            legacy_event_action: "click",
+            legacy_event_category: "check_account_help_button",
+            legacy_event_label: "open_live_chat",
+            click_text: "check_account_help_button",
+            clicked_to: "open_live_chat",
+          });
+        },
+      },
+    },
+    check_account_next_button: {
+      submit: {
+        go_to_myNJ_login: () => {
+          eventRunner.track({
+            event: "account_clicks",
+            legacy_event_action: "click",
+            legacy_event_category: "check_account_log_in",
+            legacy_event_label: "go_to_myNJ_login",
+            clicked: "go_to_myNJ_login",
+            item: "check_account_log_in",
+          });
+        },
+      },
+    },
+    check_account_link_account_button: {
+      click: {
+        link_account: () => {
+          eventRunner.track({
+            event: "link_clicks",
+            legacy_event_category: "link_your_myNJ_account_link",
+            legacy_event_action: "click",
+            legacy_event_label: "unhide_card",
+            clicked: "link_your_myNJ_account",
+            item: "link_your_myNJ_account_link",
+            clicked_to: "/onboarding",
           });
         },
       },

--- a/web/src/pages/loading.tsx
+++ b/web/src/pages/loading.tsx
@@ -1,6 +1,6 @@
 import { LoadingPageComponent } from "@/components/LoadingPageComponent";
 import { AuthContext } from "@/contexts/authContext";
-import { getActiveUser, triggerSignIn } from "@/lib/auth/sessionHelper";
+import { getActiveUser } from "@/lib/auth/sessionHelper";
 import { onGuestSignIn } from "@/lib/auth/signinHelper";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { QUERIES, ROUTES } from "@/lib/domain-logic/routes";
@@ -35,7 +35,7 @@ const LoadingPage = (): ReactElement => {
         encounteredMyNjLinkingError: true,
       });
     } else {
-      triggerSignIn();
+      router.push(ROUTES.login);
     }
   }, [router, dispatch]);
 

--- a/web/src/pages/login.tsx
+++ b/web/src/pages/login.tsx
@@ -1,0 +1,36 @@
+import { LoginEmailCheck } from "@/components/LoginEmailCheck";
+import { PageSkeleton } from "@/components/njwds-layout/PageSkeleton";
+import { getActiveUser } from "@/lib/auth/sessionHelper";
+import { ROUTES } from "@/lib/domain-logic/routes";
+import { useMountEffect } from "@/lib/utils/helpers";
+import { type GetStaticPropsResult } from "next";
+import { useRouter } from "next/router";
+
+import { ReactElement } from "react";
+
+const LoginEmailCheckPage = (): ReactElement => {
+  const router = useRouter();
+
+  useMountEffect(() => {
+    getActiveUser()
+      .then(() => {
+        router.push(ROUTES.dashboard);
+      })
+      .catch(() => {});
+  });
+  return (
+    <PageSkeleton showNavBar isLoginPage>
+      <main className="grid-container-widescreen padding-y-4 email-check-main" id="main">
+        <LoginEmailCheck />
+      </main>
+    </PageSkeleton>
+  );
+};
+
+export function getStaticProps(): GetStaticPropsResult<{ noAuth: boolean }> {
+  return {
+    props: { noAuth: true },
+  };
+}
+
+export default LoginEmailCheckPage;

--- a/web/src/styles/main.scss
+++ b/web/src/styles/main.scss
@@ -43,6 +43,7 @@
 @import "sections/roadmap.scss";
 @import "sections/cms.scss";
 @import "sections/dashboard.scss";
+@import "sections/login-page.scss";
 @import "sections/starter-kits.scss";
 
 @import "slick-carousel/slick/slick-theme.css";

--- a/web/src/styles/sections/login-page.scss
+++ b/web/src/styles/sections/login-page.scss
@@ -1,0 +1,22 @@
+.fit-screen-content:has(.email-check-main) {
+  background-color: $cool-extra-light;
+}
+
+.email-check-card {
+  background-color: $white;
+  border: 1px solid $base-lighter;
+  width: fit-content;
+  @include addDropShadow($drop-shadow-xs);
+
+  .usa-button {
+    margin-top: 10px;
+  }
+}
+
+.my-acccount-login-text {
+  color: $primary;
+}
+
+.link-account-text a {
+  display: inline-block;
+}

--- a/web/test/pages/login.test.tsx
+++ b/web/test/pages/login.test.tsx
@@ -1,0 +1,38 @@
+import * as session from "@/lib/auth/sessionHelper";
+import { ROUTES } from "@/lib/domain-logic/routes";
+import LoginPage from "@/pages/login";
+import { generateActiveUser } from "@/test/factories";
+import { mockPush, useMockRouter } from "@/test/mock/mockRouter";
+import { render, waitFor } from "@testing-library/react";
+
+jest.mock("next/router", () => ({ useRouter: jest.fn() }));
+jest.mock("@/lib/auth/sessionHelper", () => ({
+  getActiveUser: jest.fn(),
+}));
+
+const mockSession = session as jest.Mocked<typeof session>;
+
+describe("login page", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    useMockRouter({});
+  });
+
+  it("redirects to the dashboard if the user is already logged in", async () => {
+    const activeUser = generateActiveUser({});
+    mockSession.getActiveUser.mockResolvedValue(activeUser);
+
+    render(<LoginPage />);
+
+    await waitFor(async () => {
+      expect(mockPush).toHaveBeenCalledWith(ROUTES.dashboard);
+    });
+  });
+
+  it("renders the login form for any unauthenticated users", () => {
+    mockSession.getActiveUser.mockResolvedValue(Promise.reject("No current user"));
+
+    render(<LoginPage />);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
Adds a new login page that checks for a user's email in our database before triggering a login via myNJ.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188540268](https://www.pivotaltracker.com/story/show/188540268).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
Relatively straightforward. The main thing was making sure that all access points get updated from the old way, getting directed straight to myNJ login, to being directed to this intermediary page first.

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

Manually checking the flow:
1. Go through onboarding
2. Click "Log In" from nav bar
 3. Input a bad email for various error states:
	1. a string that isn't a properly formatted email
	2. an email that hasn't been linked to myNJ
4. Go to "Link with myNewJersey" from nav bar dropdown
5. Fill out and submit form, get redirected to profile page
6. Go back to "Log in"
7. This time, submitting that self-registered email should route you to myNJ to log in and successfully get redirected back to navigator upon completion

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
