### PR TITLE
chore: [#188595636 | AB#4703] refactor context used for errors across all forms

### DIFF
--- a/web/src/components/DeferredOnboardingQuestion.tsx
+++ b/web/src/components/DeferredOnboardingQuestion.tsx
@@ -1,6 +1,6 @@
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { useUserData } from "@/lib/data-hooks/useUserData";
@@ -24,7 +24,7 @@ export const DeferredOnboardingQuestion = (props: Props): ReactElement => {
     FormFuncWrapper,
     onSubmit,
     state: formContextState,
-  } = useFormContextHelper(createProfileFieldErrorMap());
+  } = useFormContextHelper(createDataFormErrorMap());
 
   useEffect(() => {
     if (!business) return;
@@ -81,7 +81,7 @@ export const DeferredOnboardingQuestion = (props: Props): ReactElement => {
   );
 
   return (
-    <ProfileFormContext.Provider value={formContextState}>
+    <DataFormErrorMapContext.Provider value={formContextState}>
       <ProfileDataContext.Provider
         value={{
           state: {
@@ -94,6 +94,6 @@ export const DeferredOnboardingQuestion = (props: Props): ReactElement => {
       >
         {props.isTaskPage ? onTaskPage : onDashboard}
       </ProfileDataContext.Provider>
-    </ProfileFormContext.Provider>
+    </DataFormErrorMapContext.Provider>
   );
 };

--- a/web/src/components/FormationDateModal.tsx
+++ b/web/src/components/FormationDateModal.tsx
@@ -4,8 +4,8 @@ import { MunicipalityField } from "@/components/data-fields/MunicipalityField";
 import { FieldLabelModal } from "@/components/field-labels/FieldLabelModal";
 import { ModalTwoButton } from "@/components/ModalTwoButton";
 import { WithErrorBar } from "@/components/WithErrorBar";
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { useUserData } from "@/lib/data-hooks/useUserData";
@@ -30,7 +30,7 @@ export const FormationDateModal = (props: Props): ReactElement => {
     onSubmit,
     isValid,
     state: formContextState,
-  } = useFormContextHelper(createProfileFieldErrorMap());
+  } = useFormContextHelper(createDataFormErrorMap());
 
   useEffect(() => {
     if (!business) return;
@@ -58,7 +58,7 @@ export const FormationDateModal = (props: Props): ReactElement => {
   });
 
   return (
-    <ProfileFormContext.Provider value={formContextState}>
+    <DataFormErrorMapContext.Provider value={formContextState}>
       <ProfileDataContext.Provider
         value={{
           state: {
@@ -113,6 +113,6 @@ export const FormationDateModal = (props: Props): ReactElement => {
           )}
         </ModalTwoButton>
       </ProfileDataContext.Provider>
-    </ProfileFormContext.Provider>
+    </DataFormErrorMapContext.Provider>
   );
 };

--- a/web/src/components/LegalStructureDropDown.tsx
+++ b/web/src/components/LegalStructureDropDown.tsx
@@ -1,7 +1,7 @@
 import { MenuOptionSelected } from "@/components/MenuOptionSelected";
 import { MenuOptionUnselected } from "@/components/MenuOptionUnselected";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { FormContextFieldProps } from "@/lib/types/types";
@@ -20,7 +20,7 @@ export const LegalStructureDropDown = <T,>(props: Props<T>): ReactElement => {
 
   const { RegisterForOnSubmit, setIsValid, isFormFieldInvalid } = useFormContextFieldHelpers(
     "legalStructureId",
-    ProfileFormContext,
+    DataFormErrorMapContext,
     props.errorTypes
   );
 

--- a/web/src/components/dashboard/SectorModal.tsx
+++ b/web/src/components/dashboard/SectorModal.tsx
@@ -3,8 +3,8 @@ import { Sectors } from "@/components/data-fields/Sectors";
 import { FieldLabelModal } from "@/components/field-labels/FieldLabelModal";
 import { ModalTwoButton } from "@/components/ModalTwoButton";
 import { WithErrorBar } from "@/components/WithErrorBar";
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { useUserData } from "@/lib/data-hooks/useUserData";
@@ -29,7 +29,7 @@ export const SectorModal = (props: Props): ReactElement => {
     FormFuncWrapper,
     onSubmit,
     state: formContextState,
-  } = useFormContextHelper(createProfileFieldErrorMap());
+  } = useFormContextHelper(createDataFormErrorMap());
 
   useMountEffectWhenDefined(() => {
     if (business) {
@@ -50,7 +50,7 @@ export const SectorModal = (props: Props): ReactElement => {
   });
 
   return (
-    <ProfileFormContext.Provider value={formContextState}>
+    <DataFormErrorMapContext.Provider value={formContextState}>
       <ProfileDataContext.Provider
         value={{
           state: {
@@ -83,6 +83,6 @@ export const SectorModal = (props: Props): ReactElement => {
           </div>
         </ModalTwoButton>
       </ProfileDataContext.Provider>
-    </ProfileFormContext.Provider>
+    </DataFormErrorMapContext.Provider>
   );
 };

--- a/web/src/components/data-fields/AccountSetupForm.tsx
+++ b/web/src/components/data-fields/AccountSetupForm.tsx
@@ -1,7 +1,7 @@
 import { GenericTextField } from "@/components/GenericTextField";
 import { WithErrorBar } from "@/components/WithErrorBar";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
-import { ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import {
@@ -26,9 +26,17 @@ export const AccountSetupForm = (props: Props): ReactElement => {
   const { Config } = useConfig();
   const { registrationStatus, setRegistrationStatus } = useContext(NeedsAccountContext);
 
-  const emailFormContextHelpers = useFormContextFieldHelpers("email", ProfileFormContext, props.errorTypes);
+  const emailFormContextHelpers = useFormContextFieldHelpers(
+    "email",
+    DataFormErrorMapContext,
+    props.errorTypes
+  );
 
-  const nameFormContextHelpers = useFormContextFieldHelpers("name", ProfileFormContext, props.errorTypes);
+  const nameFormContextHelpers = useFormContextFieldHelpers(
+    "name",
+    DataFormErrorMapContext,
+    props.errorTypes
+  );
 
   emailFormContextHelpers.RegisterForOnSubmit(() =>
     props.user.email ? validateEmail(props.user.email) : false
@@ -105,7 +113,7 @@ export const AccountSetupForm = (props: Props): ReactElement => {
           </label>
           <GenericTextField
             value={props.user.name}
-            formContext={ProfileFormContext}
+            formContext={DataFormErrorMapContext}
             fieldName={"name"}
             error={nameFormContextHelpers.isFormFieldInvalid}
             validationText={FullNameErrorMessageLookup[getFullNameErrorVariant(props.user.name)]}

--- a/web/src/components/data-fields/BusinessPersonaQuestion.tsx
+++ b/web/src/components/data-fields/BusinessPersonaQuestion.tsx
@@ -1,8 +1,8 @@
 import { Content } from "@/components/Content";
 import { Heading } from "@/components/njwds-extended/Heading";
 import { ConfigType } from "@/contexts/configContext";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { getProfileConfig } from "@/lib/domain-logic/getProfileConfig";
@@ -18,7 +18,7 @@ export const BusinessPersonaQuestion = <T,>(props: FormContextFieldProps<T>): Re
 
   const { RegisterForOnSubmit, setIsValid } = useFormContextFieldHelpers(
     "businessPersona",
-    ProfileFormContext,
+    DataFormErrorMapContext,
     props.errorTypes
   );
 

--- a/web/src/components/data-fields/DateOfFormation.tsx
+++ b/web/src/components/data-fields/DateOfFormation.tsx
@@ -1,7 +1,7 @@
 import { GenericTextField } from "@/components/GenericTextField";
 import { ConfigType } from "@/contexts/configContext";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { getProfileConfig } from "@/lib/domain-logic/getProfileConfig";
@@ -37,7 +37,7 @@ export const DateOfFormation = (props: Props): ReactElement => {
 
   const { RegisterForOnSubmit, setIsValid, isFormFieldInvalid } = useFormContextFieldHelpers(
     fieldName,
-    ProfileFormContext
+    DataFormErrorMapContext
   );
 
   const contentFromConfig: ConfigType["profileDefaults"]["fields"]["dateOfFormation"]["default"] =

--- a/web/src/components/data-fields/EssentialQuestionField.tsx
+++ b/web/src/components/data-fields/EssentialQuestionField.tsx
@@ -2,8 +2,8 @@ import { RadioQuestion } from "@/components/data-fields/RadioQuestion";
 import { FieldLabelOnboarding } from "@/components/field-labels/FieldLabelOnboarding";
 import { FieldLabelProfile } from "@/components/field-labels/FieldLabelProfile";
 import { WithErrorBar } from "@/components/WithErrorBar";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { EssentialQuestion } from "@/lib/domain-logic/essentialQuestions";
@@ -20,7 +20,7 @@ export const EssentialQuestionField = <T,>(props: Props<T>): ReactElement => {
 
   const { RegisterForOnSubmit, isFormFieldInvalid } = useFormContextFieldHelpers(
     props.essentialQuestion.fieldName,
-    ProfileFormContext,
+    DataFormErrorMapContext,
     props.errorTypes
   );
 

--- a/web/src/components/data-fields/ForeignBusinessTypeField.tsx
+++ b/web/src/components/data-fields/ForeignBusinessTypeField.tsx
@@ -1,8 +1,8 @@
 import { Content } from "@/components/Content";
 import { Alert } from "@/components/njwds-extended/Alert";
 import { ConfigType } from "@/contexts/configContext";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { getProfileConfig } from "@/lib/domain-logic/getProfileConfig";
@@ -32,7 +32,7 @@ export const ForeignBusinessTypeField = <T,>(props: Props<T>): ReactElement => {
 
   const { RegisterForOnSubmit, setIsValid } = useFormContextFieldHelpers(
     "foreignBusinessTypeIds",
-    ProfileFormContext,
+    DataFormErrorMapContext,
     props.errorTypes
   );
 

--- a/web/src/components/data-fields/Industry.tsx
+++ b/web/src/components/data-fields/Industry.tsx
@@ -3,8 +3,8 @@ import { EssentialQuestionField } from "@/components/data-fields/EssentialQuesti
 import { HomeContractor } from "@/components/data-fields/HomeContractor";
 import { IndustryDropdown } from "@/components/data-fields/IndustryDropdown";
 import { ConfigType } from "@/contexts/configContext";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { EssentialQuestion, EssentialQuestions } from "@/lib/domain-logic/essentialQuestions";
@@ -22,7 +22,7 @@ export const Industry = <T,>(props: Props<T>): ReactElement => {
 
   const { RegisterForOnSubmit, setIsValid, isFormFieldInvalid } = useFormContextFieldHelpers(
     fieldName,
-    ProfileFormContext,
+    DataFormErrorMapContext,
     props.errorTypes
   );
 

--- a/web/src/components/data-fields/MunicipalityField.tsx
+++ b/web/src/components/data-fields/MunicipalityField.tsx
@@ -1,8 +1,8 @@
 import { MunicipalityDropdown } from "@/components/data-fields/MunicipalityDropdown";
 import { ConfigType } from "@/contexts/configContext";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { MunicipalitiesContext } from "@/contexts/municipalitiesContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { getProfileConfig } from "@/lib/domain-logic/getProfileConfig";
@@ -24,7 +24,7 @@ export const MunicipalityField = (props: Props): ReactElement => {
 
   const { RegisterForOnSubmit, setIsValid, isFormFieldInvalid } = useFormContextFieldHelpers(
     fieldName,
-    ProfileFormContext,
+    DataFormErrorMapContext,
     props.errorTypes
   );
 

--- a/web/src/components/data-fields/ProfileDataField.tsx
+++ b/web/src/components/data-fields/ProfileDataField.tsx
@@ -1,6 +1,6 @@
 import { GenericTextField, GenericTextFieldProps } from "@/components/GenericTextField";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { getProfileConfig } from "@/lib/domain-logic/getProfileConfig";
 import { ProfileContentField } from "@/lib/types/types";
@@ -46,7 +46,7 @@ export const ProfileDataField = <T,>({
     <div className={className}>
       <GenericTextField
         value={state.profileData[fieldName] as string | undefined}
-        formContext={ProfileFormContext}
+        formContext={DataFormErrorMapContext}
         fieldName={fieldName as string}
         {...props}
         validationText={props.validationText ?? contentFromConfig.errorTextRequired ?? ""}

--- a/web/src/components/data-fields/RadioQuestion.tsx
+++ b/web/src/components/data-fields/RadioQuestion.tsx
@@ -1,5 +1,5 @@
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { getProfileConfig } from "@/lib/domain-logic/getProfileConfig";
@@ -31,7 +31,10 @@ export const RadioQuestion = <T extends ProfileDataTypes>(props: Props<T>): Reac
   const { Config } = useConfig();
   const fieldName = props.contentFieldName ?? props.fieldName;
 
-  const { RegisterForOnSubmit, setIsValid } = useFormContextFieldHelpers(props.fieldName, ProfileFormContext);
+  const { RegisterForOnSubmit, setIsValid } = useFormContextFieldHelpers(
+    props.fieldName,
+    DataFormErrorMapContext
+  );
 
   const contentFromConfig = getProfileConfig({
     config: Config,

--- a/web/src/components/data-fields/Sectors.tsx
+++ b/web/src/components/data-fields/Sectors.tsx
@@ -1,8 +1,8 @@
 import { MenuOptionSelected } from "@/components/MenuOptionSelected";
 import { MenuOptionUnselected } from "@/components/MenuOptionUnselected";
 import { ConfigType } from "@/contexts/configContext";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { getProfileConfig } from "@/lib/domain-logic/getProfileConfig";
@@ -24,7 +24,7 @@ export const Sectors = <T,>(props: Props<T>): ReactElement => {
 
   const { RegisterForOnSubmit, setIsValid, isFormFieldInvalid } = useFormContextFieldHelpers(
     "sectorId",
-    ProfileFormContext,
+    DataFormErrorMapContext,
     props.errorTypes
   );
 

--- a/web/src/components/data-fields/tax-id/SingleTaxId.tsx
+++ b/web/src/components/data-fields/tax-id/SingleTaxId.tsx
@@ -4,8 +4,8 @@ import { GenericTextField } from "@/components/GenericTextField";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { ProfileDataFieldProps } from "@/components/data-fields/ProfileDataField";
 import { TaxIdDisplayStatus } from "@/components/data-fields/tax-id/TaxIdHelpers";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { ProfileFormContext } from "@/contexts/profileFormContext";
 import { MediaQueries } from "@/lib/PageSizes";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { formatTaxId } from "@/lib/domain-logic/formatTaxId";
@@ -23,7 +23,7 @@ export const SingleTaxId = ({ handleChangeOverride, validationText, ...props }: 
   const isTabletAndUp = useMediaQuery(MediaQueries.tabletAndUp);
 
   const { state, setProfileData } = useContext(ProfileDataContext);
-  const { isFormFieldInvalid } = useFormContextFieldHelpers(fieldName, ProfileFormContext);
+  const { isFormFieldInvalid } = useFormContextFieldHelpers(fieldName, DataFormErrorMapContext);
 
   const handleChange = (value: string): void => {
     if (handleChangeOverride) {
@@ -43,7 +43,7 @@ export const SingleTaxId = ({ handleChangeOverride, validationText, ...props }: 
           allowMasking={true}
           disabled={props.taxIdDisplayStatus === "password-view"}
           fieldName={fieldName}
-          formContext={ProfileFormContext}
+          formContext={DataFormErrorMapContext}
           handleChange={handleChange}
           inputProps={{
             endAdornment: (

--- a/web/src/components/data-fields/tax-id/SplitTaxId.tsx
+++ b/web/src/components/data-fields/tax-id/SplitTaxId.tsx
@@ -5,8 +5,8 @@ import { TaxIdFormContext, taxIdFormContextErrorMap } from "@/components/data-fi
 import { TaxIdDisplayStatus } from "@/components/data-fields/tax-id/TaxIdHelpers";
 import { GenericTextField } from "@/components/GenericTextField";
 import { ConfigType } from "@/contexts/configContext";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
@@ -41,7 +41,7 @@ export const SplitTaxId = ({
 
   const { RegisterForOnSubmit, setIsValid, isFormFieldInvalid } = useFormContextFieldHelpers(
     fieldName,
-    ProfileFormContext
+    DataFormErrorMapContext
   );
 
   RegisterForOnSubmit(

--- a/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepOne.tsx
+++ b/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepOne.tsx
@@ -5,9 +5,9 @@ import { LegalStructureDropDown } from "@/components/LegalStructureDropDown";
 import { ModalOneButton } from "@/components/ModalOneButton";
 import { Alert } from "@/components/njwds-extended/Alert";
 import { WithErrorBar } from "@/components/WithErrorBar";
+import { DataFormErrorMapContext, DataFormErrorMapFields } from "@/contexts/dataFormErrorMapContext";
 import { createReducedFieldStates } from "@/contexts/formContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { ProfileFields, ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { useUserData } from "@/lib/data-hooks/useUserData";
@@ -23,7 +23,7 @@ interface Props {
 }
 
 export const TaxAccessStepOne = (props: Props): ReactElement => {
-  const fields: ProfileFields[] = ["legalStructureId"];
+  const fields: DataFormErrorMapFields[] = ["legalStructureId"];
   const [profileData, setProfileData] = useState<ProfileData>(createEmptyProfileData());
   const { business, updateQueue } = useUserData();
   const { Config } = useConfig();
@@ -65,7 +65,7 @@ export const TaxAccessStepOne = (props: Props): ReactElement => {
 
       <TaxAccessModalBody isStepOne={true} showHeader={true} />
 
-      <ProfileFormContext.Provider value={formContextState}>
+      <DataFormErrorMapContext.Provider value={formContextState}>
         <ProfileDataContext.Provider
           value={{
             state: {
@@ -82,7 +82,7 @@ export const TaxAccessStepOne = (props: Props): ReactElement => {
             <LegalStructureDropDown />
           </WithErrorBar>
         </ProfileDataContext.Provider>
-      </ProfileFormContext.Provider>
+      </DataFormErrorMapContext.Provider>
     </ModalOneButton>
   );
 };

--- a/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepTwo.tsx
+++ b/web/src/components/filings-calendar/tax-access-modal/TaxAccessStepTwo.tsx
@@ -7,9 +7,9 @@ import { TaxAccessModalBody } from "@/components/filings-calendar/tax-access-mod
 import { ModalTwoButton } from "@/components/ModalTwoButton";
 import { Alert } from "@/components/njwds-extended/Alert";
 import { WithErrorBar } from "@/components/WithErrorBar";
+import { DataFormErrorMapContext, DataFormErrorMapFields } from "@/contexts/dataFormErrorMapContext";
 import { createReducedFieldStates } from "@/contexts/formContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { ProfileFields, ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { useUpdateTaskProgress } from "@/lib/data-hooks/useUpdateTaskProgress";
@@ -47,7 +47,7 @@ export const TaxAccessStepTwo = (props: Props): ReactElement => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [apiFailed, setOnAPIfailed] = useState<undefined | "FAILED" | "UNKNOWN">(undefined);
   const [onSubmitClicked, setOnSubmitClicked] = useState<boolean>(false);
-  const fields: ProfileFields[] = ["businessName", "taxId", "responsibleOwnerName"];
+  const fields: DataFormErrorMapFields[] = ["businessName", "taxId", "responsibleOwnerName"];
   const has_CMS_ONLY_fakeError = props.CMS_ONLY_fakeError && props.CMS_ONLY_fakeError !== "NONE";
 
   const {
@@ -79,7 +79,7 @@ export const TaxAccessStepTwo = (props: Props): ReactElement => {
     }
   });
 
-  const errorMessages: Partial<Record<ProfileFields, string>> = {
+  const errorMessages: Partial<Record<DataFormErrorMapFields, string>> = {
     businessName: Config.taxAccess.modalBusinessFieldErrorName,
     responsibleOwnerName: Config.taxAccess.modalResponsibleOwnerFieldErrorName,
     taxId: Config.taxAccess.modalTaxFieldErrorName,
@@ -219,7 +219,7 @@ export const TaxAccessStepTwo = (props: Props): ReactElement => {
   if (profileData.legalStructureId === undefined) return <></>;
 
   return (
-    <ProfileFormContext.Provider value={formContextState}>
+    <DataFormErrorMapContext.Provider value={formContextState}>
       <ProfileDataContext.Provider
         value={{
           state: {
@@ -327,6 +327,6 @@ export const TaxAccessStepTwo = (props: Props): ReactElement => {
           </WithErrorBar>
         </ModalTwoButton>
       </ProfileDataContext.Provider>
-    </ProfileFormContext.Provider>
+    </DataFormErrorMapContext.Provider>
   );
 };

--- a/web/src/components/profile/ProfileAddress.tsx
+++ b/web/src/components/profile/ProfileAddress.tsx
@@ -3,7 +3,7 @@ import { NewJerseyAddress } from "@/components/data-fields/address/NewJerseyAddr
 import { UnitesStatesAddress } from "@/components/data-fields/address/UnitesStatesAddress";
 import { ProfileAddressLockedFields } from "@/components/profile/ProfileAddressLockedFields";
 import { AddressContext } from "@/contexts/addressContext";
-import { ProfileFormContext } from "@/contexts/profileFormContext";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { useAddressErrors } from "@/lib/data-hooks/useAddressErrors";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
@@ -22,24 +22,30 @@ export const ProfileAddress = (): ReactElement => {
   const { doesFieldHaveError } = useAddressErrors();
   const { setIsValid: setIsValidAddressLine1 } = useFormContextFieldHelpers(
     "addressLine1",
-    ProfileFormContext
+    DataFormErrorMapContext
   );
   const { setIsValid: setIsValidAddressLine2 } = useFormContextFieldHelpers(
     "addressLine2",
-    ProfileFormContext
+    DataFormErrorMapContext
   );
-  const { setIsValid: setIsValidCity } = useFormContextFieldHelpers("addressCity", ProfileFormContext);
+  const { setIsValid: setIsValidCity } = useFormContextFieldHelpers("addressCity", DataFormErrorMapContext);
   const { setIsValid: setIsValidMunicipality } = useFormContextFieldHelpers(
     "addressMunicipality",
-    ProfileFormContext
+    DataFormErrorMapContext
   );
   const { setIsValid: setIsValidProvince } = useFormContextFieldHelpers(
     "addressProvince",
-    ProfileFormContext
+    DataFormErrorMapContext
   );
-  const { setIsValid: setIsValidState } = useFormContextFieldHelpers("addressState", ProfileFormContext);
-  const { setIsValid: setIsValidCountry } = useFormContextFieldHelpers("addressCountry", ProfileFormContext);
-  const { setIsValid: setIsValidZipCode } = useFormContextFieldHelpers("addressZipCode", ProfileFormContext);
+  const { setIsValid: setIsValidState } = useFormContextFieldHelpers("addressState", DataFormErrorMapContext);
+  const { setIsValid: setIsValidCountry } = useFormContextFieldHelpers(
+    "addressCountry",
+    DataFormErrorMapContext
+  );
+  const { setIsValid: setIsValidZipCode } = useFormContextFieldHelpers(
+    "addressZipCode",
+    DataFormErrorMapContext
+  );
 
   const handleAddressTypeChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const businessLocationTypeValue = event.target.value as FormationBusinessLocationType;

--- a/web/src/components/profile/ProfileField.tsx
+++ b/web/src/components/profile/ProfileField.tsx
@@ -1,7 +1,7 @@
 import { FieldLabelProfile } from "@/components/field-labels/FieldLabelProfile";
 import { ProfileLockedField } from "@/components/profile/ProfileLockedField";
 import { WithErrorBar } from "@/components/WithErrorBar";
-import { ProfileFormContext } from "@/contexts/profileFormContext";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { ProfileContentField } from "@/lib/types/types";
 import { ReactElement, ReactNode } from "react";
@@ -20,7 +20,7 @@ interface Props {
 }
 
 export const ProfileField = (props: Props): ReactElement => {
-  const { isFormFieldInvalid } = useFormContextFieldHelpers(props.fieldName, ProfileFormContext);
+  const { isFormFieldInvalid } = useFormContextFieldHelpers(props.fieldName, DataFormErrorMapContext);
 
   if (props.isVisible === false) {
     return <></>;

--- a/web/src/components/tasks/TaxInput.tsx
+++ b/web/src/components/tasks/TaxInput.tsx
@@ -4,9 +4,9 @@ import { TaxId } from "@/components/data-fields/tax-id/TaxId";
 import { Alert } from "@/components/njwds-extended/Alert";
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
 import { Icon } from "@/components/njwds/Icon";
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
@@ -35,7 +35,7 @@ export const TaxInput = (props: Props): ReactElement => {
     onSubmit,
     isValid,
     state: formContextState,
-  } = useFormContextHelper(createProfileFieldErrorMap());
+  } = useFormContextHelper(createDataFormErrorMap());
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const isTabletAndUp = useMediaQuery(MediaQueries.tabletAndUp);
@@ -124,7 +124,7 @@ export const TaxInput = (props: Props): ReactElement => {
   };
 
   return (
-    <ProfileFormContext.Provider value={formContextState}>
+    <DataFormErrorMapContext.Provider value={formContextState}>
       <ProfileDataContext.Provider
         value={{
           state: {
@@ -162,6 +162,6 @@ export const TaxInput = (props: Props): ReactElement => {
           )}
         </div>
       </ProfileDataContext.Provider>
-    </ProfileFormContext.Provider>
+    </DataFormErrorMapContext.Provider>
   );
 };

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateElement.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateElement.tsx
@@ -5,8 +5,8 @@ import { TaxClearanceStepThree } from "@/components/tasks/anytime-action/tax-cle
 import { TaxClearanceStepTwo } from "@/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceStepTwo";
 import { AddressContext } from "@/contexts/addressContext";
 import { getMergedConfig } from "@/contexts/configContext";
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
 import { TaxClearanceCertificateDataContext } from "@/contexts/taxClearanceCertificateDataContext";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { useUserData } from "@/lib/data-hooks/useUserData";
@@ -133,7 +133,7 @@ export const AnytimeActionTaxClearanceCertificateElement = (props: Props): React
   //   state: dataFormContextState,
   //   // getInvalidFieldIds,
 
-  const { state: dataFormContextState } = useFormContextHelper(createProfileFieldErrorMap());
+  const { state: dataFormContextState } = useFormContextHelper(createDataFormErrorMap());
 
   const updateSteps = (step: number): void => {
     const steps = initialTaxClearanceCertificateSteps();
@@ -148,7 +148,7 @@ export const AnytimeActionTaxClearanceCertificateElement = (props: Props): React
   }, [stepIndex]);
 
   return (
-    <ProfileFormContext.Provider value={dataFormContextState}>
+    <DataFormErrorMapContext.Provider value={dataFormContextState}>
       <AddressContext.Provider
         value={{
           state: { formationAddressData },
@@ -199,6 +199,6 @@ export const AnytimeActionTaxClearanceCertificateElement = (props: Props): React
           </ProfileDataContext.Provider>
         </TaxClearanceCertificateDataContext.Provider>
       </AddressContext.Provider>
-    </ProfileFormContext.Provider>
+    </DataFormErrorMapContext.Provider>
   );
 };

--- a/web/src/components/tasks/business-structure/BusinessStructureTask.tsx
+++ b/web/src/components/tasks/business-structure/BusinessStructureTask.tsx
@@ -9,8 +9,8 @@ import { TaskHeader } from "@/components/TaskHeader";
 import { LegalStructureRadio } from "@/components/tasks/business-structure/LegalStructureRadio";
 import { UnlockedBy } from "@/components/tasks/UnlockedBy";
 import { TaskStatusChangeSnackbar } from "@/components/TaskStatusChangeSnackbar";
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { useUpdateTaskProgress } from "@/lib/data-hooks/useUpdateTaskProgress";
@@ -44,7 +44,7 @@ export const BusinessStructureTask = (props: Props): ReactElement => {
     FormFuncWrapper,
     onSubmit,
     state: formContextState,
-  } = useFormContextHelper(createProfileFieldErrorMap());
+  } = useFormContextHelper(createDataFormErrorMap());
 
   const whenErrorScrollToRef = useRef<HTMLDivElement>(null);
 
@@ -144,7 +144,7 @@ export const BusinessStructureTask = (props: Props): ReactElement => {
       <UnlockedBy task={props.task} />
       <Content>{preLookupContent}</Content>
       {showRadioQuestion && (
-        <ProfileFormContext.Provider value={formContextState}>
+        <DataFormErrorMapContext.Provider value={formContextState}>
           <ProfileDataContext.Provider
             value={{
               state: {
@@ -162,7 +162,7 @@ export const BusinessStructureTask = (props: Props): ReactElement => {
               </SecondaryButton>
             </div>
           </ProfileDataContext.Provider>
-        </ProfileFormContext.Provider>
+        </DataFormErrorMapContext.Provider>
       )}
       {business && !showRadioQuestion && (
         <>

--- a/web/src/components/tasks/business-structure/LegalStructureRadio.tsx
+++ b/web/src/components/tasks/business-structure/LegalStructureRadio.tsx
@@ -3,8 +3,8 @@ import { WithErrorBar } from "@/components/WithErrorBar";
 import { Alert } from "@/components/njwds-extended/Alert";
 import { Heading } from "@/components/njwds-extended/Heading";
 import { ConfigType } from "@/contexts/configContext";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { useUpdateTaskProgress } from "@/lib/data-hooks/useUpdateTaskProgress";
@@ -33,7 +33,7 @@ const LegalStructureRadio = forwardRef((props: Props, ref: ForwardedRef<HTMLDivE
 
   const { RegisterForOnSubmit, setIsValid, isFormFieldInvalid } = useFormContextFieldHelpers(
     "legalStructureId",
-    ProfileFormContext,
+    DataFormErrorMapContext,
     undefined
   );
 

--- a/web/src/contexts/dataFormErrorMapContext.ts
+++ b/web/src/contexts/dataFormErrorMapContext.ts
@@ -11,13 +11,13 @@ import {
   TaxClearanceCertificateData,
 } from "@businessnjgovnavigator/shared";
 
-export type ProfileFields =
+export type DataFormErrorMapFields =
   | keyof ProfileData
   | keyof BusinessUser
   | keyof FormationAddress
   | keyof TaxClearanceCertificateData;
 
-const allProfileFields = Object.keys(profileFieldsFromConfig) as ProfileFields[];
+const allProfileFields = Object.keys(profileFieldsFromConfig) as (keyof ProfileData)[];
 const businessUserDisplayFields = Object.keys(emptyBusinessUser) as (keyof BusinessUser)[];
 const onboardingDataFields = Object.keys(emptyProfileData) as (keyof ProfileData)[];
 const formationAddressFields = Object.keys(emptyFormationAddressData) as (keyof FormationAddress)[];
@@ -25,7 +25,7 @@ const taxClearanceCertificateFields = Object.keys(
   emptyTaxClearanceCertificateData
 ) as (keyof TaxClearanceCertificateData)[];
 
-const profileFields: ProfileFields[] = [
+const dataFormErrorMapFields: DataFormErrorMapFields[] = [
   ...new Set([
     ...allProfileFields,
     ...onboardingDataFields,
@@ -35,9 +35,11 @@ const profileFields: ProfileFields[] = [
   ]),
 ];
 
-export type ProfileFieldErrorMap = ReducedFieldStates<ProfileFields>;
+export type DataFormErrorMap = ReducedFieldStates<DataFormErrorMapFields>;
 
-export const ProfileFormContext = createFormContext<ProfileFieldErrorMap>();
+export const DataFormErrorMapContext = createFormContext<DataFormErrorMap>();
 
-export const createProfileFieldErrorMap = <FieldError>(): ReducedFieldStates<ProfileFields, FieldError> =>
-  createReducedFieldStates<(typeof profileFields)[number], FieldError>(profileFields);
+export const createDataFormErrorMap = <FieldError>(): ReducedFieldStates<
+  DataFormErrorMapFields,
+  FieldError
+> => createReducedFieldStates<(typeof dataFormErrorMapFields)[number], FieldError>(dataFormErrorMapFields);

--- a/web/src/lib/cms/previews/ProfileFieldsPreview.tsx
+++ b/web/src/lib/cms/previews/ProfileFieldsPreview.tsx
@@ -23,7 +23,7 @@ import { Heading } from "@/components/njwds-extended/Heading";
 import { ProfileDocuments } from "@/components/profile/ProfileDocuments";
 import { LegalStructureRadio } from "@/components/tasks/business-structure/LegalStructureRadio";
 import { ConfigContext } from "@/contexts/configContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { PreviewProps } from "@/lib/cms/helpers/previewHelpers";
 import { usePreviewConfig } from "@/lib/cms/helpers/usePreviewConfig";
 import { usePreviewRef } from "@/lib/cms/helpers/usePreviewRef";
@@ -41,10 +41,10 @@ const ProfileFieldsPreview = (props: PreviewProps): ReactElement => {
   const { config, setConfig } = usePreviewConfig(props);
   const ref = usePreviewRef(props);
 
-  const { state: formContextState } = useFormContextHelper(createProfileFieldErrorMap());
+  const { state: formContextState } = useFormContextHelper(createDataFormErrorMap());
   return (
     <ConfigContext.Provider value={{ config, setOverrides: setConfig }}>
-      <ProfileFormContext.Provider value={formContextState}>
+      <DataFormErrorMapContext.Provider value={formContextState}>
         <div className="cms" ref={ref} style={{ margin: 40, pointerEvents: "none" }}>
           <BusinessPersonaQuestion />
           <hr className="margin-y-4" />
@@ -190,7 +190,7 @@ const ProfileFieldsPreview = (props: PreviewProps): ReactElement => {
             );
           })}
         </div>
-      </ProfileFormContext.Provider>
+      </DataFormErrorMapContext.Provider>
     </ConfigContext.Provider>
   );
 };

--- a/web/src/pages/account-setup.tsx
+++ b/web/src/pages/account-setup.tsx
@@ -5,8 +5,8 @@ import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { PageSkeleton } from "@/components/njwds-layout/PageSkeleton";
 import { SingleColumnContainer } from "@/components/njwds/SingleColumnContainer";
 import { AuthContext } from "@/contexts/authContext";
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
 import * as api from "@/lib/api-client/apiClient";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { onSelfRegister } from "@/lib/auth/signinHelper";
@@ -50,7 +50,7 @@ const AccountSetupPage = (): ReactElement => {
     FormFuncWrapper,
     onSubmit,
     state: formContextState,
-  } = useFormContextHelper(createProfileFieldErrorMap<OnboardingErrors>());
+  } = useFormContextHelper(createDataFormErrorMap<OnboardingErrors>());
 
   FormFuncWrapper(
     async (): Promise<void> => {
@@ -117,7 +117,7 @@ const AccountSetupPage = (): ReactElement => {
           <h1>{getContent().header}</h1>
           {showAlert && <Alert variant="error">{Config.accountSetup.errorAlert}</Alert>}
           <Content>{getContent().body}</Content>
-          <ProfileFormContext.Provider value={formContextState}>
+          <DataFormErrorMapContext.Provider value={formContextState}>
             <AccountSetupForm user={user} setUser={setUser} />
 
             <hr className="margin-top-4 margin-bottom-2" />
@@ -132,7 +132,7 @@ const AccountSetupPage = (): ReactElement => {
                 {getContent().submitButton}
               </PrimaryButton>
             </div>
-          </ProfileFormContext.Provider>
+          </DataFormErrorMapContext.Provider>
         </SingleColumnContainer>
       </main>
     </PageSkeleton>

--- a/web/src/pages/njeda.tsx
+++ b/web/src/pages/njeda.tsx
@@ -8,8 +8,8 @@ import { Alert } from "@/components/njwds-extended/Alert";
 import { Heading } from "@/components/njwds-extended/Heading";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { WithErrorBar } from "@/components/WithErrorBar";
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { useUserData } from "@/lib/data-hooks/useUserData";
@@ -121,7 +121,7 @@ const NJEDAFundingsOnboardingPaage = (props: Props): ReactElement => {
     return shouldShowErrorAlert && isNonProfit === undefined;
   };
 
-  const { onSubmit, state: formContextState } = useFormContextHelper(createProfileFieldErrorMap());
+  const { onSubmit, state: formContextState } = useFormContextHelper(createDataFormErrorMap());
 
   const FundingsHeader = (): ReactElement => {
     return (
@@ -183,7 +183,7 @@ const NJEDAFundingsOnboardingPaage = (props: Props): ReactElement => {
   };
 
   return (
-    <ProfileFormContext.Provider value={formContextState}>
+    <DataFormErrorMapContext.Provider value={formContextState}>
       <ProfileDataContext.Provider
         value={{
           state: {
@@ -286,7 +286,7 @@ const NJEDAFundingsOnboardingPaage = (props: Props): ReactElement => {
           })}
         </>
       </ProfileDataContext.Provider>
-    </ProfileFormContext.Provider>
+    </DataFormErrorMapContext.Provider>
   );
 };
 

--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -8,9 +8,9 @@ import { OnboardingButtonGroup } from "@/components/onboarding/OnboardingButtonG
 import { onboardingFlows as onboardingFlowObject } from "@/components/onboarding/OnboardingFlows";
 import { ReturnToPreviousBusinessBar } from "@/components/onboarding/ReturnToPreviousBusinessBar";
 import { AuthContext } from "@/contexts/authContext";
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { MunicipalitiesContext } from "@/contexts/municipalitiesContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
 import { MediaQueries } from "@/lib/PageSizes";
 import * as api from "@/lib/api-client/apiClient";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
@@ -105,7 +105,7 @@ const OnboardingPage = (props: Props): ReactElement => {
     FormFuncWrapper,
     onSubmit,
     state: formContextState,
-  } = useFormContextHelper(createProfileFieldErrorMap<OnboardingErrors>());
+  } = useFormContextHelper(createDataFormErrorMap<OnboardingErrors>());
 
   const onboardingFlows = useMemo(() => {
     let onboardingFlows = onboardingFlowObject;
@@ -461,7 +461,7 @@ const OnboardingPage = (props: Props): ReactElement => {
   };
   return (
     <MunicipalitiesContext.Provider value={{ municipalities: props.municipalities }}>
-      <ProfileFormContext.Provider value={formContextState}>
+      <DataFormErrorMapContext.Provider value={formContextState}>
         <ProfileDataContext.Provider
           value={{
             state: {
@@ -542,7 +542,7 @@ const OnboardingPage = (props: Props): ReactElement => {
             </main>
           </PageSkeleton>
         </ProfileDataContext.Provider>
-      </ProfileFormContext.Provider>
+      </DataFormErrorMapContext.Provider>
     </MunicipalitiesContext.Provider>
   );
 };

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -50,10 +50,10 @@ import { TaxDisclaimer } from "@/components/TaxDisclaimer";
 import { UserDataErrorAlert } from "@/components/UserDataErrorAlert";
 import { AddressContext } from "@/contexts/addressContext";
 import { getMergedConfig } from "@/contexts/configContext";
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { MunicipalitiesContext } from "@/contexts/municipalitiesContext";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
 import { postGetAnnualFilings } from "@/lib/api-client/apiClient";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -128,7 +128,7 @@ const ProfilePage = (props: Props): ReactElement => {
     onTabChange: setProfileTab,
     state: formContextState,
     getInvalidFieldIds,
-  } = useFormContextHelper(createProfileFieldErrorMap(), props.CMS_ONLY_tab ?? profileTabs[0]);
+  } = useFormContextHelper(createDataFormErrorMap(), props.CMS_ONLY_tab ?? profileTabs[0]);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const redirect = (params?: { [key: string]: any }, routerType = router!.push): Promise<boolean> => {
@@ -924,7 +924,7 @@ const ProfilePage = (props: Props): ReactElement => {
   };
 
   return (
-    <ProfileFormContext.Provider value={formContextState}>
+    <DataFormErrorMapContext.Provider value={formContextState}>
       <MunicipalitiesContext.Provider value={{ municipalities: props.municipalities }}>
         <ProfileDataContext.Provider
           value={{
@@ -1027,7 +1027,7 @@ const ProfilePage = (props: Props): ReactElement => {
           </AddressContext.Provider>
         </ProfileDataContext.Provider>
       </MunicipalitiesContext.Provider>
-    </ProfileFormContext.Provider>
+    </DataFormErrorMapContext.Provider>
   );
 };
 

--- a/web/stories/Molecules/textfields/LockedTextField.stories.tsx
+++ b/web/stories/Molecules/textfields/LockedTextField.stories.tsx
@@ -3,8 +3,8 @@ import { GenericTextField } from "@/components/GenericTextField";
 import { ProfileField } from "@/components/profile/ProfileField";
 import { ReviewSubSection } from "@/components/tasks/review-screen-components/ReviewSubSection";
 import { ConfigContext, ConfigType, getMergedConfig } from "@/contexts/configContext";
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { generateProfileData } from "@businessnjgovnavigator/shared";
 import { ProfileData } from "@businessnjgovnavigator/shared/profileData";
@@ -18,13 +18,13 @@ const Template = () => {
   const [profileData, setProfileData] = useState<ProfileData>(
     generateProfileData({ businessName: "displayed text" })
   );
-  const { state: formContextState } = useFormContextHelper(createProfileFieldErrorMap());
+  const { state: formContextState } = useFormContextHelper(createDataFormErrorMap());
 
   const text =
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam gravida mattis magna et placerat.";
   const fieldName = "businessName";
   return (
-    <ProfileFormContext.Provider value={formContextState}>
+    <DataFormErrorMapContext.Provider value={formContextState}>
       <ConfigContext.Provider value={{ config, setOverrides: setConfig }}>
         <ProfileDataContext.Provider
           value={{
@@ -51,7 +51,7 @@ const Template = () => {
           </ReviewSubSection>
         </ProfileDataContext.Provider>
       </ConfigContext.Provider>
-    </ProfileFormContext.Provider>
+    </DataFormErrorMapContext.Provider>
   );
 };
 

--- a/web/stories/Molecules/textfields/OneEncryptedFieldTextField.stories.tsx
+++ b/web/stories/Molecules/textfields/OneEncryptedFieldTextField.stories.tsx
@@ -2,9 +2,9 @@ import { TaxId } from "@/components/data-fields/tax-id/TaxId";
 import { FieldLabelModal } from "@/components/field-labels/FieldLabelModal";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { ConfigContext, ConfigType, getMergedConfig } from "@/contexts/configContext";
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { createEmptyProfileData, ProfileData } from "@businessnjgovnavigator/shared/profileData";
@@ -14,10 +14,10 @@ import { useState } from "react";
 const Template = () => {
   const [config, setConfig] = useState<ConfigType>(getMergedConfig());
   const [profileData, setProfileData] = useState<ProfileData>(createEmptyProfileData());
-  const { state: formContextState } = useFormContextHelper(createProfileFieldErrorMap());
+  const { state: formContextState } = useFormContextHelper(createDataFormErrorMap());
 
   return (
-    <ProfileFormContext.Provider value={formContextState}>
+    <DataFormErrorMapContext.Provider value={formContextState}>
       <NeedsAccountContext.Provider
         value={{
           isAuthenticated: IsAuthenticated.UNKNOWN,
@@ -76,7 +76,7 @@ const Template = () => {
           </ProfileDataContext.Provider>
         </ConfigContext.Provider>
       </NeedsAccountContext.Provider>
-    </ProfileFormContext.Provider>
+    </DataFormErrorMapContext.Provider>
   );
 };
 

--- a/web/stories/Molecules/textfields/OneFieldTextField.stories.tsx
+++ b/web/stories/Molecules/textfields/OneFieldTextField.stories.tsx
@@ -2,8 +2,8 @@ import { GenericTextField } from "@/components/GenericTextField";
 import { ProfileField } from "@/components/profile/ProfileField";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { ConfigContext, ConfigType, getMergedConfig } from "@/contexts/configContext";
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { createEmptyProfileData, ProfileData } from "@businessnjgovnavigator/shared/profileData";
 import { Meta, StoryObj } from "@storybook/react";
@@ -21,11 +21,11 @@ const Template = () => {
   };
   const [config, setConfig] = useState<ConfigType>(mergedConfig);
   const [profileData, setProfileData] = useState<ProfileData>(createEmptyProfileData());
-  const { state: formContextState } = useFormContextHelper(createProfileFieldErrorMap());
+  const { state: formContextState } = useFormContextHelper(createDataFormErrorMap());
 
   const fieldName = "dateOfFormation";
   return (
-    <ProfileFormContext.Provider value={formContextState}>
+    <DataFormErrorMapContext.Provider value={formContextState}>
       <ConfigContext.Provider value={{ config, setOverrides: setConfig }}>
         <ProfileDataContext.Provider
           value={{
@@ -63,7 +63,7 @@ const Template = () => {
           </WithErrorBar>
         </ProfileDataContext.Provider>
       </ConfigContext.Provider>
-    </ProfileFormContext.Provider>
+    </DataFormErrorMapContext.Provider>
   );
 };
 

--- a/web/stories/Molecules/textfields/TextFieldLabels.stories.tsx
+++ b/web/stories/Molecules/textfields/TextFieldLabels.stories.tsx
@@ -8,9 +8,9 @@ import { ModifiedContent } from "@/components/ModifiedContent";
 import { ProfileField } from "@/components/profile/ProfileField";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { ConfigContext, ConfigType, getMergedConfig } from "@/contexts/configContext";
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { createEmptyDbaDisplayContent } from "@/lib/types/types";
@@ -29,7 +29,7 @@ const Template = () => {
   const [profileData, setProfileData] = useState<ProfileData>(
     generateProfileData({ taxId: "2", naicsCode: "" })
   );
-  const { state: formContextState } = useFormContextHelper(createProfileFieldErrorMap());
+  const { state: formContextState } = useFormContextHelper(createDataFormErrorMap());
 
   return (
     <BusinessFormationContext.Provider
@@ -56,7 +56,7 @@ const Template = () => {
         setForeignGoodStandingFile: () => {},
       }}
     >
-      <ProfileFormContext.Provider value={formContextState}>
+      <DataFormErrorMapContext.Provider value={formContextState}>
         <NeedsAccountContext.Provider
           value={{
             isAuthenticated: IsAuthenticated.UNKNOWN,
@@ -142,7 +142,7 @@ const Template = () => {
             </ProfileDataContext.Provider>
           </ConfigContext.Provider>
         </NeedsAccountContext.Provider>
-      </ProfileFormContext.Provider>
+      </DataFormErrorMapContext.Provider>
     </BusinessFormationContext.Provider>
   );
 };

--- a/web/stories/Molecules/textfields/TwoEncryptedFieldTextField.stories.tsx
+++ b/web/stories/Molecules/textfields/TwoEncryptedFieldTextField.stories.tsx
@@ -2,9 +2,9 @@ import { TaxId } from "@/components/data-fields/tax-id/TaxId";
 import { FieldLabelModal } from "@/components/field-labels/FieldLabelModal";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { ConfigContext, ConfigType, getMergedConfig } from "@/contexts/configContext";
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { generateProfileData } from "@businessnjgovnavigator/shared";
@@ -15,10 +15,10 @@ import { useState } from "react";
 const Template = () => {
   const [config, setConfig] = useState<ConfigType>(getMergedConfig());
   const [profileData, setProfileData] = useState<ProfileData>(generateProfileData({ taxId: "2" }));
-  const { state: formContextState } = useFormContextHelper(createProfileFieldErrorMap());
+  const { state: formContextState } = useFormContextHelper(createDataFormErrorMap());
 
   return (
-    <ProfileFormContext.Provider value={formContextState}>
+    <DataFormErrorMapContext.Provider value={formContextState}>
       <NeedsAccountContext.Provider
         value={{
           isAuthenticated: IsAuthenticated.UNKNOWN,
@@ -70,7 +70,7 @@ const Template = () => {
           </ProfileDataContext.Provider>
         </ConfigContext.Provider>
       </NeedsAccountContext.Provider>
-    </ProfileFormContext.Provider>
+    </DataFormErrorMapContext.Provider>
   );
 };
 

--- a/web/test/mock/withStatefulAddressData.tsx
+++ b/web/test/mock/withStatefulAddressData.tsx
@@ -1,6 +1,6 @@
 import { AddressContext } from "@/contexts/addressContext";
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { MunicipalitiesContext } from "@/contexts/municipalitiesContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { FormationAddress, Municipality } from "@businessnjgovnavigator/shared/";
 import { ReactElement, ReactNode, useState } from "react";
@@ -15,10 +15,10 @@ export const WithStatefulAddressData = ({
   municipalities: Municipality[];
 }): ReactElement => {
   const [addressData, setAddressData] = useState<FormationAddress>(initialData);
-  const { state: formContextState } = useFormContextHelper(createProfileFieldErrorMap());
+  const { state: formContextState } = useFormContextHelper(createDataFormErrorMap());
 
   return (
-    <ProfileFormContext.Provider value={formContextState}>
+    <DataFormErrorMapContext.Provider value={formContextState}>
       <MunicipalitiesContext.Provider value={{ municipalities: municipalities }}>
         <AddressContext.Provider
           value={{
@@ -31,6 +31,6 @@ export const WithStatefulAddressData = ({
           {children}
         </AddressContext.Provider>
       </MunicipalitiesContext.Provider>
-    </ProfileFormContext.Provider>
+    </DataFormErrorMapContext.Provider>
   );
 };

--- a/web/test/mock/withStatefulProfileData.tsx
+++ b/web/test/mock/withStatefulProfileData.tsx
@@ -1,5 +1,5 @@
+import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { createProfileFieldErrorMap, ProfileFormContext } from "@/contexts/profileFormContext";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { getFlow } from "@/lib/utils/helpers";
 import { statefulDataHelpers } from "@/test/mock/withStatefulData";
@@ -19,8 +19,10 @@ export const profileDataWasNotUpdated = helpers.dataWasNotUpdated;
 export const profileDataUpdatedNTimes = helpers.dataUpdatedNTimes;
 
 export const WithStatefulDataFieldFormContext = ({ children }: { children: ReactNode }): ReactElement => {
-  const { state: formContextState } = useFormContextHelper(createProfileFieldErrorMap());
-  return <ProfileFormContext.Provider value={formContextState}>{children}</ProfileFormContext.Provider>;
+  const { state: formContextState } = useFormContextHelper(createDataFormErrorMap());
+  return (
+    <DataFormErrorMapContext.Provider value={formContextState}>{children}</DataFormErrorMapContext.Provider>
+  );
 };
 
 export const WithStatefulProfileData = ({


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
This refactor was part of the tax clearance work but was split into a separate commit due to the size of the previous PR. The primary goal is to rename ProfileFormContext to DataFormErrorMapContext to better reflect its purpose. This context holds the error map used across various forms and is not limited to profile-specific data.

The main file that was changed is `dataFormErrorMapContext.ts`. The othe files were updated due to the renaming of the variables within this file.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
