### PR TITLE
feat: [#187466951] business structure task, error is now auto scroll and screen reader accessible

### DIFF
--- a/content/src/fieldConfig/business-structure-prompt.json
+++ b/content/src/fieldConfig/business-structure-prompt.json
@@ -3,6 +3,6 @@
     "notCompletedTaskPromptAnyTask": "Select your `business structure|business-structure-learn-more` to learn how to **register your business**.",
     "notCompletedTaskPromptBusinessStructureTask": "Select your `business structure|business-structure-learn-more` to learn how to **register your business**.",
     "buttonText": "Select Business Structure",
-    "businessStructureNotSelectedAlertText": "Complete the field below."
+    "businessStructureNotSelectedAlertText": "Complete the required Business Structure Question"
   }
 }

--- a/web/src/components/njwds-extended/Alert.tsx
+++ b/web/src/components/njwds-extended/Alert.tsx
@@ -1,7 +1,7 @@
 import { Heading } from "@/components/njwds-extended/Heading";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { modifyContent } from "@/lib/domain-logic/modifyContent";
-import { ReactElement, ReactNode } from "react";
+import { ForwardedRef, forwardRef, ReactElement, ReactNode } from "react";
 
 export interface AlertProps {
   variant: AlertVariant;
@@ -31,7 +31,7 @@ const composeAriaGroupLabel = (content: string, alertMappedName: string): string
   });
 };
 
-export const Alert = (props: Props): ReactElement => {
+const Alert = forwardRef((props: Props, ref: ForwardedRef<HTMLDivElement>): ReactElement => {
   const { variant, children, noIcon, heading, rounded, dataTestid } = props;
   const variantClass = variant ? `usa-alert--${variant}` : "";
   const noIconClass = noIcon ? " usa-alert--no-icon" : "";
@@ -66,6 +66,8 @@ export const Alert = (props: Props): ReactElement => {
         AlertVariantsAriaMapping[props.variant]
       )}
       {...alertRole}
+      ref={ref}
+      tabIndex={-1}
     >
       <div className="usa-alert__body">
         {heading && (
@@ -77,4 +79,8 @@ export const Alert = (props: Props): ReactElement => {
       </div>
     </div>
   );
-};
+});
+
+Alert.displayName = "Alert";
+
+export { Alert };

--- a/web/src/components/tasks/business-structure/LegalStructureRadio.tsx
+++ b/web/src/components/tasks/business-structure/LegalStructureRadio.tsx
@@ -13,13 +13,13 @@ import { LegalStructure, LegalStructures, LookupLegalStructureById } from "@busi
 import { OperatingPhaseId } from "@businessnjgovnavigator/shared/";
 import { FormControl, FormControlLabel, Radio, RadioGroup } from "@mui/material";
 import { orderBy } from "lodash";
-import React, { ReactElement, useContext } from "react";
+import React, { ForwardedRef, forwardRef, ReactElement, useContext } from "react";
 
 interface Props {
   taskId: string;
 }
 
-export const LegalStructureRadio = (props: Props): ReactElement => {
+const LegalStructureRadio = forwardRef((props: Props, ref: ForwardedRef<HTMLDivElement>): ReactElement => {
   const { state, setProfileData } = useContext(ProfileDataContext);
   const { Config } = useConfig();
   const { queueUpdateTaskProgress } = useUpdateTaskProgress();
@@ -71,7 +71,7 @@ export const LegalStructureRadio = (props: Props): ReactElement => {
     <>
       {isFormFieldInvalid && (
         <div className={"padding-bottom-1"}>
-          <Alert variant="error" dataTestid="business-structure-alert">
+          <Alert variant="error" dataTestid="business-structure-alert" ref={ref}>
             {Config.businessStructurePrompt.businessStructureNotSelectedAlertText}
           </Alert>
         </div>
@@ -123,4 +123,8 @@ export const LegalStructureRadio = (props: Props): ReactElement => {
       </WithErrorBar>
     </>
   );
-};
+});
+
+LegalStructureRadio.displayName = "LegalStructureRadio";
+
+export { LegalStructureRadio };


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

basically we wanted screen readers getting errors on the business structure selection page to get refocused to the error at the top instead of just staying at the bottom of the page. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#187466951](https://www.pivotaltracker.com/story/show/187466951).

### Approach

Used the scroll to top and focus function I made early which is awesome

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Go to the business structure task with a new business. Turn on a screen reader, save without selecting and see that scrolls  to top and reads out information

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

This was a real weird story in some ways. 

I kinda had a set of weird decision to make in terms of functionality here. I ended up deciding to focus the error group because if I focus any content in the group itself it starts getting super verbose and redundant reading out the group and the error itself and it gets messy. 

I thought about making the error group not a group so that it would read cleaner which is still an option but kinda also feels a bit wrong? Idk

probably also need a bit of a content change to the naming of the error groups or perhaps a follow up to add a bit more content to the error group name here. 

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
