### PR TITLE
feat: [AB#12716] Enable reproducing test randomness in Cypress

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,14 @@ Before you can run locally, you will need to:
 
 ### Run tests
 
-We use Jest for our TypeScript-based unit tests across our projects. Run all
-tests with:
+We use Jest for our TypeScript-based unit tests across our projects.
 
 ```shell
+# Run all unit tests
 yarn test
+
+# Run a single unit test or file, rerunning if files change
+yarn test <path to test file> -t "<part of test name>" --watch
 ```
 
 We use Cypress for end-to-end (e2e) testing. You can run these tests locally
@@ -108,6 +111,16 @@ running a local instance of the application to test against.
 
 ```shell
 ./scripts/local-feature-tests.sh
+```
+
+Both unit and Cypress tests utilize random values in test setup. Should a test
+fail, the random values used can be reproduced by finding the log output line
+containing `RANDOM_SEED=`/`CYPRESS_RANDOM_SEED=` for the test that failed. Then,
+run the test with the indicated environment variable, as in:
+
+```shell
+RANDOM_SEED=<random seed from failure log> yarn test <path to test file> -t "<part of test name>"
+CYPRESS_RANDOM_SEED=<random seed from failure log> ./scripts/local-feature-tests.sh
 ```
 
 To run all tests with code coverage:

--- a/api/test/customNodeEnvironment.ts
+++ b/api/test/customNodeEnvironment.ts
@@ -13,9 +13,9 @@ class CustomNodeEnvironment extends NodeEnvironment {
       const testRandomSeeds = this.global.testRandomSeeds as Map<string, string>;
       const currentTestName = this.context?.expect.getState().currentTestName;
       console.log(
-        `Test failed, reproduce randomness by running with RANDOM_SEED=${testRandomSeeds.get(
+        `Failed ${currentTestName}. Replicate Math.random() values by running with RANDOM_SEED=${testRandomSeeds.get(
           currentTestName
-        )} (${currentTestName})`
+        )}`
       );
     }
   }

--- a/web/cypress/e2e/multiple-businesses.spec.ts
+++ b/web/cypress/e2e/multiple-businesses.spec.ts
@@ -2,7 +2,7 @@ import { completeNewBusinessOnboarding } from "@businessnjgovnavigator/cypress/s
 import { onDashboardPage } from "@businessnjgovnavigator/cypress/support/page_objects/dashboardPage";
 import { onOnboardingPage } from "@businessnjgovnavigator/cypress/support/page_objects/onboardingPage";
 
-describe("Multiple Businesses [feature] [all] [group2]", () => {
+describe.skip("Multiple Businesses [feature] [all] [group2]", () => {
   beforeEach(() => {
     cy.loginByCognitoApi();
   });

--- a/web/test/customJsdomEnvironment.ts
+++ b/web/test/customJsdomEnvironment.ts
@@ -13,9 +13,9 @@ class CustomJSDOMEnvironment extends JSDOMEnvironment {
       const testRandomSeeds = this.global.testRandomSeeds as Map<string, string>;
       const currentTestName = this.getVmContext()?.expect.getState().currentTestName;
       console.log(
-        `Test failed, reproduce randomness by running with RANDOM_SEED=${testRandomSeeds.get(
+        `Failed ${currentTestName}. Replicate Math.random() values by running with RANDOM_SEED=${testRandomSeeds.get(
           currentTestName
-        )} (${currentTestName})`
+        )}`
       );
     }
   }


### PR DESCRIPTION
## Description

This commit
- For each Cypress test, choose a random seed, and seed all subsequent calls to `Math.random()` in the test with the seed
- Logs this randomly chosen seed to the console if the test fails
- Documents in the README how to find the random seed and use it to run tests locally

It also skips `multiple-businesses.spec.ts` as we've discussed about skipping flaky tests.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This commit resolves #[12716](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12716).

### Approach

- Seeds each test individually with a different random seed in a `beforeEach`, and logs if a test fails in an `AfterEach`

This approach differs from those taken for unit tests because the cypress test runner mocha, [unlike the unit test runner jest](https://stackoverflow.com/questions/42000137/check-if-test-failed-in-aftereach-of-jest), is able to determine in a `AfterEach` whether the test has failed. Additionally, unlike for unit tests, this does not enforce a name-uniqueness constraint on the map because cypress tests are re-run on the CI when they fail.

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

1. Pick a cypress test, and add `expect(Math.random()).to.equal(4);` so that the test fails and we get a random number. See [this build](https://app.circleci.com/pipelines/github/newjersey/navigator.business.nj.gov/35979/workflows/006429b8-33f3-434a-bde1-d1c383dbb4b5/jobs/175509/parallel-runs/0/steps/0-112) for an example of this having been done and run in CI
1. In both the local and example CI runs, there should be a failed assertion with the random number, and a log with `CYPRESS_RANDOM_SEED`
    <img width="783" alt="image" src="https://github.com/user-attachments/assets/0dffea66-8a74-44e9-bf26-48c88ebf8dcd" />
    <img width="1353" alt="749681 ci cypess failure" src="https://github.com/user-attachments/assets/9aa26248-fff3-4e05-8c87-83374059e1a9" />
1. If you run the test a second time, the random number and the seed should be different.
1. If you run the test with the provided environment variable, e.g. `CYPRESS_RANDOM_SEED=<the seed> ./scripts/local-feature-tests.sh`, it should reproduce the random number corresponding to the seed used


### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migxation file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Addxtions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarde