### PR TITLE
Updated pre-commit scripts to track both Pivotal and ADO tickets

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,16 +1,17 @@
 #!/bin/sh
 
 # Define the regex pattern for commit messages
-COMMIT_MSG_REGEX="^(fix|feat|chore|docs|style|refactor|test): \[AB#[0-9]+\] .+"
+COMMIT_MSG_REGEX="^(fix|feat|chore|docs|style|refactor|test): (\[#[0-9]+ \| AB#[0-9]+\] .+|spell check fixes)$"
 COMMIT_MSG_FILE="$1"
 COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
 
 # Check if the commit message matches the pattern
 if ! echo "$COMMIT_MSG" | grep -Eq "$COMMIT_MSG_REGEX"; then
   echo "❌ Commit message does not match the required format!"
-  echo "❌ Expected format: 'fix|feat|chore|docs|style|refactor|test: [AB#<ticket ID>] <message here>'"
-  echo "❌ Example: 'feat: [AB#1234] added status page'"
-  echo "❌ Alternatively you can ignore this by having '--no-verify' as a commandline argument to the commit command'"
+  echo "❌ Expected format: 'fix|feat|chore|docs|style|refactor|test: [#<Pivotal ID> | AB#<ticket ID>] <message here>'"
+  echo "❌ Example: 'feat: [#123456 | AB#1234] added status page'"
+  echo "---- Alternatively you can ignore this by having '--no-verify' as a commandline argument to the commit command'"
+  echo "---- We also support 'fix: spell check fixes' as a message"
   exit 1
 fi
 


### PR DESCRIPTION
## Description

Updated pre commit script to track both pivotal and ADO id's 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#8681](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8681).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test


Go onto this branch and install
Then try and commit with a variety of manual testing cases

This is correct feat: [#123455 AB#1234] updated some cool stuff
So trie variations that are correct and not correct, try unknown prefixes, try weird ID's, try removing the AB or the # or the number or the message after or whatever.
<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
