### PR TITLE
fix: [AB#12799] update invocation freq in prod for migrateusersVersion

### DIFF
--- a/api/src/functions/encryptTaxId/app.ts
+++ b/api/src/functions/encryptTaxId/app.ts
@@ -17,7 +17,7 @@ import { encryptTaxIdBatch } from "src/domain/user/encryptTaxIdBatch";
 import { encryptTaxIdFactory } from "src/domain/user/encryptTaxIdFactory";
 
 export default async function handler(): Promise<void> {
-  const logger = LogWriter(`aws/${STAGE}`, "DataMigrationLogs");
+  const logger = LogWriter(`NavigatorDBClient/${STAGE}`, "DataMigrationLogs");
 
   const dynamoDb = createDynamoDbClient(IS_OFFLINE, IS_DOCKER, DYNAMO_OFFLINE_PORT);
   const dbClient = DynamoUserDataClient(dynamoDb, USERS_TABLE, logger);

--- a/api/src/functions/express/app.ts
+++ b/api/src/functions/express/app.ts
@@ -64,7 +64,7 @@ import { taxFilingsInterfaceFactory } from "src/domain/tax-filings/taxFilingsInt
 const app = setupExpress();
 
 const logger = LogWriter(`NavigatorWebService/${STAGE}`, "ApiLogs");
-const dataLogger = LogWriter(`aws/${STAGE}`, "DataMigrationLogs");
+const dataLogger = LogWriter(`NavigatorDBClient/${STAGE}`, "DataMigrationLogs");
 
 const LICENSE_STATUS_BASE_URL =
   process.env.LICENSE_STATUS_BASE_URL || `http://${IS_DOCKER ? "wiremock" : "localhost"}:9000`;

--- a/api/src/functions/migrateUsersVersion/index.ts
+++ b/api/src/functions/migrateUsersVersion/index.ts
@@ -2,13 +2,14 @@ import { FnType } from "@functions/fnType";
 import { handlerPath } from "@libs/handlerResolver";
 
 export default (vpcConfig: FnType["vpc"]): FnType => {
+  const isProd = process.env.STAGE === "prod";
   return {
     handler: `${handlerPath(__dirname)}/app.default`,
     timeout: 30,
     events: [
       {
         schedule: {
-          rate: ["cron(0 6 ? * SUN *)"],
+          rate: [isProd ? "cron(*/5 18-23,0-5 * * ? *)" : "cron(*/5 0-5 ? * SUN *)"],
           enabled: true,
         },
       },

--- a/api/src/functions/updateExternalStatus/app.ts
+++ b/api/src/functions/updateExternalStatus/app.ts
@@ -10,7 +10,7 @@ import { addNewsletterBatch } from "src/domain/newsletter/addNewsletterBatch";
 import { addNewsletterFactory } from "src/domain/newsletter/addNewsletterFactory";
 
 export default async function handler(): Promise<void> {
-  const dataLogger = LogWriter(`aws/${STAGE}`, "DataMigrationLogs");
+  const dataLogger = LogWriter(`NavigatorDBClient/${STAGE}`, "DataMigrationLogs");
   const dynamoDb = createDynamoDbClient(IS_OFFLINE, IS_DOCKER, DYNAMO_OFFLINE_PORT);
   const dbClient = DynamoUserDataClient(dynamoDb, USERS_TABLE, dataLogger);
   const logger = LogWriter(`NavigatorWebService/${STAGE}`, "ApiLogs");


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
### Increase Lambda Invocation Frequency for User Migration
This PR addresses issues related to provisioned throughput limits on our DynamoDB table, which caused migration failures due to exceeding the configured limits.


<!-- Summary of the changes, related issue, relevant motivation, and context -->

1. Reduced batch size from the previous value to 25 to minimize throttling.

2. Updated processBatch to use Promise.allSettled, ensuring partial failures don’t halt the entire migration process.

3. Increased Lambda invocation frequency from a weekly schedule to every 5 minutes daily until all users are migrated in production only. 

4. The previous weekly updates, especially in production, is insufficient to complete the migration in a reasonable timeframe.

5. This change allows us to process users more gradually while working within throughput limits rather than relying on a single large execution.

6. Updated the dataLogger path from aws/${STAGE} to NavigatorDBClient/${STAGE} to ensure logs are written to the correct CloudWatch log group.

 - The previous path incorrectly suggested an AWS resource, which it is not.

- This aligns with the existing aws_cloudwatch_log_group.data_migration_logs configuration, ensuring migration errors are logged correctly and not missed.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#12799](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12799).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
1. Open three terminal windows on your local machine.
2. In the first terminal, run the following command to start the server:
  ```
  yarn start:dev
 ```
3. In the second terminal, run the following command to start the local DynamoDB instance:
  ```
  yarn dynamo
 ```
4. In the third terminal, run the following command to populate local DynamoDB with the required data:

  ```
cd api

npx ts-node -r tsconfig-paths/register scripts/populateLocalDynamo.ts
 ```
5. Can also validate changes in the  the testing environment with the migrateUsersVersion Lambda, where it works as expected.
 Note: The cadence of invocation (every 5 minutes) cannot be directly tested locally. 

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
