### PR TITLE
feat: [#188814053] add out of state pharmacy license task

### DIFF
--- a/api/wiremock/__files/webservice-license-status-response.json
+++ b/api/wiremock/__files/webservice-license-status-response.json
@@ -498,26 +498,9 @@
     "licenseType": "Out of State Pharmacy",
     "applicationNumber": "7777777",
     "licenseNumber": "ABC123XYZ456",
-    "licenseStatus": "Pending",
-    "issueDate": "20001005 000000.000",
-    "expirationDate": "20230724 000000.000",
-    "checklistItem": "Registration Fee 2",
-    "checkoffStatus": "Unchecked"
-  },
-  {
-    "fullName": "Cool Pharmacy",
-    "addressLine1": "102 License St",
-    "addressCity": "Cool Town",
-    "addressState": "NJ",
-    "addressCounty": "Cool County",
-    "addressZipCode": "12345",
-    "professionName": "Pharmacy",
-    "licenseType": "Out of State Pharmacy",
-    "applicationNumber": "7777777",
-    "licenseNumber": "ABC123XYZ456",
     "licenseStatus": "Expired",
     "issueDate": "20001005 000000.000",
-    "expirationDate": "20230724 000000.000",
+    "expirationDate": "20250724 000000.000",
     "checklistItem": "Registration Fee 1",
     "checkoffStatus": "Unchecked"
   }

--- a/api/wiremock/__files/webservice-license-status-response.json
+++ b/api/wiremock/__files/webservice-license-status-response.json
@@ -486,5 +486,39 @@
     "expirationDate": "20230724 000000.000",
     "checklistItem": "Registration Fee",
     "checkoffStatus": "Unchecked"
+  },
+  {
+    "fullName": "Cool Pharmacy",
+    "addressLine1": "102 License St",
+    "addressCity": "Cool Town",
+    "addressState": "NJ",
+    "addressCounty": "Cool County",
+    "addressZipCode": "12345",
+    "professionName": "Pharmacy",
+    "licenseType": "Out of State Pharmacy",
+    "applicationNumber": "7777777",
+    "licenseNumber": "ABC123XYZ456",
+    "licenseStatus": "Pending",
+    "issueDate": "20001005 000000.000",
+    "expirationDate": "20230724 000000.000",
+    "checklistItem": "Registration Fee 2",
+    "checkoffStatus": "Unchecked"
+  },
+  {
+    "fullName": "Cool Pharmacy",
+    "addressLine1": "102 License St",
+    "addressCity": "Cool Town",
+    "addressState": "NJ",
+    "addressCounty": "Cool County",
+    "addressZipCode": "12345",
+    "professionName": "Pharmacy",
+    "licenseType": "Out of State Pharmacy",
+    "applicationNumber": "7777777",
+    "licenseNumber": "ABC123XYZ456",
+    "licenseStatus": "Expired",
+    "issueDate": "20001005 000000.000",
+    "expirationDate": "20230724 000000.000",
+    "checklistItem": "Registration Fee 1",
+    "checkoffStatus": "Unchecked"
   }
 ]

--- a/content/src/license-calendar-events/oos-pharmacy.md
+++ b/content/src/license-calendar-events/oos-pharmacy.md
@@ -5,7 +5,7 @@ notesMd: >-
 
 
   1.9.25: updated with SME revisions
-licenseName: ""
+licenseName: "Pharmacy-Out of State Pharmacy"
 urlSlug: oos-pharmacy
 expirationEventDisplayName: Out-of-State Pharmacy Registration Expiration
 renewalEventDisplayName: Renew Your Out-of-State Pharmacy License
@@ -17,34 +17,35 @@ issuingAgency: Division of Consumer Affairs
 callToActionLink: "https://newjersey.mylicense.com/eGov/Login.aspx "
 callToActionText: Renew My Out-of-State Pharmacy Registration
 ---
+
 ## Application Requirements
 
 ### Pharmacy Information and Services
 
-* The pharmacy’s National Provider Identifier (NPI) number
-* Types of services the pharmacy provides (mail order, retail, etc.)
-* Any certifications or accreditations the pharmacy has, and the organization that issued them
-* Every state the pharmacy is licensed in 
-* The pharmacy’s National Council for Prescription Drug Programs (NCPDP) number, if applicable 
-* The pharmacy’s United States Drug Enforcement Administration (DEA) number, if applicable 
-* The website address through which the pharmacy fills prescriptions, if applicable
-* The name, address, and phone number of any pharmacy that makes compounded sterile products for your pharmacy, if applicable
-* Documentation of any changes to the pharmacist-in-charge (PIC), if applicable
-* New PIC license number, if applicable
-* Documentation of any change of ownership since last renewal, if applicable
-* New employee information, including name, address, phone number, and email, if applicable
+- The pharmacy’s National Provider Identifier (NPI) number
+- Types of services the pharmacy provides (mail order, retail, etc.)
+- Any certifications or accreditations the pharmacy has, and the organization that issued them
+- Every state the pharmacy is licensed in
+- The pharmacy’s National Council for Prescription Drug Programs (NCPDP) number, if applicable
+- The pharmacy’s United States Drug Enforcement Administration (DEA) number, if applicable
+- The website address through which the pharmacy fills prescriptions, if applicable
+- The name, address, and phone number of any pharmacy that makes compounded sterile products for your pharmacy, if applicable
+- Documentation of any changes to the pharmacist-in-charge (PIC), if applicable
+- New PIC license number, if applicable
+- Documentation of any change of ownership since last renewal, if applicable
+- New employee information, including name, address, phone number, and email, if applicable
 
 ### Compliance and Legal Information
 
-* A copy of your most recent `Certificate of Good Standing|good-standing` from the state where the pharmacy is licensed
-* A dated copy of the most recent inspection report
-* Each state the pharmacy distributed compounded human drug products last year
-* Documentation of any New Jersey Prescription Monitoring Program (NJPMP) exemptions or waivers, including expiration dates, if applicable
-* Criminal history of any pharmacy owner since last renewal, if applicable
-* Criminal history of any pharmacy employee since last renewal, if applicable
-* Any action taken or pending against the pharmacy’s permit since the last renewal, if applicable
-* Any action taken or pending against any employee’s license since the last renewal, if applicable
-* Applicable fees paid
+- A copy of your most recent `Certificate of Good Standing|good-standing` from the state where the pharmacy is licensed
+- A dated copy of the most recent inspection report
+- Each state the pharmacy distributed compounded human drug products last year
+- Documentation of any New Jersey Prescription Monitoring Program (NJPMP) exemptions or waivers, including expiration dates, if applicable
+- Criminal history of any pharmacy owner since last renewal, if applicable
+- Criminal history of any pharmacy employee since last renewal, if applicable
+- Any action taken or pending against the pharmacy’s permit since the last renewal, if applicable
+- Any action taken or pending against any employee’s license since the last renewal, if applicable
+- Applicable fees paid
 
 ### Prescription Totals for Compounded (Sterile and Non-sterile) Products
 
@@ -52,11 +53,11 @@ You need the total number of prescriptions for compounded (sterile and non-steri
 
 You also need last year’s total number of prescriptions for compounded human drug products:
 
-* Sent out of the pharmacy (includes mail, shipping, or delivery within the state and to other states) (sterile and non-sterile)
-* Picked up by patients at the pharmacy (sterile and non-sterile)
-* Mailed, shipped, or delivered to other states (sterile and non-sterile)
-* Mailed, shipped, or delivered to other states (sterile only)
-* Mailed, shipped, or delivered to patients in New Jersey (sterile and non-sterile)
+- Sent out of the pharmacy (includes mail, shipping, or delivery within the state and to other states) (sterile and non-sterile)
+- Picked up by patients at the pharmacy (sterile and non-sterile)
+- Mailed, shipped, or delivered to other states (sterile and non-sterile)
+- Mailed, shipped, or delivered to other states (sterile only)
+- Mailed, shipped, or delivered to patients in New Jersey (sterile and non-sterile)
 
 :::callout{ showHeader="true" headerText="What if I don’t renew my registration?" showIcon="false" calloutType="warning" }
 

--- a/content/src/roadmaps/add-ons/oos-pharmacy.json
+++ b/content/src/roadmaps/add-ons/oos-pharmacy.json
@@ -1,0 +1,12 @@
+{
+  "displayname": "oos-pharmacy",
+  "id": "oos-pharmacy",
+  "roadmapSteps": [],
+  "modifications": [
+    {
+      "step": 4,
+      "taskToReplaceFilename": "pharmacy-license",
+      "replaceWithFilename": "oos-pharmacy-registration"
+    }
+  ]
+}

--- a/content/src/roadmaps/license-tasks/oos-pharmacy-registration.md
+++ b/content/src/roadmaps/license-tasks/oos-pharmacy-registration.md
@@ -13,6 +13,7 @@ agencyAdditionalContext: New Jersey Board of Pharmacy
 industryId: pharmacy
 licenseCertificationClassification: undefined
 summaryDescriptionMd: "If your pharmacy is outside New Jersey and you send prescription drugs or devices to patients in New Jersey, you need to register as an out-of-state pharmacy."
+licenseName: "Pharmacy-Out of State Pharmacy"
 ---
 
 ## Application Requirements

--- a/shared/src/license.ts
+++ b/shared/src/license.ts
@@ -110,6 +110,7 @@ export const taskIdLicenseNameMapping = {
   "temporary-help-service-firm-reg": "Consulting Firms/Temporary Help Services-Temporary Help Service",
   "search-licenses-employment-agency": "Employment & Personnel Service-Employment Agency",
   "funeral-registration": "Mortuary Science-Funeral Home",
+  "oos-pharmacy-registration": "Pharmacy-Out of State Pharmacy",
 } as const;
 
 export const LicenseNameTaskIdMapping = Object.fromEntries(

--- a/web/src/components/TaskPageSwitchComponent.tsx
+++ b/web/src/components/TaskPageSwitchComponent.tsx
@@ -40,6 +40,7 @@ export const taskIdsWithLicenseSearchEnabled = [
   "health-club-registration",
   "home-health-aide-license",
   "license-massage-therapy",
+  "oos-pharmacy-registration",
   "pharmacy-license",
   "register-accounting-firm",
   "register-home-contractor",

--- a/web/src/lib/roadmap/buildUserRoadmap.test.ts
+++ b/web/src/lib/roadmap/buildUserRoadmap.test.ts
@@ -159,6 +159,12 @@ describe("buildUserRoadmap", () => {
       await buildUserRoadmap(createEmptyNexusProfile({ legalStructureId: "nonprofit" }));
       expect(getLastCalledWith(mockRoadmapBuilder)[0].addOns).toContain("nonprofit-and-corp-foreign");
     });
+
+    it("adds oos-pharmacy add-on for out of state pharmacy", async () => {
+      const profileData = createEmptyNexusProfile({ industryId: "pharmacy" });
+      await buildUserRoadmap(profileData);
+      expect(getLastCalledWith(mockRoadmapBuilder)[0].addOns).toContain("oos-pharmacy");
+    });
   });
 
   describe("home-based business", () => {

--- a/web/src/lib/roadmap/buildUserRoadmap.ts
+++ b/web/src/lib/roadmap/buildUserRoadmap.ts
@@ -72,6 +72,9 @@ const getForeignAddOns = (profileData: ProfileData): string[] => {
 
   if (determineForeignBusinessType(profileData.foreignBusinessTypeIds) === "NEXUS") {
     addOns.push("foreign-nexus");
+    if (profileData.industryId === "pharmacy") {
+      addOns.push("oos-pharmacy");
+    }
   }
 
   return addOns;

--- a/web/test/pages/taskUrlSlug.test.tsx
+++ b/web/test/pages/taskUrlSlug.test.tsx
@@ -228,6 +228,7 @@ describe("task page", () => {
       "health-club-registration",
       "home-health-aide-license",
       "license-massage-therapy",
+      "oos-pharmacy-registration",
       "pharmacy-license",
       "register-accounting-firm",
       "register-home-contractor",
@@ -246,6 +247,8 @@ describe("task page", () => {
 
     it.each(mockTaskIdsWithLicenseSearch)("loads License task screen for %s", (licenseId) => {
       renderPage(generateTask({ id: licenseId }), generateBusiness({ licenseData: undefined }));
+      // TODO: Consider a better way to affirm that this is the correct task screen instead of just looking for
+      // "cta-secondary" id to be in the document.
       expect(screen.getByTestId("cta-secondary")).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
Replaces the pharmacy registration license task with a license task specific to out-of-state pharmacies on the roadmap for Dakota Nexus users. In this task, users can also check the status of their license and get events on their calendar for when their license expires and their renewal deadline.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188814053](https://www.pivotaltracker.com/story/show/188814053).

### Approach
- Enabled license search by adding it to the list in [/TaskPageSwitchComponent.tsx](https://github.com/newjersey/navigator.business.nj.gov/pull/9642/files#diff-596ac947da21161feaebaaa63b7ab72d2dab81af96826f7af5141bcfd365012f)
- Added objects to the Wiremock response to allow us to test the license check locally.
- Added the licenseName field to the registration and renewal md files.
- Created an add-on with modifications to replace the original pharmacy license.
- Logic + unit test for applying this add-on only for a Dakota Nexus user's roadmap.

### Steps to Test
Run the app locally and get started as an out-of-state (Dakota Nexus) pharmacy. Select any business structure to get the rest of the steps in the roadmap, and see that the OOS pharmacy license task has replaced the pharmacy license task in the 1st task of step 4.

<img width="600" alt="Step 4 for out-of-state pharmacy, with the out-of-state pharmacy license task circled" src="https://github.com/user-attachments/assets/2831ae89-2e9a-447d-b5bf-2324dfdd1cc8" />

If the business were in-state, it would look like this instead:
<img width="654" alt="Step 4 for an in-state pharmacy, which does not have the out of state pharmacy license task" src="https://github.com/user-attachments/assets/a2a1754a-a750-4a39-8611-c55c5c65acc1" />

Click into the OOS pharmacy license task and check the status using the name "Cool Pharmacy" and the address 102 License St, 12345 NJ. It should come back with an expired task, corresponding to the last object in `/navigator.business.nj.gov/api/wiremock/__files/webservice-license-status-response.json`. 

Click the "See My Deadlines and Opportunities" button on the For You sidebar and choose any date, and then click "Show My Funding Opportunities". The Calendar should appear with the OOS pharmacy expiration and renewal events on it.

<img width="591" alt="Expiration and renewal tasks on the calendar" src="https://github.com/user-attachments/assets/b8edfe74-efef-4502-b3bd-6b45ebc5d3ce" />

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
