### PR TITLE
Update TaskProgress values to only include TO_DO and COMPLETED along with data migration

### DIFF
--- a/api/src/db/migrations/migrations.ts
+++ b/api/src/db/migrations/migrations.ts
@@ -155,6 +155,7 @@ import { migrate_v151_to_v152 } from "@db/migrations/v152_add_land_to_environmen
 import { migrate_v152_to_v153 } from "@db/migrations/v153_add_air_to_environment_data";
 import { migrate_v153_to_v154 } from "@db/migrations/v154_add_business_operating_length_and_nonprofit_status";
 import { migrate_v154_to_v155 } from "@db/migrations/v155_add_user_id_and_version_to_business";
+import { migrate_v155_to_v156 } from "@db/migrations/v156_remove_in_progress_task_status";
 
 export type MigrationFunction = (data: any) => any;
 
@@ -314,6 +315,7 @@ export const Migrations: MigrationFunction[] = [
   migrate_v152_to_v153,
   migrate_v153_to_v154,
   migrate_v154_to_v155,
+  migrate_v155_to_v156,
 ];
 
-export { generatev155UserData as CURRENT_GENERATOR } from "@db/migrations/v155_add_user_id_and_version_to_business";
+export { generatev156UserData as CURRENT_GENERATOR } from "@db/migrations/v156_remove_in_progress_task_status";

--- a/api/src/db/migrations/v156_remove_in_progress_task_status.test.ts
+++ b/api/src/db/migrations/v156_remove_in_progress_task_status.test.ts
@@ -1,0 +1,37 @@
+import {
+  generatev155Business,
+  generatev155UserData,
+} from "@db/migrations/v155_add_user_id_and_version_to_business";
+import { migrate_v155_to_v156 } from "@db/migrations/v156_remove_in_progress_task_status";
+
+describe("v156 migration updates taskProgress values, merging NOT_STARTED and IN_PROGRESS to single value of TO_DO", () => {
+  it("should upgrade v155 business.taksProgess values", () => {
+    const v155UserData = generatev155UserData({
+      businesses: {
+        "biz-1": generatev155Business({
+          id: "biz-1",
+          taskProgress: {
+            ["task-1"]: "NOT_STARTED",
+            ["task-2"]: "IN_PROGRESS",
+            ["task-3"]: "COMPLETED",
+          },
+        }),
+      },
+      version: 155,
+    });
+
+    const migratedUserData = migrate_v155_to_v156(v155UserData);
+    expect(migratedUserData.version).toBe(156);
+
+    const taskProgresses = migratedUserData.businesses["biz-1"].taskProgress;
+
+    expect(taskProgresses["task-1"]).toBeDefined();
+    expect(taskProgresses["task-1"]).toBe("TO_DO");
+
+    expect(taskProgresses["task-2"]).toBeDefined();
+    expect(taskProgresses["task-2"]).toBe("TO_DO");
+
+    expect(taskProgresses["task-3"]).toBeDefined();
+    expect(taskProgresses["task-3"]).toBe("COMPLETED");
+  });
+});

--- a/api/src/db/migrations/v156_remove_in_progress_task_status.ts
+++ b/api/src/db/migrations/v156_remove_in_progress_task_status.ts
@@ -1,0 +1,934 @@
+import { v155Business, v155UserData } from "@db/migrations/v155_add_user_id_and_version_to_business";
+import { randomInt } from "@shared/intHelpers";
+
+export const migrate_v155_to_v156 = (v155Data: v155UserData): v156UserData => {
+  return {
+    ...v155Data,
+    businesses: Object.fromEntries(
+      Object.values(v155Data.businesses)
+        .map((business: v155Business) => migrate_v155Business_to_v156Business(business, v155Data))
+        .map((currBusiness: v156Business) => [currBusiness.id, currBusiness])
+    ),
+    version: 156,
+  } as v156UserData;
+};
+
+export const migrate_v155Business_to_v156Business = (
+  business: v155Business,
+  userData: v155UserData
+): v156Business => {
+  return {
+    ...business,
+    taskProgress: Object.fromEntries(
+      Object.entries(business.taskProgress).map(([taskId, status]) => {
+        if (status === "NOT_STARTED" || status === "IN_PROGRESS") {
+          return [taskId, "TO_DO"];
+        }
+        return [taskId, status];
+      })
+    ),
+    version: 156,
+    versionWhenCreated: 156,
+    userId: userData.user.id,
+  } as v156Business;
+};
+
+export interface v156IndustrySpecificData {
+  liquorLicense: boolean;
+  requiresCpa: boolean;
+  homeBasedBusiness: boolean | undefined;
+  providesStaffingService: boolean;
+  certifiedInteriorDesigner: boolean;
+  realEstateAppraisalManagement: boolean;
+  cannabisLicenseType: v156CannabisLicenseType;
+  cannabisMicrobusiness: boolean | undefined;
+  constructionRenovationPlan: boolean | undefined;
+  carService: v156CarServiceType | undefined;
+  interstateTransport: boolean;
+  interstateLogistics: boolean | undefined;
+  interstateMoving: boolean | undefined;
+  isChildcareForSixOrMore: boolean | undefined;
+  petCareHousing: boolean | undefined;
+  willSellPetCareItems: boolean | undefined;
+  constructionType: v156ConstructionType;
+  residentialConstructionType: v156ResidentialConstructionType;
+  employmentPersonnelServiceType: v156EmploymentAndPersonnelServicesType;
+  employmentPlacementType: v156EmploymentPlacementType;
+  carnivalRideOwningBusiness: boolean | undefined;
+  propertyLeaseType: v156PropertyLeaseType;
+  hasThreeOrMoreRentalUnits: boolean | undefined;
+  travelingCircusOrCarnivalOwningBusiness: boolean | undefined;
+  vacantPropertyOwner: boolean | undefined;
+}
+
+export type v156PropertyLeaseType = "SHORT_TERM_RENTAL" | "LONG_TERM_RENTAL" | "BOTH" | undefined;
+
+// ---------------- v156 types ----------------
+type v156TaskProgress = "TO_DO" | "COMPLETED";
+type v156OnboardingFormProgress = "UNSTARTED" | "COMPLETED";
+type v156ABExperience = "ExperienceA" | "ExperienceB";
+
+export interface v156UserData {
+  user: v156BusinessUser;
+  version: number;
+  lastUpdatedISO: string;
+  dateCreatedISO: string;
+  versionWhenCreated: number;
+  businesses: Record<string, v156Business>;
+  currentBusinessId: string;
+}
+
+export interface v156Business {
+  id: string;
+  dateCreatedISO: string;
+  lastUpdatedISO: string;
+  profileData: v156ProfileData;
+  onboardingFormProgress: v156OnboardingFormProgress;
+  taskProgress: Record<string, v156TaskProgress>;
+  taskItemChecklist: Record<string, boolean>;
+  licenseData: v156LicenseData | undefined;
+  preferences: v156Preferences;
+  taxFilingData: v156TaxFilingData;
+  formationData: v156FormationData;
+  environmentData: v156EnvironmentData | undefined;
+  version: number;
+  versionWhenCreated: number;
+  userId: string;
+}
+
+export interface v156ProfileData extends v156IndustrySpecificData {
+  businessPersona: v156BusinessPersona;
+  businessName: string;
+  responsibleOwnerName: string;
+  tradeName: string;
+  industryId: string | undefined;
+  legalStructureId: string | undefined;
+  municipality: v156Municipality | undefined;
+  dateOfFormation: string | undefined;
+  entityId: string | undefined;
+  employerId: string | undefined;
+  taxId: string | undefined;
+  encryptedTaxId: string | undefined;
+  notes: string;
+  documents: v156ProfileDocuments;
+  ownershipTypeIds: string[];
+  existingEmployees: string | undefined;
+  taxPin: string | undefined;
+  sectorId: string | undefined;
+  naicsCode: string;
+  foreignBusinessTypeIds: v156ForeignBusinessTypeId[];
+  nexusDbaName: string;
+  operatingPhase: v156OperatingPhase;
+  nonEssentialRadioAnswers: Record<string, boolean | undefined>;
+  elevatorOwningBusiness: boolean | undefined;
+  communityAffairsAddress?: v156CommunityAffairsAddress;
+  plannedRenovationQuestion: boolean | undefined;
+  raffleBingoGames: boolean | undefined;
+  businessOpenMoreThanTwoYears: boolean | undefined;
+}
+
+export type v156CommunityAffairsAddress = {
+  streetAddress1: string;
+  streetAddress2?: string;
+  municipality: v156Municipality;
+};
+
+type v156BusinessUser = {
+  name?: string;
+  email: string;
+  id: string;
+  receiveNewsletter: boolean;
+  userTesting: boolean;
+  externalStatus: v156ExternalStatus;
+  myNJUserKey?: string;
+  intercomHash?: string;
+  abExperience: v156ABExperience;
+  accountCreationSource: string;
+  contactSharingWithAccountCreationPartner: boolean;
+};
+
+interface v156ProfileDocuments {
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+}
+
+type v156BusinessPersona = "STARTING" | "OWNING" | "FOREIGN" | undefined;
+type v156OperatingPhase =
+  | "GUEST_MODE"
+  | "NEEDS_TO_FORM"
+  | "NEEDS_BUSINESS_STRUCTURE"
+  | "FORMED"
+  | "UP_AND_RUNNING"
+  | "UP_AND_RUNNING_OWNING"
+  | "REMOTE_SELLER_WORKER"
+  | undefined;
+
+export type v156CannabisLicenseType = "CONDITIONAL" | "ANNUAL" | undefined;
+export type v156CarServiceType = "STANDARD" | "HIGH_CAPACITY" | "BOTH" | undefined;
+export type v156ConstructionType = "RESIDENTIAL" | "COMMERCIAL_OR_INDUSTRIAL" | "BOTH" | undefined;
+export type v156ResidentialConstructionType =
+  | "NEW_HOME_CONSTRUCTION"
+  | "HOME_RENOVATIONS"
+  | "BOTH"
+  | undefined;
+export type v156EmploymentAndPersonnelServicesType = "JOB_SEEKERS" | "EMPLOYERS" | undefined;
+export type v156EmploymentPlacementType = "TEMPORARY" | "PERMANENT" | "BOTH" | undefined;
+
+type v156ForeignBusinessTypeId =
+  | "employeeOrContractorInNJ"
+  | "officeInNJ"
+  | "propertyInNJ"
+  | "companyOperatedVehiclesInNJ"
+  | "employeesInNJ"
+  | "revenueInNJ"
+  | "transactionsInNJ"
+  | "none";
+
+type v156Municipality = {
+  name: string;
+  displayName: string;
+  county: string;
+  id: string;
+};
+
+type v156TaxFilingState = "SUCCESS" | "FAILED" | "UNREGISTERED" | "PENDING" | "API_ERROR";
+type v156TaxFilingErrorFields = "businessName" | "formFailure";
+
+type v156TaxFilingData = {
+  state?: v156TaxFilingState;
+  lastUpdatedISO?: string;
+  registeredISO?: string;
+  errorField?: v156TaxFilingErrorFields;
+  businessName?: string;
+  filings: v156TaxFilingCalendarEvent[];
+};
+
+export type v156CalendarEvent = {
+  readonly dueDate: string; // YYYY-MM-DD
+  readonly calendarEventType: "TAX-FILING" | "LICENSE";
+};
+
+export interface v156TaxFilingCalendarEvent extends v156CalendarEvent {
+  readonly identifier: string;
+  readonly calendarEventType: "TAX-FILING";
+}
+
+export type v156LicenseSearchAddress = {
+  addressLine1: string;
+  addressLine2: string;
+  zipCode: string;
+};
+
+export interface v156LicenseSearchNameAndAddress extends v156LicenseSearchAddress {
+  name: string;
+}
+
+type v156LicenseDetails = {
+  nameAndAddress: v156LicenseSearchNameAndAddress;
+  licenseStatus: v156LicenseStatus;
+  expirationDateISO: string | undefined;
+  lastUpdatedISO: string;
+  checklistItems: v156LicenseStatusItem[];
+};
+
+const v156taskIdLicenseNameMapping = {
+  "apply-for-shop-license": "Cosmetology and Hairstyling-Shop",
+  "appraiser-license": "Real Estate Appraisers-Appraisal Management Company",
+  "architect-license": "Architecture-Certificate of Authorization",
+  "health-club-registration": "Health Club Services",
+  "home-health-aide-license": "Health Care Services",
+  "hvac-license": "HVACR-HVACR CE Sponsor",
+  "landscape-architect-license": "Landscape Architecture-Certificate of Authorization",
+  "license-massage-therapy": "Massage and Bodywork Therapy-Massage and Bodywork Employer",
+  "moving-company-license": "Public Movers and Warehousemen-Public Mover and Warehouseman",
+  "pharmacy-license": "Pharmacy-Pharmacy",
+  "public-accountant-license": "Accountancy-Firm Registration",
+  "register-accounting-firm": "Accountancy-Firm Registration",
+  "register-consumer-affairs": "Home Improvement Contractors-Home Improvement Contractor",
+  "ticket-broker-reseller-registration": "Ticket Brokers",
+  "telemarketing-license": "Telemarketers",
+} as const;
+
+type v156LicenseTaskID = keyof typeof v156taskIdLicenseNameMapping;
+
+export type v156LicenseName = (typeof v156taskIdLicenseNameMapping)[v156LicenseTaskID];
+
+type v156Licenses = Partial<Record<v156LicenseName, v156LicenseDetails>>;
+
+type v156LicenseData = {
+  lastUpdatedISO: string;
+  licenses?: v156Licenses;
+};
+
+type v156Preferences = {
+  roadmapOpenSections: v156SectionType[];
+  roadmapOpenSteps: number[];
+  hiddenFundingIds: string[];
+  hiddenCertificationIds: string[];
+  visibleSidebarCards: string[];
+  isCalendarFullView: boolean;
+  returnToLink: string;
+  isHideableRoadmapOpen: boolean;
+  phaseNewlyChanged: boolean;
+  isNonProfitFromFunding?: boolean;
+};
+
+type v156LicenseStatusItem = {
+  title: string;
+  status: v156CheckoffStatus;
+};
+
+type v156CheckoffStatus = "ACTIVE" | "PENDING" | "UNKNOWN";
+
+type v156LicenseStatus =
+  | "ACTIVE"
+  | "PENDING"
+  | "UNKNOWN"
+  | "EXPIRED"
+  | "BARRED"
+  | "OUT_OF_BUSINESS"
+  | "REINSTATEMENT_PENDING"
+  | "CLOSED"
+  | "DELETED"
+  | "DENIED"
+  | "VOLUNTARY_SURRENDER"
+  | "WITHDRAWN";
+
+const v156LicenseStatuses: v156LicenseStatus[] = [
+  "ACTIVE",
+  "PENDING",
+  "UNKNOWN",
+  "EXPIRED",
+  "BARRED",
+  "OUT_OF_BUSINESS",
+  "REINSTATEMENT_PENDING",
+  "CLOSED",
+  "DELETED",
+  "DENIED",
+  "VOLUNTARY_SURRENDER",
+  "WITHDRAWN",
+];
+
+const v156SectionNames = ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"] as const;
+type v156SectionType = (typeof v156SectionNames)[number];
+
+type v156ExternalStatus = {
+  newsletter?: v156NewsletterResponse;
+  userTesting?: v156UserTestingResponse;
+};
+
+interface v156NewsletterResponse {
+  success?: boolean;
+  status: v156NewsletterStatus;
+}
+
+interface v156UserTestingResponse {
+  success?: boolean;
+  status: v156UserTestingStatus;
+}
+
+type v156NewsletterStatus = (typeof newsletterStatusList)[number];
+
+const externalStatusList = ["SUCCESS", "IN_PROGRESS", "CONNECTION_ERROR"] as const;
+
+const userTestingStatusList = [...externalStatusList] as const;
+
+type v156UserTestingStatus = (typeof userTestingStatusList)[number];
+
+const newsletterStatusList = [
+  ...externalStatusList,
+  "EMAIL_ERROR",
+  "TOPIC_ERROR",
+  "RESPONSE_WARNING",
+  "RESPONSE_ERROR",
+  "RESPONSE_FAIL",
+  "QUESTION_WARNING",
+] as const;
+
+type v156NameAvailabilityStatus =
+  | "AVAILABLE"
+  | "DESIGNATOR_ERROR"
+  | "SPECIAL_CHARACTER_ERROR"
+  | "UNAVAILABLE"
+  | "RESTRICTED_ERROR"
+  | undefined;
+
+interface v156NameAvailabilityResponse {
+  status: v156NameAvailabilityStatus;
+  similarNames: string[];
+  invalidWord?: string;
+}
+
+interface v156NameAvailability extends v156NameAvailabilityResponse {
+  lastUpdatedTimeStamp: string;
+}
+
+interface v156FormationData {
+  formationFormData: v156FormationFormData;
+  businessNameAvailability: v156NameAvailability | undefined;
+  dbaBusinessNameAvailability: v156NameAvailability | undefined;
+  formationResponse: v156FormationSubmitResponse | undefined;
+  getFilingResponse: v156GetFilingResponse | undefined;
+  completedFilingPayment: boolean;
+  lastVisitedPageIndex: number;
+}
+
+type v156InFormInBylaws = "IN_BYLAWS" | "IN_FORM" | undefined;
+
+interface v156FormationFormData extends v156FormationAddress {
+  readonly businessName: string;
+  readonly businessSuffix: v156BusinessSuffix | undefined;
+  readonly businessTotalStock: string;
+  readonly businessStartDate: string; // YYYY-MM-DD
+  readonly businessPurpose: string;
+  readonly withdrawals: string;
+  readonly combinedInvestment: string;
+  readonly dissolution: string;
+  readonly canCreateLimitedPartner: boolean | undefined;
+  readonly createLimitedPartnerTerms: string;
+  readonly canGetDistribution: boolean | undefined;
+  readonly getDistributionTerms: string;
+  readonly canMakeDistribution: boolean | undefined;
+  readonly makeDistributionTerms: string;
+  readonly hasNonprofitBoardMembers: boolean | undefined;
+  readonly nonprofitBoardMemberQualificationsSpecified: v156InFormInBylaws;
+  readonly nonprofitBoardMemberQualificationsTerms: string;
+  readonly nonprofitBoardMemberRightsSpecified: v156InFormInBylaws;
+  readonly nonprofitBoardMemberRightsTerms: string;
+  readonly nonprofitTrusteesMethodSpecified: v156InFormInBylaws;
+  readonly nonprofitTrusteesMethodTerms: string;
+  readonly nonprofitAssetDistributionSpecified: v156InFormInBylaws;
+  readonly nonprofitAssetDistributionTerms: string;
+  readonly additionalProvisions: string[] | undefined;
+  readonly agentNumberOrManual: "NUMBER" | "MANUAL_ENTRY";
+  readonly agentNumber: string;
+  readonly agentName: string;
+  readonly agentEmail: string;
+  readonly agentOfficeAddressLine1: string;
+  readonly agentOfficeAddressLine2: string;
+  readonly agentOfficeAddressCity: string;
+  readonly agentOfficeAddressZipCode: string;
+  readonly agentUseAccountInfo: boolean;
+  readonly agentUseBusinessAddress: boolean;
+  readonly members: v156FormationMember[] | undefined;
+  readonly incorporators: v156FormationIncorporator[] | undefined;
+  readonly signers: v156FormationSigner[] | undefined;
+  readonly paymentType: v156PaymentType;
+  readonly annualReportNotification: boolean;
+  readonly corpWatchNotification: boolean;
+  readonly officialFormationDocument: boolean;
+  readonly certificateOfStanding: boolean;
+  readonly certifiedCopyOfFormationDocument: boolean;
+  readonly contactFirstName: string;
+  readonly contactLastName: string;
+  readonly contactPhoneNumber: string;
+  readonly foreignStateOfFormation: v156StateObject | undefined;
+  readonly foreignDateOfFormation: string | undefined; // YYYY-MM-DD
+  readonly foreignGoodStandingFile: v156ForeignGoodStandingFileObject | undefined;
+  readonly legalType: string;
+  readonly willPracticeLaw: boolean | undefined;
+  readonly isVeteranNonprofit: boolean | undefined;
+}
+
+type v156ForeignGoodStandingFileObject = {
+  Extension: "PDF" | "PNG";
+  Content: string;
+};
+
+type v156StateObject = {
+  shortCode: string;
+  name: string;
+};
+
+interface v156FormationAddress {
+  readonly addressLine1: string;
+  readonly addressLine2: string;
+  readonly addressCity?: string;
+  readonly addressState?: v156StateObject;
+  readonly addressMunicipality?: v156Municipality;
+  readonly addressProvince?: string;
+  readonly addressZipCode: string;
+  readonly addressCountry: string;
+  readonly businessLocationType: v156FormationBusinessLocationType | undefined;
+}
+
+type v156FormationBusinessLocationType = "US" | "INTL" | "NJ";
+
+type v156SignerTitle =
+  | "Authorized Representative"
+  | "Authorized Partner"
+  | "Incorporator"
+  | "General Partner"
+  | "President"
+  | "Vice-President"
+  | "Chairman of the Board"
+  | "CEO";
+
+interface v156FormationSigner {
+  readonly name: string;
+  readonly signature: boolean;
+  readonly title: v156SignerTitle;
+}
+
+interface v156FormationIncorporator extends v156FormationSigner, v156FormationAddress {}
+
+interface v156FormationMember extends v156FormationAddress {
+  readonly name: string;
+}
+
+type v156PaymentType = "CC" | "ACH" | undefined;
+
+const llcBusinessSuffix = [
+  "LLC",
+  "L.L.C.",
+  "LTD LIABILITY CO",
+  "LTD LIABILITY CO.",
+  "LTD LIABILITY COMPANY",
+  "LIMITED LIABILITY CO",
+  "LIMITED LIABILITY CO.",
+  "LIMITED LIABILITY COMPANY",
+] as const;
+
+const llpBusinessSuffix = [
+  "Limited Liability Partnership",
+  "LLP",
+  "L.L.P.",
+  "Registered Limited Liability Partnership",
+  "RLLP",
+  "R.L.L.P.",
+] as const;
+
+export const lpBusinessSuffix = ["LIMITED PARTNERSHIP", "LP", "L.P."] as const;
+
+const corpBusinessSuffix = [
+  "Corporation",
+  "Incorporated",
+  "Company",
+  "LTD",
+  "CO",
+  "CO.",
+  "CORP",
+  "CORP.",
+  "INC",
+  "INC.",
+] as const;
+
+export const nonprofitBusinessSuffix = [
+  "A NJ NONPROFIT CORPORATION",
+  "CORPORATION",
+  "INCORPORATED",
+  "CORP",
+  "CORP.",
+  "INC",
+  "INC.",
+] as const;
+
+const foreignCorpBusinessSuffix = [...corpBusinessSuffix, "P.C.", "P.A."] as const;
+
+export const AllBusinessSuffixes = [
+  ...llcBusinessSuffix,
+  ...llpBusinessSuffix,
+  ...lpBusinessSuffix,
+  ...corpBusinessSuffix,
+  ...foreignCorpBusinessSuffix,
+  ...nonprofitBusinessSuffix,
+] as const;
+
+type v156BusinessSuffix = (typeof AllBusinessSuffixes)[number];
+
+type v156FormationSubmitResponse = {
+  success: boolean;
+  token: string | undefined;
+  formationId: string | undefined;
+  redirect: string | undefined;
+  errors: v156FormationSubmitError[];
+  lastUpdatedISO: string | undefined;
+};
+
+type v156FormationSubmitError = {
+  field: string;
+  type: "FIELD" | "UNKNOWN" | "RESPONSE";
+  message: string;
+};
+
+type v156GetFilingResponse = {
+  success: boolean;
+  entityId: string;
+  transactionDate: string;
+  confirmationNumber: string;
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+};
+
+export type v156EnvironmentData = {
+  waste?: v156WasteData;
+  land?: v156LandData;
+  air?: v156AirData;
+};
+
+export type v156MediaArea = keyof v156EnvironmentData;
+export type v156QuestionnaireFieldIds =
+  | v156WasteQuestionnaireFieldIds
+  | v156LandQuestionnaireFieldIds
+  | v156AirQuestionnaireFieldIds;
+export type v156Questionnaire = Record<v156QuestionnaireFieldIds, boolean>;
+export type v156QuestionnaireConfig = Record<v156QuestionnaireFieldIds, string>;
+
+export type v156WasteData = {
+  questionnaireData: v156WasteQuestionnaireData;
+  submitted: boolean;
+};
+
+export type v156WasteQuestionnaireFieldIds =
+  | "hazardousMedicalWaste"
+  | "compostWaste"
+  | "treatProcessWaste"
+  | "constructionDebris"
+  | "noWaste";
+
+export type v156WasteQuestionnaireData = Record<v156WasteQuestionnaireFieldIds, boolean>;
+
+export type v156LandData = {
+  questionnaireData: v156LandQuestionnaireData;
+  submitted: boolean;
+};
+
+export type v156LandQuestionnaireFieldIds =
+  | "takeOverExistingBiz"
+  | "propertyAssessment"
+  | "constructionActivities"
+  | "siteImprovementWasteLands"
+  | "noLand";
+
+export type v156LandQuestionnaireData = Record<v156LandQuestionnaireFieldIds, boolean>;
+
+export type v156AirData = {
+  questionnaireData: v156AirQuestionnaireData;
+  submitted: boolean;
+};
+
+export type v156AirQuestionnaireFieldIds =
+  | "emitPollutants"
+  | "emitEmissions"
+  | "constructionActivities"
+  | "noAir";
+
+export type v156AirQuestionnaireData = Record<v156AirQuestionnaireFieldIds, boolean>;
+
+// ---------------- v156 generators ----------------
+
+export const generatev156UserData = (overrides: Partial<v156UserData>): v156UserData => {
+  return {
+    user: generatev156BusinessUser({}),
+    version: 156,
+    lastUpdatedISO: "",
+    dateCreatedISO: "",
+    versionWhenCreated: 141,
+    businesses: {
+      "123": generatev156Business({ id: "123" }),
+    },
+    currentBusinessId: "",
+    ...overrides,
+  };
+};
+
+export const generatev156BusinessUser = (overrides: Partial<v156BusinessUser>): v156BusinessUser => {
+  return {
+    name: `some-name-${randomInt()}`,
+    email: `some-email-${randomInt()}@example.com`,
+    id: `some-id-${randomInt()}`,
+    receiveNewsletter: false,
+    userTesting: false,
+    externalStatus: {
+      userTesting: {
+        success: true,
+        status: "SUCCESS",
+      },
+    },
+    myNJUserKey: undefined,
+    intercomHash: undefined,
+    abExperience: "ExperienceA",
+    accountCreationSource: `some-source-${randomInt()}`,
+    contactSharingWithAccountCreationPartner: false,
+    ...overrides,
+  };
+};
+
+export const generatev156Business = (overrides: Partial<v156Business>): v156Business => {
+  const profileData = generatev156ProfileData({});
+
+  return {
+    id: `some-id-${randomInt()}`,
+    dateCreatedISO: "",
+    lastUpdatedISO: "",
+    profileData: profileData,
+    preferences: generatev156Preferences({}),
+    formationData: generatev156FormationData({}, profileData.legalStructureId ?? ""),
+    onboardingFormProgress: "UNSTARTED",
+    taskProgress: {
+      "business-structure": "TO_DO",
+    },
+    taskItemChecklist: {
+      "general-dvob": false,
+    },
+    licenseData: undefined,
+    taxFilingData: generatev156TaxFilingData({}),
+    environmentData: undefined,
+    userId: `some-id-${randomInt()}`,
+    version: 156,
+    versionWhenCreated: -1,
+    ...overrides,
+  };
+};
+
+export const generatev156ProfileData = (overrides: Partial<v156ProfileData>): v156ProfileData => {
+  const id = `some-id-${randomInt()}`;
+  const persona = randomInt() % 2 ? "STARTING" : "OWNING";
+  return {
+    ...generatev156IndustrySpecificData({}),
+    businessPersona: persona,
+    businessName: `some-business-name-${randomInt()}`,
+    industryId: "restaurant",
+    legalStructureId: "limited-liability-partnership",
+    dateOfFormation: undefined,
+    entityId: randomInt(10).toString(),
+    employerId: randomInt(9).toString(),
+    taxId: randomInt() % 2 ? randomInt(9).toString() : randomInt(12).toString(),
+    encryptedTaxId: `some-encrypted-value`,
+    notes: `some-notes-${randomInt()}`,
+    existingEmployees: randomInt(7).toString(),
+    naicsCode: randomInt(6).toString(),
+    nexusDbaName: "undefined",
+    operatingPhase: "NEEDS_TO_FORM",
+    ownershipTypeIds: [],
+    documents: {
+      certifiedDoc: `${id}/certifiedDoc-${randomInt()}.pdf`,
+      formationDoc: `${id}/formationDoc-${randomInt()}.pdf`,
+      standingDoc: `${id}/standingDoc-${randomInt()}.pdf`,
+    },
+    taxPin: randomInt(4).toString(),
+    sectorId: undefined,
+    foreignBusinessTypeIds: [],
+    municipality: undefined,
+    responsibleOwnerName: `some-owner-name-${randomInt()}`,
+    tradeName: `some-trade-name-${randomInt()}`,
+    elevatorOwningBusiness: undefined,
+    nonEssentialRadioAnswers: {},
+    plannedRenovationQuestion: undefined,
+    communityAffairsAddress: undefined,
+    raffleBingoGames: undefined,
+    businessOpenMoreThanTwoYears: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev156IndustrySpecificData = (
+  overrides: Partial<v156IndustrySpecificData>
+): v156IndustrySpecificData => {
+  return {
+    liquorLicense: false,
+    requiresCpa: false,
+    homeBasedBusiness: false,
+    cannabisLicenseType: undefined,
+    cannabisMicrobusiness: undefined,
+    constructionRenovationPlan: undefined,
+    providesStaffingService: false,
+    certifiedInteriorDesigner: false,
+    realEstateAppraisalManagement: false,
+    carService: undefined,
+    interstateTransport: false,
+    isChildcareForSixOrMore: undefined,
+    willSellPetCareItems: undefined,
+    petCareHousing: undefined,
+    interstateLogistics: undefined,
+    interstateMoving: undefined,
+    constructionType: undefined,
+    residentialConstructionType: undefined,
+    employmentPersonnelServiceType: undefined,
+    employmentPlacementType: undefined,
+    carnivalRideOwningBusiness: undefined,
+    propertyLeaseType: undefined,
+    hasThreeOrMoreRentalUnits: undefined,
+    travelingCircusOrCarnivalOwningBusiness: undefined,
+    vacantPropertyOwner: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev156Preferences = (overrides: Partial<v156Preferences>): v156Preferences => {
+  return {
+    roadmapOpenSections: ["PLAN", "START"],
+    roadmapOpenSteps: [],
+    hiddenCertificationIds: [],
+    hiddenFundingIds: [],
+    visibleSidebarCards: [],
+    returnToLink: "",
+    isCalendarFullView: true,
+    isHideableRoadmapOpen: false,
+    phaseNewlyChanged: false,
+    isNonProfitFromFunding: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev156FormationData = (
+  overrides: Partial<v156FormationData>,
+  legalStructureId: string
+): v156FormationData => {
+  return {
+    formationFormData: generatev156FormationFormData({}, legalStructureId),
+    formationResponse: undefined,
+    getFilingResponse: undefined,
+    completedFilingPayment: false,
+    businessNameAvailability: undefined,
+    lastVisitedPageIndex: 0,
+    dbaBusinessNameAvailability: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev156FormationFormData = (
+  overrides: Partial<v156FormationFormData>,
+  legalStructureId: string
+): v156FormationFormData => {
+  const isCorp = legalStructureId ? ["s-corporation", "c-corporation"].includes(legalStructureId) : false;
+
+  return <v156FormationFormData>{
+    businessName: `some-business-name-${randomInt()}`,
+    businessSuffix: "LLC",
+    businessTotalStock: isCorp ? randomInt().toString() : "",
+    businessStartDate: new Date(Date.now()).toISOString().split("T")[0],
+    businessPurpose: `some-purpose-${randomInt()}`,
+    addressLine1: `some-members-address-1-${randomInt()}`,
+    addressLine2: `some-members-address-2-${randomInt()}`,
+    addressCity: `some-members-address-city-${randomInt()}`,
+    addressState: { shortCode: "123", name: "new-jersey" },
+    addressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    addressCountry: `some-county`,
+    addressMunicipality: generatev156Municipality({}),
+    addressProvince: "",
+    withdrawals: `some-withdrawals-text-${randomInt()}`,
+    combinedInvestment: `some-combinedInvestment-text-${randomInt()}`,
+    dissolution: `some-dissolution-text-${randomInt()}`,
+    canCreateLimitedPartner: !!(randomInt() % 2),
+    createLimitedPartnerTerms: `some-createLimitedPartnerTerms-text-${randomInt()}`,
+    canGetDistribution: !!(randomInt() % 2),
+    getDistributionTerms: `some-getDistributionTerms-text-${randomInt()}`,
+    canMakeDistribution: !!(randomInt() % 2),
+    makeDistributionTerms: `make-getDistributionTerms-text-${randomInt()}`,
+    hasNonprofitBoardMembers: true,
+    nonprofitBoardMemberQualificationsSpecified: "IN_BYLAWS",
+    nonprofitBoardMemberQualificationsTerms: "",
+    nonprofitBoardMemberRightsSpecified: "IN_BYLAWS",
+    nonprofitBoardMemberRightsTerms: "",
+    nonprofitTrusteesMethodSpecified: "IN_BYLAWS",
+    nonprofitTrusteesMethodTerms: "",
+    nonprofitAssetDistributionSpecified: "IN_BYLAWS",
+    nonprofitAssetDistributionTerms: "",
+    provisions: [],
+    agentNumberOrManual: randomInt() % 2 ? "NUMBER" : "MANUAL_ENTRY",
+    agentNumber: `some-agent-number-${randomInt()}`,
+    agentName: `some-agent-name-${randomInt()}`,
+    agentEmail: `some-agent-email-${randomInt()}`,
+    agentOfficeAddressLine1: `some-agent-office-address-1-${randomInt()}`,
+    agentOfficeAddressLine2: `some-agent-office-address-2-${randomInt()}`,
+    agentOfficeAddressCity: `some-agent-office-address-city-${randomInt()}`,
+    agentOfficeAddressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    agentUseAccountInfo: !!(randomInt() % 2),
+    agentUseBusinessAddress: !!(randomInt() % 2),
+    signers: [],
+    members: legalStructureId === "limited-liability-partnership" ? [] : [generatev156FormationMember({})],
+    incorporators: undefined,
+    paymentType: randomInt() % 2 ? "ACH" : "CC",
+    annualReportNotification: !!(randomInt() % 2),
+    corpWatchNotification: !!(randomInt() % 2),
+    officialFormationDocument: !!(randomInt() % 2),
+    certificateOfStanding: !!(randomInt() % 2),
+    certifiedCopyOfFormationDocument: !!(randomInt() % 2),
+    contactFirstName: `some-contact-first-name-${randomInt()}`,
+    contactLastName: `some-contact-last-name-${randomInt()}`,
+    contactPhoneNumber: `some-contact-phone-number-${randomInt()}`,
+    foreignStateOfFormation: undefined,
+    foreignDateOfFormation: undefined,
+    foreignGoodStandingFile: undefined,
+    willPracticeLaw: false,
+    isVeteranNonprofit: false,
+    legalType: "",
+    additionalProvisions: undefined,
+    businessLocationType: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev156Municipality = (overrides: Partial<v156Municipality>): v156Municipality => {
+  return {
+    displayName: `some-display-name-${randomInt()}`,
+    name: `some-name-${randomInt()}`,
+    county: `some-county-${randomInt()}`,
+    id: `some-id-${randomInt()}`,
+    ...overrides,
+  };
+};
+
+export const generatev156FormationMember = (overrides: Partial<v156FormationMember>): v156FormationMember => {
+  return {
+    name: `some-name`,
+    addressLine1: `some-members-address-1-${randomInt()}`,
+    addressLine2: `some-members-address-2-${randomInt()}`,
+    addressCity: `some-members-address-city-${randomInt()}`,
+    addressState: { shortCode: "123", name: "new-jersey" },
+    addressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    addressCountry: `some-county`,
+    businessLocationType: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev156TaxFilingData = (overrides: Partial<v156TaxFilingData>): v156TaxFilingData => {
+  return {
+    state: undefined,
+    businessName: undefined,
+    errorField: undefined,
+    lastUpdatedISO: undefined,
+    registeredISO: undefined,
+    filings: [],
+    ...overrides,
+  };
+};
+
+export const generatev156LicenseDetails = (overrides: Partial<v156LicenseDetails>): v156LicenseDetails => {
+  return {
+    nameAndAddress: generatev156LicenseSearchNameAndAddress({}),
+    licenseStatus: getRandomv156LicenseStatus(),
+    expirationDateISO: "some-expiration-iso",
+    lastUpdatedISO: "some-last-updated",
+    checklistItems: [generatev156LicenseStatusItem()],
+    ...overrides,
+  };
+};
+
+const generatev156LicenseSearchNameAndAddress = (
+  overrides: Partial<v156LicenseSearchNameAndAddress>
+): v156LicenseSearchNameAndAddress => {
+  return {
+    name: `some-name`,
+    addressLine1: `some-members-address-1-${randomInt()}`,
+    addressLine2: `some-members-address-2-${randomInt()}`,
+    zipCode: `some-agent-office-zipcode-${randomInt()}`,
+    ...overrides,
+  };
+};
+
+const generatev156LicenseStatusItem = (): v156LicenseStatusItem => {
+  return {
+    title: `some-title-${randomInt()}`,
+    status: "ACTIVE",
+  };
+};
+
+export const getRandomv156LicenseStatus = (): v156LicenseStatus => {
+  const randomIndex = Math.floor(Math.random() * v156LicenseStatuses.length);
+  return v156LicenseStatuses[randomIndex];
+};

--- a/api/src/domain/updateSidebarCards.test.ts
+++ b/api/src/domain/updateSidebarCards.test.ts
@@ -100,7 +100,7 @@ describe("updateRoadmapSidebarCards", () => {
       const taskId = formationTaskId;
       const userData = generateUserDataForBusiness(
         generateBusiness({
-          taskProgress: { [taskId]: "NOT_STARTED" },
+          taskProgress: { [taskId]: "TO_DO" },
 
           profileData: generateProfileData({
             operatingPhase: OperatingPhaseId.NEEDS_TO_FORM,

--- a/api/src/domain/user/updateLicenseStatusFactory.test.ts
+++ b/api/src/domain/user/updateLicenseStatusFactory.test.ts
@@ -314,7 +314,7 @@ describe("updateLicenseStatus", () => {
 
   describe("task progress", () => {});
 
-  it("defaults the license task status to NOT_STARTED", async () => {
+  it("defaults the license task status to TO_DO", async () => {
     const webserviceChecklistItems = [generateLicenseStatusItem({})];
     const licenseType1 = {
       "Pharmacy-Pharmacy": {
@@ -339,11 +339,11 @@ describe("updateLicenseStatus", () => {
 
     expect(resultCurrentBusiness.taskProgress).toEqual({
       ...initialTaskProgress,
-      "pharmacy-license": "NOT_STARTED",
+      "pharmacy-license": "TO_DO",
     });
   });
 
-  it("updates the license task status to IN_PROGRESS when license is pending", async () => {
+  it("the license task status remains TO_DO when license is pending", async () => {
     const webserviceChecklistItems = [generateLicenseStatusItem({})];
     const licenseType1 = {
       "Pharmacy-Pharmacy": {
@@ -368,7 +368,7 @@ describe("updateLicenseStatus", () => {
 
     expect(resultCurrentBusiness.taskProgress).toEqual({
       ...initialTaskProgress,
-      "pharmacy-license": "IN_PROGRESS",
+      "pharmacy-license": "TO_DO",
     });
   });
 
@@ -437,7 +437,7 @@ describe("updateLicenseStatus", () => {
     expect(resultCurrentBusiness.taskProgress).toEqual({
       ...initialTaskProgress,
       "pharmacy-license": "COMPLETED",
-      "home-health-aide-license": "IN_PROGRESS",
+      "home-health-aide-license": "TO_DO",
     });
   });
 
@@ -460,7 +460,7 @@ describe("updateLicenseStatus", () => {
       ...business,
       taskProgress: {
         ...business.taskProgress,
-        "health-club-registration": "IN_PROGRESS",
+        "health-club-registration": "TO_DO",
       },
       licenseData: generateLicenseData({}),
     }));

--- a/api/src/domain/user/updateOperatingPhase.test.ts
+++ b/api/src/domain/user/updateOperatingPhase.test.ts
@@ -178,7 +178,7 @@ describe("updateOperatingPhase", () => {
             legalStructureId: undefined,
           }),
           taskProgress: {
-            [businessStructureTaskId]: "NOT_STARTED",
+            [businessStructureTaskId]: "TO_DO",
           },
         })
       );

--- a/content/src/fieldConfig/config.json
+++ b/content/src/fieldConfig/config.json
@@ -111,8 +111,7 @@
     "issuingAgencyText": "Issuing Agency"
   },
   "taskProgress": {
-    "NOT_STARTED": "Not started",
-    "IN_PROGRESS": "In progress",
+    "TO_DO": "To do",
     "COMPLETED": "Completed"
   },
   "taskDefaults": {

--- a/shared/src/domain-logic/licenseStatusHelpers.ts
+++ b/shared/src/domain-logic/licenseStatusHelpers.ts
@@ -19,20 +19,6 @@ export type LicenseStatusResults = Partial<
 export const getLicenseTasksProgress = (
   licenseStatusResult: LicenseStatusResults
 ): Record<string, TaskProgress> => {
-  // const licenseTasksProgress: Record<string, TaskProgress> = {};
-  // for (const licenseName of Object.keys(licenseStatusResult) as LicenseName[]) {
-  //   const taskId = Object.keys(taskIdLicenseNameMapping).find(
-  //     (taskId) => taskIdLicenseNameMapping[taskId as keyof typeof taskIdLicenseNameMapping] === licenseName
-  //   );
-  //   let taskStatus: TaskProgress = "NOT_STARTED";
-  //   if (licenseStatusResult[licenseName]!.licenseStatus === "ACTIVE") {
-  //     taskStatus = "COMPLETED";
-  //   } else if (licenseStatusResult[licenseName]!.licenseStatus === "PENDING") {
-  //     taskStatus = "IN_PROGRESS";
-  //   }
-  //   if (taskId !== undefined) licenseTasksProgress[taskId] = taskStatus;
-  // }
-
   const licenseTasksProgress: Record<string, TaskProgress> = {};
   for (const licenseName of Object.keys(licenseStatusResult) as LicenseName[]) {
     const taskId = Object.keys(taskIdLicenseNameMapping).find(
@@ -41,11 +27,9 @@ export const getLicenseTasksProgress = (
     if (taskId === undefined) {
       continue;
     }
-    let taskStatus: TaskProgress = "NOT_STARTED";
+    let taskStatus: TaskProgress = "TO_DO";
     if (licenseStatusResult[licenseName]!.licenseStatus === "ACTIVE") {
       taskStatus = "COMPLETED";
-    } else if (licenseStatusResult[licenseName]!.licenseStatus === "PENDING") {
-      taskStatus = "IN_PROGRESS";
     }
     licenseTasksProgress[taskId] = taskStatus;
   }

--- a/shared/src/userData.ts
+++ b/shared/src/userData.ts
@@ -34,7 +34,7 @@ export interface Business {
   readonly userId: string;
 }
 
-export const CURRENT_VERSION = 155;
+export const CURRENT_VERSION = 156;
 
 export const createEmptyBusiness = ({
   userId,

--- a/shared/src/userData.ts
+++ b/shared/src/userData.ts
@@ -104,7 +104,7 @@ export const createEmptyUserData = (user: BusinessUser): UserData => {
 export const sectionNames = ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"] as const;
 export type SectionType = (typeof sectionNames)[number];
 
-export type TaskProgress = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED";
+export type TaskProgress = "TO_DO" | "COMPLETED";
 
 export interface Preferences {
   roadmapOpenSections: SectionType[];

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -4611,8 +4611,7 @@ collections:
             widget: object
             summary: "{{taskProgress}}"
             fields:
-              - { label: Not Started Text, name: NOT_STARTED, widget: string }
-              - { label: In Progress Text, name: IN_PROGRESS, widget: string }
+              - { label: To Do Text, name: TO_DO, widget: string }
               - { label: Completed Text, name: COMPLETED, widget: string }
           - label: Task Progress Card
             name: taskProgressCard

--- a/web/src/components/Task.tsx
+++ b/web/src/components/Task.tsx
@@ -17,7 +17,7 @@ export const Task = (props: Props): ReactElement => {
   const { business } = useUserData();
   const { Config } = useConfig();
   const isTabletAndUp = useMediaQuery(MediaQueries.tabletAndUp);
-  const taskProgress = (business?.taskProgress && business.taskProgress[props.task.id]) || "NOT_STARTED";
+  const taskProgress = (business?.taskProgress && business.taskProgress[props.task.id]) || "TO_DO";
 
   const renderRequiredLabel = (): ReactNode => {
     if (!props.task.required) {

--- a/web/src/components/TaskHeader.tsx
+++ b/web/src/components/TaskHeader.tsx
@@ -18,7 +18,7 @@ export const TaskHeader = (props: Props): ReactElement => {
   const { business } = useUserData();
   const { roadmap } = useRoadmap();
 
-  const currentTaskProgress: TaskProgress = business?.taskProgress[props.task.id] ?? "NOT_STARTED";
+  const currentTaskProgress: TaskProgress = business?.taskProgress[props.task.id] ?? "TO_DO";
 
   const { Config } = useConfig();
 
@@ -36,10 +36,8 @@ export const TaskHeader = (props: Props): ReactElement => {
 
   const getTextColorClass = (): string => {
     switch (currentTaskProgress) {
-      case "NOT_STARTED":
+      case "TO_DO":
         return "text-base-dark";
-      case "IN_PROGRESS":
-        return "text-accent-cooler-dark";
       case "COMPLETED":
         return "text-primary";
     }
@@ -47,10 +45,8 @@ export const TaskHeader = (props: Props): ReactElement => {
 
   const getBgColorClass = (): string => {
     switch (currentTaskProgress) {
-      case "NOT_STARTED":
+      case "TO_DO":
         return "bg-base-extra-light";
-      case "IN_PROGRESS":
-        return "bg-accent-cool-lightest";
       case "COMPLETED":
         return "bg-primary-extra-light";
     }

--- a/web/src/components/TaskProgressCheckbox.test.tsx
+++ b/web/src/components/TaskProgressCheckbox.test.tsx
@@ -28,7 +28,7 @@ import {
   taxTaskId,
 } from "@businessnjgovnavigator/shared";
 import { createTheme, ThemeProvider } from "@mui/material";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 jest.mock("next/compat/router", () => ({ useRouter: jest.fn() }));
 jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
@@ -73,22 +73,22 @@ describe("<TaskProgressCheckbox />", () => {
     );
   };
 
-  it("displays Not Started status when user data does not contain status", () => {
+  it("displays To Do status when user data does not contain status", () => {
     renderTaskCheckbox("123", generateBusiness({}));
-    expect(screen.getByText(Config.taskProgress.NOT_STARTED)).toBeInTheDocument();
+    expect(screen.getByText(Config.taskProgress.TO_DO)).toBeInTheDocument();
   });
 
   it("displays task status from user data", () => {
     const taskId = "123";
     const taskProgress: Record<string, TaskProgress> = {
       "some-id": "COMPLETED",
-      [taskId]: "IN_PROGRESS",
+      [taskId]: "TO_DO",
     };
     renderTaskCheckbox(taskId, generateBusiness({ taskProgress }));
-    expect(screen.getByText(Config.taskProgress.IN_PROGRESS)).toBeInTheDocument();
+    expect(screen.getByText(Config.taskProgress.TO_DO)).toBeInTheDocument();
   });
 
-  it("cycles through updating task status when progress checkbox is clicked", async () => {
+  it("updates task status when progress checkbox is clicked", async () => {
     const taskId = "123";
     const taskProgress: Record<string, TaskProgress> = { "some-id": "COMPLETED" };
 
@@ -98,27 +98,27 @@ describe("<TaskProgressCheckbox />", () => {
     await waitFor(() => {
       return expect(currentBusiness().taskProgress).toEqual({
         "some-id": "COMPLETED",
-        [taskId]: "IN_PROGRESS",
+        [taskId]: "COMPLETED",
       });
     });
-    await screen.findByText(Config.taskProgress.IN_PROGRESS);
+    await screen.findByText(Config.taskProgress.COMPLETED);
 
     fireEvent.click(screen.getByTestId("change-task-progress-checkbox"));
     await waitFor(() => {
       return expect(currentBusiness().taskProgress).toEqual({
         "some-id": "COMPLETED",
-        [taskId]: "COMPLETED",
+        [taskId]: "TO_DO",
       });
     });
-    await screen.findByText(Config.taskProgress.COMPLETED);
+    await screen.findByText(Config.taskProgress.TO_DO);
   });
 
   it("shows a success snackbar when an option is selected", async () => {
     renderTaskCheckbox("123", generateBusiness({}));
-    expect(screen.queryByText(getTaskStatusUpdatedMessage("IN_PROGRESS"))).not.toBeInTheDocument();
+    expect(screen.queryByText(getTaskStatusUpdatedMessage("COMPLETED"))).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("change-task-progress-checkbox"));
-    await screen.findByText(getTaskStatusUpdatedMessage("IN_PROGRESS"));
+    await screen.findByText(getTaskStatusUpdatedMessage("COMPLETED"));
   });
 
   it("opens Needs Account modal for guest mode user when checkbox is clicked", async () => {
@@ -149,8 +149,8 @@ describe("<TaskProgressCheckbox />", () => {
       fireEvent.click(screen.getByTestId("change-task-progress-checkbox"));
 
       fireEvent.click(screen.getByText(Config.registeredForTaxesModal.areYouSureTaxContinueButton));
-      await screen.findByText(Config.taskProgress.NOT_STARTED);
-      expect(currentBusiness().taskProgress[taxTaskId]).toEqual("NOT_STARTED");
+      await screen.findByText(Config.taskProgress.TO_DO);
+      expect(currentBusiness().taskProgress[taxTaskId]).toEqual("TO_DO");
     });
 
     it("doesn't update the task progress if the user cancels in the warning modal", async () => {
@@ -176,7 +176,7 @@ describe("<TaskProgressCheckbox />", () => {
       expect(screen.getByText(Config.formationDateModal.header)).toBeInTheDocument();
     });
 
-    it("does not open modal when task changed to unstarted or in-progress", () => {
+    it("does not open modal when task changed to TO_DO", () => {
       renderTaskCheckbox(
         formationTaskId,
         generateBusiness({
@@ -196,7 +196,7 @@ describe("<TaskProgressCheckbox />", () => {
       renderTaskCheckbox(
         formationTaskId,
         generateBusiness({
-          taskProgress: { [formationTaskId]: "IN_PROGRESS" },
+          taskProgress: { [formationTaskId]: "TO_DO" },
         })
       );
       fireEvent.click(screen.getByTestId("change-task-progress-checkbox"));
@@ -209,7 +209,7 @@ describe("<TaskProgressCheckbox />", () => {
       renderTaskCheckbox(
         formationTaskId,
         generateBusiness({
-          taskProgress: { [formationTaskId]: "IN_PROGRESS" },
+          taskProgress: { [formationTaskId]: "TO_DO" },
         })
       );
       fireEvent.click(screen.getByTestId("change-task-progress-checkbox"));
@@ -225,14 +225,6 @@ describe("<TaskProgressCheckbox />", () => {
       const startingPersonaForRoadmapUrl = generateProfileData({ businessPersona: "STARTING" });
       renderTaskCheckbox(formationTaskId, generateBusiness({ profileData: startingPersonaForRoadmapUrl }));
       await selectCompleted();
-
-      expect(screen.getByText(getTaskStatusUpdatedMessage("IN_PROGRESS"))).toBeInTheDocument();
-      act(() => {
-        jest.advanceTimersByTime(7000);
-      });
-      await waitFor(() => {
-        return expect(screen.queryByText(getTaskStatusUpdatedMessage("IN_PROGRESS"))).not.toBeInTheDocument();
-      });
 
       const date = getCurrentDate().subtract(1, "month").date(1);
       selectDate(date);
@@ -341,7 +333,6 @@ describe("<TaskProgressCheckbox />", () => {
 
   const selectCompleted = async (): Promise<void> => {
     fireEvent.click(screen.getByTestId("change-task-progress-checkbox"));
-    await screen.findByText(Config.taskProgress.IN_PROGRESS);
-    fireEvent.click(screen.getByTestId("change-task-progress-checkbox"));
+    await screen.findByText(Config.taskProgress.TO_DO);
   };
 });

--- a/web/src/components/TaskProgressCheckbox.tsx
+++ b/web/src/components/TaskProgressCheckbox.tsx
@@ -124,7 +124,7 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
   const sendAnalytics = (nextStatus: TaskProgress): void => {
     switch (nextStatus) {
       case "TO_DO":
-        analytics.event.task_status_checkbox.click.selected_not_started_status();
+        analytics.event.task_status_checkbox.click.selected_to_do_status();
         break;
       case "COMPLETED":
         analytics.event.task_status_checkbox.click.selected_completed_status();
@@ -196,7 +196,7 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
       <button
         data-testid="change-task-progress-checkbox"
         role="checkbox"
-        aria-checked={currentTaskProgress == "COMPLETED"}
+        aria-checked={currentTaskProgress === "COMPLETED"}
         aria-label={`update task status. ${getAdditionalAriaContext()}`}
         onClick={isDisabled ? undefined : (): void => setToNextStatus()}
         className={`cursor-pointer margin-neg-105 padding-105 usa-button--unstyled task-checkbox-base ${styles.hover}`}

--- a/web/src/components/TaskProgressCheckbox.tsx
+++ b/web/src/components/TaskProgressCheckbox.tsx
@@ -53,17 +53,15 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
   }, [business, updateQueue, updateTaskProgressDueToWiremockFormationCompletion]);
 
   const currentTaskProgress: TaskProgress =
-    props.STORYBOOK_ONLY_currentTaskProgress ?? business?.taskProgress[props.taskId] ?? "NOT_STARTED";
+    props.STORYBOOK_ONLY_currentTaskProgress ?? business?.taskProgress[props.taskId] ?? "TO_DO";
   const isDisabled = !!props.disabledTooltipText;
 
   const getNextStatus = (): TaskProgress => {
     switch (currentTaskProgress) {
-      case "NOT_STARTED":
-        return "IN_PROGRESS";
-      case "IN_PROGRESS":
+      case "TO_DO":
         return "COMPLETED";
       case "COMPLETED":
-        return "NOT_STARTED";
+        return "TO_DO";
     }
   };
 
@@ -125,11 +123,8 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
 
   const sendAnalytics = (nextStatus: TaskProgress): void => {
     switch (nextStatus) {
-      case "NOT_STARTED":
+      case "TO_DO":
         analytics.event.task_status_checkbox.click.selected_not_started_status();
-        break;
-      case "IN_PROGRESS":
-        analytics.event.task_status_checkbox.click.selected_in_progress_status();
         break;
       case "COMPLETED":
         analytics.event.task_status_checkbox.click.selected_completed_status();
@@ -139,7 +134,7 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
 
   const getStyles = (): { border: string; bg: string; textColor: string; hover: string } => {
     switch (currentTaskProgress) {
-      case "NOT_STARTED":
+      case "TO_DO":
         if (isDisabled) {
           return {
             border: "border-base-light",
@@ -153,22 +148,6 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
             bg: "bg-white",
             textColor: "",
             hover: "task-checkbox-base-lighter",
-          };
-        }
-      case "IN_PROGRESS":
-        if (isDisabled) {
-          return {
-            border: "border-accent-cool-light",
-            bg: "bg-accent-cool-lightest",
-            textColor: "text-accent-cool-dark",
-            hover: "",
-          };
-        } else {
-          return {
-            border: "border-accent-cool-dark",
-            bg: "bg-white",
-            textColor: "text-accent-cool-dark",
-            hover: "task-checkbox-accent-cool-lighter",
           };
         }
       case "COMPLETED":
@@ -192,10 +171,8 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
 
   const getIcon = (): string => {
     switch (currentTaskProgress) {
-      case "NOT_STARTED":
+      case "TO_DO":
         return "";
-      case "IN_PROGRESS":
-        return "more_horiz";
       case "COMPLETED":
         return "check";
     }
@@ -218,6 +195,8 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
     return (
       <button
         data-testid="change-task-progress-checkbox"
+        role="checkbox"
+        aria-checked={currentTaskProgress == "COMPLETED"}
         aria-label={`update task status. ${getAdditionalAriaContext()}`}
         onClick={isDisabled ? undefined : (): void => setToNextStatus()}
         className={`cursor-pointer margin-neg-105 padding-105 usa-button--unstyled task-checkbox-base ${styles.hover}`}

--- a/web/src/components/TaskProgressTagLookup.tsx
+++ b/web/src/components/TaskProgressTagLookup.tsx
@@ -6,14 +6,9 @@ import { ReactElement } from "react";
 const Config = getMergedConfig();
 
 export const TaskProgressTagLookup: Record<TaskProgress, ReactElement> = {
-  NOT_STARTED: (
-    <Tag backgroundColor="base-lighter" dataTestid="NOT_STARTED" isFixedWidth>
-      {Config.taskProgress.NOT_STARTED}
-    </Tag>
-  ),
-  IN_PROGRESS: (
-    <Tag backgroundColor="accent-cool-lighter-lighttext" dataTestid="IN_PROGRESS" isFixedWidth>
-      {Config.taskProgress.IN_PROGRESS}
+  TO_DO: (
+    <Tag backgroundColor="base-lighter" dataTestid="TO_DO" isFixedWidth>
+      {Config.taskProgress.TO_DO}
     </Tag>
   ),
   COMPLETED: (

--- a/web/src/components/dashboard/DashboardOnDesktop.test.tsx
+++ b/web/src/components/dashboard/DashboardOnDesktop.test.tsx
@@ -174,20 +174,18 @@ describe("<DashboardOnDesktop />", () => {
       tasks: [
         generateTask({ id: "task1", name: "task1", stepNumber: 1 }),
         generateTask({ id: "task2", name: "task2", stepNumber: 1 }),
-        generateTask({ id: "task3", name: "task3", stepNumber: 2 }),
       ],
     });
 
     useMockBusiness({
-      taskProgress: { task1: "IN_PROGRESS", task2: "COMPLETED" },
+      taskProgress: { task1: "TO_DO", task2: "COMPLETED" },
       onboardingFormProgress: "COMPLETED",
     });
 
     renderDashboardComponent({});
 
-    expect(screen.getByText("In progress")).toBeInTheDocument();
+    expect(screen.getByText("To do")).toBeInTheDocument();
     expect(screen.getByText("Completed")).toBeInTheDocument();
-    expect(screen.getByText("Not started")).toBeInTheDocument();
   });
 
   it("displays each step under associated section", () => {

--- a/web/src/components/dashboard/DashboardOnMobile.test.tsx
+++ b/web/src/components/dashboard/DashboardOnMobile.test.tsx
@@ -187,20 +187,18 @@ describe("<DashboardOnMobile />", () => {
       tasks: [
         generateTask({ id: "task1", name: "task1", stepNumber: 1 }),
         generateTask({ id: "task2", name: "task2", stepNumber: 1 }),
-        generateTask({ id: "task3", name: "task3", stepNumber: 2 }),
       ],
     });
 
     useMockBusiness({
-      taskProgress: { task1: "IN_PROGRESS", task2: "COMPLETED" },
+      taskProgress: { task1: "TO_DO", task2: "COMPLETED" },
       onboardingFormProgress: "COMPLETED",
     });
 
     renderDashboardComponent({});
 
-    expect(screen.getByText("In progress")).toBeInTheDocument();
+    expect(screen.getByText("To do")).toBeInTheDocument();
     expect(screen.getByText("Completed")).toBeInTheDocument();
-    expect(screen.getByText("Not started")).toBeInTheDocument();
   });
 
   it("displays each step under associated section", () => {

--- a/web/src/components/roadmap/MiniRoadmapTask.tsx
+++ b/web/src/components/roadmap/MiniRoadmapTask.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 export const MiniRoadmapTask = (props: Props): ReactElement => {
   const { business } = useUserData();
-  const taskProgress = business?.taskProgress[props.task.id] || "NOT_STARTED";
+  const taskProgress = business?.taskProgress[props.task.id] || "TO_DO";
   const taskProgressReadable = taskProgress.replace("_", " ");
 
   return (

--- a/web/src/components/tasks/EinTask.test.tsx
+++ b/web/src/components/tasks/EinTask.test.tsx
@@ -62,7 +62,7 @@ describe("<EinTask />", () => {
     beforeEach(() => {
       initialBusiness = generateBusiness({
         profileData: generateProfileData({ employerId: "" }),
-        taskProgress: { [taskId]: "NOT_STARTED" },
+        taskProgress: { [taskId]: "TO_DO" },
       });
     });
 
@@ -161,16 +161,16 @@ describe("<EinTask />", () => {
       expect(currentBusiness().profileData.employerId).toEqual(undefined);
     });
 
-    it("sets task status to in-progress on edit button", () => {
+    it("sets task status to to-do on edit button", () => {
       renderPage();
       fireEvent.click(screen.getByText(Config.taskDefaults.editText));
-      expect(currentBusiness().taskProgress[taskId]).toEqual("IN_PROGRESS");
+      expect(currentBusiness().taskProgress[taskId]).toEqual("TO_DO");
     });
 
-    it("sets task status to in-progress on remove button", () => {
+    it("sets task status to to-do on remove button", () => {
       renderPage();
       fireEvent.click(screen.getByText(Config.taskDefaults.removeText));
-      expect(currentBusiness().taskProgress[taskId]).toEqual("IN_PROGRESS");
+      expect(currentBusiness().taskProgress[taskId]).toEqual("TO_DO");
     });
   });
 
@@ -193,7 +193,7 @@ describe("<EinTask />", () => {
     beforeEach(() => {
       initialBusiness = generateBusiness({
         profileData: generateProfileData({ employerId: "" }),
-        taskProgress: { [taskId]: "NOT_STARTED" },
+        taskProgress: { [taskId]: "TO_DO" },
       });
     });
 

--- a/web/src/components/tasks/EinTask.tsx
+++ b/web/src/components/tasks/EinTask.tsx
@@ -36,7 +36,7 @@ export const EinTask = (props: Props): ReactElement => {
     setShowInput(true);
     const newEinValue = remove ? emptyProfileData.employerId : business.profileData.employerId;
     updateQueue
-      .queueTaskProgress({ [props.task.id]: "IN_PROGRESS" })
+      .queueTaskProgress({ [props.task.id]: "TO_DO" })
       .queueProfileData({ employerId: newEinValue })
       .update();
   };

--- a/web/src/components/tasks/LicenseTask.test.tsx
+++ b/web/src/components/tasks/LicenseTask.test.tsx
@@ -64,7 +64,7 @@ describe("<LicenseTask />", () => {
     it("task status checkbox is editable when lastUpdatedISO is empty", async () => {
       setupStatefulUserDataContext();
       const business = generateBusiness({
-        taskProgress: { [task.id]: "IN_PROGRESS" },
+        taskProgress: { [task.id]: "TO_DO" },
         licenseData: generateLicenseData(
           {},
           { [taskIdLicenseNameMapping[task.id]]: generateLicenseDetails({ lastUpdatedISO: "" }) }
@@ -75,24 +75,23 @@ describe("<LicenseTask />", () => {
       await waitFor(() => {
         expect(screen.getByTestId("COMPLETED")).toBeInTheDocument();
       });
-      expect(screen.queryByTestId("NOT_STARTED")).not.toBeInTheDocument();
-      expect(screen.queryByTestId("IN_PROGRESS")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("TO_DO")).not.toBeInTheDocument();
       expect(screen.queryByTestId("status-info-tooltip")).not.toBeInTheDocument();
     });
 
     it("task status checkbox is not editable when lastUpdatedISO has a value", () => {
       setupStatefulUserDataContext();
       const business = generateBusiness({
-        taskProgress: { [task.id]: "IN_PROGRESS" },
+        taskProgress: { [task.id]: "TO_DO" },
         licenseData: generateLicenseData(
           {},
           { [taskIdLicenseNameMapping[task.id]]: generateLicenseDetails({}) }
         ),
       });
       renderTaskWithStatefulData(business);
-      expect(screen.getByTestId("IN_PROGRESS")).toBeInTheDocument();
+      expect(screen.getByTestId("TO_DO")).toBeInTheDocument();
       fireEvent.click(screen.getByTestId("change-task-progress-checkbox"));
-      expect(screen.getByTestId("IN_PROGRESS")).toBeInTheDocument();
+      expect(screen.getByTestId("TO_DO")).toBeInTheDocument();
       expect(screen.getByTestId("status-info-tooltip")).toBeInTheDocument();
       expect(screen.queryByTestId("COMPLETED")).not.toBeInTheDocument();
     });
@@ -371,7 +370,7 @@ describe("<LicenseTask />", () => {
 
         setupStatefulUserDataContext();
         const business = generateBusiness({
-          taskProgress: { [task.id]: "IN_PROGRESS" },
+          taskProgress: { [task.id]: "TO_DO" },
           licenseData: generateLicenseData(
             {},
             { [taskIdLicenseNameMapping[task.id]]: generateLicenseDetails({ lastUpdatedISO: "" }) }

--- a/web/src/components/tasks/NaicsCodeInput.tsx
+++ b/web/src/components/tasks/NaicsCodeInput.tsx
@@ -127,7 +127,7 @@ export const NaicsCodeInput = (props: Props): ReactElement => {
     if (!updateQueue) {
       return;
     }
-    updateQueue.queueTaskProgress({ [props.task.id]: "IN_PROGRESS" }).update();
+    updateQueue.queueTaskProgress({ [props.task.id]: "TO_DO" }).update();
   };
 
   useMountEffectWhenDefined(() => {

--- a/web/src/components/tasks/NaicsCodeTask.test.tsx
+++ b/web/src/components/tasks/NaicsCodeTask.test.tsx
@@ -83,7 +83,7 @@ describe("<NaicsCodeTask />", () => {
     beforeEach(() => {
       initialBusiness = generateBusiness({
         profileData: generateProfileData({ naicsCode: "", industryId: validIndustryId }),
-        taskProgress: { [taskId]: "NOT_STARTED" },
+        taskProgress: { [taskId]: "TO_DO" },
       });
     });
 
@@ -114,11 +114,11 @@ describe("<NaicsCodeTask />", () => {
       expect(screen.queryByLabelText("Save NAICS Code")).not.toBeInTheDocument();
     });
 
-    it("updates task progress when radio button is pressed", async () => {
+    it("task progress remains to-do when radio button is pressed", async () => {
       renderPage();
       fireEvent.click(screen.getByTestId(`naics-radio-${validNaicsCode}`));
       await waitFor(() => {
-        expect(currentBusiness().taskProgress[taskId]).toEqual("IN_PROGRESS");
+        expect(currentBusiness().taskProgress[taskId]).toEqual("TO_DO");
       });
     });
 
@@ -184,7 +184,7 @@ describe("<NaicsCodeTask />", () => {
     beforeEach(() => {
       initialBusiness = generateBusiness({
         profileData: generateProfileData({ naicsCode: "", industryId: "" }),
-        taskProgress: { [taskId]: "NOT_STARTED" },
+        taskProgress: { [taskId]: "TO_DO" },
       });
     });
 
@@ -341,16 +341,16 @@ describe("<NaicsCodeTask />", () => {
       expect(currentBusiness().profileData.naicsCode).toEqual("");
     });
 
-    it("sets task status to in-progress on edit button", () => {
+    it("keeps task status to to-do on edit button", () => {
       renderPage();
       fireEvent.click(screen.getByText(Config.taskDefaults.editText));
-      expect(currentBusiness().taskProgress[taskId]).toEqual("IN_PROGRESS");
+      expect(currentBusiness().taskProgress[taskId]).toEqual("TO_DO");
     });
 
-    it("sets task status to in-progress on remove button", () => {
+    it("sets task status to to-do on remove button", () => {
       renderPage();
       fireEvent.click(screen.getByText(Config.taskDefaults.removeText));
-      expect(currentBusiness().taskProgress[taskId]).toEqual("IN_PROGRESS");
+      expect(currentBusiness().taskProgress[taskId]).toEqual("TO_DO");
     });
 
     describe("when the naics code is present", () => {
@@ -408,7 +408,7 @@ describe("<NaicsCodeTask />", () => {
       setShowNeedsAccountModal = jest.fn();
       initialBusiness = generateBusiness({
         profileData: generateProfileData({ naicsCode: "", industryId: "" }),
-        taskProgress: { [taskId]: "NOT_STARTED" },
+        taskProgress: { [taskId]: "TO_DO" },
       });
     });
 
@@ -447,7 +447,7 @@ describe("<NaicsCodeTask />", () => {
       expect(within(screen.getByTestId("naics-radio-input")).getByRole("radio")).not.toBeChecked();
     });
 
-    it("keeps task progress as NOT_STARTED when radio button is clicked", () => {
+    it("keeps task progress as TO_DO when radio button is clicked", () => {
       initialBusiness = generateBusiness({
         profileData: generateProfileData({ naicsCode: "", industryId: "acupuncture" }),
       });

--- a/web/src/components/tasks/NaicsCodeTask.tsx
+++ b/web/src/components/tasks/NaicsCodeTask.tsx
@@ -37,7 +37,7 @@ export const NaicsCodeTask = (props: Props): ReactElement => {
     setShowInput(true);
     const newNaicsValue = remove ? emptyProfileData.naicsCode : business.profileData.naicsCode;
     updateQueue
-      .queueTaskProgress({ [props.task.id]: "IN_PROGRESS" })
+      .queueTaskProgress({ [props.task.id]: "TO_DO" })
       .queueProfileData({ naicsCode: newNaicsValue })
       .update();
   };

--- a/web/src/components/tasks/TaxInput.tsx
+++ b/web/src/components/tasks/TaxInput.tsx
@@ -62,7 +62,7 @@ export const TaxInput = (props: Props): ReactElement => {
       business.profileData.taxId?.length > 0 &&
       business.profileData.taxId?.length < 12
     ) {
-      updateQueue.queueTaskProgress({ [props.task.id]: "IN_PROGRESS" }).update();
+      updateQueue.queueTaskProgress({ [props.task.id]: "TO_DO" }).update();
     }
   }, business);
 

--- a/web/src/components/tasks/TaxTask.test.tsx
+++ b/web/src/components/tasks/TaxTask.test.tsx
@@ -118,7 +118,7 @@ describe("<TaxTask />", () => {
     beforeEach(() => {
       initialBusiness = generateBusiness({
         profileData: generateProfileData({ taxId: "" }),
-        taskProgress: { [taskId]: "NOT_STARTED" },
+        taskProgress: { [taskId]: "TO_DO" },
       });
     });
 
@@ -127,14 +127,14 @@ describe("<TaxTask />", () => {
       expect(screen.getByText(Config.tax.saveButtonText)).toBeInTheDocument();
     });
 
-    it("updates the progress of the task to IN_PROGRESS if there is a pre-existing 9 digit tax id", async () => {
+    it("updates the progress of the task to TO_DO if there is a pre-existing 9 digit tax id", async () => {
       initialBusiness = generateBusiness({
         profileData: generateProfileData({ taxId: "123456789" }),
         taskProgress: { [taskId]: "COMPLETED" },
       });
       renderPage();
       await waitFor(() => {
-        expect(currentBusiness().taskProgress[taskId]).toEqual("IN_PROGRESS");
+        expect(currentBusiness().taskProgress[taskId]).toEqual("TO_DO");
       });
     });
 
@@ -228,7 +228,7 @@ describe("<TaxTask />", () => {
     beforeEach(() => {
       initialBusiness = generateBusiness({
         profileData: generateProfileData({ taxId: "" }),
-        taskProgress: { [taskId]: "NOT_STARTED" },
+        taskProgress: { [taskId]: "TO_DO" },
       });
     });
 

--- a/web/src/components/tasks/business-structure/BusinessStructureTask.test.tsx
+++ b/web/src/components/tasks/business-structure/BusinessStructureTask.test.tsx
@@ -52,7 +52,7 @@ describe("<BusinessStructureTask />", () => {
   };
 
   it("shows tooltip text on task progress checkbox", async () => {
-    const business = generateBusiness({ taskProgress: { [taskId]: "IN_PROGRESS" } });
+    const business = generateBusiness({ taskProgress: { [taskId]: "TO_DO" } });
     renderTask(business);
     expect(screen.queryByText(Config.businessStructureTask.uncompletedTooltip)).not.toBeInTheDocument();
     expect(screen.queryByText(Config.businessStructureTask.completedTooltip)).not.toBeInTheDocument();
@@ -163,7 +163,7 @@ describe("<BusinessStructureTask />", () => {
     expect(currentBusiness().profileData.legalStructureId).toEqual(legalStructure.id);
   });
 
-  it("updates task progress to in-progress and updates tooltip when editing", async () => {
+  it("task progress remains to-do when editing", async () => {
     const legalStructure = randomLegalStructure();
     const business = generateBusiness({
       profileData: generateProfileData({ legalStructureId: legalStructure.id }),
@@ -174,7 +174,7 @@ describe("<BusinessStructureTask />", () => {
 
     triggerQueueUpdate();
     await waitFor(() => {
-      expect(currentBusiness().taskProgress[taskId]).toEqual("IN_PROGRESS");
+      expect(currentBusiness().taskProgress[taskId]).toEqual("TO_DO");
     });
 
     fireEvent.mouseOver(screen.getByTestId("status-info-tooltip"));
@@ -185,7 +185,7 @@ describe("<BusinessStructureTask />", () => {
   it("updates task progress to completed when saving", async () => {
     const business = generateBusiness({
       profileData: generateProfileData({ legalStructureId: undefined }),
-      taskProgress: { [taskId]: "IN_PROGRESS" },
+      taskProgress: { [taskId]: "TO_DO" },
     });
     renderTask(business);
     fireEvent.click(screen.getByLabelText("limited-liability-company"));
@@ -233,23 +233,23 @@ describe("<BusinessStructureTask />", () => {
   it("updates task progress to in-progress when business structure radio is selected", async () => {
     const business = generateBusiness({
       profileData: generateProfileData({ legalStructureId: undefined }),
-      taskProgress: { [taskId]: "NOT_STARTED" },
+      taskProgress: { [taskId]: "TO_DO" },
     });
     renderTask(business);
     fireEvent.click(screen.getByLabelText("limited-liability-company"));
     triggerQueueUpdate();
     await waitFor(() => {
-      expect(screen.getByTestId("taskProgress")).toHaveTextContent(Config.taskProgress.IN_PROGRESS);
+      expect(screen.getByTestId("taskProgress")).toHaveTextContent(Config.taskProgress.TO_DO);
     });
     await waitFor(() => {
-      expect(currentBusiness().taskProgress[taskId]).toEqual("IN_PROGRESS");
+      expect(currentBusiness().taskProgress[taskId]).toEqual("TO_DO");
     });
   });
 
   it("renders error message and alert when save button is clicked without a radio being selected and removed when selected", async () => {
     const business = generateBusiness({
       profileData: generateProfileData({ legalStructureId: undefined }),
-      taskProgress: { [taskId]: "NOT_STARTED" },
+      taskProgress: { [taskId]: "TO_DO" },
     });
     renderTask(business);
 
@@ -268,7 +268,7 @@ describe("<BusinessStructureTask />", () => {
     expect(screen.queryByTestId("business-structure-alert")).not.toBeInTheDocument();
   });
 
-  it("updates task to NOT_STARTED when remove button is clicked", async () => {
+  it("updates task to TO_DO when remove button is clicked", async () => {
     const legalStructure = randomLegalStructure();
 
     const business = generateBusiness({
@@ -282,7 +282,7 @@ describe("<BusinessStructureTask />", () => {
       expect(screen.queryByText(Config.taskDefaults.removeText)).not.toBeInTheDocument();
     });
     expect(screen.getByLabelText("Business structure")).toBeInTheDocument();
-    expect(currentBusiness().taskProgress[taskId]).toEqual("NOT_STARTED");
+    expect(currentBusiness().taskProgress[taskId]).toEqual("TO_DO");
     expect(currentBusiness().profileData.legalStructureId).toEqual(undefined);
   });
 
@@ -304,7 +304,7 @@ describe("<BusinessStructureTask />", () => {
       expect(screen.queryByText(Config.taskDefaults.removeText)).not.toBeInTheDocument();
     });
     expect(screen.getByLabelText("Business structure")).toBeInTheDocument();
-    expect(currentBusiness().taskProgress[taskId]).toEqual("NOT_STARTED");
+    expect(currentBusiness().taskProgress[taskId]).toEqual("TO_DO");
     expect(currentBusiness().profileData.legalStructureId).toEqual(undefined);
     expect(currentBusiness().profileData.operatingPhase).toEqual("GUEST_MODE");
   });

--- a/web/src/components/tasks/business-structure/BusinessStructureTask.tsx
+++ b/web/src/components/tasks/business-structure/BusinessStructureTask.tsx
@@ -53,7 +53,7 @@ export const BusinessStructureTask = (props: Props): ReactElement => {
       if (business?.profileData.legalStructureId) {
         queueUpdateTaskProgress(props.task.id, "COMPLETED");
       } else if (!business?.profileData.legalStructureId) {
-        queueUpdateTaskProgress(props.task.id, "NOT_STARTED");
+        queueUpdateTaskProgress(props.task.id, "TO_DO");
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -84,7 +84,7 @@ export const BusinessStructureTask = (props: Props): ReactElement => {
   const setBackToEditing = (): void => {
     if (!business || !updateQueue) return;
     setShowRadioQuestion(true);
-    queueUpdateTaskProgress(props.task.id, "IN_PROGRESS");
+    queueUpdateTaskProgress(props.task.id, "TO_DO");
   };
 
   const removeTaskCompletion = async (): Promise<void> => {
@@ -98,7 +98,7 @@ export const BusinessStructureTask = (props: Props): ReactElement => {
             ? OperatingPhaseId.GUEST_MODE
             : profileData.operatingPhase,
       })
-      .queueTaskProgress({ [props.task.id]: "NOT_STARTED" });
+      .queueTaskProgress({ [props.task.id]: "TO_DO" });
 
     setShowRadioQuestion(true);
     await updateQueue.update();

--- a/web/src/components/tasks/business-structure/LegalStructureRadio.tsx
+++ b/web/src/components/tasks/business-structure/LegalStructureRadio.tsx
@@ -48,7 +48,7 @@ const LegalStructureRadio = forwardRef((props: Props, ref: ForwardedRef<HTMLDivE
 
   const handleLegalStructure = (event: React.ChangeEvent<{ name?: string; value: unknown }>): void => {
     setIsValid(true);
-    queueUpdateTaskProgress(props.taskId, "IN_PROGRESS");
+    queueUpdateTaskProgress(props.taskId, "TO_DO");
     setProfileData({
       ...state.profileData,
       legalStructureId: event.target.value as string,

--- a/web/src/components/tasks/cannabis/CannabisApplyForLicenseTask.test.tsx
+++ b/web/src/components/tasks/cannabis/CannabisApplyForLicenseTask.test.tsx
@@ -191,7 +191,7 @@ describe("<CannabisApplyForLicenseTask />", () => {
   describe("requirements tab", () => {
     it("does not show unlocked-by alert on requirements tab", async () => {
       const business = generateBusiness({
-        taskProgress: { "annual-license-cannabis": "NOT_STARTED" },
+        taskProgress: { "annual-license-cannabis": "TO_DO" },
       });
       const task = generateTask({
         id: "annual-license-cannabis",
@@ -204,14 +204,14 @@ describe("<CannabisApplyForLicenseTask />", () => {
       expect(screen).not.toContain("Do this first");
     });
 
-    it("updates taskProgress to from not_started to in-progress when View Requirements is clicked", () => {
+    it("taskProgress remains to-do when View Requirements is clicked", () => {
       const business = generateBusiness({
-        taskProgress: { "annual-license-cannabis": "NOT_STARTED" },
+        taskProgress: { "annual-license-cannabis": "TO_DO" },
       });
       renderPage(generateTask({ id: "annual-license-cannabis" }), business);
       fireEvent.click(screen.getByText(Config.cannabisApplyForLicense.viewRequirementsButton));
       expect(currentBusiness().taskProgress).toEqual({
-        "annual-license-cannabis": "IN_PROGRESS",
+        "annual-license-cannabis": "TO_DO",
       });
     });
 

--- a/web/src/components/tasks/cannabis/CannabisApplyForLicenseTask.tsx
+++ b/web/src/components/tasks/cannabis/CannabisApplyForLicenseTask.tsx
@@ -108,10 +108,10 @@ export const CannabisApplyForLicenseTask = (props: Props): ReactElement => {
     sendNextTabButtonAnalytics();
     if (
       business.taskProgress[props.task.id] === undefined ||
-      business.taskProgress[props.task.id] === "NOT_STARTED"
+      business.taskProgress[props.task.id] === "TO_DO"
     ) {
       setSuccessSnackbarIsOpen(true);
-      updateQueue.queueTaskProgress({ [props.task.id]: "IN_PROGRESS" }).update();
+      updateQueue.queueTaskProgress({ [props.task.id]: "TO_DO" }).update();
     }
   };
 
@@ -120,7 +120,7 @@ export const CannabisApplyForLicenseTask = (props: Props): ReactElement => {
       <TaskStatusChangeSnackbar
         isOpen={successSnackbarIsOpen}
         close={(): void => setSuccessSnackbarIsOpen(false)}
-        status={business?.taskProgress[props.task.id] ?? "NOT_STARTED"}
+        status={business?.taskProgress[props.task.id] ?? "TO_DO"}
       />
       <TaskHeader task={props.task} />
       {displayFirstTab ? (

--- a/web/src/components/tasks/cannabis/CannabisPriorityStatusTask.test.tsx
+++ b/web/src/components/tasks/cannabis/CannabisPriorityStatusTask.test.tsx
@@ -140,7 +140,7 @@ describe("<CannabisPriorityStatusTask />", () => {
     expect(currentBusiness().taskItemChecklist[noneOfTheAbovePriorityId]).toBe(false);
   });
 
-  it("updates task progress from not started to in progress when user navigates to the second tab", async () => {
+  it("task progress remains to-do when user navigates to the second tab", async () => {
     const randomPriorityType = randomElementFromArray([...allPriorityTypes, noneOfTheAbovePriorityId]);
 
     const task = generateTask({
@@ -154,9 +154,9 @@ describe("<CannabisPriorityStatusTask />", () => {
     fireEvent.click(screen.getByText(C.nextButtonText));
 
     await waitFor(() => {
-      expect(within(screen.getByTestId("taskProgress")).getByTestId("IN_PROGRESS")).toBeInTheDocument();
+      expect(within(screen.getByTestId("taskProgress")).getByTestId("TO_DO")).toBeInTheDocument();
     });
-    expect(screen.getByText(getTaskStatusUpdatedMessage("IN_PROGRESS"))).toBeInTheDocument();
+    expect(screen.getByText(getTaskStatusUpdatedMessage("TO_DO"))).toBeInTheDocument();
   });
 
   it("navigates to and from second tab", async () => {

--- a/web/src/components/tasks/cannabis/CannabisPriorityStatusTask.tsx
+++ b/web/src/components/tasks/cannabis/CannabisPriorityStatusTask.tsx
@@ -35,10 +35,10 @@ export const CannabisPriorityStatusTask = (props: Props): ReactElement => {
     scrollToTop();
     if (
       business.taskProgress[props.task.id] === undefined ||
-      business.taskProgress[props.task.id] === "NOT_STARTED"
+      business.taskProgress[props.task.id] === "TO_DO"
     ) {
       setSuccessSnackbarIsOpen(true);
-      updateQueue.queueTaskProgress({ [props.task.id]: "IN_PROGRESS" }).update();
+      updateQueue.queueTaskProgress({ [props.task.id]: "TO_DO" }).update();
     }
   };
 
@@ -60,7 +60,7 @@ export const CannabisPriorityStatusTask = (props: Props): ReactElement => {
       <TaskStatusChangeSnackbar
         isOpen={successSnackbarIsOpen}
         close={(): void => setSuccessSnackbarIsOpen(false)}
-        status={business?.taskProgress[props.task.id] ?? "NOT_STARTED"}
+        status={business?.taskProgress[props.task.id] ?? "TO_DO"}
       />
       <TaskHeader task={props.task} />
       <UnlockedBy task={props.task} />

--- a/web/src/components/tasks/environment-questionnaire/EnvPermitsResults.test.tsx
+++ b/web/src/components/tasks/environment-questionnaire/EnvPermitsResults.test.tsx
@@ -145,7 +145,7 @@ describe("<EnvPermitsResults />", () => {
       expect(currentBusiness().environmentData?.waste?.submitted).toBe(false);
     });
 
-    it("updates task progress to IN_PROGRESS when the user clicks edit", async () => {
+    it("updates task progress to TO_DO when the user clicks edit", async () => {
       const { user } = renderEnvPermitsResultsAndSetupUser(
         generateBusiness({
           environmentData: generateEnvironmentData({
@@ -157,10 +157,10 @@ describe("<EnvPermitsResults />", () => {
         })
       );
       await user.click(screen.getByText(Config.envResultsPage.editText));
-      expect(currentBusiness().taskProgress[taskId]).toBe("IN_PROGRESS");
+      expect(currentBusiness().taskProgress[taskId]).toBe("TO_DO");
     });
 
-    it("updates task progress to IN_PROGRESS when the user clicks redo form", async () => {
+    it("updates task progress to TO_DO when the user clicks redo form", async () => {
       const { user } = renderEnvPermitsResultsAndSetupUser(
         generateBusiness({
           environmentData: generateEnvironmentData({
@@ -175,7 +175,7 @@ describe("<EnvPermitsResults />", () => {
         })
       );
       await user.click(screen.getByText(Config.envResultsPage.lowApplicability.calloutRedo));
-      expect(currentBusiness().taskProgress[taskId]).toBe("IN_PROGRESS");
+      expect(currentBusiness().taskProgress[taskId]).toBe("TO_DO");
     });
   });
 
@@ -278,7 +278,7 @@ describe("<EnvPermitsResults />", () => {
       expect(currentBusiness().environmentData?.land?.submitted).toBe(false);
     });
 
-    it("updates task progress to IN_PROGRESS when the user clicks edit", async () => {
+    it("updates task progress to TO_DO when the user clicks edit", async () => {
       const { user } = renderEnvPermitsResultsAndSetupUser(
         generateBusiness({
           environmentData: generateEnvironmentData({
@@ -290,10 +290,10 @@ describe("<EnvPermitsResults />", () => {
         })
       );
       await user.click(screen.getByText(Config.envResultsPage.editText));
-      expect(currentBusiness().taskProgress[taskId]).toBe("IN_PROGRESS");
+      expect(currentBusiness().taskProgress[taskId]).toBe("TO_DO");
     });
 
-    it("updates task progress to IN_PROGRESS when the user clicks redo form", async () => {
+    it("updates task progress to TO_DO when the user clicks redo form", async () => {
       const { user } = renderEnvPermitsResultsAndSetupUser(
         generateBusiness({
           environmentData: generateEnvironmentData({
@@ -308,7 +308,7 @@ describe("<EnvPermitsResults />", () => {
         })
       );
       await user.click(screen.getByText(Config.envResultsPage.lowApplicability.calloutRedo));
-      expect(currentBusiness().taskProgress[taskId]).toBe("IN_PROGRESS");
+      expect(currentBusiness().taskProgress[taskId]).toBe("TO_DO");
     });
   });
 
@@ -403,7 +403,7 @@ describe("<EnvPermitsResults />", () => {
       expect(currentBusiness().environmentData?.air?.submitted).toBe(false);
     });
 
-    it("updates task progress to IN_PROGRESS when the user clicks edit", async () => {
+    it("updates task progress to TO_DO when the user clicks edit", async () => {
       const { user } = renderEnvPermitsResultsAndSetupUser(
         generateBusiness({
           environmentData: generateEnvironmentData({
@@ -415,10 +415,10 @@ describe("<EnvPermitsResults />", () => {
         })
       );
       await user.click(screen.getByText(Config.envResultsPage.editText));
-      expect(currentBusiness().taskProgress[taskId]).toBe("IN_PROGRESS");
+      expect(currentBusiness().taskProgress[taskId]).toBe("TO_DO");
     });
 
-    it("updates task progress to IN_PROGRESS when the user clicks redo form", async () => {
+    it("updates task progress to TO_DO when the user clicks redo form", async () => {
       const { user } = renderEnvPermitsResultsAndSetupUser(
         generateBusiness({
           environmentData: generateEnvironmentData({
@@ -433,7 +433,7 @@ describe("<EnvPermitsResults />", () => {
         })
       );
       await user.click(screen.getByText(Config.envResultsPage.lowApplicability.calloutRedo));
-      expect(currentBusiness().taskProgress[taskId]).toBe("IN_PROGRESS");
+      expect(currentBusiness().taskProgress[taskId]).toBe("TO_DO");
     });
   });
 });

--- a/web/src/components/tasks/environment-questionnaire/EnvPermitsResults.tsx
+++ b/web/src/components/tasks/environment-questionnaire/EnvPermitsResults.tsx
@@ -52,7 +52,7 @@ export const EnvPermitsResults = (props: Props): ReactElement => {
         },
       })
       .queueTaskProgress({
-        [props.taskId]: "IN_PROGRESS",
+        [props.taskId]: "TO_DO",
       })
       .update();
   };

--- a/web/src/lib/data-hooks/useRoadmap.test.tsx
+++ b/web/src/lib/data-hooks/useRoadmap.test.tsx
@@ -95,7 +95,7 @@ describe("useRoadmap", () => {
           task1: "COMPLETED",
           task2: "COMPLETED",
           task3: "COMPLETED",
-          task4: "NOT_STARTED",
+          task4: "TO_DO",
         },
       });
 
@@ -109,7 +109,7 @@ describe("useRoadmap", () => {
         taskProgress: {
           task1: "COMPLETED",
           task2: "COMPLETED",
-          task3: "IN_PROGRESS",
+          task3: "TO_DO",
           task4: "COMPLETED",
         },
       });
@@ -124,8 +124,8 @@ describe("useRoadmap", () => {
         taskProgress: {
           task1: "COMPLETED",
           task2: "COMPLETED",
-          task3: "IN_PROGRESS",
-          task4: "IN_PROGRESS",
+          task3: "TO_DO",
+          task4: "TO_DO",
         },
       });
 
@@ -160,10 +160,10 @@ describe("useRoadmap", () => {
     beforeEach(() => {
       useMockBusiness({
         taskProgress: {
-          task1: "NOT_STARTED",
-          task2: "NOT_STARTED",
-          task3: "NOT_STARTED",
-          task4: "NOT_STARTED",
+          task1: "TO_DO",
+          task2: "TO_DO",
+          task3: "TO_DO",
+          task4: "TO_DO",
         },
       });
     });

--- a/web/src/lib/data-hooks/useUpdateTaskProgress.test.tsx
+++ b/web/src/lib/data-hooks/useUpdateTaskProgress.test.tsx
@@ -64,13 +64,13 @@ describe("useUpdateTaskProgress", () => {
       taskProgress: { "some-id": "COMPLETED" },
     });
     const { queueUpdateTaskProgress, updateQueue } = setupHook(initialBusiness);
-    queueUpdateTaskProgress("some-other-id", "IN_PROGRESS");
+    queueUpdateTaskProgress("some-other-id", "TO_DO");
     await act(() => {
       return updateQueue.update();
     });
     expect(currentBusiness().taskProgress).toEqual({
       "some-id": "COMPLETED",
-      "some-other-id": "IN_PROGRESS",
+      "some-other-id": "TO_DO",
     });
   });
 
@@ -93,7 +93,7 @@ describe("useUpdateTaskProgress", () => {
       const business = generateBusiness({
         taskProgress: {
           [planTaskId]: "COMPLETED",
-          [startTaskId]: "NOT_STARTED",
+          [startTaskId]: "TO_DO",
         },
         preferences: generatePreferences({ roadmapOpenSections: ["START"] }),
       });
@@ -126,8 +126,8 @@ describe("useUpdateTaskProgress", () => {
     it("closes PLAN roadmap section when complete", async () => {
       const business = generateBusiness({
         taskProgress: {
-          [planTaskId]: "NOT_STARTED",
-          [startTaskId]: "NOT_STARTED",
+          [planTaskId]: "TO_DO",
+          [startTaskId]: "TO_DO",
         },
         preferences: generatePreferences({ roadmapOpenSections: ["PLAN", "START"] }),
       });
@@ -151,7 +151,7 @@ describe("useUpdateTaskProgress", () => {
 
       expect(currentBusiness().taskProgress).toEqual({
         [planTaskId]: "COMPLETED",
-        [startTaskId]: "NOT_STARTED",
+        [startTaskId]: "TO_DO",
       });
 
       expect(currentBusiness().preferences.roadmapOpenSections).toEqual(["START"]);

--- a/web/src/lib/domain-logic/isStepCompleted.test.ts
+++ b/web/src/lib/domain-logic/isStepCompleted.test.ts
@@ -12,7 +12,7 @@ describe("isStepCompleted", () => {
       taskProgress: {
         "step1-task1": "COMPLETED",
         "step1-task2": "COMPLETED",
-        "step2-task1": "IN_PROGRESS",
+        "step2-task1": "TO_DO",
       },
     });
 
@@ -33,7 +33,7 @@ describe("isStepCompleted", () => {
     const business = generateBusiness({
       taskProgress: {
         "step1-task1": "COMPLETED",
-        "step1-task2": "IN_PROGRESS",
+        "step1-task2": "TO_DO",
         "step2-task1": "COMPLETED",
       },
     });

--- a/web/src/lib/utils/analytics.ts
+++ b/web/src/lib/utils/analytics.ts
@@ -985,22 +985,13 @@ export default {
     },
     task_status_checkbox: {
       click: {
-        selected_not_started_status: () => {
+        selected_to_do_status: () => {
           eventRunner.track({
             event: "task_manual_status_change",
             legacy_event_action: "click",
             legacy_event_category: "task_status_checkbox",
             legacy_event_label: "selected_not_started_status",
             status_selected: "selected_not_started",
-          });
-        },
-        selected_in_progress_status: () => {
-          eventRunner.track({
-            event: "task_manual_status_change",
-            legacy_event_action: "click",
-            legacy_event_category: "task_status_checkbox",
-            legacy_event_label: "selected_in_progress_status",
-            status_selected: "selected_in_progress",
           });
         },
         selected_completed_status: () => {

--- a/web/src/lib/utils/helpers.ts
+++ b/web/src/lib/utils/helpers.ts
@@ -73,10 +73,8 @@ export const getTaskStatusUpdatedMessage = (taskStatus: TaskProgress): string =>
   const taskUpdatedMessagePrefix = Config.taskDefaults.taskProgressSnackbarPrefix;
 
   switch (taskStatus) {
-    case "NOT_STARTED":
-      return `${taskUpdatedMessagePrefix} "${Config.taskProgress.NOT_STARTED}"`;
-    case "IN_PROGRESS":
-      return `${taskUpdatedMessagePrefix} "${Config.taskProgress.IN_PROGRESS}"`;
+    case "TO_DO":
+      return `${taskUpdatedMessagePrefix} "${Config.taskProgress.TO_DO}"`;
     case "COMPLETED":
       return `${taskUpdatedMessagePrefix} "${Config.taskProgress.COMPLETED}"`;
   }

--- a/web/src/pages/mgmt/modifyBusiness.tsx
+++ b/web/src/pages/mgmt/modifyBusiness.tsx
@@ -75,8 +75,7 @@ const ModifyBusinessPage = (): ReactElement => {
               Note 1: to view an anytime actions reinstatement, the license status must be set to expired.
             </div>
             <div>
-              Note 2: deleting the license data will reset all license search enabled task statuses to
-              NOT_STARTED
+              Note 2: deleting the license data will reset all license search enabled task statuses to TO_DO
             </div>
             <div>
               Note 3: to view the license details in the task, you must select an industry that has the task
@@ -167,7 +166,7 @@ const ModifyBusinessPage = (): ReactElement => {
                   if (business?.licenseData) {
                     const taskProgress = sortedLicenseNames.reduce(
                       (acc: Record<string, TaskProgress>, curr: string): Record<string, TaskProgress> => {
-                        acc[curr] = "NOT_STARTED";
+                        acc[curr] = "TO_DO";
                         return acc;
                       },
                       {}

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -193,7 +193,7 @@ const ProfilePage = (props: Props): ReactElement => {
       if (dateOfFormationHasBeenDeleted) {
         if (isFormationDateDeletionModalOpen) {
           setFormationDateDeletionModalOpen(false);
-          updateQueue.queueTaskProgress({ [formationTaskId]: "IN_PROGRESS" });
+          updateQueue.queueTaskProgress({ [formationTaskId]: "TO_DO" });
         } else {
           setFormationDateDeletionModalOpen(true);
           return;
@@ -217,7 +217,7 @@ const ProfilePage = (props: Props): ReactElement => {
       if (business.profileData.industryId !== profileData.industryId) {
         updateQueue
           .queueBusiness({ ...updateQueue.currentBusiness(), taskItemChecklist: {} })
-          .queueTaskProgress({ [naicsCodeTaskId]: "NOT_STARTED" });
+          .queueTaskProgress({ [naicsCodeTaskId]: "TO_DO" });
       }
 
       updateQueue.queueProfileData(profileData);

--- a/web/stories/Molecules/checkbox/TaskProgressCheckbox.stories.tsx
+++ b/web/stories/Molecules/checkbox/TaskProgressCheckbox.stories.tsx
@@ -8,28 +8,14 @@ const Template = () => {
         <TaskProgressCheckbox
           disabledTooltipText={undefined}
           taskId={`1`}
-          STORYBOOK_ONLY_currentTaskProgress={"NOT_STARTED"}
+          STORYBOOK_ONLY_currentTaskProgress={"TO_DO"}
         />
       </div>
       <div className={"margin-bottom-2"}>
         <TaskProgressCheckbox
           disabledTooltipText={"disabled text"}
           taskId={`2`}
-          STORYBOOK_ONLY_currentTaskProgress={"NOT_STARTED"}
-        />
-      </div>
-      <div className={"margin-bottom-2"}>
-        <TaskProgressCheckbox
-          disabledTooltipText={undefined}
-          taskId={`3`}
-          STORYBOOK_ONLY_currentTaskProgress={"IN_PROGRESS"}
-        />
-      </div>
-      <div className={"margin-bottom-2"}>
-        <TaskProgressCheckbox
-          disabledTooltipText={"disabled text"}
-          taskId={`4`}
-          STORYBOOK_ONLY_currentTaskProgress={"IN_PROGRESS"}
+          STORYBOOK_ONLY_currentTaskProgress={"TO_DO"}
         />
       </div>
       <div className={"margin-bottom-2"}>

--- a/web/test/pages/profile/profile-starting.test.tsx
+++ b/web/test/pages/profile/profile-starting.test.tsx
@@ -229,7 +229,7 @@ describe("profile - starting business", () => {
         expect(userDataWasNotUpdated()).toBe(true);
       });
 
-      it("allows user to delete formation date and sets task progress to IN_PROGRESS", async () => {
+      it("allows user to delete formation date and sets task progress to TO_DO", async () => {
         const initialBusiness = generateBusinessForProfile({
           profileData: generateProfileData({
             businessPersona: "STARTING",
@@ -247,7 +247,7 @@ describe("profile - starting business", () => {
         );
 
         await waitFor(() => {
-          expect(currentBusiness().taskProgress[formationTaskId]).toEqual("IN_PROGRESS");
+          expect(currentBusiness().taskProgress[formationTaskId]).toEqual("TO_DO");
         });
         expect(currentBusiness().profileData.dateOfFormation).toEqual(undefined);
       });
@@ -344,7 +344,7 @@ describe("profile - starting business", () => {
       },
       taskProgress: {
         [einTaskId]: "COMPLETED",
-        [naicsCodeTaskId]: "NOT_STARTED",
+        [naicsCodeTaskId]: "TO_DO",
       },
       taskItemChecklist: {},
     });
@@ -975,7 +975,7 @@ describe("profile - starting business", () => {
           },
           taskProgress: {
             ...business.taskProgress,
-            [naicsCodeTaskId]: "NOT_STARTED",
+            [naicsCodeTaskId]: "TO_DO",
           },
           taskItemChecklist: {},
         })
@@ -1100,7 +1100,7 @@ describe("profile - starting business", () => {
     clickSave();
 
     await waitFor(() => {
-      expect(currentBusiness().taskProgress[naicsCodeTaskId]).toEqual("NOT_STARTED");
+      expect(currentBusiness().taskProgress[naicsCodeTaskId]).toEqual("TO_DO");
     });
     expect(currentBusiness().profileData.naicsCode).toEqual("");
   });

--- a/web/test/pages/taskUrlSlug.test.tsx
+++ b/web/test/pages/taskUrlSlug.test.tsx
@@ -427,7 +427,7 @@ describe("task page", () => {
           profileData: generateProfileData({
             operatingPhase,
           }),
-          taskProgress: { [businessStructureTaskId]: "NOT_STARTED" },
+          taskProgress: { [businessStructureTaskId]: "TO_DO" },
         })
       );
       expect(screen.queryByTestId("nextUrlSlugButton")).not.toBeInTheDocument();


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
Updated TaskProgress values:
* previously there were three values: `NOT_STARTED`, `IN_PROGRESS`, and `COMPLETED`
* now there are only two available values: `TO_DO` and `COMPLETED`

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188887762](https://www.pivotaltracker.com/story/show/188887762).

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->
Going through normal onboarding for a business you should only see the two updated states available for all checkboxes. 

### Notes

<!-- Additional information, key learnings, and future development considerations. -->
* This PR includes a migration to change any `TaskProgress` values from `NOT_STARTED` and `IN_PROGRESS` to `TO_DO`. 
* This touches a lot of files, but is almost entirely consolidating the two values `NOT_STARTED` and `IN_PROGRESS` to `TO_DO`. Many tests needed to be updated to reflect these new values. 

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
