### PR TITLE
feat: [#188666282] add new onboarding page for fundings

### DIFF
--- a/api/src/client/ApiFormationHealth.ts
+++ b/api/src/client/ApiFormationHealth.ts
@@ -39,6 +39,7 @@ export const ApiFormationHealth: UserData = {
         isCalendarFullView: true,
         isHideableRoadmapOpen: true,
         phaseNewlyChanged: false,
+        isNonProfitFromFunding: false,
       },
       taxFilingData: {
         filings: [
@@ -105,6 +106,7 @@ export const ApiFormationHealth: UserData = {
         hasThreeOrMoreRentalUnits: undefined,
         travelingCircusOrCarnivalOwningBusiness: undefined,
         vacantPropertyOwner: undefined,
+        businessOpenMoreThanTwoYears: undefined,
       },
       formationData: {
         formationResponse: undefined,

--- a/api/src/db/migrations/migrations.ts
+++ b/api/src/db/migrations/migrations.ts
@@ -153,6 +153,7 @@ import { migrate_v149_to_v150 } from "@db/migrations/v150_remove_needs_nexus_dba
 import { migrate_v150_to_v151 } from "@db/migrations/v151_extract_business_data";
 import { migrate_v151_to_v152 } from "@db/migrations/v152_add_land_to_environment_data";
 import { migrate_v152_to_v153 } from "@db/migrations/v153_add_air_to_environment_data";
+import { migrate_v153_to_v154 } from "@db/migrations/v154_add_business_operating_length_and_nonprofit_status";
 
 export type MigrationFunction = (data: any) => any;
 
@@ -310,6 +311,7 @@ export const Migrations: MigrationFunction[] = [
   migrate_v150_to_v151,
   migrate_v151_to_v152,
   migrate_v152_to_v153,
+  migrate_v153_to_v154,
 ];
 
-export { generatev153UserData as CURRENT_GENERATOR } from "@db/migrations/v153_add_air_to_environment_data";
+export { generatev154UserData as CURRENT_GENERATOR } from "@db/migrations/v154_add_business_operating_length_and_nonprofit_status";

--- a/api/src/db/migrations/v154_add_business_operating_length_and_nonprofit_status.ts
+++ b/api/src/db/migrations/v154_add_business_operating_length_and_nonprofit_status.ts
@@ -1,0 +1,921 @@
+import { v153Business, v153UserData } from "@db/migrations/v153_add_air_to_environment_data";
+import { randomInt } from "@shared/intHelpers";
+
+export const migrate_v153_to_v154 = (v153Data: v153UserData): v154UserData => {
+  return {
+    ...v153Data,
+    businesses: Object.fromEntries(
+      Object.values(v153Data.businesses)
+        .map((business: v153Business) => migrate_v153Business_to_v154Business(business))
+        .map((currBusiness: v154Business) => [currBusiness.id, currBusiness])
+    ),
+    version: 154,
+  } as v154UserData;
+};
+
+export const migrate_v153Business_to_v154Business = (business: v153Business): v154Business => {
+  return {
+    ...business,
+    profileData: {
+      ...business.profileData,
+      businessOpenMoreThanTwoYears: undefined,
+    },
+    preferences: {
+      ...business.preferences,
+      isNonProfitFromFunding: undefined,
+    },
+  } as v154Business;
+};
+
+export interface v154IndustrySpecificData {
+  liquorLicense: boolean;
+  requiresCpa: boolean;
+  homeBasedBusiness: boolean | undefined;
+  providesStaffingService: boolean;
+  certifiedInteriorDesigner: boolean;
+  realEstateAppraisalManagement: boolean;
+  cannabisLicenseType: v154CannabisLicenseType;
+  cannabisMicrobusiness: boolean | undefined;
+  constructionRenovationPlan: boolean | undefined;
+  carService: v154CarServiceType | undefined;
+  interstateTransport: boolean;
+  interstateLogistics: boolean | undefined;
+  interstateMoving: boolean | undefined;
+  isChildcareForSixOrMore: boolean | undefined;
+  petCareHousing: boolean | undefined;
+  willSellPetCareItems: boolean | undefined;
+  constructionType: v154ConstructionType;
+  residentialConstructionType: v154ResidentialConstructionType;
+  employmentPersonnelServiceType: v154EmploymentAndPersonnelServicesType;
+  employmentPlacementType: v154EmploymentPlacementType;
+  carnivalRideOwningBusiness: boolean | undefined;
+  propertyLeaseType: v154PropertyLeaseType;
+  hasThreeOrMoreRentalUnits: boolean | undefined;
+  travelingCircusOrCarnivalOwningBusiness: boolean | undefined;
+  vacantPropertyOwner: boolean | undefined;
+}
+
+export type v154PropertyLeaseType = "SHORT_TERM_RENTAL" | "LONG_TERM_RENTAL" | "BOTH" | undefined;
+
+// ---------------- v154 types ----------------
+type v154TaskProgress = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+type v154OnboardingFormProgress = "UNSTARTED" | "COMPLETED";
+type v154ABExperience = "ExperienceA" | "ExperienceB";
+
+export interface v154UserData {
+  user: v154BusinessUser;
+  version: number;
+  lastUpdatedISO: string;
+  dateCreatedISO: string;
+  versionWhenCreated: number;
+  businesses: Record<string, v154Business>;
+  currentBusinessId: string;
+}
+
+export interface v154Business {
+  id: string;
+  dateCreatedISO: string;
+  lastUpdatedISO: string;
+  profileData: v154ProfileData;
+  onboardingFormProgress: v154OnboardingFormProgress;
+  taskProgress: Record<string, v154TaskProgress>;
+  taskItemChecklist: Record<string, boolean>;
+  licenseData: v154LicenseData | undefined;
+  preferences: v154Preferences;
+  taxFilingData: v154TaxFilingData;
+  formationData: v154FormationData;
+  environmentData: v154EnvironmentData | undefined;
+}
+
+export interface v154ProfileData extends v154IndustrySpecificData {
+  businessPersona: v154BusinessPersona;
+  businessName: string;
+  responsibleOwnerName: string;
+  tradeName: string;
+  industryId: string | undefined;
+  legalStructureId: string | undefined;
+  municipality: v154Municipality | undefined;
+  dateOfFormation: string | undefined;
+  entityId: string | undefined;
+  employerId: string | undefined;
+  taxId: string | undefined;
+  encryptedTaxId: string | undefined;
+  notes: string;
+  documents: v154ProfileDocuments;
+  ownershipTypeIds: string[];
+  existingEmployees: string | undefined;
+  taxPin: string | undefined;
+  sectorId: string | undefined;
+  naicsCode: string;
+  foreignBusinessTypeIds: v154ForeignBusinessTypeId[];
+  nexusDbaName: string;
+  operatingPhase: v154OperatingPhase;
+  nonEssentialRadioAnswers: Record<string, boolean | undefined>;
+  elevatorOwningBusiness: boolean | undefined;
+  communityAffairsAddress?: v154CommunityAffairsAddress;
+  plannedRenovationQuestion: boolean | undefined;
+  raffleBingoGames: boolean | undefined;
+  businessOpenMoreThanTwoYears: boolean | undefined;
+}
+
+export type v154CommunityAffairsAddress = {
+  streetAddress1: string;
+  streetAddress2?: string;
+  municipality: v154Municipality;
+};
+
+type v154BusinessUser = {
+  name?: string;
+  email: string;
+  id: string;
+  receiveNewsletter: boolean;
+  userTesting: boolean;
+  externalStatus: v154ExternalStatus;
+  myNJUserKey?: string;
+  intercomHash?: string;
+  abExperience: v154ABExperience;
+  accountCreationSource: string;
+  contactSharingWithAccountCreationPartner: boolean;
+};
+
+interface v154ProfileDocuments {
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+}
+
+type v154BusinessPersona = "STARTING" | "OWNING" | "FOREIGN" | undefined;
+type v154OperatingPhase =
+  | "GUEST_MODE"
+  | "NEEDS_TO_FORM"
+  | "NEEDS_BUSINESS_STRUCTURE"
+  | "FORMED"
+  | "UP_AND_RUNNING"
+  | "UP_AND_RUNNING_OWNING"
+  | "REMOTE_SELLER_WORKER"
+  | undefined;
+
+export type v154CannabisLicenseType = "CONDITIONAL" | "ANNUAL" | undefined;
+export type v154CarServiceType = "STANDARD" | "HIGH_CAPACITY" | "BOTH" | undefined;
+export type v154ConstructionType = "RESIDENTIAL" | "COMMERCIAL_OR_INDUSTRIAL" | "BOTH" | undefined;
+export type v154ResidentialConstructionType =
+  | "NEW_HOME_CONSTRUCTION"
+  | "HOME_RENOVATIONS"
+  | "BOTH"
+  | undefined;
+export type v154EmploymentAndPersonnelServicesType = "JOB_SEEKERS" | "EMPLOYERS" | undefined;
+export type v154EmploymentPlacementType = "TEMPORARY" | "PERMANENT" | "BOTH" | undefined;
+
+type v154ForeignBusinessTypeId =
+  | "employeeOrContractorInNJ"
+  | "officeInNJ"
+  | "propertyInNJ"
+  | "companyOperatedVehiclesInNJ"
+  | "employeesInNJ"
+  | "revenueInNJ"
+  | "transactionsInNJ"
+  | "none";
+
+type v154Municipality = {
+  name: string;
+  displayName: string;
+  county: string;
+  id: string;
+};
+
+type v154TaxFilingState = "SUCCESS" | "FAILED" | "UNREGISTERED" | "PENDING" | "API_ERROR";
+type v154TaxFilingErrorFields = "businessName" | "formFailure";
+
+type v154TaxFilingData = {
+  state?: v154TaxFilingState;
+  lastUpdatedISO?: string;
+  registeredISO?: string;
+  errorField?: v154TaxFilingErrorFields;
+  businessName?: string;
+  filings: v154TaxFilingCalendarEvent[];
+};
+
+export type v154CalendarEvent = {
+  readonly dueDate: string; // YYYY-MM-DD
+  readonly calendarEventType: "TAX-FILING" | "LICENSE";
+};
+
+export interface v154TaxFilingCalendarEvent extends v154CalendarEvent {
+  readonly identifier: string;
+  readonly calendarEventType: "TAX-FILING";
+}
+
+export type v154LicenseSearchAddress = {
+  addressLine1: string;
+  addressLine2: string;
+  zipCode: string;
+};
+
+export interface v154LicenseSearchNameAndAddress extends v154LicenseSearchAddress {
+  name: string;
+}
+
+type v154LicenseDetails = {
+  nameAndAddress: v154LicenseSearchNameAndAddress;
+  licenseStatus: v154LicenseStatus;
+  expirationDateISO: string | undefined;
+  lastUpdatedISO: string;
+  checklistItems: v154LicenseStatusItem[];
+};
+
+const v154taskIdLicenseNameMapping = {
+  "apply-for-shop-license": "Cosmetology and Hairstyling-Shop",
+  "appraiser-license": "Real Estate Appraisers-Appraisal Management Company",
+  "architect-license": "Architecture-Certificate of Authorization",
+  "health-club-registration": "Health Club Services",
+  "home-health-aide-license": "Health Care Services",
+  "hvac-license": "HVACR-HVACR CE Sponsor",
+  "landscape-architect-license": "Landscape Architecture-Certificate of Authorization",
+  "license-massage-therapy": "Massage and Bodywork Therapy-Massage and Bodywork Employer",
+  "moving-company-license": "Public Movers and Warehousemen-Public Mover and Warehouseman",
+  "pharmacy-license": "Pharmacy-Pharmacy",
+  "public-accountant-license": "Accountancy-Firm Registration",
+  "register-accounting-firm": "Accountancy-Firm Registration",
+  "register-consumer-affairs": "Home Improvement Contractors-Home Improvement Contractor",
+  "ticket-broker-reseller-registration": "Ticket Brokers",
+  "telemarketing-license": "Telemarketers",
+} as const;
+
+type v154LicenseTaskID = keyof typeof v154taskIdLicenseNameMapping;
+
+export type v154LicenseName = (typeof v154taskIdLicenseNameMapping)[v154LicenseTaskID];
+
+type v154Licenses = Partial<Record<v154LicenseName, v154LicenseDetails>>;
+
+type v154LicenseData = {
+  lastUpdatedISO: string;
+  licenses?: v154Licenses;
+};
+
+type v154Preferences = {
+  roadmapOpenSections: v154SectionType[];
+  roadmapOpenSteps: number[];
+  hiddenFundingIds: string[];
+  hiddenCertificationIds: string[];
+  visibleSidebarCards: string[];
+  isCalendarFullView: boolean;
+  returnToLink: string;
+  isHideableRoadmapOpen: boolean;
+  phaseNewlyChanged: boolean;
+  isNonProfitFromFunding?: boolean;
+};
+
+type v154LicenseStatusItem = {
+  title: string;
+  status: v154CheckoffStatus;
+};
+
+type v154CheckoffStatus = "ACTIVE" | "PENDING" | "UNKNOWN";
+
+type v154LicenseStatus =
+  | "ACTIVE"
+  | "PENDING"
+  | "UNKNOWN"
+  | "EXPIRED"
+  | "BARRED"
+  | "OUT_OF_BUSINESS"
+  | "REINSTATEMENT_PENDING"
+  | "CLOSED"
+  | "DELETED"
+  | "DENIED"
+  | "VOLUNTARY_SURRENDER"
+  | "WITHDRAWN";
+
+const v154LicenseStatuses: v154LicenseStatus[] = [
+  "ACTIVE",
+  "PENDING",
+  "UNKNOWN",
+  "EXPIRED",
+  "BARRED",
+  "OUT_OF_BUSINESS",
+  "REINSTATEMENT_PENDING",
+  "CLOSED",
+  "DELETED",
+  "DENIED",
+  "VOLUNTARY_SURRENDER",
+  "WITHDRAWN",
+];
+
+const v154SectionNames = ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"] as const;
+type v154SectionType = (typeof v154SectionNames)[number];
+
+type v154ExternalStatus = {
+  newsletter?: v154NewsletterResponse;
+  userTesting?: v154UserTestingResponse;
+};
+
+interface v154NewsletterResponse {
+  success?: boolean;
+  status: v154NewsletterStatus;
+}
+
+interface v154UserTestingResponse {
+  success?: boolean;
+  status: v154UserTestingStatus;
+}
+
+type v154NewsletterStatus = (typeof newsletterStatusList)[number];
+
+const externalStatusList = ["SUCCESS", "IN_PROGRESS", "CONNECTION_ERROR"] as const;
+
+const userTestingStatusList = [...externalStatusList] as const;
+
+type v154UserTestingStatus = (typeof userTestingStatusList)[number];
+
+const newsletterStatusList = [
+  ...externalStatusList,
+  "EMAIL_ERROR",
+  "TOPIC_ERROR",
+  "RESPONSE_WARNING",
+  "RESPONSE_ERROR",
+  "RESPONSE_FAIL",
+  "QUESTION_WARNING",
+] as const;
+
+type v154NameAvailabilityStatus =
+  | "AVAILABLE"
+  | "DESIGNATOR_ERROR"
+  | "SPECIAL_CHARACTER_ERROR"
+  | "UNAVAILABLE"
+  | "RESTRICTED_ERROR"
+  | undefined;
+
+interface v154NameAvailabilityResponse {
+  status: v154NameAvailabilityStatus;
+  similarNames: string[];
+  invalidWord?: string;
+}
+
+interface v154NameAvailability extends v154NameAvailabilityResponse {
+  lastUpdatedTimeStamp: string;
+}
+
+interface v154FormationData {
+  formationFormData: v154FormationFormData;
+  businessNameAvailability: v154NameAvailability | undefined;
+  dbaBusinessNameAvailability: v154NameAvailability | undefined;
+  formationResponse: v154FormationSubmitResponse | undefined;
+  getFilingResponse: v154GetFilingResponse | undefined;
+  completedFilingPayment: boolean;
+  lastVisitedPageIndex: number;
+}
+
+type v154InFormInBylaws = "IN_BYLAWS" | "IN_FORM" | undefined;
+
+interface v154FormationFormData extends v154FormationAddress {
+  readonly businessName: string;
+  readonly businessSuffix: v154BusinessSuffix | undefined;
+  readonly businessTotalStock: string;
+  readonly businessStartDate: string; // YYYY-MM-DD
+  readonly businessPurpose: string;
+  readonly withdrawals: string;
+  readonly combinedInvestment: string;
+  readonly dissolution: string;
+  readonly canCreateLimitedPartner: boolean | undefined;
+  readonly createLimitedPartnerTerms: string;
+  readonly canGetDistribution: boolean | undefined;
+  readonly getDistributionTerms: string;
+  readonly canMakeDistribution: boolean | undefined;
+  readonly makeDistributionTerms: string;
+  readonly hasNonprofitBoardMembers: boolean | undefined;
+  readonly nonprofitBoardMemberQualificationsSpecified: v154InFormInBylaws;
+  readonly nonprofitBoardMemberQualificationsTerms: string;
+  readonly nonprofitBoardMemberRightsSpecified: v154InFormInBylaws;
+  readonly nonprofitBoardMemberRightsTerms: string;
+  readonly nonprofitTrusteesMethodSpecified: v154InFormInBylaws;
+  readonly nonprofitTrusteesMethodTerms: string;
+  readonly nonprofitAssetDistributionSpecified: v154InFormInBylaws;
+  readonly nonprofitAssetDistributionTerms: string;
+  readonly additionalProvisions: string[] | undefined;
+  readonly agentNumberOrManual: "NUMBER" | "MANUAL_ENTRY";
+  readonly agentNumber: string;
+  readonly agentName: string;
+  readonly agentEmail: string;
+  readonly agentOfficeAddressLine1: string;
+  readonly agentOfficeAddressLine2: string;
+  readonly agentOfficeAddressCity: string;
+  readonly agentOfficeAddressZipCode: string;
+  readonly agentUseAccountInfo: boolean;
+  readonly agentUseBusinessAddress: boolean;
+  readonly members: v154FormationMember[] | undefined;
+  readonly incorporators: v154FormationIncorporator[] | undefined;
+  readonly signers: v154FormationSigner[] | undefined;
+  readonly paymentType: v154PaymentType;
+  readonly annualReportNotification: boolean;
+  readonly corpWatchNotification: boolean;
+  readonly officialFormationDocument: boolean;
+  readonly certificateOfStanding: boolean;
+  readonly certifiedCopyOfFormationDocument: boolean;
+  readonly contactFirstName: string;
+  readonly contactLastName: string;
+  readonly contactPhoneNumber: string;
+  readonly foreignStateOfFormation: v154StateObject | undefined;
+  readonly foreignDateOfFormation: string | undefined; // YYYY-MM-DD
+  readonly foreignGoodStandingFile: v154ForeignGoodStandingFileObject | undefined;
+  readonly legalType: string;
+  readonly willPracticeLaw: boolean | undefined;
+  readonly isVeteranNonprofit: boolean | undefined;
+}
+
+type v154ForeignGoodStandingFileObject = {
+  Extension: "PDF" | "PNG";
+  Content: string;
+};
+
+type v154StateObject = {
+  shortCode: string;
+  name: string;
+};
+
+interface v154FormationAddress {
+  readonly addressLine1: string;
+  readonly addressLine2: string;
+  readonly addressCity?: string;
+  readonly addressState?: v154StateObject;
+  readonly addressMunicipality?: v154Municipality;
+  readonly addressProvince?: string;
+  readonly addressZipCode: string;
+  readonly addressCountry: string;
+  readonly businessLocationType: v154FormationBusinessLocationType | undefined;
+}
+
+type v154FormationBusinessLocationType = "US" | "INTL" | "NJ";
+
+type v154SignerTitle =
+  | "Authorized Representative"
+  | "Authorized Partner"
+  | "Incorporator"
+  | "General Partner"
+  | "President"
+  | "Vice-President"
+  | "Chairman of the Board"
+  | "CEO";
+
+interface v154FormationSigner {
+  readonly name: string;
+  readonly signature: boolean;
+  readonly title: v154SignerTitle;
+}
+
+interface v154FormationIncorporator extends v154FormationSigner, v154FormationAddress {}
+
+interface v154FormationMember extends v154FormationAddress {
+  readonly name: string;
+}
+
+type v154PaymentType = "CC" | "ACH" | undefined;
+
+const llcBusinessSuffix = [
+  "LLC",
+  "L.L.C.",
+  "LTD LIABILITY CO",
+  "LTD LIABILITY CO.",
+  "LTD LIABILITY COMPANY",
+  "LIMITED LIABILITY CO",
+  "LIMITED LIABILITY CO.",
+  "LIMITED LIABILITY COMPANY",
+] as const;
+
+const llpBusinessSuffix = [
+  "Limited Liability Partnership",
+  "LLP",
+  "L.L.P.",
+  "Registered Limited Liability Partnership",
+  "RLLP",
+  "R.L.L.P.",
+] as const;
+
+export const lpBusinessSuffix = ["LIMITED PARTNERSHIP", "LP", "L.P."] as const;
+
+const corpBusinessSuffix = [
+  "Corporation",
+  "Incorporated",
+  "Company",
+  "LTD",
+  "CO",
+  "CO.",
+  "CORP",
+  "CORP.",
+  "INC",
+  "INC.",
+] as const;
+
+export const nonprofitBusinessSuffix = [
+  "A NJ NONPROFIT CORPORATION",
+  "CORPORATION",
+  "INCORPORATED",
+  "CORP",
+  "CORP.",
+  "INC",
+  "INC.",
+] as const;
+
+const foreignCorpBusinessSuffix = [...corpBusinessSuffix, "P.C.", "P.A."] as const;
+
+export const AllBusinessSuffixes = [
+  ...llcBusinessSuffix,
+  ...llpBusinessSuffix,
+  ...lpBusinessSuffix,
+  ...corpBusinessSuffix,
+  ...foreignCorpBusinessSuffix,
+  ...nonprofitBusinessSuffix,
+] as const;
+
+type v154BusinessSuffix = (typeof AllBusinessSuffixes)[number];
+
+type v154FormationSubmitResponse = {
+  success: boolean;
+  token: string | undefined;
+  formationId: string | undefined;
+  redirect: string | undefined;
+  errors: v154FormationSubmitError[];
+  lastUpdatedISO: string | undefined;
+};
+
+type v154FormationSubmitError = {
+  field: string;
+  type: "FIELD" | "UNKNOWN" | "RESPONSE";
+  message: string;
+};
+
+type v154GetFilingResponse = {
+  success: boolean;
+  entityId: string;
+  transactionDate: string;
+  confirmationNumber: string;
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+};
+
+export type v154EnvironmentData = {
+  waste?: v154WasteData;
+  land?: v154LandData;
+  air?: v154AirData;
+};
+
+export type v154MediaArea = keyof v154EnvironmentData;
+export type v154QuestionnaireFieldIds =
+  | v154WasteQuestionnaireFieldIds
+  | v154LandQuestionnaireFieldIds
+  | v154AirQuestionnaireFieldIds;
+export type v154Questionnaire = Record<v154QuestionnaireFieldIds, boolean>;
+export type v154QuestionnaireConfig = Record<v154QuestionnaireFieldIds, string>;
+
+export type v154WasteData = {
+  questionnaireData: v154WasteQuestionnaireData;
+  submitted: boolean;
+};
+
+export type v154WasteQuestionnaireFieldIds =
+  | "hazardousMedicalWaste"
+  | "compostWaste"
+  | "treatProcessWaste"
+  | "constructionDebris"
+  | "noWaste";
+
+export type v154WasteQuestionnaireData = Record<v154WasteQuestionnaireFieldIds, boolean>;
+
+export type v154LandData = {
+  questionnaireData: v154LandQuestionnaireData;
+  submitted: boolean;
+};
+
+export type v154LandQuestionnaireFieldIds =
+  | "takeOverExistingBiz"
+  | "propertyAssessment"
+  | "constructionActivities"
+  | "siteImprovementWasteLands"
+  | "noLand";
+
+export type v154LandQuestionnaireData = Record<v154LandQuestionnaireFieldIds, boolean>;
+
+export type v154AirData = {
+  questionnaireData: v154AirQuestionnaireData;
+  submitted: boolean;
+};
+
+export type v154AirQuestionnaireFieldIds =
+  | "emitPollutants"
+  | "emitEmissions"
+  | "constructionActivities"
+  | "noAir";
+
+export type v154AirQuestionnaireData = Record<v154AirQuestionnaireFieldIds, boolean>;
+
+// ---------------- v154 generators ----------------
+
+export const generatev154UserData = (overrides: Partial<v154UserData>): v154UserData => {
+  return {
+    user: generatev154BusinessUser({}),
+    version: 154,
+    lastUpdatedISO: "",
+    dateCreatedISO: "",
+    versionWhenCreated: 141,
+    businesses: {
+      "123": generatev154Business({ id: "123" }),
+    },
+    currentBusinessId: "",
+    ...overrides,
+  };
+};
+
+export const generatev154BusinessUser = (overrides: Partial<v154BusinessUser>): v154BusinessUser => {
+  return {
+    name: `some-name-${randomInt()}`,
+    email: `some-email-${randomInt()}@example.com`,
+    id: `some-id-${randomInt()}`,
+    receiveNewsletter: false,
+    userTesting: false,
+    externalStatus: {
+      userTesting: {
+        success: true,
+        status: "SUCCESS",
+      },
+    },
+    myNJUserKey: undefined,
+    intercomHash: undefined,
+    abExperience: "ExperienceA",
+    accountCreationSource: `some-source-${randomInt()}`,
+    contactSharingWithAccountCreationPartner: false,
+    ...overrides,
+  };
+};
+
+export const generatev154Business = (overrides: Partial<v154Business>): v154Business => {
+  const profileData = generatev154ProfileData({});
+  return {
+    id: `some-id-${randomInt()}`,
+    dateCreatedISO: "",
+    lastUpdatedISO: "",
+    profileData: profileData,
+    preferences: generatev154Preferences({}),
+    formationData: generatev154FormationData({}, profileData.legalStructureId ?? ""),
+    onboardingFormProgress: "UNSTARTED",
+    taskProgress: {
+      "business-structure": "NOT_STARTED",
+    },
+    taskItemChecklist: {
+      "general-dvob": false,
+    },
+    licenseData: undefined,
+    taxFilingData: generatev154TaxFilingData({}),
+    environmentData: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev154ProfileData = (overrides: Partial<v154ProfileData>): v154ProfileData => {
+  const id = `some-id-${randomInt()}`;
+  const persona = randomInt() % 2 ? "STARTING" : "OWNING";
+  return {
+    ...generatev154IndustrySpecificData({}),
+    businessPersona: persona,
+    businessName: `some-business-name-${randomInt()}`,
+    industryId: "restaurant",
+    legalStructureId: "limited-liability-partnership",
+    dateOfFormation: undefined,
+    entityId: randomInt(10).toString(),
+    employerId: randomInt(9).toString(),
+    taxId: randomInt() % 2 ? randomInt(9).toString() : randomInt(12).toString(),
+    encryptedTaxId: `some-encrypted-value`,
+    notes: `some-notes-${randomInt()}`,
+    existingEmployees: randomInt(7).toString(),
+    naicsCode: randomInt(6).toString(),
+    nexusDbaName: "undefined",
+    operatingPhase: "NEEDS_TO_FORM",
+    ownershipTypeIds: [],
+    documents: {
+      certifiedDoc: `${id}/certifiedDoc-${randomInt()}.pdf`,
+      formationDoc: `${id}/formationDoc-${randomInt()}.pdf`,
+      standingDoc: `${id}/standingDoc-${randomInt()}.pdf`,
+    },
+    taxPin: randomInt(4).toString(),
+    sectorId: undefined,
+    foreignBusinessTypeIds: [],
+    municipality: undefined,
+    responsibleOwnerName: `some-owner-name-${randomInt()}`,
+    tradeName: `some-trade-name-${randomInt()}`,
+    elevatorOwningBusiness: undefined,
+    nonEssentialRadioAnswers: {},
+    plannedRenovationQuestion: undefined,
+    communityAffairsAddress: undefined,
+    raffleBingoGames: undefined,
+    businessOpenMoreThanTwoYears: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev154IndustrySpecificData = (
+  overrides: Partial<v154IndustrySpecificData>
+): v154IndustrySpecificData => {
+  return {
+    liquorLicense: false,
+    requiresCpa: false,
+    homeBasedBusiness: false,
+    cannabisLicenseType: undefined,
+    cannabisMicrobusiness: undefined,
+    constructionRenovationPlan: undefined,
+    providesStaffingService: false,
+    certifiedInteriorDesigner: false,
+    realEstateAppraisalManagement: false,
+    carService: undefined,
+    interstateTransport: false,
+    isChildcareForSixOrMore: undefined,
+    willSellPetCareItems: undefined,
+    petCareHousing: undefined,
+    interstateLogistics: undefined,
+    interstateMoving: undefined,
+    constructionType: undefined,
+    residentialConstructionType: undefined,
+    employmentPersonnelServiceType: undefined,
+    employmentPlacementType: undefined,
+    carnivalRideOwningBusiness: undefined,
+    propertyLeaseType: undefined,
+    hasThreeOrMoreRentalUnits: undefined,
+    travelingCircusOrCarnivalOwningBusiness: undefined,
+    vacantPropertyOwner: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev154Preferences = (overrides: Partial<v154Preferences>): v154Preferences => {
+  return {
+    roadmapOpenSections: ["PLAN", "START"],
+    roadmapOpenSteps: [],
+    hiddenCertificationIds: [],
+    hiddenFundingIds: [],
+    visibleSidebarCards: [],
+    returnToLink: "",
+    isCalendarFullView: true,
+    isHideableRoadmapOpen: false,
+    phaseNewlyChanged: false,
+    isNonProfitFromFunding: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev154FormationData = (
+  overrides: Partial<v154FormationData>,
+  legalStructureId: string
+): v154FormationData => {
+  return {
+    formationFormData: generatev154FormationFormData({}, legalStructureId),
+    formationResponse: undefined,
+    getFilingResponse: undefined,
+    completedFilingPayment: false,
+    businessNameAvailability: undefined,
+    lastVisitedPageIndex: 0,
+    dbaBusinessNameAvailability: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev154FormationFormData = (
+  overrides: Partial<v154FormationFormData>,
+  legalStructureId: string
+): v154FormationFormData => {
+  const isCorp = legalStructureId ? ["s-corporation", "c-corporation"].includes(legalStructureId) : false;
+
+  return <v154FormationFormData>{
+    businessName: `some-business-name-${randomInt()}`,
+    businessSuffix: "LLC",
+    businessTotalStock: isCorp ? randomInt().toString() : "",
+    businessStartDate: new Date(Date.now()).toISOString().split("T")[0],
+    businessPurpose: `some-purpose-${randomInt()}`,
+    addressLine1: `some-members-address-1-${randomInt()}`,
+    addressLine2: `some-members-address-2-${randomInt()}`,
+    addressCity: `some-members-address-city-${randomInt()}`,
+    addressState: { shortCode: "123", name: "new-jersey" },
+    addressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    addressCountry: `some-county`,
+    addressMunicipality: generatev154Municipality({}),
+    addressProvince: "",
+    withdrawals: `some-withdrawals-text-${randomInt()}`,
+    combinedInvestment: `some-combinedInvestment-text-${randomInt()}`,
+    dissolution: `some-dissolution-text-${randomInt()}`,
+    canCreateLimitedPartner: !!(randomInt() % 2),
+    createLimitedPartnerTerms: `some-createLimitedPartnerTerms-text-${randomInt()}`,
+    canGetDistribution: !!(randomInt() % 2),
+    getDistributionTerms: `some-getDistributionTerms-text-${randomInt()}`,
+    canMakeDistribution: !!(randomInt() % 2),
+    makeDistributionTerms: `make-getDistributionTerms-text-${randomInt()}`,
+    hasNonprofitBoardMembers: true,
+    nonprofitBoardMemberQualificationsSpecified: "IN_BYLAWS",
+    nonprofitBoardMemberQualificationsTerms: "",
+    nonprofitBoardMemberRightsSpecified: "IN_BYLAWS",
+    nonprofitBoardMemberRightsTerms: "",
+    nonprofitTrusteesMethodSpecified: "IN_BYLAWS",
+    nonprofitTrusteesMethodTerms: "",
+    nonprofitAssetDistributionSpecified: "IN_BYLAWS",
+    nonprofitAssetDistributionTerms: "",
+    provisions: [],
+    agentNumberOrManual: randomInt() % 2 ? "NUMBER" : "MANUAL_ENTRY",
+    agentNumber: `some-agent-number-${randomInt()}`,
+    agentName: `some-agent-name-${randomInt()}`,
+    agentEmail: `some-agent-email-${randomInt()}`,
+    agentOfficeAddressLine1: `some-agent-office-address-1-${randomInt()}`,
+    agentOfficeAddressLine2: `some-agent-office-address-2-${randomInt()}`,
+    agentOfficeAddressCity: `some-agent-office-address-city-${randomInt()}`,
+    agentOfficeAddressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    agentUseAccountInfo: !!(randomInt() % 2),
+    agentUseBusinessAddress: !!(randomInt() % 2),
+    signers: [],
+    members: legalStructureId === "limited-liability-partnership" ? [] : [generatev154FormationMember({})],
+    incorporators: undefined,
+    paymentType: randomInt() % 2 ? "ACH" : "CC",
+    annualReportNotification: !!(randomInt() % 2),
+    corpWatchNotification: !!(randomInt() % 2),
+    officialFormationDocument: !!(randomInt() % 2),
+    certificateOfStanding: !!(randomInt() % 2),
+    certifiedCopyOfFormationDocument: !!(randomInt() % 2),
+    contactFirstName: `some-contact-first-name-${randomInt()}`,
+    contactLastName: `some-contact-last-name-${randomInt()}`,
+    contactPhoneNumber: `some-contact-phone-number-${randomInt()}`,
+    foreignStateOfFormation: undefined,
+    foreignDateOfFormation: undefined,
+    foreignGoodStandingFile: undefined,
+    willPracticeLaw: false,
+    isVeteranNonprofit: false,
+    legalType: "",
+    additionalProvisions: undefined,
+    businessLocationType: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev154Municipality = (overrides: Partial<v154Municipality>): v154Municipality => {
+  return {
+    displayName: `some-display-name-${randomInt()}`,
+    name: `some-name-${randomInt()}`,
+    county: `some-county-${randomInt()}`,
+    id: `some-id-${randomInt()}`,
+    ...overrides,
+  };
+};
+
+export const generatev154FormationMember = (overrides: Partial<v154FormationMember>): v154FormationMember => {
+  return {
+    name: `some-name`,
+    addressLine1: `some-members-address-1-${randomInt()}`,
+    addressLine2: `some-members-address-2-${randomInt()}`,
+    addressCity: `some-members-address-city-${randomInt()}`,
+    addressState: { shortCode: "123", name: "new-jersey" },
+    addressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    addressCountry: `some-county`,
+    businessLocationType: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev154TaxFilingData = (overrides: Partial<v154TaxFilingData>): v154TaxFilingData => {
+  return {
+    state: undefined,
+    businessName: undefined,
+    errorField: undefined,
+    lastUpdatedISO: undefined,
+    registeredISO: undefined,
+    filings: [],
+    ...overrides,
+  };
+};
+
+export const generatev154LicenseDetails = (overrides: Partial<v154LicenseDetails>): v154LicenseDetails => {
+  return {
+    nameAndAddress: generatev154LicenseSearchNameAndAddress({}),
+    licenseStatus: getRandomv154LicenseStatus(),
+    expirationDateISO: "some-expiration-iso",
+    lastUpdatedISO: "some-last-updated",
+    checklistItems: [generatev154LicenseStatusItem()],
+    ...overrides,
+  };
+};
+
+const generatev154LicenseSearchNameAndAddress = (
+  overrides: Partial<v154LicenseSearchNameAndAddress>
+): v154LicenseSearchNameAndAddress => {
+  return {
+    name: `some-name`,
+    addressLine1: `some-members-address-1-${randomInt()}`,
+    addressLine2: `some-members-address-2-${randomInt()}`,
+    zipCode: `some-agent-office-zipcode-${randomInt()}`,
+    ...overrides,
+  };
+};
+
+const generatev154LicenseStatusItem = (): v154LicenseStatusItem => {
+  return {
+    title: `some-title-${randomInt()}`,
+    status: "ACTIVE",
+  };
+};
+
+export const getRandomv154LicenseStatus = (): v154LicenseStatus => {
+  const randomIndex = Math.floor(Math.random() * v154LicenseStatuses.length);
+  return v154LicenseStatuses[randomIndex];
+};

--- a/content/src/fieldConfig/fundings-onboarding.json
+++ b/content/src/fieldConfig/fundings-onboarding.json
@@ -1,0 +1,30 @@
+{
+  "fundingsOnboardingModal": {
+    "headerTooltip": "This tool is only for New Jersey-based businesses. Others can explore NJEDA funding on Business.NJ.gov.",
+    "modalHeader": "Tell Us About Your Business",
+    "incompleteWarningSingularText": "Complete the field below.",
+    "incompleteWarningMultipleText": "Complete the fields below.",
+    "saveButtonText": "Save",
+    "nonProfitQuestion": {
+      "questionText": "Is your business a nonprofit?",
+      "responses": {
+        "no": "No",
+        "yes": "Yes"
+      },
+      "selectAnAnswerText": "Select if your New Jersey business is a nonprofit"
+    },
+    "businessOperatingLengthQuestion": {
+      "questionText": "How long has your New Jersey business been open for?",
+      "responses": {
+        "short": "Less than 2 years",
+        "long": "2+ years"
+      },
+      "selectAnAnswerText": "Select how long your New Jersey business has been open for"
+    },
+    "pageHeader": {
+      "headerText": "Explore NJEDA Funding Programs",
+      "subHeaderText": "Discover funding programs your business may be eligible for. To see more personalized funding and business resources, create a Business.NJ.gov account.",
+      "buttonText": "See More Funding & Resources"
+    }
+  }
+}

--- a/shared/src/profileData.ts
+++ b/shared/src/profileData.ts
@@ -132,6 +132,7 @@ export interface ProfileData extends IndustrySpecificData {
   readonly elevatorOwningBusiness: boolean | undefined;
   readonly communityAffairsAddress?: CommunityAffairsAddress;
   readonly raffleBingoGames: boolean | undefined;
+  readonly businessOpenMoreThanTwoYears: boolean | undefined;
 }
 
 export const emptyProfileData: ProfileData = {
@@ -161,6 +162,7 @@ export const emptyProfileData: ProfileData = {
   elevatorOwningBusiness: undefined,
   communityAffairsAddress: undefined,
   raffleBingoGames: undefined,
+  businessOpenMoreThanTwoYears: undefined,
   ...emptyIndustrySpecificData,
 };
 

--- a/shared/src/test/factories.ts
+++ b/shared/src/test/factories.ts
@@ -304,6 +304,7 @@ export const generateProfileData = (
     elevatorOwningBusiness: undefined,
     carnivalRideOwningBusiness: undefined,
     raffleBingoGames: undefined,
+    businessOpenMoreThanTwoYears: undefined,
     ...overrides,
   };
 };

--- a/shared/src/userData.ts
+++ b/shared/src/userData.ts
@@ -32,7 +32,7 @@ export interface Business {
   readonly version: number;
 }
 
-export const CURRENT_VERSION = 153;
+export const CURRENT_VERSION = 154;
 
 export const createEmptyBusiness = (id?: string): Business => {
   return {
@@ -106,6 +106,7 @@ export interface Preferences {
   isCalendarFullView: boolean;
   isHideableRoadmapOpen: boolean;
   phaseNewlyChanged: boolean;
+  isNonProfitFromFunding?: boolean;
 }
 
 export type OnboardingFormProgress = "UNSTARTED" | "COMPLETED";

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -1140,6 +1140,54 @@ collections:
                       name: "confirmationNumberLabel",
                       widget: "markdown",
                     }
+  - label: "Fundings Onboarding Modal"
+    name: "business-fundings-onboarding-page"
+    file: "content/src/fieldConfig/fundings-onboarding.json"
+    editor:
+      preview: true
+    fields:
+      - label: fundingsOnboardingModal
+        name: fundingsOnboardingModal
+        collapsed: false
+        widget: object
+        fields:
+          - { label: Header Tooltip, name: headerTooltip, widget: string }
+          - { label: Modal Header, name: modalHeader, widget: string }
+          - { label: Incomplete Warning Singular Text, name: incompleteWarningSingularText, widget: string }
+          - { label: Incomplete Warning Multiple Text, name: incompleteWarningMultipleText, widget: string }
+          - { label: Save Button Text, name: saveButtonText, widget: string }
+          - label: "Non Profit Question"
+            name: "nonProfitQuestion"
+            widget: object
+            fields:
+              - { label: Question Text, name: questionText, widget: string }
+              - { label: Select an Answer Text, name: selectAnAnswerText, widget: string }
+              - label: Responses
+                name: responses
+                widget: object
+                fields:
+                  - { label: no, name: no, widget: string }
+                  - { label: yes, name: yes, widget: string }
+          - label: "Business Operating Length Question"
+            name: "businessOperatingLengthQuestion"
+            widget: object
+            fields:
+              - { label: Question Text, name: questionText, widget: string }
+              - { label: Select an Answer Text, name: selectAnAnswerText, widget: string }
+              - label: Responses
+                name: responses
+                widget: object
+                fields:
+                  - { label: short, name: short, widget: string }
+                  - { label: long, name: long, widget: string }
+          - label: "Page header"
+            name: "pageHeader"
+            widget: object
+            fields:
+              - { label: Header Text, name: headerText, widget: string }
+              - { label: Subheader Text, name: subHeaderText, widget: string }
+              - { label: Button Text, name: buttonText, widget: string }
+
   - name: nexus
     label: "Nexus"
     delete: false

--- a/web/src/components/ModalOneButton.tsx
+++ b/web/src/components/ModalOneButton.tsx
@@ -4,13 +4,13 @@ import { ReactElement, ReactNode } from "react";
 
 interface Props {
   isOpen: boolean;
-  close: () => void;
+  close?: () => void;
   title: string;
   children: ReactNode;
   primaryButtonText: string;
   primaryButtonOnClick: () => void;
   isLoading?: boolean;
-  uncloseable?: boolean;
+  maxWidth?: boolean;
 }
 
 export const ModalOneButton = (props: Props): ReactElement => {
@@ -36,6 +36,7 @@ export const ModalOneButton = (props: Props): ReactElement => {
       close={props.close}
       title={props.title}
       unpaddedChildren={buttonNode}
+      maxWidth={props.maxWidth}
     >
       {props.children}
     </ModalZeroButton>

--- a/web/src/components/ModalZeroButton.tsx
+++ b/web/src/components/ModalZeroButton.tsx
@@ -6,10 +6,11 @@ import { ReactElement, ReactNode, useContext } from "react";
 
 interface Props {
   isOpen: boolean;
-  close: () => void;
+  close?: () => void;
   title: string;
   children: ReactNode;
   unpaddedChildren?: ReactNode;
+  maxWidth?: boolean;
 }
 
 export const ModalZeroButton = (props: Props): ReactElement => {
@@ -17,7 +18,7 @@ export const ModalZeroButton = (props: Props): ReactElement => {
 
   return (
     <Dialog
-      fullWidth={false}
+      fullWidth={props.maxWidth ?? false}
       maxWidth="sm"
       open={props.isOpen}
       onClose={props.close}
@@ -33,16 +34,18 @@ export const ModalZeroButton = (props: Props): ReactElement => {
             {props.title}
           </Heading>
         </DialogTitle>
-        <IconButton
-          aria-label="close"
-          className="margin-left-auto margin-3"
-          onClick={props.close}
-          sx={{
-            color: "#757575",
-          }}
-        >
-          <Icon className="usa-icon--size-4" iconName="close" />
-        </IconButton>
+        {props.close && (
+          <IconButton
+            aria-label="close"
+            className="margin-left-auto margin-3"
+            onClick={props.close}
+            sx={{
+              color: "#757575",
+            }}
+          >
+            <Icon className="usa-icon--size-4" iconName="close" />
+          </IconButton>
+        )}
       </div>
       <DialogContent sx={{ padding: 0 }} dividers>
         <div className="padding-x-4 margin-bottom-4 margin-top-2" data-testid="modal-body">

--- a/web/src/components/dashboard/OpportunityCard.tsx
+++ b/web/src/components/dashboard/OpportunityCard.tsx
@@ -16,6 +16,9 @@ interface Props {
   opportunity: Opportunity;
   urlPath: "funding" | "certification";
   isLast?: boolean;
+  removeHideButton?: boolean;
+  removeLabel?: boolean;
+  hideTopBorder?: boolean;
 }
 
 export const OPPORTUNITY_CARD_MAX_BODY_CHARS = 150;
@@ -82,34 +85,38 @@ export const OpportunityCard = (props: Props): ReactElement => {
 
   return (
     <>
-      <hr className="bg-cool-lighter" aria-hidden={true} />
+      {!props.hideTopBorder && <hr className="bg-cool-lighter" aria-hidden={true} />}
+
       <div
         data-testid={props.opportunity.id}
         className={`${props.isLast ? "" : " margin-bottom-205"} margin-top-3`}
       >
         <div className="fdr margin-bottom-105">
-          <div>{TYPE_TO_LABEL[props.urlPath]}</div>
+          {!props.removeLabel && <div>{TYPE_TO_LABEL[props.urlPath]}</div>}
+
           <div className="mla">
-            <SecondaryButton
-              size={"small"}
-              isColor={"border-base-light"}
-              onClick={(): void => {
-                isHidden() ? unhideSelf() : hideSelf();
-              }}
-            >
-              <div className="fdr fac">
-                <Icon iconName={isHidden() ? "visibility" : "visibility_off"} />
-                <span className="margin-left-05 line-height-sans-2">
-                  {isHidden()
-                    ? Config.dashboardDefaults.unHideOpportunityText
-                    : Config.dashboardDefaults.hideOpportunityText}
-                </span>
-              </div>
-            </SecondaryButton>
+            {!props.removeHideButton && (
+              <SecondaryButton
+                size={"small"}
+                isColor={"border-base-light"}
+                onClick={(): void => {
+                  isHidden() ? unhideSelf() : hideSelf();
+                }}
+              >
+                <div className="fdr fac">
+                  <Icon iconName={isHidden() ? "visibility" : "visibility_off"} />
+                  <span className="margin-left-05 line-height-sans-2">
+                    {isHidden()
+                      ? Config.dashboardDefaults.unHideOpportunityText
+                      : Config.dashboardDefaults.hideOpportunityText}
+                  </span>
+                </div>
+              </SecondaryButton>
+            )}
           </div>
         </div>
         <div className="text-normal font-body-md margin-bottom-105">
-          <UnStyledButton isUnderline onClick={routeToPage}>
+          <UnStyledButton isUnderline onClick={routeToPage} dataTestid={`${props.opportunity.id}-button`}>
             {props.opportunity.name}
           </UnStyledButton>
         </div>

--- a/web/src/contexts/configContext.ts
+++ b/web/src/contexts/configContext.ts
@@ -23,6 +23,7 @@ import * as ElevatorRegistration from "@businessnjgovnavigator/content/fieldConf
 import * as EnvQuestionnaire from "@businessnjgovnavigator/content/fieldConfig/env-questionnaire.json";
 import * as FormationInterimSuccessPage from "@businessnjgovnavigator/content/fieldConfig/formation-interim-success-page.json";
 import * as FormationSuccessPage from "@businessnjgovnavigator/content/fieldConfig/formation-success-page.json";
+import * as FundingsOnboarding from "@businessnjgovnavigator/content/fieldConfig/fundings-onboarding.json";
 import * as SiteWideErrorMessages from "@businessnjgovnavigator/content/fieldConfig/global-errors-defaults.json";
 import * as HousingRegistrationSearchTask from "@businessnjgovnavigator/content/fieldConfig/housing-registration.json";
 import * as LandingPageExperienceB from "@businessnjgovnavigator/content/fieldConfig/landing-page-experience-b.json";
@@ -88,7 +89,8 @@ const merged = JSON.parse(
       CheckAccountEmailPage,
       LicenseSearchTask,
       LandingPage,
-      LandingPageExperienceB
+      LandingPageExperienceB,
+      FundingsOnboarding
     )
   )
 );
@@ -135,7 +137,8 @@ export type ConfigType = typeof ConfigOriginal &
   typeof EnvQuestionnaire &
   typeof LicenseSearchTask &
   typeof LandingPage &
-  typeof LandingPageExperienceB;
+  typeof LandingPageExperienceB &
+  typeof FundingsOnboarding;
 
 export const getMergedConfig = (): ConfigType => {
   return merge(
@@ -178,7 +181,8 @@ export const getMergedConfig = (): ConfigType => {
     CheckAccountEmailPage,
     LicenseSearchTask,
     LandingPage,
-    LandingPageExperienceB
+    LandingPageExperienceB,
+    FundingsOnboarding
   );
 };
 

--- a/web/src/lib/auth/signinHelper.ts
+++ b/web/src/lib/auth/signinHelper.ts
@@ -150,6 +150,9 @@ export const onGuestSignIn = async ({
         push(ROUTES.onboarding);
         break;
       }
+      case ROUTES.fundings: {
+        break;
+      }
       default: {
         setRegistrationDimension("Not Started");
         push(ROUTES.landing);

--- a/web/src/lib/domain-logic/routes.ts
+++ b/web/src/lib/domain-logic/routes.ts
@@ -13,6 +13,7 @@ export const ROUTES = {
   accountSetup: "/account-setup",
   starterKits: "/starter-kits",
   login: "/login",
+  fundings: "/fundings",
 };
 
 export interface QUERY_PARAMS_VALUES {

--- a/web/src/pages/fundings.tsx
+++ b/web/src/pages/fundings.tsx
@@ -1,0 +1,300 @@
+import { OpportunityCard } from "@/components/dashboard/OpportunityCard";
+import { Sectors } from "@/components/data-fields/Sectors";
+import { FieldLabelDescriptionOnly } from "@/components/field-labels/FieldLabelDescriptionOnly";
+import { ModalOneButton } from "@/components/ModalOneButton";
+import { Alert } from "@/components/njwds-extended/Alert";
+import { Heading } from "@/components/njwds-extended/Heading";
+import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
+import { WithErrorBar } from "@/components/WithErrorBar";
+import { ProfileDataContext } from "@/contexts/profileDataContext";
+import { ProfileFormContext } from "@/contexts/profileFormContext";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
+import { useUserData } from "@/lib/data-hooks/useUserData";
+import { ROUTES } from "@/lib/domain-logic/routes";
+import { filterFundings } from "@/lib/domain-logic/sidebarCardsHelpers";
+import { loadAllFundings } from "@/lib/static/loadFundings";
+import { createProfileFieldErrorMap, Funding } from "@/lib/types/types";
+import {
+  createEmptyUser,
+  createEmptyUserData,
+  OperatingPhaseId,
+  ProfileData,
+} from "@businessnjgovnavigator/shared";
+import { FormControl, FormControlLabel, Radio, RadioGroup } from "@mui/material";
+import { GetStaticPropsResult } from "next";
+import { useRouter } from "next/compat/router";
+import { ReactElement, useEffect, useState } from "react";
+
+interface Props {
+  fundings: Funding[];
+}
+
+const FundingsPage = (props: Props): ReactElement => {
+  const { Config } = useConfig();
+  const router = useRouter();
+  const currentUserData = createEmptyUserData(createEmptyUser());
+  const { business, updateQueue, createUpdateQueue } = useUserData();
+  const [profileData, setProfileData] = useState<ProfileData>(
+    business?.profileData || currentUserData.businesses[currentUserData.currentBusinessId].profileData
+  );
+  const [isNonProfit, setIsNonProfit] = useState<boolean | undefined>(undefined);
+  const [isBusinessOpenLongerThanTwoYears, setIsBusinessOpenLongerThanTwoYears] = useState<
+    boolean | undefined
+  >(business?.profileData.businessOpenMoreThanTwoYears);
+  const [shouldCloseModal, setShouldCloseModal] = useState<boolean>(false);
+  const [filteredFundings, setFilteredFundings] = useState<Funding[]>(props.fundings);
+  const [shouldShowErrorAlert, setShouldShowErrorAlert] = useState<boolean>(false);
+
+  const allQuestionsAnswered = (): boolean => {
+    return getQuestionsAnsweredCount() === 3;
+  };
+
+  const getQuestionsAnsweredCount = (): number => {
+    let count = 0;
+    if (profileData.sectorId !== undefined) {
+      count += 1;
+    }
+
+    if (isBusinessOpenLongerThanTwoYears !== undefined) {
+      count += 1;
+    }
+
+    if (isNonProfit !== undefined) {
+      count += 1;
+    }
+    return count;
+  };
+
+  useEffect(() => {
+    if (!updateQueue) {
+      createUpdateQueue(currentUserData);
+    }
+  }, [updateQueue, createUpdateQueue, currentUserData]);
+
+  const saveUserData = async (): Promise<void> => {
+    onSubmit();
+
+    if (allQuestionsAnswered()) {
+      updateQueue?.queueBusiness({
+        ...updateQueue?.currentBusiness(),
+        onboardingFormProgress: "COMPLETED",
+      });
+      updateQueue?.queueProfileData({
+        businessPersona: "OWNING",
+        operatingPhase: OperatingPhaseId.GUEST_MODE_OWNING,
+        industryId: "generic",
+        legalStructureId: isNonProfit ? "nonprofit" : undefined,
+        businessOpenMoreThanTwoYears: isBusinessOpenLongerThanTwoYears,
+        sectorId: profileData.sectorId,
+      });
+      updateQueue?.queuePreferences({
+        visibleSidebarCards: ["not-registered-up-and-running"],
+        isNonProfitFromFunding: isNonProfit,
+      });
+      await updateQueue?.update();
+      setShouldCloseModal(true);
+      setFilteredFundings(filterFundings({ fundings: filteredFundings, business }));
+    } else {
+      setShouldShowErrorAlert(true);
+    }
+  };
+
+  const shouldShowBusinessLengthError = (): boolean => {
+    return shouldShowErrorAlert && isBusinessOpenLongerThanTwoYears === undefined;
+  };
+
+  const shouldShowNonProfitError = (): boolean => {
+    return shouldShowErrorAlert && isNonProfit === undefined;
+  };
+
+  const { onSubmit, state: formContextState } = useFormContextHelper(createProfileFieldErrorMap());
+
+  const FundingsHeader = (): ReactElement => {
+    return (
+      <div className={"bg-accent-cool-lightest padding-bottom-4 border-bottom border-accent-cool-light"}>
+        <div className={"margin-left-3ch"}>
+          <Heading
+            level={1}
+            styleVariant="h1"
+            className="text-base-darkest margin-bottom-4 desktop:margin-bottom-3 text-accent-cool-darker"
+          >
+            {Config.fundingsOnboardingModal.pageHeader.headerText}
+          </Heading>
+          <div className={"text-lg-left text-accent-cool-dark-medium margin-bottom-1"}>
+            {Config.fundingsOnboardingModal.pageHeader.subHeaderText}
+          </div>
+          <PrimaryButton
+            isColor={"accent-cool-darker"}
+            onClick={() => {
+              router && router.push(ROUTES.dashboard);
+            }}
+          >
+            {Config.fundingsOnboardingModal.pageHeader.buttonText}
+          </PrimaryButton>
+        </div>
+      </div>
+    );
+  };
+
+  const fundingEntry = (funding: Funding, hideTopBorder: boolean): ReactElement => {
+    return (
+      <div className={"margin-left-3ch"} key={funding.id}>
+        <OpportunityCard
+          key={funding.id}
+          opportunity={funding}
+          urlPath="funding"
+          removeHideButton={true}
+          removeLabel={true}
+          hideTopBorder={hideTopBorder}
+        />
+      </div>
+    );
+  };
+
+  const radioButtonOption = (option: string, error: boolean): ReactElement => {
+    return (
+      <div key={option}>
+        <FormControlLabel
+          aria-label={option}
+          style={{ alignItems: "center" }}
+          labelPlacement="end"
+          key={option}
+          data-testid={option}
+          value={option}
+          control={<Radio color={error ? "error" : "primary"} />}
+          label={option}
+        />
+      </div>
+    );
+  };
+
+  return (
+    <ProfileFormContext.Provider value={formContextState}>
+      <ProfileDataContext.Provider
+        value={{
+          state: {
+            profileData: profileData,
+            flow: "OWNING",
+          },
+          setProfileData,
+          onBack: () => {},
+        }}
+      >
+        <>
+          <ModalOneButton
+            isOpen={!shouldCloseModal}
+            title={Config.fundingsOnboardingModal.modalHeader}
+            primaryButtonOnClick={() => {
+              saveUserData();
+            }}
+            primaryButtonText={Config.fundingsOnboardingModal.saveButtonText}
+            maxWidth={true}
+          >
+            <div>
+              <div className={"padding-bottom-3"}>
+                {shouldShowErrorAlert && (
+                  <Alert variant={"error"}>
+                    {getQuestionsAnsweredCount() === 2
+                      ? Config.fundingsOnboardingModal.incompleteWarningSingularText
+                      : Config.fundingsOnboardingModal.incompleteWarningMultipleText}
+                  </Alert>
+                )}
+                {!shouldShowErrorAlert && (
+                  <Alert variant={"info"}>{Config.fundingsOnboardingModal.headerTooltip}</Alert>
+                )}
+              </div>
+              <div className={"text-bold"}>
+                <FieldLabelDescriptionOnly fieldName="sectorId" />
+                <Sectors />
+              </div>
+
+              <div className={"padding-top-1 border-error error-side-border"}>
+                <WithErrorBar hasError={shouldShowBusinessLengthError()} type={"ALWAYS"}>
+                  <div className={"text-bold"}>
+                    {Config.fundingsOnboardingModal.businessOperatingLengthQuestion.questionText}
+                  </div>
+                  <FormControl variant="outlined" fullWidth>
+                    <RadioGroup
+                      aria-label="business operating length"
+                      name="business-operating-length"
+                      onChange={(event) => {
+                        setIsBusinessOpenLongerThanTwoYears(
+                          (event.target.value as string) ===
+                            Config.fundingsOnboardingModal.businessOperatingLengthQuestion.responses.long
+                        );
+                      }}
+                    >
+                      {radioButtonOption(
+                        Config.fundingsOnboardingModal.businessOperatingLengthQuestion.responses.short,
+                        shouldShowBusinessLengthError()
+                      )}
+                      {radioButtonOption(
+                        Config.fundingsOnboardingModal.businessOperatingLengthQuestion.responses.long,
+                        shouldShowBusinessLengthError()
+                      )}
+                    </RadioGroup>
+                  </FormControl>
+                  {shouldShowBusinessLengthError() && (
+                    <div className="text-error-dark text-bold" data-testid="business-structure-error">
+                      {Config.fundingsOnboardingModal.businessOperatingLengthQuestion.selectAnAnswerText}
+                    </div>
+                  )}
+                </WithErrorBar>
+              </div>
+
+              <div className={"padding-top-1"}>
+                <WithErrorBar hasError={shouldShowNonProfitError()} type={"ALWAYS"}>
+                  <div className={"text-bold"}>
+                    {Config.fundingsOnboardingModal.nonProfitQuestion.questionText}
+                  </div>
+                  <FormControl variant="outlined" fullWidth>
+                    <RadioGroup
+                      aria-label="Nonprofit status"
+                      name="nonprofit-status"
+                      onChange={(event) => {
+                        setIsNonProfit(
+                          (event.target.value as string) ===
+                            Config.fundingsOnboardingModal.nonProfitQuestion.responses.yes
+                        );
+                      }}
+                      row={true}
+                    >
+                      {radioButtonOption(
+                        Config.fundingsOnboardingModal.nonProfitQuestion.responses.yes,
+                        shouldShowNonProfitError()
+                      )}
+                      {radioButtonOption(
+                        Config.fundingsOnboardingModal.nonProfitQuestion.responses.no,
+                        shouldShowNonProfitError()
+                      )}
+                    </RadioGroup>
+                  </FormControl>
+                  {shouldShowNonProfitError() && (
+                    <div className="text-error-dark text-bold" data-testid="business-structure-error">
+                      {Config.fundingsOnboardingModal.nonProfitQuestion.selectAnAnswerText}
+                    </div>
+                  )}
+                </WithErrorBar>
+              </div>
+            </div>
+          </ModalOneButton>
+          <FundingsHeader />
+          {filteredFundings.map((funding, index) => {
+            return fundingEntry(funding, index === 0);
+          })}
+        </>
+      </ProfileDataContext.Provider>
+    </ProfileFormContext.Provider>
+  );
+};
+
+export const getStaticProps = (): GetStaticPropsResult<Props> => {
+  return {
+    props: {
+      fundings: loadAllFundings(),
+    },
+  };
+};
+
+export default FundingsPage;

--- a/web/test/pages/fundings.test.tsx
+++ b/web/test/pages/fundings.test.tsx
@@ -1,0 +1,162 @@
+import { getMergedConfig } from "@/contexts/configContext";
+import { ROUTES } from "@/lib/domain-logic/routes";
+import { Funding } from "@/lib/types/types";
+import FundingsPage from "@/pages/fundings";
+import { generateFunding } from "@/test/factories";
+import { mockPush, useMockRouter } from "@/test/mock/mockRouter";
+import { useMockRoadmap } from "@/test/mock/mockUseRoadmap";
+import { setupStatefulUserDataContext, WithStatefulUserData } from "@/test/mock/withStatefulUserData";
+import { selectByValue } from "@/test/pages/profile/profile-helpers";
+import {
+  generateBusiness,
+  generateProfileData,
+  generateUserDataForBusiness,
+} from "@businessnjgovnavigator/shared/test";
+import { Business } from "@businessnjgovnavigator/shared/userData";
+import { createTheme, ThemeProvider } from "@mui/material";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+jest.mock("next/compat/router", () => ({ useRouter: jest.fn() }));
+jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
+jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
+jest.mock("@/lib/roadmap/buildUserRoadmap", () => ({ buildUserRoadmap: jest.fn() }));
+
+const Config = getMergedConfig();
+
+const renderStatefulFundingsPageComponent = (business: Business, fundings: Funding[]): void => {
+  setupStatefulUserDataContext();
+
+  render(
+    <WithStatefulUserData initialUserData={generateUserDataForBusiness(business ?? generateBusiness({}))}>
+      <ThemeProvider theme={createTheme()}>
+        <FundingsPage fundings={fundings} />
+      </ThemeProvider>
+    </WithStatefulUserData>
+  );
+};
+
+describe("fundings onboarding", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    useMockRouter({});
+    useMockRoadmap({});
+  });
+
+  it("renders the radio buttons", async () => {
+    useMockRouter({});
+    const business = generateBusiness({});
+    renderStatefulFundingsPageComponent(business, []);
+    expect(
+      screen.getByText(Config.fundingsOnboardingModal.nonProfitQuestion.questionText)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(Config.fundingsOnboardingModal.businessOperatingLengthQuestion.questionText)
+    ).toBeInTheDocument();
+  });
+
+  it("closes the modal when all questions are answered", async () => {
+    useMockRouter({});
+    const business = generateBusiness({});
+    renderStatefulFundingsPageComponent(business, []);
+    expect(
+      screen.getByText(Config.fundingsOnboardingModal.nonProfitQuestion.questionText)
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByText(Config.fundingsOnboardingModal.nonProfitQuestion.responses.yes));
+    fireEvent.click(
+      screen.getByText(Config.fundingsOnboardingModal.businessOperatingLengthQuestion.responses.long)
+    );
+    await waitFor(() => {
+      selectByValue("Sector", "clean-energy");
+    });
+    fireEvent.click(screen.getByText("Save"));
+    fireEvent.click(screen.getByText(Config.fundingsOnboardingModal.pageHeader.buttonText));
+    expect(mockPush).toHaveBeenCalledWith(ROUTES.dashboard);
+  });
+
+  it("triggers validation when questions are unanswered and Save is pressed", async () => {
+    useMockRouter({});
+    const business = generateBusiness({});
+    renderStatefulFundingsPageComponent(business, []);
+    expect(
+      screen.getByText(Config.fundingsOnboardingModal.nonProfitQuestion.questionText)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(Config.fundingsOnboardingModal.businessOperatingLengthQuestion.questionText)
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Save"));
+    expect(
+      screen.getByText(Config.fundingsOnboardingModal.incompleteWarningMultipleText)
+    ).toBeInTheDocument();
+  });
+
+  it("triggers validation when sector question is unanswered and Save is pressed", async () => {
+    useMockRouter({});
+    const business = generateBusiness({});
+    renderStatefulFundingsPageComponent(business, []);
+    fireEvent.click(screen.getByText(Config.fundingsOnboardingModal.nonProfitQuestion.responses.yes));
+    fireEvent.click(
+      screen.getByText(Config.fundingsOnboardingModal.businessOperatingLengthQuestion.responses.long)
+    );
+    fireEvent.click(screen.getByText("Save"));
+    expect(
+      screen.getByText(Config.fundingsOnboardingModal.incompleteWarningSingularText)
+    ).toBeInTheDocument();
+  });
+
+  it("navigates to funding when clicked", async () => {
+    useMockRouter({});
+    const profileData = generateProfileData({ sectorId: "" });
+    const business = generateBusiness({ profileData: profileData });
+    const fundings = [
+      generateFunding({
+        isNonprofitOnly: false,
+        sector: ["clean-energy"],
+        employeesRequired: "n/a",
+        county: ["All"],
+        homeBased: "yes",
+      }),
+    ];
+    renderStatefulFundingsPageComponent(business, fundings);
+    fireEvent.click(screen.getByText(Config.fundingsOnboardingModal.nonProfitQuestion.responses.yes));
+    fireEvent.click(
+      screen.getByText(Config.fundingsOnboardingModal.businessOperatingLengthQuestion.responses.long)
+    );
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() => {
+      selectByValue("Sector", "clean-energy");
+    });
+    expect(
+      screen.queryByText(Config.fundingsOnboardingModal.incompleteWarningSingularText)
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId(`${fundings[0].id}-button`));
+    expect(mockPush).toHaveBeenCalled();
+  });
+
+  it("filters out unrelated fundings", async () => {
+    useMockRouter({});
+    const profileData = generateProfileData({ sectorId: "" });
+    const business = generateBusiness({ profileData: profileData });
+    const fundings = [
+      generateFunding({
+        isNonprofitOnly: true,
+        sector: ["clean-energy"],
+        employeesRequired: "n/a",
+        county: ["All"],
+        homeBased: "yes",
+      }),
+    ];
+    renderStatefulFundingsPageComponent(business, fundings);
+    fireEvent.click(screen.getByText(Config.fundingsOnboardingModal.nonProfitQuestion.responses.no));
+    fireEvent.click(
+      screen.getByText(Config.fundingsOnboardingModal.businessOperatingLengthQuestion.responses.long)
+    );
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() => {
+      selectByValue("Sector", "clean-energy");
+    });
+    expect(
+      screen.queryByText(Config.fundingsOnboardingModal.incompleteWarningSingularText)
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId(`${fundings[0].id}-button`)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
- Adds a new onboarding flow with fundings prominently featured

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188666282](https://www.pivotaltracker.com/story/show/188666282).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

- In a new window/incognito window, navigate to localhost:3000/fundings
- Answer the onboarding questions. If you don't answer either radio question, there will be a popup with a request to finish the onboarding questions
- Click save
- You should be able to click on any funding. Clicking "Back" on the funding or the big button at the top should take you back to the Oscar onboarding sections

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
