### PR TITLE
Disable Auto-Tax Filing Cypress Test

### DIFF
--- a/web/cypress/e2e/auto-tax-filing.spec.ts
+++ b/web/cypress/e2e/auto-tax-filing.spec.ts
@@ -12,7 +12,7 @@ import { randomNonHomeBasedNonDomesticEmployerIndustry } from "@businessnjgovnav
 import { onDashboardPage } from "@businessnjgovnavigator/cypress/support/page_objects/dashboardPage";
 import { onProfilePage } from "@businessnjgovnavigator/cypress/support/page_objects/profilePage";
 
-describe(
+describe.skip(
   "auto tax filing [feature] [all] [group4]",
   { retries: 1 }, // Retry due to a race condition
   () => {


### PR DESCRIPTION
## Description

This test is consistently flaking an causing ❌ in our CI Pipeline. I think we're all on the same page that this test works inconsistently, might have been someone hastily made, and isn't bringing a ton of value. I'd like to disable this until a time when we're able to better address so that we can more confidently rely on CI as an indicator of codebase health and hopefully not introduce additional breaking changes.

Specifically, this test was causing `Integration Tests - Group 4-1` to fail fairly consistently.