### PR TITLE
feat: [AB#6768] add carnival permits for up and running poppies

### DIFF
--- a/web/src/components/dashboard/AnytimeActionDropdown.test.tsx
+++ b/web/src/components/dashboard/AnytimeActionDropdown.test.tsx
@@ -434,7 +434,7 @@ describe("<AnytimeActionDropdown />", () => {
       expect(screen.getByTestId("carnival-ride-supplemental-modification-option")).toBeInTheDocument();
     });
 
-    it("adds operating carnival fire permit for carnvial owning businesses", () => {
+    it("adds operating carnival fire permit for carnival owning businesses", () => {
       anytimeActionTasks = [
         generateAnytimeActionTask({ filename: "operating-carnival-fire-permit" }),
         ...anytimeActionTasks,
@@ -484,6 +484,62 @@ describe("<AnytimeActionDropdown />", () => {
       renderAnytimeActionDropdown();
       fireEvent.click(screen.getByLabelText("Open"));
       expect(screen.getByTestId("operating-carnival-fire-permit-option")).toBeInTheDocument();
+    });
+
+    it("adds operating carnival fire permit for traveling circus or carnival owning businesses based on non-essential question answers", () => {
+      anytimeActionTasks = [
+        generateAnytimeActionTask({ filename: "operating-carnival-fire-permit" }),
+        ...anytimeActionTasks,
+      ];
+      useMockBusiness({
+        profileData: generateProfileData({
+          nonEssentialRadioAnswers: {
+            "carnival-fire-licenses": false,
+          },
+        }),
+      });
+      renderAnytimeActionDropdown();
+      fireEvent.click(screen.getByLabelText("Open"));
+      expect(screen.queryByTestId("operating-carnival-fire-permit-option")).not.toBeInTheDocument();
+
+      useMockBusiness({
+        profileData: generateProfileData({
+          nonEssentialRadioAnswers: {
+            "carnival-fire-licenses": true,
+          },
+        }),
+      });
+      renderAnytimeActionDropdown();
+      fireEvent.click(screen.getByLabelText("Open"));
+      expect(screen.getByTestId("operating-carnival-fire-permit-option")).toBeInTheDocument();
+    });
+
+    it("adds carnival ride supplemental modification for traveling circus or carnival owning businesses based on non-essential question answers", () => {
+      anytimeActionTasks = [
+        generateAnytimeActionTask({ filename: "carnival-ride-supplemental-modification" }),
+        ...anytimeActionTasks,
+      ];
+      useMockBusiness({
+        profileData: generateProfileData({
+          nonEssentialRadioAnswers: {
+            "carnival-ride-permitting": false,
+          },
+        }),
+      });
+      renderAnytimeActionDropdown();
+      fireEvent.click(screen.getByLabelText("Open"));
+      expect(screen.queryByTestId("carnival-ride-supplemental-modification-option")).not.toBeInTheDocument();
+
+      useMockBusiness({
+        profileData: generateProfileData({
+          nonEssentialRadioAnswers: {
+            "carnival-ride-permitting": true,
+          },
+        }),
+      });
+      renderAnytimeActionDropdown();
+      fireEvent.click(screen.getByLabelText("Open"));
+      expect(screen.getByTestId("carnival-ride-supplemental-modification-option")).toBeInTheDocument();
     });
 
     it("renders an anytime action with a description", () => {

--- a/web/src/components/dashboard/AnytimeActionDropdown.tsx
+++ b/web/src/components/dashboard/AnytimeActionDropdown.tsx
@@ -95,11 +95,16 @@ export const AnytimeActionDropdown = (props: Props): ReactElement => {
   const isAnytimeActionFromNonEssentialQuestions = (action: AnytimeActionTask): boolean => {
     switch (action.filename) {
       case "carnival-ride-supplemental-modification":
-        return !!business?.profileData.carnivalRideOwningBusiness;
+        return (
+          !!business?.profileData.carnivalRideOwningBusiness ||
+          !!business?.profileData.nonEssentialRadioAnswers["carnival-ride-permitting"]
+        );
       case "operating-carnival-fire-permit":
         return (
           !!business?.profileData.carnivalRideOwningBusiness ||
-          !!business?.profileData.travelingCircusOrCarnivalOwningBusiness
+          !!business?.profileData.travelingCircusOrCarnivalOwningBusiness ||
+          !!business?.profileData.nonEssentialRadioAnswers["carnival-ride-permitting"] ||
+          !!business?.profileData.nonEssentialRadioAnswers["carnival-fire-licenses"]
         );
       case "vacant-building-fire-permit":
         return !!business?.profileData.vacantPropertyOwner;


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
Adds the ability for up and running poppies to see carnival related permits based on answers to non-essential questions
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#6768](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/6768).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
1. Create a Poppy user in the entertainment industry
2. Proceed to up and running
3. Answer yes to the two carnival non-essential questions
4. You should see 2 carnival related Anytime Actions

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
