### PR TITLE
fix: [#188838423] from login page to onboarding working again

### DIFF
--- a/web/src/components/LoginEmailCheck.tsx
+++ b/web/src/components/LoginEmailCheck.tsx
@@ -3,20 +3,24 @@ import { WithErrorBar } from "@/components/WithErrorBar";
 import { Heading } from "@/components/njwds-extended/Heading";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
+import { AuthContext } from "@/contexts/authContext";
 import { postUserEmailCheck } from "@/lib/api-client/apiClient";
 import { triggerSignIn } from "@/lib/auth/sessionHelper";
+import { onGuestSignIn } from "@/lib/auth/signinHelper";
 import { useConfig } from "@/lib/data-hooks/useConfig";
-import { ROUTES } from "@/lib/domain-logic/routes";
 import analytics from "@/lib/utils/analytics";
 import { validateEmail } from "@/lib/utils/helpers";
 import { InputLabel } from "@mui/material";
-import Link from "next/link";
+import { useRouter } from "next/compat/router";
 
-import { useState, type ReactElement } from "react";
+import { useContext, useState, type ReactElement } from "react";
 
 export const LoginEmailCheck = (): ReactElement => {
   const [email, setEmail] = useState<string>("");
   const [emailError, setEmailError] = useState<string>("");
+  const router = useRouter();
+
+  const { dispatch } = useContext(AuthContext);
 
   const handleSubmit = (email: string): void => {
     const isValidEmail = validateEmail(email);
@@ -88,7 +92,16 @@ export const LoginEmailCheck = (): ReactElement => {
       <hr className="margin-y-3" />
       <p className="link-account-text">
         <span className="margin-right-05">{Config.checkAccountEmailPage.noAccountText}</span>
-        <Link href={ROUTES.onboarding}>{Config.checkAccountEmailPage.linkAccountLinkText}</Link>
+        <UnStyledButton
+          isUnderline
+          onClick={() => {
+            if (!router) return;
+            onGuestSignIn({ push: router.push, pathname: router.pathname, dispatch });
+          }}
+          isButtonALink
+        >
+          {Config.checkAccountEmailPage.linkAccountLinkText}
+        </UnStyledButton>
       </p>
       <div className="display-flex flex-align-end">
         <p>{Config.checkAccountEmailPage.needHelpText}</p>

--- a/web/src/components/njwds-extended/UnStyledButton.tsx
+++ b/web/src/components/njwds-extended/UnStyledButton.tsx
@@ -11,6 +11,7 @@ interface Props {
   isIntercomEnabled?: boolean;
   ariaLabel?: string;
   isBgTransparent?: boolean;
+  isButtonALink?: boolean;
 }
 
 // eslint-disable-next-line react/display-name
@@ -52,6 +53,7 @@ export const UnStyledButton = forwardRef(
         type={"button"}
         ref={ref}
         onClick={props.onClick}
+        {...(props.isButtonALink ? { role: "link" } : {})}
         {...(props.dataTestid ? { "data-testid": props.dataTestid } : {})}
         {...(props.ariaLabel ? { "aria-label": props.ariaLabel } : {})}
       >

--- a/web/src/lib/auth/signinHelper.ts
+++ b/web/src/lib/auth/signinHelper.ts
@@ -150,6 +150,11 @@ export const onGuestSignIn = async ({
         push(ROUTES.onboarding);
         break;
       }
+      case ROUTES.login: {
+        setRegistrationDimension("Began Onboarding");
+        push(ROUTES.onboarding);
+        break;
+      }
       case ROUTES.fundings: {
         break;
       }


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

We were having an issue when going to the login page from the webflow site, and then navigating to onboarding via the link on the login, onboarding would break. Specifically it would be on onboarding rather than onboarding page 1 (designated via a query param)

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188838423](https://www.pivotaltracker.com/story/show/188838423).

### Approach

Lots of logging and trying to figure out whey useEffects aren't triggering as desired and figuring out how to get them to work

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

1. try going directly to /login,
2. click the first link (Sign up and link your myNewJersey account)
3. navigation through onboarding to dashboard

(the same steps will not work on prod)

1. go to landing
2. click login button in nav bar
3. click the first link (Sign up and link your myNewJersey account)
4. navigation through onboarding to dashboard

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

Turns out this triggers whenever you go directly to the login page, does not appear if you go to landing first. Has to do with initialization of auth state and userState. 

Turns out this wasn't triggering because it doesn't work for pages that you can route to directly and need to call the triggerGuestSignIn to get this initialization when redirecting to onboarding it seems. 

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
