### PR TITLE
chore(release): 2025.2.1 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2025.2.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.2.0...v2025.2.1) (2025-01-31)
+
+
+### Bug Fixes
+
+* [[#188666282](https://github.com/newjersey/navigator.business.nj.gov/issues/188666282)] add url and additional filtering ([a2f342b](https://github.com/newjersey/navigator.business.nj.gov/commit/a2f342bab45bfb5b200629a075cea3be0d0a969d))
+* [[#188826997](https://github.com/newjersey/navigator.business.nj.gov/issues/188826997)] check router.isReady in onboarding ([4f7e5e3](https://github.com/newjersey/navigator.business.nj.gov/commit/4f7e5e31c51039f71d8dc917be8c546047d053b8))
+
 # [2025.2.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.1.0...v2025.2.0) (2025-01-29)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businessnjgovnavigator/root",
-  "version": "2025.2.0",
+  "version": "2025.2.1",
   "description": "This is the development repository for the work-in-progress business navigator from the New Jersey Office of Innovation. For info on the existing [Business.NJ.gov](https://business.nj.gov) site, please see the [bottom of this document](https://github.com/newjersey/navigator.business.nj.gov#businessnjgov)",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
## [2025.2.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.2.0...v2025.2.1) (2025-01-31)

### Bug Fixes

* [[#188666282](https://github.com/newjersey/navigator.business.nj.gov/issues/188666282)] add url and additional filtering ([a2f342b](https://github.com/newjersey/navigator.business.nj.gov/commit/a2f342bab45bfb5b200629a075cea3be0d0a969d))
* [[#188826997](https://github.com/newjersey/navigator.business.nj.gov/issues/188826997)] check router.isReady in onboarding ([4f7e5e3](https://github.com/newjersey/navigator.business.nj.gov/commit/4f7e5e31c51039f71d8dc917be8c546047d053b8))
