### PR TITLE
feat: [AB#13166] add alert when no fundings are applicable on njeda fundings page

### DIFF
--- a/content/src/fieldConfig/njeda-fundings-onboarding.json
+++ b/content/src/fieldConfig/njeda-fundings-onboarding.json
@@ -23,6 +23,9 @@
       "buttonText": "See More Funding & Resources",
       "logoLink": "https://www.njeda.gov/",
       "logoAriaText": "Visit NJEDA home"
+    },
+    "page": {
+      "noResultsFoundAlertText": "We couldn’t find NJEDA programs matching your criteria, but you may still be eligible for others. Explore more funding options at [Business.NJ.gov](https://business.nj.gov/funding)."
     }
   }
 }

--- a/web/public/mgmt/config.yml
+++ b/web/public/mgmt/config.yml
@@ -6115,6 +6115,11 @@ collections:
                   - { label: Button Text, name: buttonText, widget: string }
                   - { label: Logo link, name: logoLink, widget: string }
                   - { label: Logo Aria Text, name: logoAriaText, widget: string }
+              - label: "Page"
+                name: "page"
+                widget: object
+                fields:
+                  - { label: No Results Found Alert Text, name: noResultsFoundAlertText, widget: string }
 
   - name: "contextual-information"
     label: "Contextual Information"

--- a/web/src/pages/njeda.tsx
+++ b/web/src/pages/njeda.tsx
@@ -99,19 +99,25 @@ const NJEDAFundingsOnboardingPaage = (props: Props): ReactElement => {
       });
       await updateQueue?.update();
       setShouldCloseModal(true);
-      setFilteredFundings(
-        sortFundingsForUser(
-          filterFundings({ fundings: filteredFundings, business: updateQueue?.currentBusiness() }).filter(
-            (it) => {
-              return it.agency?.includes("njeda");
-            }
-          ),
-          updateQueue?.current()
-        )
-      );
+      setFilteredFundings(getFilteredAndSortedFundings());
     } else {
       setShouldShowErrorAlert(true);
     }
+  };
+
+  const getFilteredAndSortedFundings = (): Funding[] => {
+    if (updateQueue?.currentBusiness().profileData.sectorId === "cannabis") {
+      return [];
+    }
+
+    return sortFundingsForUser(
+      filterFundings({ fundings: filteredFundings, business: updateQueue?.currentBusiness() }).filter(
+        (it) => {
+          return it.agency?.includes("njeda");
+        }
+      ),
+      updateQueue?.current()
+    );
   };
 
   const shouldShowEmployeeCountError = (): boolean => {
@@ -298,6 +304,11 @@ const NJEDAFundingsOnboardingPaage = (props: Props): ReactElement => {
             </div>
           </ModalOneButton>
           <FundingsHeader />
+          {filteredFundings.length === 0 && (
+            <Alert variant={"info"} dataTestid={"alert-no-results"}>
+              <Content>{Config.fundingsOnboardingModal.page.noResultsFoundAlertText}</Content>
+            </Alert>
+          )}
           {filteredFundings.map((funding, index) => {
             return fundingEntry(funding, index === 0);
           })}

--- a/web/test/pages/njeda.test.tsx
+++ b/web/test/pages/njeda.test.tsx
@@ -223,4 +223,68 @@ describe("njeda fundings onboarding", () => {
       Node.DOCUMENT_POSITION_PRECEDING
     );
   });
+
+  it("displays alert when no fundings provided", async () => {
+    const user = userEvent.setup();
+    const profileData = generateProfileData({ sectorId: "" });
+    const business = generateBusiness({ profileData: profileData });
+    const fundings: Funding[] = [];
+    renderStatefulFundingsPageComponent(business, fundings);
+
+    await user.click(screen.getByText(Config.fundingsOnboardingModal.nonProfitQuestion.responses.yes));
+    await user.type(screen.getByRole("textbox", { name: "Existing employees" }), "2");
+
+    await waitFor(() => {
+      selectByValue("Sector", "cannabis");
+    });
+    await user.click(screen.getByText(Config.fundingsOnboardingModal.saveButtonText));
+
+    expect(screen.getByTestId("alert-no-results")).toBeInTheDocument();
+  });
+
+  it("filters out all njeda fundings for cannabis sector and displays alert", async () => {
+    const user = userEvent.setup();
+    const profileData = generateProfileData({ sectorId: "" });
+    const business = generateBusiness({ profileData: profileData });
+    const fundings = [
+      generateFunding({
+        isNonprofitOnly: false,
+        sector: ["clean-energy"],
+        employeesRequired: "n/a",
+        county: ["All"],
+        homeBased: "yes",
+        publishStageArchive: null,
+        dueDate: undefined,
+        status: "rolling application",
+        certifications: null,
+        agency: ["njeda"],
+        name: "funding-1",
+      }),
+      generateFunding({
+        isNonprofitOnly: false,
+        sector: ["cannabis"],
+        employeesRequired: "n/a",
+        county: ["All"],
+        homeBased: "yes",
+        publishStageArchive: null,
+        dueDate: undefined,
+        status: "rolling application",
+        certifications: null,
+        agency: ["njeda"],
+        name: "funding-2",
+      }),
+    ];
+    renderStatefulFundingsPageComponent(business, fundings);
+
+    await user.click(screen.getByText(Config.fundingsOnboardingModal.nonProfitQuestion.responses.yes));
+    await user.type(screen.getByRole("textbox", { name: "Existing employees" }), "2");
+
+    await waitFor(() => {
+      selectByValue("Sector", "cannabis");
+    });
+    await user.click(screen.getByText(Config.fundingsOnboardingModal.saveButtonText));
+
+    expect(screen.queryByTestId(`${fundings[0].id}-button`)).not.toBeInTheDocument();
+    expect(screen.getByTestId("alert-no-results")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION

<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#13166](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13166).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
1. Go to localhost:3000/njeda
2. Sign up for a business in the cannabis industry
3. You should see no fundings and an alert indicating that

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
