### PR TITLE
feat: [AB#7714] Tax Clearance rename SYSTEM_ERROR -> NATURAL_PROGRAM_ERROR

### DIFF
--- a/api/src/client/ApiTaxClearanceCertificateClient.test.ts
+++ b/api/src/client/ApiTaxClearanceCertificateClient.test.ts
@@ -3,7 +3,7 @@ import {
   FAILED_TAX_ID_AND_PIN_VALIDATION,
   INELIGIBLE_TAX_CLEARANCE_FORM,
   MISSING_FIELD,
-  SYSTEM_ERROR,
+  NATURAL_PROGRAM_ERROR,
   TAX_ID_MISSING_FIELD,
   TAX_ID_MISSING_FIELD_WITH_EXTRA_SPACE,
 } from "@client/ApiTaxClearanceCertificateClient";
@@ -192,15 +192,15 @@ describe("TaxClearanceCertificateClient", () => {
     });
   });
 
-  it("returns SYSTEM_ERROR error", async () => {
+  it("returns NATURAL_PROGRAM_ERROR error", async () => {
     const userData = generateUserData({});
     mockAxios.post.mockRejectedValue({
-      response: { status: StatusCodes.BAD_REQUEST, data: SYSTEM_ERROR },
+      response: { status: StatusCodes.BAD_REQUEST, data: NATURAL_PROGRAM_ERROR },
     });
     expect(await client.postTaxClearanceCertificate(userData)).toEqual({
       error: {
-        message: SYSTEM_ERROR,
-        type: "SYSTEM_ERROR",
+        message: NATURAL_PROGRAM_ERROR,
+        type: "NATURAL_PROGRAM_ERROR",
       },
     });
   });

--- a/api/src/client/ApiTaxClearanceCertificateClient.ts
+++ b/api/src/client/ApiTaxClearanceCertificateClient.ts
@@ -21,7 +21,7 @@ export const FAILED_TAX_ID_AND_PIN_VALIDATION =
   "ADABase validation failed. Please verify the data submitted and retry.";
 export const MISSING_FIELD =
   "Mandatory Field Missing. TaxpayerId, TaxpayerName, AddressLine1, City, State, Zip, Agency name, Rep Id and RepName are required.";
-export const SYSTEM_ERROR = "Error calling Natural Program. Please try again later.";
+export const NATURAL_PROGRAM_ERROR = "Error calling Natural Program. Please try again later.";
 
 export const ApiTaxClearanceCertificateClient = (
   logWriter: LogWriterType,
@@ -104,10 +104,10 @@ export const ApiTaxClearanceCertificateClient = (
               },
             };
           }
-          if (errorMessage === SYSTEM_ERROR) {
+          if (errorMessage === NATURAL_PROGRAM_ERROR) {
             return {
               error: {
-                type: "SYSTEM_ERROR",
+                type: "NATURAL_PROGRAM_ERROR",
                 message: errorMessage,
               },
             };

--- a/shared/src/taxClearanceCertificate.ts
+++ b/shared/src/taxClearanceCertificate.ts
@@ -8,7 +8,7 @@ export type TaxClearanceCertificateResponse = {
       | "INELIGIBLE_TAX_CLEARANCE_FORM"
       | "FAILED_TAX_ID_AND_PIN_VALIDATION"
       | "MISSING_FIELD"
-      | "SYSTEM_ERROR";
+      | "NATURAL_PROGRAM_ERROR";
     message: string;
   };
   certificatePdfArray?: number[];

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceStepThree.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceStepThree.tsx
@@ -53,7 +53,7 @@ export const TaxClearanceStepThree = (props: Props): ReactElement => {
 
     // TODO: Error Response will be addressed in a separate ticket
     // Note: if there is a server error, we may return a 500 status code, or
-    // return the error object with type = SYSTEM_ERROR
+    // return the error object with type = NATURAL_PROGRAM_ERROR
     scrollToTop();
   };
 


### PR DESCRIPTION
## Description

This commit renames SYSTEM_ERROR -> NATURAL_PROGRAM_ERROR, as a prefactor for #[7714](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7714).

`SYSTEM_ERROR` currently specifically refers to the `"Error calling Natural Program. Please try again later."` message returned by the taxation API. I'm understanding that this refers to a service, Natural Program, upstream of the taxation service having an error.

In working on this, I kept seeing `SYSTEM_ERROR` and being confused whether it's our system (api) error, their taxation system error, or the further upstream error. I think it's the last one, but when I see `SYSTEM_ERROR`, my first guess would be our system or their system, not a third up the line.

I think this is important to distinguish as the error path for the taxation service being down (returning a 500), or our service being down (returning a 500) is entirely different. We might make them look the same to the user, but they do need separate handling.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request contributes to #[7714](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7714).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migxation file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Addxtions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
