### PR TITLE
fix: [#188844549] add userId, versionWhenCreated and version to business object

### DIFF
--- a/api/src/client/ApiFormationHealth.ts
+++ b/api/src/client/ApiFormationHealth.ts
@@ -178,7 +178,9 @@ export const ApiFormationHealth: UserData = {
         lastVisitedPageIndex: 0,
       },
       lastUpdatedISO: getCurrentDateISOString(),
+      userId: "test-user-id-17591518",
       version: CURRENT_VERSION,
+      versionWhenCreated: -1,
     },
   },
 };

--- a/api/src/db/migrations/migrations.ts
+++ b/api/src/db/migrations/migrations.ts
@@ -154,6 +154,7 @@ import { migrate_v150_to_v151 } from "@db/migrations/v151_extract_business_data"
 import { migrate_v151_to_v152 } from "@db/migrations/v152_add_land_to_environment_data";
 import { migrate_v152_to_v153 } from "@db/migrations/v153_add_air_to_environment_data";
 import { migrate_v153_to_v154 } from "@db/migrations/v154_add_business_operating_length_and_nonprofit_status";
+import { migrate_v154_to_v155 } from "@db/migrations/v155_add_user_id_and_version_to_business";
 
 export type MigrationFunction = (data: any) => any;
 
@@ -312,6 +313,7 @@ export const Migrations: MigrationFunction[] = [
   migrate_v151_to_v152,
   migrate_v152_to_v153,
   migrate_v153_to_v154,
+  migrate_v154_to_v155,
 ];
 
-export { generatev154UserData as CURRENT_GENERATOR } from "@db/migrations/v154_add_business_operating_length_and_nonprofit_status";
+export { generatev155UserData as CURRENT_GENERATOR } from "@db/migrations/v155_add_user_id_and_version_to_business";

--- a/api/src/db/migrations/v155_add_user_id_and_version_to_business.test.ts
+++ b/api/src/db/migrations/v155_add_user_id_and_version_to_business.test.ts
@@ -1,0 +1,36 @@
+import {
+  generatev154Business,
+  generatev154UserData,
+} from "@db/migrations/v154_add_business_operating_length_and_nonprofit_status";
+import { migrate_v154_to_v155 } from "@db/migrations/v155_add_user_id_and_version_to_business";
+
+describe("v155 migration adds version, versionWhenCreated and userId fields to the businesses object", () => {
+  it("should upgrade v155 user by adding version, versionWhenCreated and userId fields to the businesses object", () => {
+    const v154UserData = generatev154UserData({
+      businesses: {
+        "biz-1": generatev154Business({ id: "biz-1" }),
+        "biz-2": generatev154Business({ id: "biz-2" }),
+        "biz-3": generatev154Business({ id: "biz-3" }),
+      },
+      version: 154,
+      versionWhenCreated: 151,
+    });
+
+    const migratedUserData = migrate_v154_to_v155(v154UserData);
+    expect(migratedUserData.version).toBe(155);
+
+    for (const business of Object.values(migratedUserData.businesses)) {
+      expect(business.version).toBeDefined();
+      expect(typeof business.version).toBe("number");
+      expect(business.version).toBe(155);
+
+      expect(business.versionWhenCreated).toBeDefined();
+      expect(typeof business.versionWhenCreated).toBe("number");
+      expect(business.versionWhenCreated).toBe(155);
+
+      expect(business.userId).toBeDefined();
+      expect(typeof business.userId).toBe("string");
+      expect(business.userId).toEqual(migratedUserData.user.id);
+    }
+  });
+});

--- a/api/src/db/migrations/v155_add_user_id_and_version_to_business.ts
+++ b/api/src/db/migrations/v155_add_user_id_and_version_to_business.ts
@@ -1,0 +1,929 @@
+import {
+  v154Business,
+  v154UserData,
+} from "@db/migrations/v154_add_business_operating_length_and_nonprofit_status";
+import { randomInt } from "@shared/intHelpers";
+
+export const migrate_v154_to_v155 = (v154Data: v154UserData): v155UserData => {
+  return {
+    ...v154Data,
+    businesses: Object.fromEntries(
+      Object.values(v154Data.businesses)
+        .map((business: v154Business) => migrate_v154Business_to_v155Business(business, v154Data))
+        .map((currBusiness: v155Business) => [currBusiness.id, currBusiness])
+    ),
+    version: 155,
+  } as v155UserData;
+};
+
+export const migrate_v154Business_to_v155Business = (
+  business: v154Business,
+  userData: v154UserData
+): v155Business => {
+  return {
+    ...business,
+    version: 155,
+    versionWhenCreated: 155,
+    userId: userData.user.id,
+  } as v155Business;
+};
+
+export interface v155IndustrySpecificData {
+  liquorLicense: boolean;
+  requiresCpa: boolean;
+  homeBasedBusiness: boolean | undefined;
+  providesStaffingService: boolean;
+  certifiedInteriorDesigner: boolean;
+  realEstateAppraisalManagement: boolean;
+  cannabisLicenseType: v155CannabisLicenseType;
+  cannabisMicrobusiness: boolean | undefined;
+  constructionRenovationPlan: boolean | undefined;
+  carService: v155CarServiceType | undefined;
+  interstateTransport: boolean;
+  interstateLogistics: boolean | undefined;
+  interstateMoving: boolean | undefined;
+  isChildcareForSixOrMore: boolean | undefined;
+  petCareHousing: boolean | undefined;
+  willSellPetCareItems: boolean | undefined;
+  constructionType: v155ConstructionType;
+  residentialConstructionType: v155ResidentialConstructionType;
+  employmentPersonnelServiceType: v155EmploymentAndPersonnelServicesType;
+  employmentPlacementType: v155EmploymentPlacementType;
+  carnivalRideOwningBusiness: boolean | undefined;
+  propertyLeaseType: v155PropertyLeaseType;
+  hasThreeOrMoreRentalUnits: boolean | undefined;
+  travelingCircusOrCarnivalOwningBusiness: boolean | undefined;
+  vacantPropertyOwner: boolean | undefined;
+}
+
+export type v155PropertyLeaseType = "SHORT_TERM_RENTAL" | "LONG_TERM_RENTAL" | "BOTH" | undefined;
+
+// ---------------- v155 types ----------------
+type v155TaskProgress = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+type v155OnboardingFormProgress = "UNSTARTED" | "COMPLETED";
+type v155ABExperience = "ExperienceA" | "ExperienceB";
+
+export interface v155UserData {
+  user: v155BusinessUser;
+  version: number;
+  lastUpdatedISO: string;
+  dateCreatedISO: string;
+  versionWhenCreated: number;
+  businesses: Record<string, v155Business>;
+  currentBusinessId: string;
+}
+
+export interface v155Business {
+  id: string;
+  dateCreatedISO: string;
+  lastUpdatedISO: string;
+  profileData: v155ProfileData;
+  onboardingFormProgress: v155OnboardingFormProgress;
+  taskProgress: Record<string, v155TaskProgress>;
+  taskItemChecklist: Record<string, boolean>;
+  licenseData: v155LicenseData | undefined;
+  preferences: v155Preferences;
+  taxFilingData: v155TaxFilingData;
+  formationData: v155FormationData;
+  environmentData: v155EnvironmentData | undefined;
+  version: number;
+  versionWhenCreated: number;
+  userId: string;
+}
+
+export interface v155ProfileData extends v155IndustrySpecificData {
+  businessPersona: v155BusinessPersona;
+  businessName: string;
+  responsibleOwnerName: string;
+  tradeName: string;
+  industryId: string | undefined;
+  legalStructureId: string | undefined;
+  municipality: v155Municipality | undefined;
+  dateOfFormation: string | undefined;
+  entityId: string | undefined;
+  employerId: string | undefined;
+  taxId: string | undefined;
+  encryptedTaxId: string | undefined;
+  notes: string;
+  documents: v155ProfileDocuments;
+  ownershipTypeIds: string[];
+  existingEmployees: string | undefined;
+  taxPin: string | undefined;
+  sectorId: string | undefined;
+  naicsCode: string;
+  foreignBusinessTypeIds: v155ForeignBusinessTypeId[];
+  nexusDbaName: string;
+  operatingPhase: v155OperatingPhase;
+  nonEssentialRadioAnswers: Record<string, boolean | undefined>;
+  elevatorOwningBusiness: boolean | undefined;
+  communityAffairsAddress?: v155CommunityAffairsAddress;
+  plannedRenovationQuestion: boolean | undefined;
+  raffleBingoGames: boolean | undefined;
+  businessOpenMoreThanTwoYears: boolean | undefined;
+}
+
+export type v155CommunityAffairsAddress = {
+  streetAddress1: string;
+  streetAddress2?: string;
+  municipality: v155Municipality;
+};
+
+type v155BusinessUser = {
+  name?: string;
+  email: string;
+  id: string;
+  receiveNewsletter: boolean;
+  userTesting: boolean;
+  externalStatus: v155ExternalStatus;
+  myNJUserKey?: string;
+  intercomHash?: string;
+  abExperience: v155ABExperience;
+  accountCreationSource: string;
+  contactSharingWithAccountCreationPartner: boolean;
+};
+
+interface v155ProfileDocuments {
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+}
+
+type v155BusinessPersona = "STARTING" | "OWNING" | "FOREIGN" | undefined;
+type v155OperatingPhase =
+  | "GUEST_MODE"
+  | "NEEDS_TO_FORM"
+  | "NEEDS_BUSINESS_STRUCTURE"
+  | "FORMED"
+  | "UP_AND_RUNNING"
+  | "UP_AND_RUNNING_OWNING"
+  | "REMOTE_SELLER_WORKER"
+  | undefined;
+
+export type v155CannabisLicenseType = "CONDITIONAL" | "ANNUAL" | undefined;
+export type v155CarServiceType = "STANDARD" | "HIGH_CAPACITY" | "BOTH" | undefined;
+export type v155ConstructionType = "RESIDENTIAL" | "COMMERCIAL_OR_INDUSTRIAL" | "BOTH" | undefined;
+export type v155ResidentialConstructionType =
+  | "NEW_HOME_CONSTRUCTION"
+  | "HOME_RENOVATIONS"
+  | "BOTH"
+  | undefined;
+export type v155EmploymentAndPersonnelServicesType = "JOB_SEEKERS" | "EMPLOYERS" | undefined;
+export type v155EmploymentPlacementType = "TEMPORARY" | "PERMANENT" | "BOTH" | undefined;
+
+type v155ForeignBusinessTypeId =
+  | "employeeOrContractorInNJ"
+  | "officeInNJ"
+  | "propertyInNJ"
+  | "companyOperatedVehiclesInNJ"
+  | "employeesInNJ"
+  | "revenueInNJ"
+  | "transactionsInNJ"
+  | "none";
+
+type v155Municipality = {
+  name: string;
+  displayName: string;
+  county: string;
+  id: string;
+};
+
+type v155TaxFilingState = "SUCCESS" | "FAILED" | "UNREGISTERED" | "PENDING" | "API_ERROR";
+type v155TaxFilingErrorFields = "businessName" | "formFailure";
+
+type v155TaxFilingData = {
+  state?: v155TaxFilingState;
+  lastUpdatedISO?: string;
+  registeredISO?: string;
+  errorField?: v155TaxFilingErrorFields;
+  businessName?: string;
+  filings: v155TaxFilingCalendarEvent[];
+};
+
+export type v155CalendarEvent = {
+  readonly dueDate: string; // YYYY-MM-DD
+  readonly calendarEventType: "TAX-FILING" | "LICENSE";
+};
+
+export interface v155TaxFilingCalendarEvent extends v155CalendarEvent {
+  readonly identifier: string;
+  readonly calendarEventType: "TAX-FILING";
+}
+
+export type v155LicenseSearchAddress = {
+  addressLine1: string;
+  addressLine2: string;
+  zipCode: string;
+};
+
+export interface v155LicenseSearchNameAndAddress extends v155LicenseSearchAddress {
+  name: string;
+}
+
+type v155LicenseDetails = {
+  nameAndAddress: v155LicenseSearchNameAndAddress;
+  licenseStatus: v155LicenseStatus;
+  expirationDateISO: string | undefined;
+  lastUpdatedISO: string;
+  checklistItems: v155LicenseStatusItem[];
+};
+
+const v155taskIdLicenseNameMapping = {
+  "apply-for-shop-license": "Cosmetology and Hairstyling-Shop",
+  "appraiser-license": "Real Estate Appraisers-Appraisal Management Company",
+  "architect-license": "Architecture-Certificate of Authorization",
+  "health-club-registration": "Health Club Services",
+  "home-health-aide-license": "Health Care Services",
+  "hvac-license": "HVACR-HVACR CE Sponsor",
+  "landscape-architect-license": "Landscape Architecture-Certificate of Authorization",
+  "license-massage-therapy": "Massage and Bodywork Therapy-Massage and Bodywork Employer",
+  "moving-company-license": "Public Movers and Warehousemen-Public Mover and Warehouseman",
+  "pharmacy-license": "Pharmacy-Pharmacy",
+  "public-accountant-license": "Accountancy-Firm Registration",
+  "register-accounting-firm": "Accountancy-Firm Registration",
+  "register-consumer-affairs": "Home Improvement Contractors-Home Improvement Contractor",
+  "ticket-broker-reseller-registration": "Ticket Brokers",
+  "telemarketing-license": "Telemarketers",
+} as const;
+
+type v155LicenseTaskID = keyof typeof v155taskIdLicenseNameMapping;
+
+export type v155LicenseName = (typeof v155taskIdLicenseNameMapping)[v155LicenseTaskID];
+
+type v155Licenses = Partial<Record<v155LicenseName, v155LicenseDetails>>;
+
+type v155LicenseData = {
+  lastUpdatedISO: string;
+  licenses?: v155Licenses;
+};
+
+type v155Preferences = {
+  roadmapOpenSections: v155SectionType[];
+  roadmapOpenSteps: number[];
+  hiddenFundingIds: string[];
+  hiddenCertificationIds: string[];
+  visibleSidebarCards: string[];
+  isCalendarFullView: boolean;
+  returnToLink: string;
+  isHideableRoadmapOpen: boolean;
+  phaseNewlyChanged: boolean;
+  isNonProfitFromFunding?: boolean;
+};
+
+type v155LicenseStatusItem = {
+  title: string;
+  status: v155CheckoffStatus;
+};
+
+type v155CheckoffStatus = "ACTIVE" | "PENDING" | "UNKNOWN";
+
+type v155LicenseStatus =
+  | "ACTIVE"
+  | "PENDING"
+  | "UNKNOWN"
+  | "EXPIRED"
+  | "BARRED"
+  | "OUT_OF_BUSINESS"
+  | "REINSTATEMENT_PENDING"
+  | "CLOSED"
+  | "DELETED"
+  | "DENIED"
+  | "VOLUNTARY_SURRENDER"
+  | "WITHDRAWN";
+
+const v155LicenseStatuses: v155LicenseStatus[] = [
+  "ACTIVE",
+  "PENDING",
+  "UNKNOWN",
+  "EXPIRED",
+  "BARRED",
+  "OUT_OF_BUSINESS",
+  "REINSTATEMENT_PENDING",
+  "CLOSED",
+  "DELETED",
+  "DENIED",
+  "VOLUNTARY_SURRENDER",
+  "WITHDRAWN",
+];
+
+const v155SectionNames = ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"] as const;
+type v155SectionType = (typeof v155SectionNames)[number];
+
+type v155ExternalStatus = {
+  newsletter?: v155NewsletterResponse;
+  userTesting?: v155UserTestingResponse;
+};
+
+interface v155NewsletterResponse {
+  success?: boolean;
+  status: v155NewsletterStatus;
+}
+
+interface v155UserTestingResponse {
+  success?: boolean;
+  status: v155UserTestingStatus;
+}
+
+type v155NewsletterStatus = (typeof newsletterStatusList)[number];
+
+const externalStatusList = ["SUCCESS", "IN_PROGRESS", "CONNECTION_ERROR"] as const;
+
+const userTestingStatusList = [...externalStatusList] as const;
+
+type v155UserTestingStatus = (typeof userTestingStatusList)[number];
+
+const newsletterStatusList = [
+  ...externalStatusList,
+  "EMAIL_ERROR",
+  "TOPIC_ERROR",
+  "RESPONSE_WARNING",
+  "RESPONSE_ERROR",
+  "RESPONSE_FAIL",
+  "QUESTION_WARNING",
+] as const;
+
+type v155NameAvailabilityStatus =
+  | "AVAILABLE"
+  | "DESIGNATOR_ERROR"
+  | "SPECIAL_CHARACTER_ERROR"
+  | "UNAVAILABLE"
+  | "RESTRICTED_ERROR"
+  | undefined;
+
+interface v155NameAvailabilityResponse {
+  status: v155NameAvailabilityStatus;
+  similarNames: string[];
+  invalidWord?: string;
+}
+
+interface v155NameAvailability extends v155NameAvailabilityResponse {
+  lastUpdatedTimeStamp: string;
+}
+
+interface v155FormationData {
+  formationFormData: v155FormationFormData;
+  businessNameAvailability: v155NameAvailability | undefined;
+  dbaBusinessNameAvailability: v155NameAvailability | undefined;
+  formationResponse: v155FormationSubmitResponse | undefined;
+  getFilingResponse: v155GetFilingResponse | undefined;
+  completedFilingPayment: boolean;
+  lastVisitedPageIndex: number;
+}
+
+type v155InFormInBylaws = "IN_BYLAWS" | "IN_FORM" | undefined;
+
+interface v155FormationFormData extends v155FormationAddress {
+  readonly businessName: string;
+  readonly businessSuffix: v155BusinessSuffix | undefined;
+  readonly businessTotalStock: string;
+  readonly businessStartDate: string; // YYYY-MM-DD
+  readonly businessPurpose: string;
+  readonly withdrawals: string;
+  readonly combinedInvestment: string;
+  readonly dissolution: string;
+  readonly canCreateLimitedPartner: boolean | undefined;
+  readonly createLimitedPartnerTerms: string;
+  readonly canGetDistribution: boolean | undefined;
+  readonly getDistributionTerms: string;
+  readonly canMakeDistribution: boolean | undefined;
+  readonly makeDistributionTerms: string;
+  readonly hasNonprofitBoardMembers: boolean | undefined;
+  readonly nonprofitBoardMemberQualificationsSpecified: v155InFormInBylaws;
+  readonly nonprofitBoardMemberQualificationsTerms: string;
+  readonly nonprofitBoardMemberRightsSpecified: v155InFormInBylaws;
+  readonly nonprofitBoardMemberRightsTerms: string;
+  readonly nonprofitTrusteesMethodSpecified: v155InFormInBylaws;
+  readonly nonprofitTrusteesMethodTerms: string;
+  readonly nonprofitAssetDistributionSpecified: v155InFormInBylaws;
+  readonly nonprofitAssetDistributionTerms: string;
+  readonly additionalProvisions: string[] | undefined;
+  readonly agentNumberOrManual: "NUMBER" | "MANUAL_ENTRY";
+  readonly agentNumber: string;
+  readonly agentName: string;
+  readonly agentEmail: string;
+  readonly agentOfficeAddressLine1: string;
+  readonly agentOfficeAddressLine2: string;
+  readonly agentOfficeAddressCity: string;
+  readonly agentOfficeAddressZipCode: string;
+  readonly agentUseAccountInfo: boolean;
+  readonly agentUseBusinessAddress: boolean;
+  readonly members: v155FormationMember[] | undefined;
+  readonly incorporators: v155FormationIncorporator[] | undefined;
+  readonly signers: v155FormationSigner[] | undefined;
+  readonly paymentType: v155PaymentType;
+  readonly annualReportNotification: boolean;
+  readonly corpWatchNotification: boolean;
+  readonly officialFormationDocument: boolean;
+  readonly certificateOfStanding: boolean;
+  readonly certifiedCopyOfFormationDocument: boolean;
+  readonly contactFirstName: string;
+  readonly contactLastName: string;
+  readonly contactPhoneNumber: string;
+  readonly foreignStateOfFormation: v155StateObject | undefined;
+  readonly foreignDateOfFormation: string | undefined; // YYYY-MM-DD
+  readonly foreignGoodStandingFile: v155ForeignGoodStandingFileObject | undefined;
+  readonly legalType: string;
+  readonly willPracticeLaw: boolean | undefined;
+  readonly isVeteranNonprofit: boolean | undefined;
+}
+
+type v155ForeignGoodStandingFileObject = {
+  Extension: "PDF" | "PNG";
+  Content: string;
+};
+
+type v155StateObject = {
+  shortCode: string;
+  name: string;
+};
+
+interface v155FormationAddress {
+  readonly addressLine1: string;
+  readonly addressLine2: string;
+  readonly addressCity?: string;
+  readonly addressState?: v155StateObject;
+  readonly addressMunicipality?: v155Municipality;
+  readonly addressProvince?: string;
+  readonly addressZipCode: string;
+  readonly addressCountry: string;
+  readonly businessLocationType: v155FormationBusinessLocationType | undefined;
+}
+
+type v155FormationBusinessLocationType = "US" | "INTL" | "NJ";
+
+type v155SignerTitle =
+  | "Authorized Representative"
+  | "Authorized Partner"
+  | "Incorporator"
+  | "General Partner"
+  | "President"
+  | "Vice-President"
+  | "Chairman of the Board"
+  | "CEO";
+
+interface v155FormationSigner {
+  readonly name: string;
+  readonly signature: boolean;
+  readonly title: v155SignerTitle;
+}
+
+interface v155FormationIncorporator extends v155FormationSigner, v155FormationAddress {}
+
+interface v155FormationMember extends v155FormationAddress {
+  readonly name: string;
+}
+
+type v155PaymentType = "CC" | "ACH" | undefined;
+
+const llcBusinessSuffix = [
+  "LLC",
+  "L.L.C.",
+  "LTD LIABILITY CO",
+  "LTD LIABILITY CO.",
+  "LTD LIABILITY COMPANY",
+  "LIMITED LIABILITY CO",
+  "LIMITED LIABILITY CO.",
+  "LIMITED LIABILITY COMPANY",
+] as const;
+
+const llpBusinessSuffix = [
+  "Limited Liability Partnership",
+  "LLP",
+  "L.L.P.",
+  "Registered Limited Liability Partnership",
+  "RLLP",
+  "R.L.L.P.",
+] as const;
+
+export const lpBusinessSuffix = ["LIMITED PARTNERSHIP", "LP", "L.P."] as const;
+
+const corpBusinessSuffix = [
+  "Corporation",
+  "Incorporated",
+  "Company",
+  "LTD",
+  "CO",
+  "CO.",
+  "CORP",
+  "CORP.",
+  "INC",
+  "INC.",
+] as const;
+
+export const nonprofitBusinessSuffix = [
+  "A NJ NONPROFIT CORPORATION",
+  "CORPORATION",
+  "INCORPORATED",
+  "CORP",
+  "CORP.",
+  "INC",
+  "INC.",
+] as const;
+
+const foreignCorpBusinessSuffix = [...corpBusinessSuffix, "P.C.", "P.A."] as const;
+
+export const AllBusinessSuffixes = [
+  ...llcBusinessSuffix,
+  ...llpBusinessSuffix,
+  ...lpBusinessSuffix,
+  ...corpBusinessSuffix,
+  ...foreignCorpBusinessSuffix,
+  ...nonprofitBusinessSuffix,
+] as const;
+
+type v155BusinessSuffix = (typeof AllBusinessSuffixes)[number];
+
+type v155FormationSubmitResponse = {
+  success: boolean;
+  token: string | undefined;
+  formationId: string | undefined;
+  redirect: string | undefined;
+  errors: v155FormationSubmitError[];
+  lastUpdatedISO: string | undefined;
+};
+
+type v155FormationSubmitError = {
+  field: string;
+  type: "FIELD" | "UNKNOWN" | "RESPONSE";
+  message: string;
+};
+
+type v155GetFilingResponse = {
+  success: boolean;
+  entityId: string;
+  transactionDate: string;
+  confirmationNumber: string;
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+};
+
+export type v155EnvironmentData = {
+  waste?: v155WasteData;
+  land?: v155LandData;
+  air?: v155AirData;
+};
+
+export type v155MediaArea = keyof v155EnvironmentData;
+export type v155QuestionnaireFieldIds =
+  | v155WasteQuestionnaireFieldIds
+  | v155LandQuestionnaireFieldIds
+  | v155AirQuestionnaireFieldIds;
+export type v155Questionnaire = Record<v155QuestionnaireFieldIds, boolean>;
+export type v155QuestionnaireConfig = Record<v155QuestionnaireFieldIds, string>;
+
+export type v155WasteData = {
+  questionnaireData: v155WasteQuestionnaireData;
+  submitted: boolean;
+};
+
+export type v155WasteQuestionnaireFieldIds =
+  | "hazardousMedicalWaste"
+  | "compostWaste"
+  | "treatProcessWaste"
+  | "constructionDebris"
+  | "noWaste";
+
+export type v155WasteQuestionnaireData = Record<v155WasteQuestionnaireFieldIds, boolean>;
+
+export type v155LandData = {
+  questionnaireData: v155LandQuestionnaireData;
+  submitted: boolean;
+};
+
+export type v155LandQuestionnaireFieldIds =
+  | "takeOverExistingBiz"
+  | "propertyAssessment"
+  | "constructionActivities"
+  | "siteImprovementWasteLands"
+  | "noLand";
+
+export type v155LandQuestionnaireData = Record<v155LandQuestionnaireFieldIds, boolean>;
+
+export type v155AirData = {
+  questionnaireData: v155AirQuestionnaireData;
+  submitted: boolean;
+};
+
+export type v155AirQuestionnaireFieldIds =
+  | "emitPollutants"
+  | "emitEmissions"
+  | "constructionActivities"
+  | "noAir";
+
+export type v155AirQuestionnaireData = Record<v155AirQuestionnaireFieldIds, boolean>;
+
+// ---------------- v155 generators ----------------
+
+export const generatev155UserData = (overrides: Partial<v155UserData>): v155UserData => {
+  return {
+    user: generatev155BusinessUser({}),
+    version: 155,
+    lastUpdatedISO: "",
+    dateCreatedISO: "",
+    versionWhenCreated: 141,
+    businesses: {
+      "123": generatev155Business({ id: "123" }),
+    },
+    currentBusinessId: "",
+    ...overrides,
+  };
+};
+
+export const generatev155BusinessUser = (overrides: Partial<v155BusinessUser>): v155BusinessUser => {
+  return {
+    name: `some-name-${randomInt()}`,
+    email: `some-email-${randomInt()}@example.com`,
+    id: `some-id-${randomInt()}`,
+    receiveNewsletter: false,
+    userTesting: false,
+    externalStatus: {
+      userTesting: {
+        success: true,
+        status: "SUCCESS",
+      },
+    },
+    myNJUserKey: undefined,
+    intercomHash: undefined,
+    abExperience: "ExperienceA",
+    accountCreationSource: `some-source-${randomInt()}`,
+    contactSharingWithAccountCreationPartner: false,
+    ...overrides,
+  };
+};
+
+export const generatev155Business = (overrides: Partial<v155Business>): v155Business => {
+  const profileData = generatev155ProfileData({});
+
+  return {
+    id: `some-id-${randomInt()}`,
+    dateCreatedISO: "",
+    lastUpdatedISO: "",
+    profileData: profileData,
+    preferences: generatev155Preferences({}),
+    formationData: generatev155FormationData({}, profileData.legalStructureId ?? ""),
+    onboardingFormProgress: "UNSTARTED",
+    taskProgress: {
+      "business-structure": "NOT_STARTED",
+    },
+    taskItemChecklist: {
+      "general-dvob": false,
+    },
+    licenseData: undefined,
+    taxFilingData: generatev155TaxFilingData({}),
+    environmentData: undefined,
+    userId: `some-id-${randomInt()}`,
+    version: 155,
+    versionWhenCreated: -1,
+    ...overrides,
+  };
+};
+
+export const generatev155ProfileData = (overrides: Partial<v155ProfileData>): v155ProfileData => {
+  const id = `some-id-${randomInt()}`;
+  const persona = randomInt() % 2 ? "STARTING" : "OWNING";
+  return {
+    ...generatev155IndustrySpecificData({}),
+    businessPersona: persona,
+    businessName: `some-business-name-${randomInt()}`,
+    industryId: "restaurant",
+    legalStructureId: "limited-liability-partnership",
+    dateOfFormation: undefined,
+    entityId: randomInt(10).toString(),
+    employerId: randomInt(9).toString(),
+    taxId: randomInt() % 2 ? randomInt(9).toString() : randomInt(12).toString(),
+    encryptedTaxId: `some-encrypted-value`,
+    notes: `some-notes-${randomInt()}`,
+    existingEmployees: randomInt(7).toString(),
+    naicsCode: randomInt(6).toString(),
+    nexusDbaName: "undefined",
+    operatingPhase: "NEEDS_TO_FORM",
+    ownershipTypeIds: [],
+    documents: {
+      certifiedDoc: `${id}/certifiedDoc-${randomInt()}.pdf`,
+      formationDoc: `${id}/formationDoc-${randomInt()}.pdf`,
+      standingDoc: `${id}/standingDoc-${randomInt()}.pdf`,
+    },
+    taxPin: randomInt(4).toString(),
+    sectorId: undefined,
+    foreignBusinessTypeIds: [],
+    municipality: undefined,
+    responsibleOwnerName: `some-owner-name-${randomInt()}`,
+    tradeName: `some-trade-name-${randomInt()}`,
+    elevatorOwningBusiness: undefined,
+    nonEssentialRadioAnswers: {},
+    plannedRenovationQuestion: undefined,
+    communityAffairsAddress: undefined,
+    raffleBingoGames: undefined,
+    businessOpenMoreThanTwoYears: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev155IndustrySpecificData = (
+  overrides: Partial<v155IndustrySpecificData>
+): v155IndustrySpecificData => {
+  return {
+    liquorLicense: false,
+    requiresCpa: false,
+    homeBasedBusiness: false,
+    cannabisLicenseType: undefined,
+    cannabisMicrobusiness: undefined,
+    constructionRenovationPlan: undefined,
+    providesStaffingService: false,
+    certifiedInteriorDesigner: false,
+    realEstateAppraisalManagement: false,
+    carService: undefined,
+    interstateTransport: false,
+    isChildcareForSixOrMore: undefined,
+    willSellPetCareItems: undefined,
+    petCareHousing: undefined,
+    interstateLogistics: undefined,
+    interstateMoving: undefined,
+    constructionType: undefined,
+    residentialConstructionType: undefined,
+    employmentPersonnelServiceType: undefined,
+    employmentPlacementType: undefined,
+    carnivalRideOwningBusiness: undefined,
+    propertyLeaseType: undefined,
+    hasThreeOrMoreRentalUnits: undefined,
+    travelingCircusOrCarnivalOwningBusiness: undefined,
+    vacantPropertyOwner: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev155Preferences = (overrides: Partial<v155Preferences>): v155Preferences => {
+  return {
+    roadmapOpenSections: ["PLAN", "START"],
+    roadmapOpenSteps: [],
+    hiddenCertificationIds: [],
+    hiddenFundingIds: [],
+    visibleSidebarCards: [],
+    returnToLink: "",
+    isCalendarFullView: true,
+    isHideableRoadmapOpen: false,
+    phaseNewlyChanged: false,
+    isNonProfitFromFunding: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev155FormationData = (
+  overrides: Partial<v155FormationData>,
+  legalStructureId: string
+): v155FormationData => {
+  return {
+    formationFormData: generatev155FormationFormData({}, legalStructureId),
+    formationResponse: undefined,
+    getFilingResponse: undefined,
+    completedFilingPayment: false,
+    businessNameAvailability: undefined,
+    lastVisitedPageIndex: 0,
+    dbaBusinessNameAvailability: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev155FormationFormData = (
+  overrides: Partial<v155FormationFormData>,
+  legalStructureId: string
+): v155FormationFormData => {
+  const isCorp = legalStructureId ? ["s-corporation", "c-corporation"].includes(legalStructureId) : false;
+
+  return <v155FormationFormData>{
+    businessName: `some-business-name-${randomInt()}`,
+    businessSuffix: "LLC",
+    businessTotalStock: isCorp ? randomInt().toString() : "",
+    businessStartDate: new Date(Date.now()).toISOString().split("T")[0],
+    businessPurpose: `some-purpose-${randomInt()}`,
+    addressLine1: `some-members-address-1-${randomInt()}`,
+    addressLine2: `some-members-address-2-${randomInt()}`,
+    addressCity: `some-members-address-city-${randomInt()}`,
+    addressState: { shortCode: "123", name: "new-jersey" },
+    addressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    addressCountry: `some-county`,
+    addressMunicipality: generatev155Municipality({}),
+    addressProvince: "",
+    withdrawals: `some-withdrawals-text-${randomInt()}`,
+    combinedInvestment: `some-combinedInvestment-text-${randomInt()}`,
+    dissolution: `some-dissolution-text-${randomInt()}`,
+    canCreateLimitedPartner: !!(randomInt() % 2),
+    createLimitedPartnerTerms: `some-createLimitedPartnerTerms-text-${randomInt()}`,
+    canGetDistribution: !!(randomInt() % 2),
+    getDistributionTerms: `some-getDistributionTerms-text-${randomInt()}`,
+    canMakeDistribution: !!(randomInt() % 2),
+    makeDistributionTerms: `make-getDistributionTerms-text-${randomInt()}`,
+    hasNonprofitBoardMembers: true,
+    nonprofitBoardMemberQualificationsSpecified: "IN_BYLAWS",
+    nonprofitBoardMemberQualificationsTerms: "",
+    nonprofitBoardMemberRightsSpecified: "IN_BYLAWS",
+    nonprofitBoardMemberRightsTerms: "",
+    nonprofitTrusteesMethodSpecified: "IN_BYLAWS",
+    nonprofitTrusteesMethodTerms: "",
+    nonprofitAssetDistributionSpecified: "IN_BYLAWS",
+    nonprofitAssetDistributionTerms: "",
+    provisions: [],
+    agentNumberOrManual: randomInt() % 2 ? "NUMBER" : "MANUAL_ENTRY",
+    agentNumber: `some-agent-number-${randomInt()}`,
+    agentName: `some-agent-name-${randomInt()}`,
+    agentEmail: `some-agent-email-${randomInt()}`,
+    agentOfficeAddressLine1: `some-agent-office-address-1-${randomInt()}`,
+    agentOfficeAddressLine2: `some-agent-office-address-2-${randomInt()}`,
+    agentOfficeAddressCity: `some-agent-office-address-city-${randomInt()}`,
+    agentOfficeAddressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    agentUseAccountInfo: !!(randomInt() % 2),
+    agentUseBusinessAddress: !!(randomInt() % 2),
+    signers: [],
+    members: legalStructureId === "limited-liability-partnership" ? [] : [generatev155FormationMember({})],
+    incorporators: undefined,
+    paymentType: randomInt() % 2 ? "ACH" : "CC",
+    annualReportNotification: !!(randomInt() % 2),
+    corpWatchNotification: !!(randomInt() % 2),
+    officialFormationDocument: !!(randomInt() % 2),
+    certificateOfStanding: !!(randomInt() % 2),
+    certifiedCopyOfFormationDocument: !!(randomInt() % 2),
+    contactFirstName: `some-contact-first-name-${randomInt()}`,
+    contactLastName: `some-contact-last-name-${randomInt()}`,
+    contactPhoneNumber: `some-contact-phone-number-${randomInt()}`,
+    foreignStateOfFormation: undefined,
+    foreignDateOfFormation: undefined,
+    foreignGoodStandingFile: undefined,
+    willPracticeLaw: false,
+    isVeteranNonprofit: false,
+    legalType: "",
+    additionalProvisions: undefined,
+    businessLocationType: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev155Municipality = (overrides: Partial<v155Municipality>): v155Municipality => {
+  return {
+    displayName: `some-display-name-${randomInt()}`,
+    name: `some-name-${randomInt()}`,
+    county: `some-county-${randomInt()}`,
+    id: `some-id-${randomInt()}`,
+    ...overrides,
+  };
+};
+
+export const generatev155FormationMember = (overrides: Partial<v155FormationMember>): v155FormationMember => {
+  return {
+    name: `some-name`,
+    addressLine1: `some-members-address-1-${randomInt()}`,
+    addressLine2: `some-members-address-2-${randomInt()}`,
+    addressCity: `some-members-address-city-${randomInt()}`,
+    addressState: { shortCode: "123", name: "new-jersey" },
+    addressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    addressCountry: `some-county`,
+    businessLocationType: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev155TaxFilingData = (overrides: Partial<v155TaxFilingData>): v155TaxFilingData => {
+  return {
+    state: undefined,
+    businessName: undefined,
+    errorField: undefined,
+    lastUpdatedISO: undefined,
+    registeredISO: undefined,
+    filings: [],
+    ...overrides,
+  };
+};
+
+export const generatev155LicenseDetails = (overrides: Partial<v155LicenseDetails>): v155LicenseDetails => {
+  return {
+    nameAndAddress: generatev155LicenseSearchNameAndAddress({}),
+    licenseStatus: getRandomv155LicenseStatus(),
+    expirationDateISO: "some-expiration-iso",
+    lastUpdatedISO: "some-last-updated",
+    checklistItems: [generatev155LicenseStatusItem()],
+    ...overrides,
+  };
+};
+
+const generatev155LicenseSearchNameAndAddress = (
+  overrides: Partial<v155LicenseSearchNameAndAddress>
+): v155LicenseSearchNameAndAddress => {
+  return {
+    name: `some-name`,
+    addressLine1: `some-members-address-1-${randomInt()}`,
+    addressLine2: `some-members-address-2-${randomInt()}`,
+    zipCode: `some-agent-office-zipcode-${randomInt()}`,
+    ...overrides,
+  };
+};
+
+const generatev155LicenseStatusItem = (): v155LicenseStatusItem => {
+  return {
+    title: `some-title-${randomInt()}`,
+    status: "ACTIVE",
+  };
+};
+
+export const getRandomv155LicenseStatus = (): v155LicenseStatus => {
+  const randomIndex = Math.floor(Math.random() * v155LicenseStatuses.length);
+  return v155LicenseStatuses[randomIndex];
+};

--- a/shared/src/test/factories.ts
+++ b/shared/src/test/factories.ts
@@ -458,6 +458,8 @@ export const generateBusiness = (overrides: Partial<Business>): Business => {
     taxFilingData: generateTaxFilingData({}),
     environmentData: generateEnvironmentData({}),
     version: CURRENT_VERSION,
+    userId: generateUser({}).id,
+    versionWhenCreated: CURRENT_VERSION,
     profileData,
     formationData,
     ...overrides,
@@ -487,7 +489,7 @@ export const generateUserDataForBusiness = (business: Business, overrides?: Part
     versionWhenCreated: -1,
     dateCreatedISO: getCurrentDateISOString(),
     lastUpdatedISO: getCurrentDateISOString(),
-    user: generateUser({}),
+    user: generateUser({ id: business.userId }),
     currentBusinessId: business.id,
     businesses: {
       [business.id]: business,

--- a/shared/src/userData.ts
+++ b/shared/src/userData.ts
@@ -29,14 +29,22 @@ export interface Business {
   readonly taxFilingData: TaxFilingData;
   readonly formationData: FormationData;
   readonly environmentData: EnvironmentData | undefined;
+  readonly versionWhenCreated: number;
   readonly version: number;
+  readonly userId: string;
 }
 
-export const CURRENT_VERSION = 154;
+export const CURRENT_VERSION = 155;
 
-export const createEmptyBusiness = (id?: string): Business => {
+export const createEmptyBusiness = ({
+  userId,
+  businessId,
+}: {
+  userId: string;
+  businessId?: string;
+}): Business => {
   return {
-    id: id || createBusinessId(),
+    id: businessId || createBusinessId(),
     dateCreatedISO: new Date(Date.now()).toISOString(),
     lastUpdatedISO: new Date(Date.now()).toISOString(),
     profileData: createEmptyProfileData(),
@@ -73,6 +81,8 @@ export const createEmptyBusiness = (id?: string): Business => {
     },
     environmentData: undefined,
     version: CURRENT_VERSION,
+    versionWhenCreated: CURRENT_VERSION,
+    userId: userId,
   };
 };
 
@@ -86,7 +96,7 @@ export const createEmptyUserData = (user: BusinessUser): UserData => {
     versionWhenCreated: CURRENT_VERSION,
     currentBusinessId: businessId,
     businesses: {
-      [businessId]: createEmptyBusiness(businessId),
+      [businessId]: createEmptyBusiness({ userId: user.id, businessId }),
     },
   };
 };

--- a/web/src/lib/domain-logic/addAdditionalBusiness.test.ts
+++ b/web/src/lib/domain-logic/addAdditionalBusiness.test.ts
@@ -3,6 +3,7 @@
 import { addAdditionalBusiness } from "@/lib/domain-logic/addAdditionalBusiness";
 import { createEmptyProfileData } from "@businessnjgovnavigator/shared/profileData";
 import { generateBusiness, generateUserDataForBusiness } from "@businessnjgovnavigator/shared/test";
+import { CURRENT_VERSION } from "@businessnjgovnavigator/shared/userData";
 
 describe("addAdditionalBusiness", () => {
   it("adds a new empty business to a userData", () => {
@@ -18,5 +19,36 @@ describe("addAdditionalBusiness", () => {
     expect(newUserData.currentBusinessId).toEqual(newBusinessId);
 
     expect(newUserData.businesses[newBusinessId].profileData).toEqual(createEmptyProfileData());
+  });
+
+  it("adds a new empty business with matching userId", () => {
+    const userId = "multiple-biz-user-123";
+    const firstBusiness = generateBusiness({ userId: userId });
+    const userData = generateUserDataForBusiness(firstBusiness);
+    const newUserData = addAdditionalBusiness(userData);
+
+    expect(Object.keys(newUserData.businesses)).toHaveLength(2);
+    const newBusinessId = Object.keys(newUserData.businesses).find((id) => id !== firstBusiness.id)!;
+
+    expect(newUserData.businesses[newBusinessId].userId).toEqual(userId);
+  });
+
+  it("adds a new empty business with versionWhenAdded as the userData's current version", () => {
+    const userId = "multiple-biz-user-123";
+    const firstBusiness = generateBusiness({
+      userId: userId,
+      versionWhenCreated: 153,
+      version: CURRENT_VERSION,
+    });
+    const userData = generateUserDataForBusiness(firstBusiness, {
+      version: CURRENT_VERSION,
+      versionWhenCreated: 153,
+    });
+    const newUserData = addAdditionalBusiness(userData);
+
+    expect(Object.keys(newUserData.businesses)).toHaveLength(2);
+    const newBusinessId = Object.keys(newUserData.businesses).find((id) => id !== firstBusiness.id)!;
+
+    expect(newUserData.businesses[newBusinessId].versionWhenCreated).toEqual(CURRENT_VERSION);
   });
 });

--- a/web/src/lib/domain-logic/addAdditionalBusiness.ts
+++ b/web/src/lib/domain-logic/addAdditionalBusiness.ts
@@ -1,7 +1,9 @@
 import { createEmptyBusiness, UserData } from "@businessnjgovnavigator/shared/userData";
 
 export const addAdditionalBusiness = (userData: UserData): UserData => {
-  const additionalBusiness = createEmptyBusiness();
+  const additionalBusiness = createEmptyBusiness({
+    userId: userData.user.id,
+  });
   return {
     ...userData,
     currentBusinessId: additionalBusiness.id,

--- a/web/test/pages/onboarding/onboarding-additional-business.test.tsx
+++ b/web/test/pages/onboarding/onboarding-additional-business.test.tsx
@@ -79,8 +79,9 @@ describe("onboarding - additional business", () => {
   });
 
   it("onboards and saves an additional empty business", async () => {
-    const emptyBusiness = createEmptyBusiness();
-    const initialBusiness = generateBusiness({});
+    const userId = "user-id";
+    const emptyBusiness = createEmptyBusiness({ userId: userId });
+    const initialBusiness = generateBusiness({ userId: userId });
     const initialData = generateUserDataForBusiness(initialBusiness);
     expect(Object.keys(initialData.businesses)).toHaveLength(1);
 

--- a/web/test/pages/profile/profile-starting.test.tsx
+++ b/web/test/pages/profile/profile-starting.test.tsx
@@ -287,7 +287,7 @@ describe("profile - starting business", () => {
   });
 
   it("updates the user data on save", async () => {
-    const emptyBusiness = createEmptyBusiness();
+    const emptyBusiness = createEmptyBusiness({ userId: "user-id" });
     const initialBusiness: Business = {
       ...emptyBusiness,
       profileData: {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
Added a migration to add missing fields (`userId`, `version` & `versionWhenCreated`) in the `business` object from previous migrations.
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Steps to Test
Review the migrations from `v151` onwards to ensure that this migration fixes any missing fields.

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
