### PR TITLE
fix: [AB#13379] resolve requestException in fetchAuthSession

### DIFF
--- a/web/src/lib/auth/sessionHelper.ts
+++ b/web/src/lib/auth/sessionHelper.ts
@@ -44,7 +44,7 @@ type CognitoIdentityPayload = {
 };
 
 export const getCredentialsAndIdentity = async (): Promise<CredentialsAndIdentityId> => {
-  const session = await fetchAuthSession({ forceRefresh: true });
+  const session = await fetchAuthSession();
   const credentials = session?.credentials;
   const identityId = session?.identityId;
   if (!credentials || !identityId) {
@@ -108,7 +108,7 @@ export const getSignedS3Link = async (value: string, expires?: number): Promise<
 };
 
 export const getCurrentToken = async (): Promise<JWT> => {
-  const session = await fetchAuthSession({ forceRefresh: true });
+  const session = await fetchAuthSession();
   if (!session.tokens || !session.tokens.idToken) {
     throw new Error("Unable to retrieve access token. Ensure the session is valid.");
   }


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
We were encountering a TooManyRequestsException: Rate exceeded error in our Cypress tests due to repeated calls to the fetchAuthSession API with the forceRefresh flag enabled. This change resolves the issue by removing the forceRefresh flag, preventing unnecessary session refreshes and avoiding rate limit errors.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#13379](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13379).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test


<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
