### PR TITLE
chore: [AB#13378] add waitfor to flakey business  formation paginator test

### DIFF
--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
@@ -1440,7 +1440,9 @@ describe("<BusinessFormationPaginator />", () => {
             if (formationStepName === "Billing") await page.stepperClickToBillingStep();
             expect(screen.getByTestId("alert-error")).toBeInTheDocument();
             page.fillText(fieldLabel as string as string, newTextInput as string);
-            expect(screen.queryByTestId("alert-error")).not.toBeInTheDocument();
+            await waitFor(() => {
+              expect(screen.queryByTestId("alert-error")).not.toBeInTheDocument();
+            });
             expect(screen.queryByText(Config.formation.errorBanner.errorOnStep)).not.toBeInTheDocument();
             expect(page.getStepStateInStepper(LookupStepIndexByName(formationStepName))).toEqual(
               "COMPLETE-ACTIVE"


### PR DESCRIPTION
## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13378

### Approach

To investigate this bug and the flaky test, I ran it 200 times to identify the cause of the issue. Out of those 200 runs, there were no failures.

While reviewing another test for foreign nexus in this file, I noticed it includes a waitFor to ensure the error message is removed. Given how this test is structured, the likely cause of the flakiness is that Jest attempts to assert the error message’s removal before it has fully disappeared from the DOM.

To address this, I added a waitFor to ensure proper timing. With this change, I don’t see a need to skip these tests for now. We can continue monitoring them and investigate further if failures occur in the future.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
