### PR TITLE
feat: [#188843468] implement sector query in onboarding

### DIFF
--- a/web/src/lib/domain-logic/routes.ts
+++ b/web/src/lib/domain-logic/routes.ts
@@ -51,6 +51,7 @@ export enum QUERIES {
   path = "path",
   signUp = "signUp",
   industry = "industry",
+  sector = "sector",
   code = "code",
   openTaxFilingsModal = "openTaxFilingsModal",
   flow = "flow",

--- a/web/src/lib/utils/onboardingPageHelpers.ts
+++ b/web/src/lib/utils/onboardingPageHelpers.ts
@@ -1,7 +1,6 @@
 import { OnboardingFlow } from "@/components/onboarding/OnboardingFlows";
 import { getMergedConfig } from "@/contexts/configContext";
-import { LookupIndustryById } from "@businessnjgovnavigator/shared/industry";
-import { Business } from "@businessnjgovnavigator/shared/userData";
+import { Business, LookupIndustryById, LookupSectorTypeById } from "@businessnjgovnavigator/shared";
 import { QUERY_PARAMS_VALUES } from "../domain-logic/routes";
 import { FlowType, Page } from "../types/types";
 import { getFlow, templateEval } from "./helpers";
@@ -16,6 +15,10 @@ export const mapFlowQueryToPersona: Record<QUERY_PARAMS_VALUES["flow"], FlowType
 
 export const industryQueryParamIsValid = (industryId: string | undefined): boolean => {
   return !!LookupIndustryById(industryId).id;
+};
+
+export const sectorQueryParamIsValid = (sectorId: string): boolean => {
+  return !!LookupSectorTypeById(sectorId).id;
 };
 
 export const flowQueryParamIsValid = (flow: string): boolean => {

--- a/web/test/pages/onboarding/onboarding-shared.test.tsx
+++ b/web/test/pages/onboarding/onboarding-shared.test.tsx
@@ -17,6 +17,7 @@ import {
   mockSuccessfulApiSignups,
   renderPage,
 } from "@/test/pages/onboarding/helpers-onboarding";
+import { arrayOfSectors as sectors } from "@businessnjgovnavigator/shared";
 import {
   createEmptyProfileData,
   generateProfileData,
@@ -99,7 +100,7 @@ describe("onboarding - shared", () => {
     expect(screen.getByTestId("step-1")).toBeInTheDocument();
   });
 
-  it("routes to dashboard page when industry WITHOUT essential question is set by using industry query string", async () => {
+  it("autocompletes onboarding and routes to dashboard page when industry WITHOUT essential question is set by using industry query string", async () => {
     const industry = randomElementFromArray(industriesWithOutEssentialQuestion).id;
     useMockRouter({ isReady: true, query: { industry } });
     renderPage({});
@@ -112,6 +113,23 @@ describe("onboarding - shared", () => {
     expect(currentBusiness().profileData.businessPersona).toEqual("STARTING");
     expect(currentBusiness().profileData.industryId).toEqual(industry);
     expect(currentBusiness().onboardingFormProgress).toEqual("COMPLETED");
+    expect(currentBusiness().profileData.operatingPhase).toEqual(OperatingPhaseId.GUEST_MODE);
+  });
+
+  it("autocompletes onboarding and routes to dashboard page when sector question is set by using sector query string", async () => {
+    const sector = randomElementFromArray(sectors).id;
+    useMockRouter({ isReady: true, query: { sector } });
+    renderPage({});
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith({
+        pathname: ROUTES.dashboard,
+        query: { [QUERIES.fromOnboarding]: "true" },
+      });
+    });
+    expect(currentBusiness().profileData.businessPersona).toEqual("OWNING");
+    expect(currentBusiness().profileData.sectorId).toEqual(sector);
+    expect(currentBusiness().onboardingFormProgress).toEqual("COMPLETED");
+    expect(currentBusiness().profileData.operatingPhase).toEqual(OperatingPhaseId.GUEST_MODE_OWNING);
   });
 
   it("routes to the onboarding industry page when industry WITH essential question is set by using industry query string", async () => {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves https://www.pivotaltracker.com/story/show/188843468

### Approach
This ticket introduces a sector-based query that allows users to autocomplete onboarding. By accessing a URL path containing a sector ID query, guest mode users can automatically complete the onboarding process.

Previously, we were unnecessarily creating new user data at random. However, this is redundant due to our existing update queue functionality. The queue effectively maintains the latest version of the data. As long as new values continue to be queued, there should be no issues. This ticket also includes a cleanup to remove the redundant data creation.
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
The steps work by navigating to the onboarding path with a sector query parameter included. For example - `/onboarding?sector=transportation-and-warehousing`



## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
