### PR TITLE
Set options_length: 500 for all relation widgets in the CMS

### DIFF
--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -55,6 +55,7 @@ collections:
         search_fields: ["arrayOfTaskAgencies.*.name"]
         value_field: "arrayOfTaskAgencies.*.id"
         display_fields: ["arrayOfTaskAgencies.*.name"]
+        options_length: 500
   - name: "business-formation-config"
     label: "Biz Form - Config"
     delete: false
@@ -1411,6 +1412,7 @@ collections:
         search_fields: ["arrayOfFundingAgencies.*.name"]
         value_field: "arrayOfFundingAgencies.*.id"
         display_fields: ["arrayOfFundingAgencies.*.name"]
+        options_length: 500
       - label: "Applicable Ownership Types"
         name: applicableOwnershipTypes
         widget: "select"
@@ -1457,6 +1459,7 @@ collections:
         search_fields: ["arrayOfFundingAgencies.*.name"]
         value_field: "arrayOfFundingAgencies.*.id"
         display_fields: ["arrayOfFundingAgencies.*.name"]
+        options_length: 500
       - label: "Applicable Ownership Types"
         name: applicableOwnershipTypes
         widget: "select"
@@ -1581,6 +1584,7 @@ collections:
         search_fields: ["arrayOfFundingAgencies.*.name"]
         value_field: "arrayOfFundingAgencies.*.id"
         display_fields: ["arrayOfFundingAgencies.*.name"]
+        options_length: 500
       - {
           label: "Agency Contact",
           name: "agencyContact",
@@ -1661,6 +1665,7 @@ collections:
         search_fields: ["arrayOfSectors.*.name"]
         value_field: "arrayOfSectors.*.id"
         display_fields: ["arrayOfSectors.*.name"]
+        options_length: 500
       - label: "Publish/Stage/Archive"
         name: "publishStageArchive"
         widget: "select"
@@ -1796,6 +1801,7 @@ collections:
         search_fields: ["arrayOfFundingAgencies.*.name"]
         value_field: "arrayOfFundingAgencies.*.id"
         display_fields: ["arrayOfFundingAgencies.*.name"]
+        options_length: 500
       - {
           label: "Agency Contact",
           name: "agencyContact",
@@ -1876,6 +1882,7 @@ collections:
         search_fields: ["arrayOfSectors.*.name"]
         value_field: "arrayOfSectors.*.id"
         display_fields: ["arrayOfSectors.*.name"]
+        options_length: 500
       - label: "Publish/Stage/Archive"
         name: "publishStageArchive"
         widget: "select"
@@ -1930,6 +1937,7 @@ collections:
         search_fields: ["arrayOfSectors.*.name"]
         value_field: "arrayOfSectors.*.id"
         display_fields: ["arrayOfSectors.*.name"]
+        options_length: 500
       - label: NAICS Codes
         name: naicsCodes
         widget: string
@@ -2029,6 +2037,7 @@ collections:
         search_fields: ["nonEssentialQuestionsArray.*.id"]
         value_field: "nonEssentialQuestionsArray.*.id"
         display_fields: ["nonEssentialQuestionsArray.*.id"]
+        options_length: 500
       - label: Roadmap Steps
         name: roadmapSteps
         widget: list
@@ -2041,6 +2050,7 @@ collections:
             search_fields: ["steps.*.name"]
             value_field: "steps.*.stepNumber"
             display_fields: ["steps.*.name"]
+            options_length: 500
           - label: Weight
             name: weight
             widget: number
@@ -2118,6 +2128,7 @@ collections:
             search_fields: ["steps.*.name"]
             value_field: "steps.*.stepNumber"
             display_fields: ["steps.*.name"]
+            options_length: 500
           - label: Weight
             name: weight
             widget: number
@@ -2602,6 +2613,7 @@ collections:
         search_fields: ["arrayOfTaskAgencies.*.name"]
         value_field: "arrayOfTaskAgencies.*.id"
         display_fields: ["arrayOfTaskAgencies.*.name"]
+        options_length: 500
       - {
           label: "Additional Agency Context",
           name: "agencyAdditionalContext",
@@ -2687,6 +2699,7 @@ collections:
         search_fields: ["arrayOfTaskAgencies.*.name"]
         value_field: "arrayOfTaskAgencies.*.id"
         display_fields: ["arrayOfTaskAgencies.*.name"]
+        options_length: 500
       - {
           label: "Agency additional context (Webflow & Navigator)",
           name: "agencyAdditionalContext",
@@ -2769,6 +2782,7 @@ collections:
         search_fields: ["arrayOfTaskAgencies.*.name"]
         value_field: "arrayOfTaskAgencies.*.id"
         display_fields: ["arrayOfTaskAgencies.*.name"]
+        options_length: 500
       - {
           label: "Agency additional context (Webflow & Navigator)",
           name: "agencyAdditionalContext",


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

The CMS uses a widget called a `relation` that is used to create a dropdown or multi-select with values from other collections. By default, the `relation` will show 20 values. The user can search for additional items not displayed in the first 20, but this is not always the most discoverable. Setting this value for all widgets should mitigate any future confusion.

### Ticket

<!-- Link to ticket in pivotal. Append ticket_id to provided URL. -->

This pull request resolves [#188924188](https://www.pivotaltracker.com/story/show/188924188).

### Approach

Set `options_length: 500` for all relations in the CMS config file.

### Steps to Test

Look for a collection that has a relation, all items from the source collection should be visible.

Example:
Look at industry roadmaps. The "Non Essential Questions" section is populated by a multi-select relation. This was the collection that spawned [this conversation in Slack](https://njcio.slack.com/archives/C02AJKBCH38/p1740418555203319). The collection contains 24 items. All now display when the multi-select is opened.

### Notes

Should it be more than 500? Maybe. This will definitely cover us for some time.

Unfortunately there is not a way for us to set the value to infinity. The cap just needs to be large.

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
