### PR TITLE
feat: [#188789999] tax pin field in profile for everyone

### DIFF
--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -457,6 +457,10 @@ const ProfilePage = (props: Props): ReactElement => {
             </div>
           )}
         </ProfileField>
+
+        <ProfileField fieldName="taxPin">
+          <TaxPin handleChangeOverride={showNeedsAccountModalForGuest()} />
+        </ProfileField>
       </>
     ),
   };
@@ -504,6 +508,10 @@ const ProfilePage = (props: Props): ReactElement => {
               <TaxId handleChangeOverride={showNeedsAccountModalForGuest()} />
             )}
           </div>
+        </ProfileField>
+
+        <ProfileField fieldName="taxPin">
+          <TaxPin handleChangeOverride={showNeedsAccountModalForGuest()} />
         </ProfileField>
       </>
     ),
@@ -701,6 +709,10 @@ const ProfilePage = (props: Props): ReactElement => {
               <TaxId handleChangeOverride={showNeedsAccountModalForGuest()} />
             )}
           </div>
+        </ProfileField>
+
+        <ProfileField fieldName="taxPin">
+          <TaxPin handleChangeOverride={showNeedsAccountModalForGuest()} />
         </ProfileField>
       </>
     ),

--- a/web/test/pages/profile/profile-foreign.test.tsx
+++ b/web/test/pages/profile/profile-foreign.test.tsx
@@ -11,6 +11,7 @@ import {
   defaultDateFormat,
   emptyAddressData,
   emptyIndustrySpecificData,
+  ForeignBusinessTypeId,
   FormationData,
   generateFormationFormData,
   generateMunicipality,
@@ -30,6 +31,7 @@ import {
 import { useMockRoadmap } from "@/test/mock/mockUseRoadmap";
 import { industryIdsWithSingleRequiredEssentialQuestion } from "@/test/pages/onboarding/helpers-onboarding";
 import {
+  chooseTab,
   clickBack,
   clickSave,
   expectLocationNotSavedAndError,
@@ -211,6 +213,12 @@ describe("profile-foreign", () => {
       expect(
         screen.getByText(Config.profileDefaults.fields.nexusBusinessName.default.outOfStateNameHeader)
       ).toBeInTheDocument();
+    });
+
+    it("displays the tax pin field", () => {
+      renderPage({ business: nexusForeignBusinessProfile({}) });
+      chooseTab("numbers");
+      expect(screen.getByText(Config.profileDefaults.fields.taxPin.default.header)).toBeInTheDocument();
     });
 
     it("displays Not Entered when the user hasn't entered a business name yet", () => {
@@ -549,32 +557,37 @@ describe("profile-foreign", () => {
     });
   });
 
-  describe("Remote Worker", () => {
-    const foreignRemoteWorkerProfile = generateBusinessForProfile({
-      profileData: generateProfileData({
-        businessPersona: "FOREIGN",
-        foreignBusinessTypeIds: ["employeesInNJ"],
-      }),
-    });
+  describe("Remote Worker and Seller", () => {
+    it.each(["employeesInNJ", "revenueInNJ", "transactionsInNJ"])(
+      "renders the business name field for %s",
+      (foreignBusinessTypeId) => {
+        renderPage({
+          business: generateBusinessForProfile({
+            profileData: generateProfileData({
+              businessPersona: "FOREIGN",
+              foreignBusinessTypeIds: [foreignBusinessTypeId as ForeignBusinessTypeId],
+            }),
+          }),
+        });
+        expect(screen.getByTestId("businessName")).toBeInTheDocument();
+      }
+    );
 
-    it("renders the business name field for remote worker", () => {
-      renderPage({ business: foreignRemoteWorkerProfile });
-      expect(screen.getByTestId("businessName")).toBeInTheDocument();
-    });
-  });
-
-  describe("Remote Seller", () => {
-    const foreignRemoteSellerProfile = generateBusinessForProfile({
-      profileData: generateProfileData({
-        businessPersona: "FOREIGN",
-        foreignBusinessTypeIds: ["revenueInNJ", "transactionsInNJ"],
-      }),
-    });
-
-    it("renders the business name field for remote seller", () => {
-      renderPage({ business: foreignRemoteSellerProfile });
-      expect(screen.getByTestId("businessName")).toBeInTheDocument();
-    });
+    it.each(["employeesInNJ", "revenueInNJ", "transactionsInNJ"])(
+      "renders the tax pin field for %s",
+      (foreignBusinessTypeId) => {
+        renderPage({
+          business: generateBusinessForProfile({
+            profileData: generateProfileData({
+              businessPersona: "FOREIGN",
+              foreignBusinessTypeIds: [foreignBusinessTypeId as ForeignBusinessTypeId],
+            }),
+          }),
+        });
+        chooseTab("numbers");
+        expect(screen.getByText(Config.profileDefaults.fields.taxPin.default.header)).toBeInTheDocument();
+      }
+    );
   });
 
   describe("non essential questions", () => {

--- a/web/test/pages/profile/profile-shared.test.tsx
+++ b/web/test/pages/profile/profile-shared.test.tsx
@@ -389,6 +389,23 @@ describe("profile - shared", () => {
         });
       });
     });
+
+    describe("tax pin", () => {
+      it.each(["STARTING", "OWNING"])(
+        "displays the tax pin field for %s businessPersona",
+        (businessPersona) => {
+          renderPage({
+            business: generateBusinessForProfile({
+              profileData: generateProfileData({
+                businessPersona: businessPersona as BusinessPersona,
+              }),
+            }),
+          });
+          chooseTab("numbers");
+          expect(screen.getByText(Config.profileDefaults.fields.taxPin.default.header)).toBeInTheDocument();
+        }
+      );
+    });
   });
 
   describe("profile opportunities alert", () => {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
This feature adds the tax PIN profile field for all business personas, along with tests to validate the logic.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188789999](https://www.pivotaltracker.com/story/show/#188789999).

### Notes

<!-- Additional information, key learnings, and future development considerations. -->
Prior to this implementation, the tax PIN field already rendered for the `OSCAR` persona.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
