### PR TITLE
fix: [AB#12799] update query to use current version dynamically

### DIFF
--- a/api/src/db/DynamoDataClient.test.ts
+++ b/api/src/db/DynamoDataClient.test.ts
@@ -15,7 +15,7 @@ import {
   generateTaxFilingData,
   generateUserDataForBusiness,
 } from "@shared/test";
-import { UserData } from "@shared/userData";
+import { CURRENT_VERSION, UserData } from "@shared/userData";
 import dayjs from "dayjs";
 
 // references jest-dynalite-config values
@@ -128,5 +128,15 @@ describe("User and Business Migration with DynamoDataClient", () => {
     expect(logger.LogError).toHaveBeenCalledWith(`MigrateData Failed: ${mockError.message}`);
 
     expect(logger.LogInfo).not.toHaveBeenCalledWith("Successfully migrated business");
+  });
+
+  it("should log an info message when no users with outdated versions are found", async () => {
+    jest.spyOn(dynamoUsersDataClient, "getUsersWithOutdatedVersion").mockResolvedValueOnce([]);
+
+    const logSpy = jest.spyOn(logger, "LogInfo");
+
+    await dynamoDataClient.migrateData();
+
+    expect(logSpy).toHaveBeenCalledWith(`No users need migration. Current version: ${CURRENT_VERSION}`);
   });
 });

--- a/api/src/db/DynamoDataClient.ts
+++ b/api/src/db/DynamoDataClient.ts
@@ -15,7 +15,7 @@ export const DynamoDataClient = (
     try {
       const usersToMigrate = await userDataClient.getUsersWithOutdatedVersion(CURRENT_VERSION);
       if (usersToMigrate.length === 0) {
-        logger.LogInfo("No users need migration.");
+        logger.LogInfo(`No users need migration. Current version: ${CURRENT_VERSION}`);
         return { success: true, migratedCount: 0 };
       }
 

--- a/api/src/db/DynamoUserDataClient.ts
+++ b/api/src/db/DynamoUserDataClient.ts
@@ -138,7 +138,7 @@ export const DynamoUserDataClient = (
   };
 
   const getUsersWithOutdatedVersion = async (latestVersion: number): Promise<UserData[]> => {
-    const statement = `SELECT data FROM "${tableName}" WHERE data["version"] < ${CURRENT_VERSION}`;
+    const statement = `SELECT data FROM "${tableName}" WHERE data["version"] < ${latestVersion}`;
     return await search(statement);
   };
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

This PR updates the `getUsersWithOutdatedVersion`  to use current_version dynamically instead of a fixed value. This ensures that the query always reflects the correct version during deployments, including weekend migrations.
Previously, the query used a hardcoded version, which could lead to outdated checks and inconsistent migrations. This update ensures that only users with an outdated version are correctly identified and migrated

Changes:

- Updated the query in getUsersWithOutdatedVersion to use the latestVersion parameter dynamically.
- Improved logging by including current_version for better monitoring.
- Added a unit test to verify that the correct log message is generated when no users need migration.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#12799](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12799).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
 - Run unit test to ensure the existing functionality works as expected. 

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
