### PR TITLE
Updates to accessibility for Profile Screen

### DIFF
--- a/web/src/components/profile/ProfileTab.tsx
+++ b/web/src/components/profile/ProfileTab.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "@/components/njwds/Icon";
 import { ProfileTabs } from "@/lib/types/types";
-import { ReactElement } from "react";
+import { ReactElement, RefObject, forwardRef } from "react";
 
 interface Props {
   tab: ProfileTabs;
@@ -8,14 +8,23 @@ interface Props {
   setProfileTab: (profileTab: ProfileTabs) => void;
   tabIcon: "info-outline" | "bar-chart" | "folder-open" | "edit";
   tabText: string;
+  onKeyDown?: (event: React.KeyboardEvent) => void;
+  ref: RefObject<HTMLButtonElement>;
 }
 
-export const ProfileTab = (props: Props): ReactElement => {
+export const ProfileTab = forwardRef<HTMLButtonElement, Props>((props: Props, ref): ReactElement => {
   return (
     <button
+      id={`tab-${props.tab}`}
+      role="tab"
+      aria-selected={props.activeTab === props.tab}
+      aria-controls={`tabpanel-${props.tab}`}
       className={`profile-tab ${props.activeTab === props.tab ? "selected" : ""}`}
       data-testid={props.tab}
+      tabIndex={props.activeTab === props.tab ? 0 : -1}
       onClick={(): void => props.setProfileTab(props.tab)}
+      onKeyDown={props.onKeyDown}
+      ref={ref}
     >
       <div className="profile-tab-left-content">
         <img src={`/img/${props.tabIcon}.svg`} alt="" role="presentation" />
@@ -24,4 +33,6 @@ export const ProfileTab = (props: Props): ReactElement => {
       <Icon className="usa-icon--size-3" iconName="navigate_next" />
     </button>
   );
-};
+});
+
+ProfileTab.displayName = "ProfileTab";

--- a/web/src/components/profile/ProfileTabNav.tsx
+++ b/web/src/components/profile/ProfileTabNav.tsx
@@ -5,7 +5,7 @@ import { isStartingBusiness } from "@businessnjgovnavigator/shared/domain-logic/
 import { LookupLegalStructureById } from "@businessnjgovnavigator/shared/legalStructure";
 import { BusinessPersona } from "@businessnjgovnavigator/shared/profileData";
 import { Business } from "@businessnjgovnavigator/shared/userData";
-import { ReactElement } from "react";
+import { ReactElement, useRef } from "react";
 
 const infoTab = "info";
 const numbersTab = "numbers";
@@ -30,19 +30,70 @@ export const ProfileTabNav = (props: Props): ReactElement => {
     );
   const shouldShowDocuments = isSuccessfulFilingResponse || shouldDisplayFormationDocuments;
 
+  const tabRefs = {
+    [infoTab]: useRef<HTMLButtonElement>(null),
+    [numbersTab]: useRef<HTMLButtonElement>(null),
+    [documentsTab]: useRef<HTMLButtonElement>(null),
+    [notesTab]: useRef<HTMLButtonElement>(null),
+  };
+
+  const availableTabs = [infoTab, numbersTab, ...(shouldShowDocuments ? [documentsTab] : []), notesTab];
+
+  const handleKeyDown = (event: React.KeyboardEvent, currentTab: ProfileTabs): void => {
+    const currentIndex = availableTabs.indexOf(currentTab);
+    let nextTabToFocus: ProfileTabs | undefined;
+
+    switch (event.key) {
+      case "ArrowLeft":
+      case "ArrowUp":
+        event.preventDefault();
+        if (currentIndex > 0) {
+          nextTabToFocus = availableTabs[currentIndex - 1] as ProfileTabs;
+        } else {
+          nextTabToFocus = availableTabs[availableTabs.length - 1] as ProfileTabs;
+        }
+        break;
+      case "ArrowRight":
+      case "ArrowDown":
+        event.preventDefault();
+        if (currentIndex < availableTabs.length - 1) {
+          nextTabToFocus = availableTabs[currentIndex + 1] as ProfileTabs;
+        } else {
+          nextTabToFocus = availableTabs[0] as ProfileTabs;
+        }
+        break;
+      case "Enter":
+        event.preventDefault();
+        props.setProfileTab(currentTab);
+        return;
+    }
+
+    if (nextTabToFocus) {
+      tabRefs[nextTabToFocus]?.current?.focus();
+    }
+  };
+
   return (
-    <div className="width-100 font-body-md desktop:padding-top-2 padding-top-2">
+    <div
+      role="tablist"
+      aria-orientation="vertical"
+      className="width-100 font-body-md desktop:padding-top-2 padding-top-2"
+    >
       <ProfileTab
         {...props}
         tab={infoTab}
         tabIcon="info-outline"
         tabText={Config.profileDefaults.default.profileTabInfoTitle}
+        onKeyDown={(e) => handleKeyDown(e, infoTab)}
+        ref={tabRefs[infoTab]}
       />
       <ProfileTab
         {...props}
         tab={numbersTab}
         tabIcon="bar-chart"
         tabText={Config.profileDefaults.default.profileTabNumbersTitle}
+        onKeyDown={(e) => handleKeyDown(e, numbersTab)}
+        ref={tabRefs[numbersTab]}
       />
       {shouldShowDocuments && (
         <ProfileTab
@@ -50,6 +101,8 @@ export const ProfileTabNav = (props: Props): ReactElement => {
           tab={documentsTab}
           tabIcon="folder-open"
           tabText={Config.profileDefaults.default.profileTabDocsTitle}
+          onKeyDown={(e) => handleKeyDown(e, documentsTab)}
+          ref={tabRefs[documentsTab]}
         />
       )}
       <ProfileTab
@@ -57,6 +110,8 @@ export const ProfileTabNav = (props: Props): ReactElement => {
         tab={notesTab}
         tabIcon="edit"
         tabText={Config.profileDefaults.default.profileTabNoteTitle}
+        onKeyDown={(e) => handleKeyDown(e, notesTab)}
+        ref={tabRefs[notesTab]}
       />
     </div>
   );

--- a/web/src/components/profile/ProfileTabPanel.tsx
+++ b/web/src/components/profile/ProfileTabPanel.tsx
@@ -1,30 +1,30 @@
 import { BackButtonForLayout } from "@/components/njwds-layout/BackButtonForLayout";
+import { ProfileHeader } from "@/components/profile/ProfileHeader";
+import { ProfileNoteDisclaimerForSubmittingData } from "@/components/profile/ProfileNoteForBusinessesFormedOutsideNavigator";
+import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
+import { useUserData } from "@/lib/data-hooks/useUserData";
 import { MediaQueries } from "@/lib/PageSizes";
 import { useMediaQuery } from "@mui/material";
-import React, { ReactElement } from "react";
+import React, { ReactElement, useContext } from "react";
 
-export interface SidebarPageLayoutProps {
+export interface ProfileTabPanelProps {
   children: React.ReactNode;
   navChildren?: React.ReactNode;
-  stackNav?: boolean;
-  divider?: boolean;
-  outlineBox?: boolean;
-  belowBoxComponent?: React.ReactNode;
-  titleOverColumns?: React.ReactNode;
-  nonWrappingLeftColumn?: boolean;
 }
 
-export const SidebarPageLayout = ({
-  children,
-  navChildren,
-  divider = true,
-  outlineBox = true,
-  stackNav,
-  belowBoxComponent,
-  titleOverColumns,
-  nonWrappingLeftColumn,
-}: SidebarPageLayoutProps): ReactElement => {
+export const ProfileTabPanel = ({ children, navChildren }: ProfileTabPanelProps): ReactElement => {
+  const userDataFromHook = useUserData();
+  const business = userDataFromHook.business;
+  const { isAuthenticated } = useContext(NeedsAccountContext);
+
+  const titleOverColumns: React.ReactNode = (
+    <>
+      <ProfileHeader business={business} isAuthenticated={isAuthenticated === "TRUE"} />
+      <ProfileNoteDisclaimerForSubmittingData business={business} isAuthenticated={isAuthenticated} />
+    </>
+  );
+
   const isLargeScreen = useMediaQuery(MediaQueries.desktopAndUp);
   const { Config } = useConfig();
 
@@ -41,32 +41,19 @@ export const SidebarPageLayout = ({
 
           <div className="grid-row grid-gap flex-no-wrap">
             {isLargeScreen && (
-              <nav
-                aria-label="Secondary"
-                className={`${nonWrappingLeftColumn ? "" : "desktop:grid-col-3"}  order-first`}
-              >
-                {divider && <hr className="margin-bottom-1 margin-top-0" aria-hidden={true} />}
+              <nav aria-label="Secondary" className="order-first">
                 {navChildren}
               </nav>
             )}
-            <div className={nonWrappingLeftColumn ? "fg1" : "desktop:grid-col-9"}>
+            <div className="fg1">
               {!isLargeScreen && (
                 <div>
                   <BackButtonForLayout backButtonText={Config.taskDefaults.backToRoadmapText} />
                   {titleOverColumns}
-                  {stackNav && navChildren}
+                  {navChildren}
                 </div>
               )}
-              <div
-                className={
-                  outlineBox
-                    ? "border-1px border-base-light usa-prose min-height-40rem padding-4 radius-lg"
-                    : "min-height-40rem"
-                }
-              >
-                {children}
-              </div>
-              {belowBoxComponent}
+              <div className="min-height-40rem">{children}</div>
             </div>
           </div>
         </div>

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -31,7 +31,6 @@ import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
 import { ActionBarLayout } from "@/components/njwds-layout/ActionBarLayout";
 import { PageSkeleton } from "@/components/njwds-layout/PageSkeleton";
-import { SidebarPageLayout } from "@/components/njwds-layout/SidebarPageLayout";
 import { SingleColumnContainer } from "@/components/njwds/SingleColumnContainer";
 import { PageCircularIndicator } from "@/components/PageCircularIndicator";
 import { DevOnlyResetUserDataButton } from "@/components/profile/DevOnlyResetUserDataButton";
@@ -40,12 +39,11 @@ import { ProfileDocuments } from "@/components/profile/ProfileDocuments";
 import { ProfileErrorAlert } from "@/components/profile/ProfileErrorAlert";
 import { ProfileEscapeModal } from "@/components/profile/ProfileEscapeModal";
 import { ProfileField } from "@/components/profile/ProfileField";
-import { ProfileHeader } from "@/components/profile/ProfileHeader";
-import { ProfileNoteDisclaimerForSubmittingData } from "@/components/profile/ProfileNoteForBusinessesFormedOutsideNavigator";
 import { ProfileOpportunitiesAlert } from "@/components/profile/ProfileOpportunitiesAlert";
 import { ProfileSnackbarAlert } from "@/components/profile/ProfileSnackbarAlert";
 import { ProfileTabHeader } from "@/components/profile/ProfileTabHeader";
 import { ProfileTabNav } from "@/components/profile/ProfileTabNav";
+import { ProfileTabPanel } from "@/components/profile/ProfileTabPanel";
 import { TaxDisclaimer } from "@/components/TaxDisclaimer";
 import { UserDataErrorAlert } from "@/components/UserDataErrorAlert";
 import { AddressContext } from "@/contexts/addressContext";
@@ -342,7 +340,7 @@ const ProfilePage = (props: Props): ReactElement => {
 
   const nexusBusinessElements: Record<ProfileTabs, ReactNode> = {
     info: (
-      <>
+      <div id="tabpanel-info" role="tabpanel" aria-labelledby="tab-info">
         <ProfileTabHeader tab="info" />
 
         <ProfileErrorAlert fieldErrors={getInvalidFieldIds()} />
@@ -420,20 +418,20 @@ const ProfilePage = (props: Props): ReactElement => {
         >
           <RenovationQuestion />
         </ProfileField>
-      </>
+      </div>
     ),
     documents: <></>,
     notes: (
-      <>
+      <div id="tabpanel-notes" role="tabpanel" aria-labelledby="tab-notes">
         <ProfileTabHeader tab="notes" />
 
         <ProfileField fieldName="notes">
           <Notes handleChangeOverride={showNeedsAccountModalForGuest()} />
         </ProfileField>
-      </>
+      </div>
     ),
     numbers: (
-      <>
+      <div id="tabpanel-numbers" role="tabpanel" aria-labelledby="tab-numbers">
         <ProfileTabHeader tab="numbers" />
 
         <ProfileField fieldName="taxId" noLabel={true}>
@@ -460,13 +458,13 @@ const ProfilePage = (props: Props): ReactElement => {
         <ProfileField fieldName="taxPin">
           <TaxPin handleChangeOverride={showNeedsAccountModalForGuest()} />
         </ProfileField>
-      </>
+      </div>
     ),
   };
 
   const foreignBusinessElements: Record<ProfileTabs, ReactNode> = {
     info: (
-      <>
+      <div id="tabpanel-info" role="tabpanel" aria-labelledby="tab-info">
         <ProfileTabHeader tab="info" />
 
         <ProfileErrorAlert fieldErrors={getInvalidFieldIds()} />
@@ -478,20 +476,20 @@ const ProfilePage = (props: Props): ReactElement => {
         <ProfileField fieldName="foreignBusinessTypeIds">
           <ForeignBusinessTypeField required />
         </ProfileField>
-      </>
+      </div>
     ),
     documents: <></>,
     notes: (
-      <>
+      <div id="tabpanel-notes" role="tabpanel" aria-labelledby="tab-notes">
         <ProfileTabHeader tab="notes" />
 
         <ProfileField fieldName="notes">
           <Notes handleChangeOverride={showNeedsAccountModalForGuest()} />
         </ProfileField>
-      </>
+      </div>
     ),
     numbers: (
-      <>
+      <div id="tabpanel-numbers" role="tabpanel" aria-labelledby="tab-numbers">
         <ProfileTabHeader tab="numbers" />
 
         <ProfileField fieldName="taxId" noLabel={true}>
@@ -511,7 +509,7 @@ const ProfilePage = (props: Props): ReactElement => {
         <ProfileField fieldName="taxPin">
           <TaxPin handleChangeOverride={showNeedsAccountModalForGuest()} />
         </ProfileField>
-      </>
+      </div>
     ),
   };
 
@@ -520,16 +518,16 @@ const ProfilePage = (props: Props): ReactElement => {
 
   const startingNewBusinessElements: Record<ProfileTabs, ReactNode> = {
     notes: (
-      <>
+      <div id="tabpanel-notes" role="tabpanel" aria-labelledby="tab-notes">
         <ProfileTabHeader tab="notes" />
 
         <ProfileField fieldName="notes">
           <Notes handleChangeOverride={showNeedsAccountModalForGuest()} />
         </ProfileField>
-      </>
+      </div>
     ),
     documents: (
-      <>
+      <div id="tabpanel-documents" role="tabpanel" aria-labelledby="tab-documents">
         <ProfileTabHeader tab="documents" />
 
         <ProfileField
@@ -540,10 +538,10 @@ const ProfilePage = (props: Props): ReactElement => {
         >
           <ProfileDocuments />
         </ProfileField>
-      </>
+      </div>
     ),
     info: (
-      <>
+      <div id="tabpanel-info" role="tabpanel" aria-labelledby="tab-info">
         <ProfileTabHeader tab="info" />
 
         <ProfileErrorAlert fieldErrors={getInvalidFieldIds()} />
@@ -670,10 +668,10 @@ const ProfilePage = (props: Props): ReactElement => {
         >
           <ExistingEmployees />
         </ProfileField>
-      </>
+      </div>
     ),
     numbers: (
-      <>
+      <div id="tabpanel-numbers" role="tabpanel" aria-labelledby="tab-numbers">
         <ProfileTabHeader tab="numbers" />
 
         <ProfileField fieldName="naicsCode" noLabel={true}>
@@ -711,23 +709,23 @@ const ProfilePage = (props: Props): ReactElement => {
         <ProfileField fieldName="taxPin">
           <TaxPin handleChangeOverride={showNeedsAccountModalForGuest()} />
         </ProfileField>
-      </>
+      </div>
     ),
   };
 
   const owningBusinessElements: Record<ProfileTabs, ReactNode> = {
     notes: (
-      <>
+      <div id="tabpanel-notes" role="tabpanel" aria-labelledby="tab-notes">
         <ProfileTabHeader tab="notes" />
 
         <ProfileField fieldName="notes">
           <Notes handleChangeOverride={showNeedsAccountModalForGuest()} />
         </ProfileField>
-      </>
+      </div>
     ),
     documents: <></>,
     info: (
-      <>
+      <div id="tabpanel-info" role="tabpanel" aria-labelledby="tab-info">
         <ProfileTabHeader tab="info" />
 
         <ProfileErrorAlert fieldErrors={getInvalidFieldIds()} />
@@ -819,10 +817,10 @@ const ProfilePage = (props: Props): ReactElement => {
         <ProfileField fieldName="ownershipTypeIds">
           <Ownership />
         </ProfileField>
-      </>
+      </div>
     ),
     numbers: (
-      <>
+      <div id="tabpanel-numbers" role="tabpanel" aria-labelledby="tab-numbers">
         <ProfileTabHeader tab="numbers" />
 
         {business?.profileData.naicsCode && (
@@ -858,23 +856,23 @@ const ProfilePage = (props: Props): ReactElement => {
         <ProfileField fieldName="taxPin">
           <TaxPin handleChangeOverride={showNeedsAccountModalForGuest()} />
         </ProfileField>
-      </>
+      </div>
     ),
   };
 
   const domesticEmployerBusinessElements: Record<ProfileTabs, ReactNode> = {
     notes: (
-      <>
+      <div id="tabpanel-notes" role="tabpanel" aria-labelledby="tab-notes">
         <ProfileTabHeader tab="notes" />
 
         <ProfileField fieldName="notes">
           <Notes handleChangeOverride={showNeedsAccountModalForGuest()} />
         </ProfileField>
-      </>
+      </div>
     ),
     documents: <></>,
     info: (
-      <>
+      <div id="tabpanel-info" role="tabpanel" aria-labelledby="tab-info">
         <ProfileTabHeader tab="info" />
 
         <ProfileErrorAlert fieldErrors={getInvalidFieldIds()} />
@@ -889,10 +887,10 @@ const ProfilePage = (props: Props): ReactElement => {
         <ProfileField fieldName="industryId">
           <Industry />
         </ProfileField>
-      </>
+      </div>
     ),
     numbers: (
-      <>
+      <div id="tabpanel-numbers" role="tabpanel" aria-labelledby="tab-numbers">
         <ProfileTabHeader tab="numbers" />
 
         <ProfileField fieldName="naicsCode" noLabel={true}>
@@ -914,7 +912,7 @@ const ProfilePage = (props: Props): ReactElement => {
             )}
           </div>
         </ProfileField>
-      </>
+      </div>
     ),
   };
 
@@ -961,20 +959,7 @@ const ProfilePage = (props: Props): ReactElement => {
                     {business === undefined ? (
                       <PageCircularIndicator />
                     ) : (
-                      <SidebarPageLayout
-                        divider={false}
-                        outlineBox={false}
-                        stackNav={true}
-                        nonWrappingLeftColumn={true}
-                        titleOverColumns={
-                          <>
-                            <ProfileHeader business={business} isAuthenticated={isAuthenticated === "TRUE"} />
-                            <ProfileNoteDisclaimerForSubmittingData
-                              business={business}
-                              isAuthenticated={isAuthenticated}
-                            />
-                          </>
-                        }
+                      <ProfileTabPanel
                         navChildren={
                           <ProfileTabNav
                             business={business}
@@ -1019,7 +1004,7 @@ const ProfilePage = (props: Props): ReactElement => {
                             <DevOnlyResetUserDataButton />
                           </form>
                         </>
-                      </SidebarPageLayout>
+                      </ProfileTabPanel>
                     )}
                   </div>
                 </div>

--- a/web/test/pages/profile/profile-guest.test.tsx
+++ b/web/test/pages/profile/profile-guest.test.tsx
@@ -138,7 +138,9 @@ describe("profile - guest mode", () => {
         setShowNeedsAccountModal,
       });
       chooseTab("notes");
-      fireEvent.change(screen.getByLabelText("Notes"), { target: { value: "some note" } });
+      fireEvent.change(screen.getByLabelText("Notes", { selector: "textarea" }), {
+        target: { value: "some note" },
+      });
       expect(setShowNeedsAccountModal).toHaveBeenCalledWith(true);
     });
   }

--- a/web/test/pages/profile/profile-helpers.tsx
+++ b/web/test/pages/profile/profile-helpers.tsx
@@ -81,9 +81,12 @@ export const renderPage = ({
   );
 };
 
-export const fillText = (label: string, value: string): void => {
-  fireEvent.change(screen.getByLabelText(label), { target: { value: value } });
-  fireEvent.blur(screen.getByLabelText(label));
+export const fillText = (label: string, value: string, selector?: string): void => {
+  const options = selector ? { selector } : undefined;
+  const element = screen.getByLabelText(label, options);
+
+  fireEvent.change(element, { target: { value: value } });
+  fireEvent.blur(element);
 };
 
 export const selectByValue = (label: string, value: string): void => {
@@ -128,7 +131,7 @@ export const getDateOfFormation = (): string => {
 };
 
 export const getNotesValue = (): string => {
-  return (screen.queryByLabelText("Notes") as HTMLInputElement)?.value;
+  return (screen.queryByLabelText("Notes", { selector: "textarea" }) as HTMLInputElement)?.value;
 };
 
 export const getTaxIdValue = (): string => {

--- a/web/test/pages/profile/profile-owning.test.tsx
+++ b/web/test/pages/profile/profile-owning.test.tsx
@@ -159,7 +159,7 @@ describe("profile - owning existing business", () => {
     fillText("Tax id location", "123");
     fillText("Tax pin", "6666");
     chooseTab("notes");
-    fillText("Notes", "whats appppppp");
+    fillText("Notes", "whats appppppp", "textarea");
     clickSave();
 
     await waitFor(() => {

--- a/web/test/pages/profile/profile-starting.test.tsx
+++ b/web/test/pages/profile/profile-starting.test.tsx
@@ -308,7 +308,7 @@ describe("profile - starting business", () => {
     fillText("Tax id", "023456790123");
     fillText("Employer id", "02-3456780");
     chooseTab("notes");
-    fillText("Notes", "whats appppppp");
+    fillText("Notes", "whats appppppp", "textarea");
     clickSave();
 
     await waitFor(() => {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

This PR addresses three flagged accessibility areas:
* Focus order makes sense and there are no “Focus Traps”
* When page content changes dramatically, the screen reader notifies the user (ie, new menu options appear, new section locked or unlocked, etc)
* Element is described correctly (ie, link is described as link)

### Ticket

This pull request resolves [#13908](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13908).

### Approach

The profile nav section very closely resembles html [tabs](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-manual/). With that in mind, rather than using the slightly non-optimized `SidebarPageLayout` component, a custom `ProfileTabPanel` component was created. This component moves the `navChildren` higher up in the dom (fixing the focus order issue). Relevant tab elements were added to `ProfileTab` and ProfileTabNav`. These coupled with A custom `handleKeyDown` function addressed the other two accessibility issues by turning the ProfileNav into a tab group. 

### Steps to Test

* navigate to the `Profile` page
* confirm that tab navigates to the tabgroup
* once on the tab group, tab will navigate to that tabs content
* shift+tab will navigate back to the active tab
* while on the tab, the up and down arrow will cycle through the tabs
* enter will select the tab

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden

