### PR TITLE
feat: [AB#12716] Enable reproducing test randomness in `web/`

### DIFF
--- a/api/jest.config.ts
+++ b/api/jest.config.ts
@@ -9,7 +9,10 @@ export default {
   displayName: "api",
   testEnvironment: "<rootDir>/test/customNodeEnvironment.ts",
   setupFiles: ["<rootDir>/test/setupFile.ts"],
-  setupFilesAfterEnv: ["<rootDir>/test/setupFileAfterEnv.ts"],
+  setupFilesAfterEnv: [
+    "<rootDir>/test/setupJestDynalite.ts",
+    "<rootDir>/../shared/src/test/setupRandomSeed.ts",
+  ],
   moduleNameMapper: {
     "@shared/(.*)": "<rootDir>/../shared/src/$1",
     "@domain/(.*)": "<rootDir>/src/domain/$1",

--- a/api/test/setupJestDynalite.ts
+++ b/api/test/setupJestDynalite.ts
@@ -1,0 +1,1 @@
+import "jest-dynalite/withDb";

--- a/shared/src/test/setupRandomSeed.ts
+++ b/shared/src/test/setupRandomSeed.ts
@@ -1,4 +1,3 @@
-import "jest-dynalite/withDb";
 import seedrandom from "seedrandom";
 
 type TestGlobalThis = {

--- a/web/jest.config.ts
+++ b/web/jest.config.ts
@@ -13,8 +13,8 @@ process.env = Object.assign(process.env, {
 export default {
   ...sharedConfig,
   displayName: "web",
-  setupFilesAfterEnv: ["./setupTests.js"],
-  testEnvironment: "jsdom",
+  setupFilesAfterEnv: ["./setupTests.js", "<rootDir>/../shared/src/test/setupRandomSeed.ts"],
+  testEnvironment: "<rootDir>/test/customJsdomEnvironment.ts",
   testPathIgnorePatterns: ["<rootDir>/.next/", "<rootDir>/node_modules/", "<rootDir>/cypress/"],
   rootDir: "./",
   moduleDirectories: ["node_modules", "<rootDir>"],

--- a/web/src/components/Header.test.tsx
+++ b/web/src/components/Header.test.tsx
@@ -80,7 +80,7 @@ describe("<Header />", () => {
     describe("when in guest mode - other phases", () => {
       const personas: BusinessPersona[] = ["OWNING", "FOREIGN"];
 
-      it.each(personas)("displays greeting text", (persona) => {
+      it.each(personas)("displays greeting text for %s", (persona) => {
         const business = generateBusiness({
           profileData: generateProfileData({ industryId: "generic", businessPersona: persona }),
         });

--- a/web/src/components/dashboard/SidebarCardsList.test.tsx
+++ b/web/src/components/dashboard/SidebarCardsList.test.tsx
@@ -154,7 +154,7 @@ describe("<SidebarCardsList />", () => {
       ];
 
       it.each(foreignBusinessTypeIds)(
-        "displays when the business is a Remote Seller/Worker",
+        "displays when the business %s is a Remote Seller/Worker",
         (foreignBusinessTypeId) => {
           const mockBusiness = generateBusiness({
             profileData: generateProfileData({
@@ -173,7 +173,7 @@ describe("<SidebarCardsList />", () => {
       );
 
       it.each(foreignBusinessTypeIds)(
-        "displays when the business is a Remote Seller/Worker and operating phase is GUEST_MODE",
+        "displays when the business %s is a Remote Seller/Worker and operating phase is GUEST_MODE",
         (foreignBusinessTypeId) => {
           const mockBusiness = generateBusiness({
             profileData: generateProfileData({

--- a/web/src/components/data-fields/Industry.test.tsx
+++ b/web/src/components/data-fields/Industry.test.tsx
@@ -97,6 +97,7 @@ describe("<Industry />", () => {
         eq.fieldName !== "hasThreeOrMoreRentalUnits"
       );
     });
+
     nonConditionalEssentialQuestions.map((el) => {
       const validIndustryId = filterRandomIndustry(el.isQuestionApplicableToIndustry);
       const nonValidIndustryId = randomNegativeFilteredIndustry(el.isQuestionApplicableToIndustry);
@@ -148,7 +149,7 @@ describe("<Industry />", () => {
           ).not.toBeInTheDocument();
         });
 
-        it(`sets ${el.fieldName} back to ${
+        it(`sets ${el.fieldName} as a ${persona} back to ${
           emptyIndustrySpecificData[el.fieldName]
         } if they select a different industry`, () => {
           const profileData = {
@@ -169,7 +170,7 @@ describe("<Industry />", () => {
           expect(currentProfileData()[el.fieldName]).toEqual(emptyIndustrySpecificData[el.fieldName]);
         });
 
-        it(`displays FieldLabelProfile for ${validIndustryId.id} as a ${persona} when onboardingFieldLabel is false`, () => {
+        it(`displays FieldLabelProfile for ${validIndustryId.id} as a ${persona} when onboardingFieldLabel is false for ${el.fieldName}`, () => {
           render(
             <WithStatefulProfileData initialData={generateProfileData({ industryId: validIndustryId.id })}>
               <Industry onboardingFieldLabel={false} />
@@ -178,7 +179,7 @@ describe("<Industry />", () => {
           expect(screen.getAllByTestId("FieldLabelProfile")[0]).toBeInTheDocument();
         });
 
-        it(`displays FieldLabelOnboarding for ${validIndustryId.id} as a ${persona} when onboardingFieldLabel is true`, () => {
+        it(`displays FieldLabelOnboarding for ${validIndustryId.id} as a ${persona} when onboardingFieldLabel is true for ${el.fieldName}`, () => {
           render(
             <WithStatefulProfileData initialData={generateProfileData({ industryId: validIndustryId.id })}>
               <Industry onboardingFieldLabel={true} />

--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
@@ -1793,7 +1793,7 @@ describe("<BusinessFormationPaginator />", () => {
             },
           ];
           const foreignIntlMainAddressZipCode: MockApiErrorJestArray = [
-            "foreignUsMainAddressZipCode",
+            "foreignIntlMainAddressZipCode",
             {
               formationFormData: generateFormationFormData(
                 {

--- a/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
+++ b/web/src/components/tasks/business-formation/business/BusinessStep.test.tsx
@@ -591,7 +591,7 @@ describe("Formation - BusinessStep", () => {
 
       describe("Business Designator Options based on Will Practice Law Answer", () => {
         it.each(corpLegalStructures)(
-          "Shows PA and PC options for Business Designator when Will You Practice Law is Yes",
+          "Shows PA and PC options for Business Designator when Will You Practice Law is Yes for %s",
           async (legalStructureId) => {
             await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, { willPracticeLaw: true });
 
@@ -605,7 +605,7 @@ describe("Formation - BusinessStep", () => {
         );
 
         it.each(corpLegalStructures)(
-          "Does not show PA and PC options for Business Designator when Will You Practice Law is No",
+          "Does not show PA and PC options for Business Designator when Will You Practice Law is No for %s",
           async (legalStructureId) => {
             await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, { willPracticeLaw: false });
             expect(screen.queryByText("P.C.")).not.toBeInTheDocument();
@@ -619,7 +619,7 @@ describe("Formation - BusinessStep", () => {
         );
 
         it.each(corpLegalStructures)(
-          "Does not show PA and PC options for Business Designator when Will You Practice Law is Undefined",
+          "Does not show PA and PC options for Business Designator when Will You Practice Law is Undefined for %s",
           async (legalStructureId) => {
             await getPageHelper(
               { businessPersona: "FOREIGN", legalStructureId },
@@ -636,7 +636,7 @@ describe("Formation - BusinessStep", () => {
         );
 
         it.each(corpLegalStructures)(
-          "Displays an Alert when selecting an option for the Will you practice law question to tell the user Business Designator options have changed",
+          "Displays an Alert when selecting an option for the Will you practice law question to tell the user Business Designator options have changed for %s",
           async (legalStructureId) => {
             await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, {});
             expect(
@@ -650,7 +650,7 @@ describe("Formation - BusinessStep", () => {
         );
 
         it.each(corpLegalStructures)(
-          "clears Business Designator if Will you practice law question is changed and Business designator is selected",
+          "clears Business Designator if Will you practice law question is changed and Business designator is selected for %s",
           async (legalStructureId) => {
             await getPageHelper({ businessPersona: "FOREIGN", legalStructureId }, { willPracticeLaw: true });
             await userEvent.click(screen.getByTestId("business-suffix-main"));

--- a/web/src/components/tasks/business-formation/business/MainBusinessAddressNj.test.tsx
+++ b/web/src/components/tasks/business-formation/business/MainBusinessAddressNj.test.tsx
@@ -129,7 +129,7 @@ describe("<MainBusinessAddressNj />", () => {
       ["addressLine1", ""],
       ["addressMunicipality", undefined],
       ["addressZipCode", ""],
-    ])("shows an error on submission when missing address field", async (field, initialValue) => {
+    ])("shows an error on submission when missing address field for %s", async (field, initialValue) => {
       const page = await getPageHelper({
         [field]: initialValue,
         legalType: "limited-liability-company",

--- a/web/src/components/tasks/business-formation/getErrorStateForFormationField.test.ts
+++ b/web/src/components/tasks/business-formation/getErrorStateForFormationField.test.ts
@@ -1235,7 +1235,6 @@ describe("getErrorStateForField", () => {
     runTests(onlyHasErrorIfUndefinedTest);
 
     runTests(["foreignStateOfFormation"], Config.formation.fields.foreignStateOfFormation.error);
-    runTests(["foreignStateOfFormation"], Config.formation.fields.foreignStateOfFormation.error);
   });
 
   describe("foreignGoodStandingFile", () => {

--- a/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.test.tsx
@@ -698,7 +698,7 @@ describe("Formation - ReviewStep", () => {
       { radio: "nonprofitBoardMemberRightsSpecified", terms: "nonprofitBoardMemberRightsTerms" },
       { radio: "nonprofitTrusteesMethodSpecified", terms: "nonprofitTrusteesMethodTerms" },
       { radio: "nonprofitAssetDistributionSpecified", terms: "nonprofitAssetDistributionTerms" },
-    ])("provisions radio questions", (args) => {
+    ])("provisions $radio radio questions", (args) => {
       it(`does not display ${args.radio} when no board members`, async () => {
         await renderStep({ legalStructureId }, { hasNonprofitBoardMembers: false, [args.radio]: "IN_FORM" });
         expect(

--- a/web/src/lib/domain-logic/getNavBarBusinessTitle.test.ts
+++ b/web/src/lib/domain-logic/getNavBarBusinessTitle.test.ts
@@ -41,20 +41,23 @@ describe("getNavBarBusinessTitle", () => {
 
   describe("when name is defined", () => {
     describe("when legal structure undefined", () => {
-      it.each(["STARTING", "OWNING"])("shows business name", (businessPersona) => {
-        const business = generateBusiness({
-          profileData: generateProfileData({
-            businessPersona: businessPersona as BusinessPersona,
-            businessName: name,
-            tradeName: "",
-            legalStructureId: undefined,
-          }),
-        });
-        const navBarBusinessTitle = getNavBarBusinessTitle(business, true);
-        expect(navBarBusinessTitle).toEqual(name);
-      });
+      it.each(["STARTING", "OWNING"])(
+        "shows business name for %s when name is populated",
+        (businessPersona) => {
+          const business = generateBusiness({
+            profileData: generateProfileData({
+              businessPersona: businessPersona as BusinessPersona,
+              businessName: name,
+              tradeName: "",
+              legalStructureId: undefined,
+            }),
+          });
+          const navBarBusinessTitle = getNavBarBusinessTitle(business, true);
+          expect(navBarBusinessTitle).toEqual(name);
+        }
+      );
 
-      it.each(["STARTING", "OWNING"])("shows business name", (businessPersona) => {
+      it.each(["STARTING", "OWNING"])("shows business name for %s when name is empty", (businessPersona) => {
         const business = generateBusiness({
           profileData: generateProfileData({
             businessPersona: businessPersona as BusinessPersona,
@@ -68,7 +71,7 @@ describe("getNavBarBusinessTitle", () => {
       });
 
       it.each(["STARTING", "OWNING"])(
-        "shows business name over trade name if both defined",
+        "shows business name over trade name if both defined for %s",
         (businessPersona) => {
           const business = generateBusiness({
             profileData: generateProfileData({
@@ -331,7 +334,7 @@ describe("getNavBarBusinessTitle", () => {
   });
 
   describe("when legal structure, industry, and name undefined", () => {
-    it.each(["STARTING", "OWNING"])("shows Unnamed Business", (persona) => {
+    it.each(["STARTING", "OWNING"])("shows Unnamed Business for %s", (persona) => {
       const business = generateBusiness({
         profileData: generateProfileData({
           businessPersona: persona as BusinessPersona,

--- a/web/test/customJsdomEnvironment.ts
+++ b/web/test/customJsdomEnvironment.ts
@@ -1,8 +1,8 @@
 import type { EnvironmentContext, JestEnvironmentConfig } from "@jest/environment";
 import { Circus } from "@jest/types";
-import NodeEnvironment from "jest-environment-node";
+import JSDOMEnvironment from "jest-environment-jsdom";
 
-class CustomNodeEnvironment extends NodeEnvironment {
+class CustomJSDOMEnvironment extends JSDOMEnvironment {
   constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
     super(config, context);
     this.global.testRandomSeeds = new Map<string, string>();
@@ -11,7 +11,7 @@ class CustomNodeEnvironment extends NodeEnvironment {
   async handleTestEvent(event: Circus.Event): Promise<void> {
     if (event.name === "hook_failure" || event.name === "test_fn_failure") {
       const testRandomSeeds = this.global.testRandomSeeds as Map<string, string>;
-      const currentTestName = this.context?.expect.getState().currentTestName;
+      const currentTestName = this.getVmContext()?.expect.getState().currentTestName;
       console.log(
         `Test failed, reproduce randomness by running with RANDOM_SEED=${testRandomSeeds.get(
           currentTestName
@@ -21,4 +21,4 @@ class CustomNodeEnvironment extends NodeEnvironment {
   }
 }
 
-export default CustomNodeEnvironment;
+export default CustomJSDOMEnvironment;

--- a/web/test/pages/profile/profile-shared.test.tsx
+++ b/web/test/pages/profile/profile-shared.test.tsx
@@ -523,21 +523,24 @@ describe("profile - shared", () => {
   });
 
   describe("Special Note Alert for Businesses Formed outside the Navigator", () => {
-    it.each(businessPersonas)("shows the Note Alert for all personas when unauthenticated", (persona) => {
-      const business = generateBusinessForProfile({
-        formationData: generateFormationData({
-          completedFilingPayment: false,
-        }),
-        profileData: generateProfileData({
-          dateOfFormation: undefined,
-          businessPersona: persona,
-        }),
-      });
-      renderPage({ business, isAuthenticated: IsAuthenticated.FALSE });
-      expect(
-        screen.getByText(Config.profileDefaults.default.noteForBusinessesFormedOutsideNavigator)
-      ).toBeInTheDocument();
-    });
+    it.each(businessPersonas)(
+      "shows the Note Alert for all personas when unauthenticated for %s",
+      (persona) => {
+        const business = generateBusinessForProfile({
+          formationData: generateFormationData({
+            completedFilingPayment: false,
+          }),
+          profileData: generateProfileData({
+            dateOfFormation: undefined,
+            businessPersona: persona,
+          }),
+        });
+        renderPage({ business, isAuthenticated: IsAuthenticated.FALSE });
+        expect(
+          screen.getByText(Config.profileDefaults.default.noteForBusinessesFormedOutsideNavigator)
+        ).toBeInTheDocument();
+      }
+    );
 
     it("shows the Note Alert for OWNING businesses and authenticated", () => {
       const business = generateBusinessForProfile({


### PR DESCRIPTION
## Description

This commit
- For each test in `web/`, choose a random seed, and seed all subsequent calls to `Math.random()` in the test with the seed
- Logs this randomly chosen seed to the console if the test fails

It also
- Modifies all test names within `web` to be unique
- Refactors the Math.random() seeding code from `api/` to `shared/`, breaking up the jest-dynalite setup in `api/`

This was done for `api` in https://github.com/newjersey/navigator.business.nj.gov/pull/9937. The intention is to do this for cypress as well, but that will take more finagling.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request contributes to [#12716](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12716).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

- Seeds each test individually with a different random seed, by doing so in a `beforeEach` specified in the `setupFilesAfterEnv` jest configuration. The chosen seed is stored in a global map.
- Creates and uses a custom `testEnvironment` that extends the default `JSDOMEnvironment`. This environment has access to both 1) whether the test has failed, and 2) the global map with the random seeds, and is thereby able to retrieve and console.log the seed when a test fails.

For a graveyard of other alternative approaches considered, see the description section in https://github.com/newjersey/navigator.business.nj.gov/pull/9937

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

1. Pick a non-cypress test in `web/`, and add `expect(Math.random()).toEqual(4);` so that the test fails and we get a random number. 
2. Run the test and note the random number that failed the `expect`. There should also be a console.log like `Test failed, reproduce randomness by running with RANDOM_SEED=<the seed> (<test name>)`.
3. If you run the test a second time, the random number and the seed should be different.
4. If you run the test with the env var `RANDOM_SEED=<the seed>`, it should reproduce the random number that failed the `expect`

This also works if running multiple tests.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migxation file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Addxtions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
