### PR TITLE
fix: filter out domestic employers for auto-tax-filing e2e tests

### DIFF
--- a/web/cypress/e2e/auto-tax-filing.spec.ts
+++ b/web/cypress/e2e/auto-tax-filing.spec.ts
@@ -8,7 +8,7 @@ import {
   selectLocation,
 } from "@businessnjgovnavigator/cypress/support/helpers/helpers";
 import { completeNewBusinessOnboarding } from "@businessnjgovnavigator/cypress/support/helpers/helpers-onboarding";
-import { randomNonHomeBasedIndustry } from "@businessnjgovnavigator/cypress/support/helpers/helpers-select-industries";
+import { randomNonHomeBasedNonDomesticEmployerIndustry } from "@businessnjgovnavigator/cypress/support/helpers/helpers-select-industries";
 import { onDashboardPage } from "@businessnjgovnavigator/cypress/support/page_objects/dashboardPage";
 import { onProfilePage } from "@businessnjgovnavigator/cypress/support/page_objects/profilePage";
 
@@ -21,7 +21,7 @@ describe("auto tax filing [feature] [all] [group4]", () => {
 
   // TODO: There is an issue in Cypress where the value of the taxId is being entered incorrectly by the automation. Need to investigate further. Temporarily skipping this test to avoid false failures.
   it.skip("automatically registers for Gov2Go and retrieves tax events if business name and tax id are provided", () => {
-    completeNewBusinessOnboarding({ industry: randomNonHomeBasedIndustry() });
+    completeNewBusinessOnboarding({ industry: randomNonHomeBasedNonDomesticEmployerIndustry() });
     completeBusinessStructureTask({ legalStructureId: randomPublicFilingLegalStructure() });
 
     onDashboardPage.getEditProfileLink().should("exist");
@@ -45,7 +45,7 @@ describe("auto tax filing [feature] [all] [group4]", () => {
   });
 
   it("does not automatically register for Gov2Go and retrieve tax filing if missing business name", () => {
-    completeNewBusinessOnboarding({ industry: randomNonHomeBasedIndustry() });
+    completeNewBusinessOnboarding({ industry: randomNonHomeBasedNonDomesticEmployerIndustry() });
     completeBusinessStructureTask({ legalStructureId: randomPublicFilingLegalStructure() });
 
     onDashboardPage.getEditProfileLink().should("exist");
@@ -64,7 +64,7 @@ describe("auto tax filing [feature] [all] [group4]", () => {
   });
 
   it("does not automatically register for Gov2Go and retrieve tax filing if missing tax id", () => {
-    completeNewBusinessOnboarding({ industry: randomNonHomeBasedIndustry() });
+    completeNewBusinessOnboarding({ industry: randomNonHomeBasedNonDomesticEmployerIndustry() });
     completeBusinessStructureTask({ legalStructureId: randomPublicFilingLegalStructure() });
 
     onDashboardPage.getEditProfileLink().should("exist");

--- a/web/cypress/e2e/auto-tax-filing.spec.ts
+++ b/web/cypress/e2e/auto-tax-filing.spec.ts
@@ -12,71 +12,75 @@ import { randomNonHomeBasedNonDomesticEmployerIndustry } from "@businessnjgovnav
 import { onDashboardPage } from "@businessnjgovnavigator/cypress/support/page_objects/dashboardPage";
 import { onProfilePage } from "@businessnjgovnavigator/cypress/support/page_objects/profilePage";
 
-describe("auto tax filing [feature] [all] [group4]", () => {
-  let businessName: string;
-  beforeEach(() => {
-    cy.loginByCognitoApi();
-    businessName = "Cool Business Name";
-  });
+describe(
+  "auto tax filing [feature] [all] [group4]",
+  { retries: 1 }, // Retry due to a race condition
+  () => {
+    let businessName: string;
+    beforeEach(() => {
+      cy.loginByCognitoApi();
+      businessName = "Cool Business Name";
+    });
 
-  // TODO: There is an issue in Cypress where the value of the taxId is being entered incorrectly by the automation. Need to investigate further. Temporarily skipping this test to avoid false failures.
-  it.skip("automatically registers for Gov2Go and retrieves tax events if business name and tax id are provided", () => {
-    completeNewBusinessOnboarding({ industry: randomNonHomeBasedNonDomesticEmployerIndustry() });
-    completeBusinessStructureTask({ legalStructureId: randomPublicFilingLegalStructure() });
+    // TODO: There is an issue in Cypress where the value of the taxId is being entered incorrectly by the automation. Need to investigate further. Temporarily skipping this test to avoid false failures.
+    it.skip("automatically registers for Gov2Go and retrieves tax events if business name and tax id are provided", () => {
+      completeNewBusinessOnboarding({ industry: randomNonHomeBasedNonDomesticEmployerIndustry() });
+      completeBusinessStructureTask({ legalStructureId: randomPublicFilingLegalStructure() });
 
-    onDashboardPage.getEditProfileLink().should("exist");
-    cy.visit("/profile");
-    cy.get('input[data-testid="businessName"]').type(businessName);
-    onProfilePage.getSaveButton().first().click();
-    openFormationDateModal();
-    selectDate("04/2021");
-    selectLocation("Allendale");
-    clickModalSaveButton();
+      onDashboardPage.getEditProfileLink().should("exist");
+      cy.visit("/profile");
+      cy.get('input[data-testid="businessName"]').type(businessName);
+      onProfilePage.getSaveButton().first().click();
+      openFormationDateModal();
+      selectDate("04/2021");
+      selectLocation("Allendale");
+      clickModalSaveButton();
 
-    onDashboardPage.registerForTaxes();
-    cy.get('input[name="taxId"]').type("123456789098");
-    cy.get("button").contains("Save").click();
-    cy.get(`[data-testid="back-to-dashboard"]`).first().click({ force: true });
-    cy.get('[data-testid="cta-funding-nudge"]').first().click();
-    cy.get('[data-testid="get-tax-access"]').should("not.exist");
-    cy.get('[data-testid="alert-content-container"]').should("exist");
-    onDashboardPage.getTaxFilingCalendar().should("contain", "Your Tax Calendar is pending.");
-    onDashboardPage.getTaxFilingCalendar().should("contain", "Sales and Use Tax");
-  });
+      onDashboardPage.registerForTaxes();
+      cy.get('input[name="taxId"]').type("123456789098");
+      cy.get("button").contains("Save").click();
+      cy.get(`[data-testid="back-to-dashboard"]`).first().click({ force: true });
+      cy.get('[data-testid="cta-funding-nudge"]').first().click();
+      cy.get('[data-testid="get-tax-access"]').should("not.exist");
+      cy.get('[data-testid="alert-content-container"]').should("exist");
+      onDashboardPage.getTaxFilingCalendar().should("contain", "Your Tax Calendar is pending.");
+      onDashboardPage.getTaxFilingCalendar().should("contain", "Sales and Use Tax");
+    });
 
-  it("does not automatically register for Gov2Go and retrieve tax filing if missing business name", () => {
-    completeNewBusinessOnboarding({ industry: randomNonHomeBasedNonDomesticEmployerIndustry() });
-    completeBusinessStructureTask({ legalStructureId: randomPublicFilingLegalStructure() });
+    it("does not automatically register for Gov2Go and retrieve tax filing if missing business name", () => {
+      completeNewBusinessOnboarding({ industry: randomNonHomeBasedNonDomesticEmployerIndustry() });
+      completeBusinessStructureTask({ legalStructureId: randomPublicFilingLegalStructure() });
 
-    onDashboardPage.getEditProfileLink().should("exist");
-    openFormationDateModal();
-    selectDate("04/2021");
-    selectLocation("Allendale");
-    clickModalSaveButton();
+      onDashboardPage.getEditProfileLink().should("exist");
+      openFormationDateModal();
+      selectDate("04/2021");
+      selectLocation("Allendale");
+      clickModalSaveButton();
 
-    onDashboardPage.registerForTaxes();
-    cy.get('input[name="taxId"]').type("123456789098");
-    cy.get("button").contains("Save").click();
-    cy.get(`[data-testid="back-to-dashboard"]`).first().click({ force: true });
-    cy.get('[data-testid="cta-funding-nudge"]').first().click();
-    cy.get('[data-testid="get-tax-access"]').should("exist");
-    cy.get('[data-testid="alert-content-container"]').should("not.exist");
-  });
+      onDashboardPage.registerForTaxes();
+      cy.get('input[name="taxId"]').type("123456789098");
+      cy.get("button").contains("Save").click();
+      cy.get(`[data-testid="back-to-dashboard"]`).first().click({ force: true });
+      cy.get('[data-testid="cta-funding-nudge"]').first().click();
+      cy.get('[data-testid="get-tax-access"]').should("exist");
+      cy.get('[data-testid="alert-content-container"]').should("not.exist");
+    });
 
-  it("does not automatically register for Gov2Go and retrieve tax filing if missing tax id", () => {
-    completeNewBusinessOnboarding({ industry: randomNonHomeBasedNonDomesticEmployerIndustry() });
-    completeBusinessStructureTask({ legalStructureId: randomPublicFilingLegalStructure() });
+    it("does not automatically register for Gov2Go and retrieve tax filing if missing tax id", () => {
+      completeNewBusinessOnboarding({ industry: randomNonHomeBasedNonDomesticEmployerIndustry() });
+      completeBusinessStructureTask({ legalStructureId: randomPublicFilingLegalStructure() });
 
-    onDashboardPage.getEditProfileLink().should("exist");
-    cy.visit("/profile");
-    cy.get('input[data-testid="businessName"]').type(businessName);
-    onProfilePage.getSaveButton().first().click();
-    openFormationDateModal();
-    selectDate("04/2021");
-    selectLocation("Allendale");
-    clickModalSaveButton();
-    cy.get('[data-testid="cta-funding-nudge"]').first().click();
-    cy.get('[data-testid="get-tax-access"]').should("exist");
-    cy.get('[data-testid="alert-content-container"]').should("not.exist");
-  });
-});
+      onDashboardPage.getEditProfileLink().should("exist");
+      cy.visit("/profile");
+      cy.get('input[data-testid="businessName"]').type(businessName);
+      onProfilePage.getSaveButton().first().click();
+      openFormationDateModal();
+      selectDate("04/2021");
+      selectLocation("Allendale");
+      clickModalSaveButton();
+      cy.get('[data-testid="cta-funding-nudge"]').first().click();
+      cy.get('[data-testid="get-tax-access"]').should("exist");
+      cy.get('[data-testid="alert-content-container"]').should("not.exist");
+    });
+  }
+);

--- a/web/cypress/support/helpers/helpers-select-industries.ts
+++ b/web/cypress/support/helpers/helpers-select-industries.ts
@@ -22,3 +22,11 @@ export const randomNonHomeBasedIndustry = (): Industry => {
     industriesNotHomeBasedOrLiquorLicense.filter((x) => x.isEnabled) as Industry[]
   );
 };
+
+export const randomNonHomeBasedNonDomesticEmployerIndustry = (): Industry => {
+  return randomElementFromArray(
+    industriesNotHomeBasedOrLiquorLicense.filter(
+      (x) => x.isEnabled && x.name !== "Domestic Employer"
+    ) as Industry[]
+  );
+};

--- a/web/cypress/support/helpers/helpers.ts
+++ b/web/cypress/support/helpers/helpers.ts
@@ -44,7 +44,7 @@ export const randomElementFromArray = (array: any[]) => {
 export const completeBusinessStructureTask = ({ legalStructureId }: { legalStructureId: string }): void => {
   cy.get('[data-task="business-structure"]').first().scrollIntoView();
   cy.get('[data-task="business-structure"]').first().click();
-  cy.get('[data-testid="business-structure-task"]');
+  cy.get('[data-testid="business-structure-task"]').should("be.visible");
 
   onBusinessStructurePage.selectLegalStructure(legalStructureId as string);
   onBusinessStructurePage.getLegalStructure(legalStructureId as string).should("be.checked");


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

This PR addresses some of the flakiness in our Cypress tests through the following:
- Added a `randomNonHomeBasedNonDomesticEmployerIndustry`, as "Domestic Employer" businesses were sometimes the random seed, and that is not a business type that would yield the elements these tests are expecting.
- Added a retry in the first test suite to workaround a race condition. (A new ticket was created to address the race condition)
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188895388](https://www.pivotaltracker.com/story/show/188895388).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
