### PR TITLE
chore: [#188347470] new script to check for unused CMS roadmap task f…

### DIFF
--- a/content/scripts/find_unused_tasks.py
+++ b/content/scripts/find_unused_tasks.py
@@ -1,0 +1,85 @@
+import os
+import json
+
+
+def find_unused_task_files(root: str, directories: list[str]) -> None:
+    task_names = get_all_tasks_in_roadmaps(root, directories)
+    filenames = get_all_task_markdown_filenames(root)
+
+    task_names_not_in_filenames = find_task_names_not_in_filenames(
+        task_names, filenames
+    )
+    print(
+        f"Markdown files not in any roadmap: \n{list_to_output_str(task_names_not_in_filenames)}"
+    )
+    return
+
+
+def find_task_names_not_in_filenames(
+    tasks_in_roadmap: set[str], filenames: list[str]
+) -> list[str]:
+    for task in tasks_in_roadmap:
+        try:
+            filenames.remove(task)
+        except ValueError:
+            print(f"No matching markdown file for task: {task}")
+    return filenames
+
+
+def list_to_output_str(filenames: list[str]) -> str:
+    output = ""
+    for filename in filenames:
+        output += f"{filename}\n"
+    return output
+
+
+def get_all_tasks_in_roadmaps(root: str, directories: list[str]) -> set[str]:
+    tasks: set[str] = set()
+    for directory in directories:
+        dir_path = os.path.join(root, directory)
+        filenames = os.listdir(dir_path)
+        for filename in filenames:
+            full_path = os.path.join(dir_path, filename)
+            tasks = tasks.union(get_task_names_from_roadmap_file(full_path))
+    if "" in tasks:
+        tasks.remove("")
+    return tasks
+
+
+def get_task_names_from_roadmap_file(file_path: str) -> set[str]:
+    with open(file_path) as file:
+        roadmap_config = json.load(file)
+
+        task_names: set[str] = set()
+
+        if "roadmapSteps" in roadmap_config:
+            roadmap_steps = roadmap_config["roadmapSteps"]
+
+            task_names.update(
+              # reminder that curly braces are the syntax for set literals in Python when no keys are included
+                {step["task"] for step in roadmap_steps if "task" in step},
+                {
+                    step["licenseTask"]
+                    for step in roadmap_steps
+                    if "licenseTask" in step
+                },
+            )
+
+        if "modifications" in roadmap_config:
+            modifications = roadmap_config["modifications"]
+            task_names.update(
+                {modification["replaceWithFilename"] for modification in modifications}
+            )
+
+        return task_names
+
+
+def get_all_task_markdown_filenames(root: str) -> list[str]:
+    filenames: list[str] = []
+    for _, _, files in os.walk(root):
+        filenames.extend(file[:-3] for file in files if file.endswith(".md"))
+    return filenames
+
+
+if __name__ == "__main__":
+    find_unused_task_files(root="../src/roadmaps", directories=["add-ons", "industries"])

--- a/content/scripts/test_find_unused_tasks.py
+++ b/content/scripts/test_find_unused_tasks.py
@@ -1,0 +1,125 @@
+import unittest
+import os
+import tempfile
+import json
+from find_unused_tasks import (
+    find_unused_task_files,
+)
+
+
+class TestFindUnusedTaskFiles(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary directory for test files
+        self.temp_dir = tempfile.mkdtemp()
+        self.roadmap_content = {
+            "roadmapSteps": [
+                {"task": "task1"},
+                {"licenseTask": "license1"},
+                {"task": "task2"},
+            ],
+            "modifications": [{"replaceWithFilename": "mod1"}],
+        }
+
+    def tearDown(self):
+        # Clean up temporary files
+        for root, dirs, files in os.walk(self.temp_dir, topdown=False):
+            for name in files:
+                os.remove(os.path.join(root, name))
+            for name in dirs:
+                os.rmdir(os.path.join(root, name))
+        os.rmdir(self.temp_dir)
+
+    def create_test_roadmap_file(self, directory: str, filename: str):
+        dir_path = os.path.join(self.temp_dir, directory)
+        os.makedirs(dir_path, exist_ok=True)
+        file_path = os.path.join(dir_path, filename)
+        with open(file_path, "w") as f:
+            json.dump(self.roadmap_content, f)
+        return file_path
+
+    def create_test_markdown_file(self, filename: str):
+        file_path = os.path.join(self.temp_dir, f"{filename}.md")
+        with open(file_path, "w") as f:
+            f.write("Test content")
+
+    def test_find_unused_task_files_basic(self):
+        """Test finding unused task files in a simple scenario"""
+        # Create test directory structure and files
+        roadmap_dir = "roadmaps"
+        self.create_test_roadmap_file(roadmap_dir, "roadmap1.json")
+
+        # Create markdown files (both used and unused)
+        self.create_test_markdown_file("task1")
+        self.create_test_markdown_file("task2")
+        self.create_test_markdown_file("unused_task")
+        self.create_test_markdown_file("another_unused")
+
+        # Capture stdout to verify output
+        import io
+        import sys
+
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+
+        # Execute the function with full path
+        find_unused_task_files(os.path.join(self.temp_dir), [roadmap_dir])
+
+        # Restore stdout
+        sys.stdout = sys.__stdout__
+        output = captured_output.getvalue()
+
+        # Verify output contains unused files and doesn't contain used files
+        self.assertIn("unused_task", output)
+        self.assertIn("another_unused", output)
+        self.assertNotIn("task1", output)
+        self.assertNotIn("task2", output)
+
+    def test_find_unused_task_files_empty_directory(self):
+        """Test behavior with empty directories"""
+        # Create empty directory
+        os.makedirs(os.path.join(self.temp_dir, "roadmaps"))
+
+        # Capture stdout
+        import io
+        import sys
+
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+
+        # Execute the function with full path
+        find_unused_task_files(os.path.join(self.temp_dir), ["roadmaps"])
+
+        # Restore stdout
+        sys.stdout = sys.__stdout__
+        output = captured_output.getvalue()
+
+        # Verify output is empty or contains appropriate message
+        self.assertEqual(output.strip(), "Markdown files not in any roadmap:")
+
+    def test_find_unused_task_files_no_markdown(self):
+        """Test behavior when there are roadmaps but no markdown files"""
+        # Create roadmap file but no markdown files
+        self.create_test_roadmap_file("roadmaps", "roadmap1.json")
+
+        # Capture stdout
+        import io
+        import sys
+
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+
+        # Execute the function with full path
+        find_unused_task_files(os.path.join(self.temp_dir), ["roadmaps"])
+
+        # Restore stdout
+        sys.stdout = sys.__stdout__
+        output = captured_output.getvalue()
+
+        # Verify output indicates no unused files
+        self.assertTrue(
+            output.strip().endswith("Markdown files not in any roadmap:"), True
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yarn.lock
+++ b/yarn.lock
@@ -7445,15 +7445,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/eslint-plugin-next@npm:15.1.4":
-  version: 15.1.4
-  resolution: "@next/eslint-plugin-next@npm:15.1.4"
-  dependencies:
-    fast-glob: 3.3.1
-  checksum: f09cfb50cf26672df5cbeac9594ff4ce2196eeb3a3192f7f53b2b88770d7e40c5bd4a39e4129a7cae5d623d65c7f5f4d1580ba289a2922438073bae7326cae40
-  languageName: node
-  linkType: hard
-
 "@next/swc-darwin-arm64@npm:15.1.4":
   version: 15.1.4
   resolution: "@next/swc-darwin-arm64@npm:15.1.4"


### PR DESCRIPTION
…iles

<!-- Please complete the following sections as necessary. -->

## Description

This Python script checks for any unused CMS roadmap task markdown files in the content folder for the purpose of bringing the list to content so they may confirm and remove unused files. Specifically, this script checks for any markdown files for tasks, then checks them against all tasks mentioned in roadmap files.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188347470](https://www.pivotaltracker.com/story/show/188347470).

### Steps to Test

run `python ./content/scripts/find_unused_tasks.py` and `yarn test:python`

### Notes

With the end of dev sprint coming up, I didn't get around to confirming whether or not a file with common utilities for this scripts would be helpful. Something worth noting for the future. There's probably a decent amount of duplication around traversing the filesystem between scripts.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
