### PR TITLE
Prevent license auto lookup with empty business name

### DIFF
--- a/api/src/api/userRouter.test.ts
+++ b/api/src/api/userRouter.test.ts
@@ -201,6 +201,32 @@ describe("userRouter", () => {
         expect(stubUpdateLicenseStatus).not.toHaveBeenCalled();
       });
 
+      it("does not update license if businessName is empty string and licenses is undefined and has formation address", async () => {
+        const userData = generateUserDataForBusiness(
+          generateBusiness({
+            licenseData: {
+              licenses: undefined,
+              lastUpdatedISO: sixtyOneMinutesAgo,
+            },
+            formationData: generateFormationData({
+              formationFormData: generateFormationFormData({
+                addressLine1: "123 Main Street",
+                addressLine2: "Suite 100",
+                addressZipCode: "07123",
+              }),
+            }),
+            profileData: generateProfileData({
+              businessName: "",
+            }),
+          })
+        );
+
+        stubUnifiedDataClient.get.mockResolvedValue(userData);
+
+        await request(app).get(`/users/123`).set("Authorization", "Bearer user-123-token");
+        expect(stubUpdateLicenseStatus).not.toHaveBeenCalled();
+      });
+
       it("does not update license if licenses is undefined and formationFormData address does not exist", async () => {
         const userData = generateUserDataForBusiness(
           generateBusiness({
@@ -222,7 +248,7 @@ describe("userRouter", () => {
         expect(stubUpdateLicenseStatus).not.toHaveBeenCalled();
       });
 
-      it("updates license if licenseData is undefined and if an address exists in formationFormData", async () => {
+      it("updates license if licenseData is undefined and if an address exists in formationFormData and has a business name", async () => {
         const userData = generateUserDataForBusiness(
           generateBusiness({
             licenseData: undefined,

--- a/api/src/api/userRouter.ts
+++ b/api/src/api/userRouter.ts
@@ -59,11 +59,13 @@ const clearTaskItemChecklists = (userData: UserData): UserData => {
 
 const shouldCheckLicense = (currentBusiness: Business): boolean => {
   const formationFormData = currentBusiness.formationData.formationFormData;
-  const hasFormationAddress =
-    formationFormData.addressLine1.length > 0 && formationFormData.addressZipCode.length > 0;
+  const hasFormationAddressAndBusinessName =
+    formationFormData.addressLine1.length > 0 &&
+    formationFormData.addressZipCode.length > 0 &&
+    !!currentBusiness.profileData.businessName;
 
   const hasLicenseDataOrFormationAddress =
-    currentBusiness.licenseData?.licenses !== undefined || hasFormationAddress;
+    currentBusiness.licenseData?.licenses !== undefined || hasFormationAddressAndBusinessName;
   const licenseDataOlderThanOneHour =
     currentBusiness.licenseData === undefined
       ? true


### PR DESCRIPTION
## Description

Prevents the automatic license check from firing if the business has a formation address but no business name.

### Ticket

This pull request resolves [#188671705](https://www.pivotaltracker.com/story/show/188671705) and may resolve [#188820162](https://www.pivotaltracker.com/story/show/188820162).

### Approach

When pulling user data from the database, we initiate a check for license data if the user has 1) previously queried for license data and successfully returned results or 2) the user has provided a business address. In the 2nd case, when the business does not have a name we run into a bug during the RGB query.

The first step of the RGB license search is to make an API request to get all of the business IDs in the system that have a name _like_ the one we provide. In the case of an empty string, the system will return _all_ of the business IDs. The next step is to fetch all addresses associated with the IDs returned by the first API call. This results in us hammering the RGB Dynamics API, and the API calls take so long to resolve that the user's connection times out, which ultimately results in us returning a 504 to the user.

I believe that the this is the behavior that we initially observed when writing this ticket [#188671705](https://www.pivotaltracker.com/story/show/188671705), and is the root cause of the long requests captured in this ticket [#188820162](https://www.pivotaltracker.com/story/show/188820162).

We solved this by simply checking that if a formation address is present that a business name is also present before querying the license application databases.

### Steps to Test

- Sign into the application
- Complete onboarding
- Add an address via profile or formation task
  - leave business name empty
- Close the browser window
- Return to the application. You should be able to view the site and interact as expected.

### Notes

- We made this logical update to check if business name is present in `userRouter`. We should have a follow-on ticket to prevent the actual `RegulatedBusinessDynamicsLicenseStatusClient` from querying with an empty business name. Ticket to be created.
- Communicate with product team and identify if there is a minimum number of characters that we should support for searching for a business. I could easily see something similar happening if a user searched for a business with the name "E" or another common single character that would appear in many business names.
- Need to validate that this actually is the solution for [#188820162](https://www.pivotaltracker.com/story/show/188820162). We're quite confident, but we should monitor over the next couple of days to confirm.
- Unrelated to the issue we were solving, but we did notice that some new migrations are not incrementing the business data version. We split the database in version 151 and since then should be incrementing business data versions along side our user data versions. This is not causing any functional problems, but it should be addressed before there are any further inconsistency.

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
