### PR TITLE
feat: [#188887754 | AB#8670] Alphabetize anytime actions dropdown category order

### DIFF
--- a/web/src/components/dashboard/AnytimeActionDropdown.test.tsx
+++ b/web/src/components/dashboard/AnytimeActionDropdown.test.tsx
@@ -231,18 +231,10 @@ describe("<AnytimeActionDropdown />", () => {
       const taskLicenseReinstatement = screen.getByText("some-license-reinstatement-name");
       const tasklicenseReinstatementLast = screen.getByText("zzz-some-license-reinstatement-name");
 
-      const categoryTitleGeneral = screen.getByText("Some Category");
       const categoryTitleReinstatements = screen.getByText(
         "Reactivate My Expired Permit, License or Registration"
       );
-
-      expect(categoryTitleGeneral.compareDocumentPosition(taskGeneral)).toBe(
-        Node.DOCUMENT_POSITION_FOLLOWING
-      );
-
-      expect(taskGeneral.compareDocumentPosition(categoryTitleReinstatements)).toBe(
-        Node.DOCUMENT_POSITION_FOLLOWING
-      );
+      const categoryTitleGeneral = screen.getByText("Some Category");
 
       expect(categoryTitleReinstatements.compareDocumentPosition(taskLicenseReinstatement)).toBe(
         Node.DOCUMENT_POSITION_FOLLOWING
@@ -251,6 +243,14 @@ describe("<AnytimeActionDropdown />", () => {
         Node.DOCUMENT_POSITION_FOLLOWING
       );
       expect(taskLicenseReinstatement.compareDocumentPosition(tasklicenseReinstatementLast)).toBe(
+        Node.DOCUMENT_POSITION_FOLLOWING
+      );
+
+      expect(tasklicenseReinstatementLast.compareDocumentPosition(categoryTitleGeneral)).toBe(
+        Node.DOCUMENT_POSITION_FOLLOWING
+      );
+
+      expect(categoryTitleGeneral.compareDocumentPosition(taskGeneral)).toBe(
         Node.DOCUMENT_POSITION_FOLLOWING
       );
     });

--- a/web/src/components/dashboard/AnytimeActionDropdown.tsx
+++ b/web/src/components/dashboard/AnytimeActionDropdown.tsx
@@ -10,6 +10,7 @@ import { ROUTES } from "@/lib/domain-logic/routes";
 import { AnytimeActionLicenseReinstatement, AnytimeActionTask } from "@/lib/types/types";
 import analytics from "@/lib/utils/analytics";
 import { Autocomplete, TextField, useMediaQuery } from "@mui/material";
+import { orderBy } from "lodash";
 import { useRouter } from "next/compat/router";
 import { ChangeEvent, type ReactElement, useState } from "react";
 
@@ -32,36 +33,8 @@ export const AnytimeActionDropdown = (props: Props): ReactElement => {
   const industryId = business?.profileData.industryId;
   const sectorId = business?.profileData.sectorId;
 
-  const alphabetizeByName = (
-    anytimeActions: AnytimeActionWithTypeAndCategory[]
-  ): AnytimeActionWithTypeAndCategory[] => {
-    return anytimeActions.sort((a, b) => {
-      if (a.name < b.name) {
-        return -1;
-      }
-      if (a.name > b.name) {
-        return 1;
-      }
-      return 0;
-    });
-  };
-
-  const reverseAlphabetizeByCategory = (
-    anytimeActions: AnytimeActionWithTypeAndCategory[]
-  ): AnytimeActionWithTypeAndCategory[] => {
-    return anytimeActions.sort((a, b) => {
-      if (a.category < b.category) {
-        return 1;
-      }
-      if (a.category > b.category) {
-        return -1;
-      }
-      return 0;
-    });
-  };
-
   const getApplicableAnytimeActions = (): AnytimeActionWithTypeAndCategory[] => {
-    const anytimeActionTasksWithType = props.anytimeActionTasks
+    let anytimeActionTasksWithType = props.anytimeActionTasks
       .filter((action) => findMatch(action))
       .map((action) => {
         return {
@@ -70,9 +43,9 @@ export const AnytimeActionDropdown = (props: Props): ReactElement => {
           category: action.category,
         };
       });
-    alphabetizeByName(anytimeActionTasksWithType);
+    anytimeActionTasksWithType = orderBy(anytimeActionTasksWithType, ["name"]);
 
-    const anytimeActionLicenseReinstatementsWithType = props.anytimeActionLicenseReinstatements
+    let anytimeActionLicenseReinstatementsWithType = props.anytimeActionLicenseReinstatements
       .filter((action) => licenseReinstatementMatch(action))
       .map((action) => {
         return {
@@ -81,15 +54,14 @@ export const AnytimeActionDropdown = (props: Props): ReactElement => {
           category: ["Reactivate My Expired Permit, License or Registration"],
         };
       });
+    anytimeActionLicenseReinstatementsWithType = orderBy(anytimeActionLicenseReinstatementsWithType, [
+      "name",
+    ]);
 
-    alphabetizeByName(anytimeActionLicenseReinstatementsWithType);
-
-    const applicableAnytimeActions: AnytimeActionWithTypeAndCategory[] = [];
-
+    let applicableAnytimeActions: AnytimeActionWithTypeAndCategory[] = [];
     applicableAnytimeActions.push(...anytimeActionTasksWithType);
     applicableAnytimeActions.push(...anytimeActionLicenseReinstatementsWithType);
-
-    reverseAlphabetizeByCategory(applicableAnytimeActions);
+    applicableAnytimeActions = orderBy(applicableAnytimeActions, ["category"]);
 
     return applicableAnytimeActions;
   };


### PR DESCRIPTION


## Description

This commit modifies the categories and the anytime actions dropdown from being previously sorted by reverse alphabetical order, to instead be sorted by alphabetical order as described in the ticket.

Before:
<img width="809" alt="image" src="https://github.com/user-attachments/assets/0e9a26a0-d2d0-41ba-9946-764b7ef1ebd7" />

After:
<img width="796" alt="image" src="https://github.com/user-attachments/assets/2c041277-49a2-4f19-bf29-cd57592a66b3" />


### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [8670](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8670).



### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migxation file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Addxtions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden