### PR TITLE
fix: [#187166104] add dependency for cypress accessibility feat

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "body-parser": "1.20.3",
     "broken-link-checker": "0.7.8",
     "cors": "2.8.5",
+    "cypress-axe": "1.5.0",
     "dayjs": "1.11.13",
     "decap-cms-app": "3.4.0",
     "dedent": "1.5.3",

--- a/web/package.json
+++ b/web/package.json
@@ -63,6 +63,7 @@
     "@types/mdast": "4.0.4",
     "axios": "1.7.9",
     "broken-link-checker": "0.7.8",
+    "cypress-axe": "1.5.0",
     "dayjs": "1.11.13",
     "decap-cms-app": "3.4.0",
     "fast-deep-equal": "3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4418,6 +4418,7 @@ __metadata:
     cspell: 8.17.1
     css-loader: 6.11.0
     cypress: 13.17.0
+    cypress-axe: 1.5.0
     cypress-dotenv: 2.0.2
     cypress-wait-until: 3.0.2
     dayjs: 1.11.13
@@ -4617,6 +4618,7 @@ __metadata:
     cspell: 8.17.1
     css-loader: 6.11.0
     cypress: 13.17.0
+    cypress-axe: 1.5.0
     cypress-dotenv: 2.0.2
     cypress-wait-until: 3.0.2
     dayjs: 1.11.13
@@ -17213,6 +17215,16 @@ __metadata:
   version: 3.1.3
   resolution: "csstype@npm:3.1.3"
   checksum: 8db785cc92d259102725b3c694ec0c823f5619a84741b5c7991b8ad135dfaa66093038a1cc63e03361a6cd28d122be48f2106ae72334e067dd619a51f49eddf7
+  languageName: node
+  linkType: hard
+
+"cypress-axe@npm:1.5.0":
+  version: 1.5.0
+  resolution: "cypress-axe@npm:1.5.0"
+  peerDependencies:
+    axe-core: ^3 || ^4
+    cypress: ^10 || ^11 || ^12 || ^13
+  checksum: 7b5574da4ea2c1a1141f79cb4465a4f30879e30b9ac08da4aca935dfc7662d3fa170254be8c4eff26841bc065e6115bf6e6b8a8eee5ff7cb9812bbcbeb863ff2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
This ticket resolves a missing dependency related that brings in the missing properties `checkA11y` and `injectAxe`. 
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#187166104](https://www.pivotaltracker.com/story/show/187166104).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
