### PR TITLE
feat: [AB#13315] Tax Clearance Download PR Feedback

### DIFF
--- a/api/src/client/ApiTaxClearanceCertificateClient.test.ts
+++ b/api/src/client/ApiTaxClearanceCertificateClient.test.ts
@@ -36,7 +36,7 @@ describe("TaxClearanceCertificateClient", () => {
     jest.resetAllMocks();
     client = ApiTaxClearanceCertificateClient(DummyLogWriter, config);
     userData = generateUserData({});
-    mockAxios.post.mockResolvedValue({ data: {} });
+    mockAxios.post.mockResolvedValue({ data: { certificate: [1] } });
   });
 
   it("makes a post request to correct url with basic auth and data", () => {

--- a/api/src/client/ApiTaxClearanceCertificateClient.ts
+++ b/api/src/client/ApiTaxClearanceCertificateClient.ts
@@ -69,6 +69,13 @@ export const ApiTaxClearanceCertificateClient = (
             certificate: "Succussful Response - PDF data omitted",
           })}`
         );
+        if (!Array.isArray(response.data.certificate) || response.data.certificate.length === 0) {
+          const errorMessage = `Tax Clearance Certificate Client - Id:${logId} - Error: Certificate is empty or not an array ${JSON.stringify(
+            response.data.certificate
+          )}`;
+          logWriter.LogError(errorMessage);
+          throw errorMessage;
+        }
         return { certificatePdfArray: response.data.certificate };
       })
       .catch((error: AxiosError) => {

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceDownload.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceDownload.tsx
@@ -11,13 +11,7 @@ interface Props {
 
 export const TaxClearanceDownload = (props: Props): ReactElement => {
   const { Config } = useConfig();
-
-  let downloadLink = undefined;
-  // window is only available on client side
-  if (typeof window !== "undefined") {
-    const URL = window.URL || window.webkitURL;
-    downloadLink = URL.createObjectURL(props.certificatePdfBlob);
-  }
+  const downloadLink = URL.createObjectURL(props.certificatePdfBlob);
 
   return (
     <>


### PR DESCRIPTION
## Description

This commit
- Throws an explicit error if the taxation service returns a non-array for the certificate, or an empty array
- Uses Node's `URL` instead of `window.URL`

Following up on feedback from https://github.com/newjersey/navigator.business.nj.gov/pull/10087

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This commit resolves #[13315](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13315).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migxation file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Addxtions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarde