### PR TITLE
fix: [#188924007 | AB#12737] add space in Additional Provisions header

### DIFF
--- a/web/src/components/tasks/business-formation/business/AdditionalProvisions.tsx
+++ b/web/src/components/tasks/business-formation/business/AdditionalProvisions.tsx
@@ -61,7 +61,7 @@ export const AdditionalProvisions = (): ReactElement => {
     <div data-testid="additional-provisions">
       <div className="flex flex-column mobile-lg:flex-row mobile-lg:flex-align-center margin-bottom-2">
         <Heading level={2} styleVariant="h3" className="margin-0-override">
-          {Config.formation.fields.additionalProvisions.label}
+          {Config.formation.fields.additionalProvisions.label}{" "}
           <span className="text-normal font-body-lg">{Config.formation.general.optionalLabel}</span>
         </Heading>
         <div className="mobile-lg:margin-left-auto flex mobile-lg:flex-justify-center">


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Added a space `{" "}` between the Additional Provisions header text, and Optional text

### Ticket

This pull request resolves [#12737](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12737) and `#188924007` in Pivotal Tracker

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
