### PR TITLE
Updated routing from /login to /account-setup for users with completed onboarding

### DIFF
--- a/web/src/lib/auth/signinHelper.test.ts
+++ b/web/src/lib/auth/signinHelper.test.ts
@@ -94,7 +94,7 @@ describe("SigninHelper", () => {
 
     it("sets registration status to IN_PROGRESS", async () => {
       mockApi.postSelfReg.mockResolvedValue({ userData: userData, authRedirectURL: "" });
-      await onSelfRegister({
+      onSelfRegister({
         router: fakeRouter,
         updateQueue,
         userData,
@@ -111,7 +111,7 @@ describe("SigninHelper", () => {
       updateQueue = new UpdateQueueFactory(userData, update);
 
       mockApi.postSelfReg.mockResolvedValue({ userData: userData, authRedirectURL: "" });
-      await onSelfRegister({
+      onSelfRegister({
         router: fakeRouter,
         updateQueue,
         userData,
@@ -141,7 +141,7 @@ describe("SigninHelper", () => {
       updateQueue = new UpdateQueueFactory(userData, update);
 
       mockApi.postSelfReg.mockResolvedValue({ userData: userData, authRedirectURL: "" });
-      await onSelfRegister({
+      onSelfRegister({
         router: fakeRouter,
         updateQueue,
         userData,
@@ -169,7 +169,7 @@ describe("SigninHelper", () => {
       userData = generateUserDataForBusiness(business);
       updateQueue = new UpdateQueueFactory(userData, update);
       mockApi.postSelfReg.mockResolvedValue({ userData: userData, authRedirectURL: "" });
-      await onSelfRegister({
+      onSelfRegister({
         router: fakeRouter,
         updateQueue,
         userData,
@@ -195,7 +195,7 @@ describe("SigninHelper", () => {
         userData: returnedUserData,
         authRedirectURL: "/some-url",
       });
-      await onSelfRegister({
+      onSelfRegister({
         router: fakeRouter,
         updateQueue,
         userData,
@@ -209,7 +209,7 @@ describe("SigninHelper", () => {
 
     it("sets alert to DUPLICATE_ERROR on 409 response code", async () => {
       mockApi.postSelfReg.mockRejectedValue(409);
-      await onSelfRegister({
+      onSelfRegister({
         router: fakeRouter,
         updateQueue,
         userData,
@@ -224,7 +224,7 @@ describe("SigninHelper", () => {
 
     it("sets alert to RESPONSE_ERROR on generic error", async () => {
       mockApi.postSelfReg.mockRejectedValue(500);
-      await onSelfRegister({
+      onSelfRegister({
         router: fakeRouter,
         updateQueue,
         userData,
@@ -353,6 +353,41 @@ describe("SigninHelper", () => {
       });
       await onGuestSignIn({ push: mockPush, pathname: ROUTES.welcome, dispatch: mockDispatch });
       expect(mockPush).not.toHaveBeenCalledWith(ROUTES.landing);
+    });
+
+    it("redirects user to /account-setup from /login when onboarding has been completed", async () => {
+      const userData = generateUserDataForBusiness(generateBusiness({ onboardingFormProgress: "COMPLETED" }));
+      mockGetCurrentUserData.mockImplementation(() => {
+        return userData;
+      });
+      mockSession.getActiveUser.mockImplementation(() => {
+        throw new Error("New");
+      });
+      await onGuestSignIn({ push: mockPush, pathname: ROUTES.login, dispatch: mockDispatch });
+      expect(mockPush).toHaveBeenCalledWith(ROUTES.accountSetup);
+    });
+
+    it("redirects user to /onboarding from /login when onboarding has not been completed", async () => {
+      const userData = generateUserDataForBusiness(generateBusiness({ onboardingFormProgress: "UNSTARTED" }));
+      mockGetCurrentUserData.mockImplementation(() => {
+        return userData;
+      });
+      mockSession.getActiveUser.mockImplementation(() => {
+        throw new Error("New");
+      });
+      await onGuestSignIn({ push: mockPush, pathname: ROUTES.login, dispatch: mockDispatch });
+      expect(mockPush).toHaveBeenCalledWith(ROUTES.onboarding);
+    });
+
+    it("redirects user to /onboarding from /login when userData is undefined", async () => {
+      mockGetCurrentUserData.mockImplementation(() => {
+        return undefined;
+      });
+      mockSession.getActiveUser.mockImplementation(() => {
+        throw new Error("New");
+      });
+      await onGuestSignIn({ push: mockPush, pathname: ROUTES.login, dispatch: mockDispatch });
+      expect(mockPush).toHaveBeenCalledWith(ROUTES.onboarding);
     });
   });
 

--- a/web/src/lib/auth/signinHelper.ts
+++ b/web/src/lib/auth/signinHelper.ts
@@ -131,6 +131,9 @@ export const onGuestSignIn = async ({
     if (getCurrentBusiness(userData).onboardingFormProgress === "UNSTARTED") {
       setRegistrationDimension("Began Onboarding");
       push(ROUTES.onboarding);
+    } else if (pathname === ROUTES.login) {
+      setRegistrationDimension("Onboarded Guest");
+      push(ROUTES.accountSetup);
     } else {
       setRegistrationDimension("Onboarded Guest");
     }


### PR DESCRIPTION
## Description

Added logic to `onGuestSignin` in `signinHelper.ts` for users coming from `/login` that click `Sign up and link your myNewJersey account`. If onboarding is completed, it will route users to `/account-setup`, if not, it will route to `onboarding`. Added relevant tests to `signinHelper.test.ts`

### Ticket

This pull request resolves [#13427](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13427).

### Steps to Test

1. Run navigator, click on the `Log In` button with no user data, then click `Sign up and link your myNewJersey account`. Should route directly to `onboarding`
2. Run navigator, click on the `Get Started` button. Complete steps 1 and 2 of onboarding. Directly route to `/login` and click `Sign up and link your myNewJersey account`. Should route directly to  `account-setup`

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
