### PR TITLE
fix: [#188172536] add owningUser to v151 migration

### DIFF
--- a/api/src/db/DynamoUserDataClient.test.ts
+++ b/api/src/db/DynamoUserDataClient.test.ts
@@ -33,7 +33,7 @@ describe("DynamoUserDataClient", () => {
 
   it("should throw an error when attempting to retrieve a non-existent user by ID", async () => {
     const randomUserId = `user-id-${randomInt()}`;
-    await expect(dynamoUserDataClient.get(randomUserId)).rejects.toEqual(new Error("Not Found"));
+    await expect(dynamoUserDataClient.get(randomUserId)).rejects.toEqual(new Error("Not found"));
   });
 
   it("gets inserted items", async () => {

--- a/api/src/db/migrations/v150_remove_needs_nexus_dba_name.ts
+++ b/api/src/db/migrations/v150_remove_needs_nexus_dba_name.ts
@@ -117,7 +117,7 @@ export type v150CommunityAffairsAddress = {
   municipality: v150Municipality;
 };
 
-type v150BusinessUser = {
+export type v150BusinessUser = {
   name?: string;
   email: string;
   id: string;

--- a/api/src/db/migrations/v151_extract_business_data.test.ts
+++ b/api/src/db/migrations/v151_extract_business_data.test.ts
@@ -1,14 +1,17 @@
 import { generatev150UserData } from "@db/migrations/v150_remove_needs_nexus_dba_name";
 import { migrate_v150_to_v151 } from "@db/migrations/v151_extract_business_data";
 
-describe("v151 migration adds version field to businesses object", () => {
-  it("should upgrade v150 user by adding version field to businesses object", () => {
+describe("v151 migration adds version field and userId to businesses object", () => {
+  it("should upgrade v150 user by adding version field and userId field to businesses object", () => {
     const v150UserData = generatev150UserData({});
 
     const migratedUserData = migrate_v150_to_v151(v150UserData);
     expect(migratedUserData.version).toBe(151);
     for (const business of Object.values(migratedUserData.businesses)) {
       expect(business.version).toBe(151);
+
+      expect(business.userId).toBeDefined();
+      expect(typeof business.userId).toBe("string");
     }
   });
 });

--- a/api/src/db/migrations/v151_extract_business_data.ts
+++ b/api/src/db/migrations/v151_extract_business_data.ts
@@ -1,4 +1,8 @@
-import { v150Business, v150UserData } from "@db/migrations/v150_remove_needs_nexus_dba_name";
+import {
+  v150Business,
+  v150BusinessUser,
+  v150UserData,
+} from "@db/migrations/v150_remove_needs_nexus_dba_name";
 import { randomInt } from "@shared/intHelpers";
 
 export const migrate_v150_to_v151 = (v150Data: v150UserData): v151UserData => {
@@ -7,17 +11,21 @@ export const migrate_v150_to_v151 = (v150Data: v150UserData): v151UserData => {
     businesses: Object.fromEntries(
       Object.entries(v150Data.businesses).map(([id, business]) => [
         id,
-        migrate_v150Business_to_v151Business(business),
+        migrate_v150Business_to_v151Business(business, v150Data.user),
       ])
     ),
     version: 151,
   } as v151UserData;
 };
 
-export const migrate_v150Business_to_v151Business = (business: v150Business): v151Business => {
+export const migrate_v150Business_to_v151Business = (
+  business: v150Business,
+  user: v150BusinessUser
+): v151Business => {
   return {
     ...business,
     version: 151,
+    userId: user.id,
   } as v151Business;
 };
 
@@ -80,6 +88,7 @@ export interface v151Business {
   formationData: v151FormationData;
   environmentData: v151EnvironmentData | undefined;
   version: number;
+  userId: string;
 }
 
 export interface v151ProfileData extends v151IndustrySpecificData {
@@ -605,6 +614,7 @@ export const generatev151BusinessUser = (overrides: Partial<v151BusinessUser>): 
 
 export const generatev151Business = (overrides: Partial<v151Business>): v151Business => {
   const profileData = generatev151ProfileData({});
+  const user = generatev151BusinessUser({});
   return {
     id: `some-id-${randomInt()}`,
     dateCreatedISO: "",
@@ -623,6 +633,7 @@ export const generatev151Business = (overrides: Partial<v151Business>): v151Busi
     licenseData: undefined,
     taxFilingData: generatev151TaxFilingData({}),
     environmentData: undefined,
+    userId: user.id,
     ...overrides,
   };
 };


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
This change adds userId to the businessesObject to make querying easy in the future. 
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188172536](https://www.pivotaltracker.com/story/show/188172536).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
- updated the test for migration.
<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
