### PR TITLE
chore: [AB#13772] replace data-testid with preferred matchers for tax clearance cert tests

### DIFF
--- a/web/src/components/tasks/anytime-action/AnytimeActionSwitchComponent.test.tsx
+++ b/web/src/components/tasks/anytime-action/AnytimeActionSwitchComponent.test.tsx
@@ -14,14 +14,15 @@ describe("AnytimeActionSwitchComponent", () => {
       process.env.FEATURE_TAX_CLEARANCE_CERTIFICATE = "true";
       const task = generateAnytimeActionTask({ filename: "tax-clearance-certificate" });
       render(<AnytimeActionSwitchComponent anytimeActionTask={task} />);
-      expect(screen.getByTestId("AnytimeActionTaxClearanceCertificateElement")).toBeInTheDocument();
+      const firstTab = screen.getAllByRole("tab")[0];
+      expect(firstTab).toHaveAttribute("aria-selected", "true");
     });
 
     it("does not render tax clearance certificate element", () => {
       process.env.FEATURE_TAX_CLEARANCE_CERTIFICATE = "some random string";
       const task = generateAnytimeActionTask({ filename: "tax-clearance-certificate" });
       render(<AnytimeActionSwitchComponent anytimeActionTask={task} />);
-      expect(screen.queryByTestId("AnytimeActionTaxClearanceCertificateElement")).not.toBeInTheDocument();
+      expect(screen.queryByRole("tab")).not.toBeInTheDocument();
     });
   });
 });

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateElement.test.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateElement.test.tsx
@@ -74,51 +74,54 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
   describe("navigation", () => {
     it("renders the requirements tab on load", () => {
       renderComponent({});
-      expect(screen.getByTestId("requirements-tab")).toBeInTheDocument();
+      const firstTab = screen.getAllByRole("tab")[0];
+      expect(firstTab).toHaveAttribute("aria-selected", "true");
     });
 
     it("renders the eligibility tab on click", () => {
       renderComponent({});
-      fireEvent.click(screen.getByTestId("stepper-1"));
-      expect(screen.getByTestId("eligibility-tab")).toBeInTheDocument();
+      const secondTab = screen.getAllByRole("tab")[1];
+      fireEvent.click(secondTab);
+      expect(secondTab).toHaveAttribute("aria-selected", "true");
     });
 
     it("renders the review tab on click", () => {
       renderComponent({});
-      fireEvent.click(screen.getByTestId("stepper-2"));
-      expect(screen.getByTestId("review-tab")).toBeInTheDocument();
+      const thirdTab = screen.getAllByRole("tab")[2];
+      fireEvent.click(thirdTab);
+      expect(thirdTab).toHaveAttribute("aria-selected", "true");
     });
 
     it("renders back to tab one when the back button is clicked on tab 2", () => {
       renderComponent({});
-      fireEvent.click(screen.getByTestId("stepper-1"));
-      expect(screen.getByTestId("eligibility-tab")).toBeInTheDocument();
+      fireEvent.click(screen.getAllByRole("tab")[1]);
+      expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
       fireEvent.click(screen.getByText(Config.taxClearanceCertificateShared.backButtonText));
-      expect(screen.getByTestId("requirements-tab")).toBeInTheDocument();
+      expect(screen.getAllByRole("tab")[0]).toBeInTheDocument();
     });
 
     it("renders tab three when the save button is clicked on tab two", () => {
       renderComponent({});
-      fireEvent.click(screen.getByTestId("stepper-1"));
-      expect(screen.getByTestId("eligibility-tab")).toBeInTheDocument();
+      fireEvent.click(screen.getAllByRole("tab")[1]);
+      expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
       fireEvent.click(screen.getByText(Config.taxClearanceCertificateShared.saveButtonText));
-      expect(screen.getByTestId("review-tab")).toBeInTheDocument();
+      expect(screen.getAllByRole("tab")[2]).toHaveAttribute("aria-selected", "true");
     });
 
     it("renders back to tab two when the back button is clicked on tab three", () => {
       renderComponent({});
-      fireEvent.click(screen.getByTestId("stepper-2"));
-      expect(screen.getByTestId("review-tab")).toBeInTheDocument();
+      fireEvent.click(screen.getAllByRole("tab")[2]);
+      expect(screen.getAllByRole("tab")[2]).toHaveAttribute("aria-selected", "true");
       fireEvent.click(screen.getByText(Config.taxClearanceCertificateShared.backButtonText));
-      expect(screen.getByTestId("eligibility-tab")).toBeInTheDocument();
+      expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
     });
 
     it("renders back to tab two when the back edit button is clicked on tab three", () => {
       renderComponent({});
-      fireEvent.click(screen.getByTestId("stepper-2"));
-      expect(screen.getByTestId("review-tab")).toBeInTheDocument();
+      fireEvent.click(screen.getAllByRole("tab")[2]);
+      expect(screen.getAllByRole("tab")[2]).toHaveAttribute("aria-selected", "true");
       fireEvent.click(screen.getByText(Config.taxClearanceCertificateStep3.editButtonText));
-      expect(screen.getByTestId("eligibility-tab")).toBeInTheDocument();
+      expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
     });
   });
 
@@ -132,7 +135,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(screen.getByText(agencyId.name)).toBeInTheDocument();
       });
 
@@ -143,7 +146,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Business name").value).toEqual(
           "business name in taxClearanceCertificateData"
         );
@@ -156,7 +159,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Address line1").value).toEqual("1010 Main Street");
       });
 
@@ -167,7 +170,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Address line2").value).toEqual("1010 Main Street");
       });
 
@@ -178,7 +181,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Address city").value).toEqual("1010 Main Street");
       });
 
@@ -190,7 +193,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Address state").value).toEqual(addressState.shortCode);
       });
 
@@ -201,7 +204,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Address zip code").value).toEqual("12345");
       });
 
@@ -212,7 +215,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Tax id").value).toEqual("123-456-789/123");
       });
 
@@ -223,7 +226,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Tax pin").value).toEqual("1234");
       });
     });
@@ -235,7 +238,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           taxClearanceCertificateData: generateTaxClearanceCertificateData({ businessName: "" }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Business name").value).toEqual("business name in profile data");
       });
 
@@ -249,7 +252,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           taxClearanceCertificateData: generateTaxClearanceCertificateData({ addressLine1: "" }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Address line1").value).toEqual("1010 Main Street");
       });
 
@@ -263,7 +266,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           taxClearanceCertificateData: generateTaxClearanceCertificateData({ addressLine2: "" }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Address line2").value).toEqual("1010 Main Street");
       });
 
@@ -278,7 +281,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           taxClearanceCertificateData: generateTaxClearanceCertificateData({ addressCity: "" }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Address city").value).toEqual("1010 Main Street");
       });
 
@@ -293,7 +296,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           taxClearanceCertificateData: generateTaxClearanceCertificateData({ addressCity: "" }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Address city").value).toEqual("1010 Main Street");
       });
 
@@ -312,7 +315,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           taxClearanceCertificateData: generateTaxClearanceCertificateData({ addressCity: "" }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Address city").value).toEqual("Newark");
       });
 
@@ -329,7 +332,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Address state").value).toEqual(addressState.shortCode);
       });
 
@@ -343,7 +346,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           taxClearanceCertificateData: generateTaxClearanceCertificateData({ addressZipCode: "" }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Address zip code").value).toEqual("12345");
       });
 
@@ -355,7 +358,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Tax id").value).toEqual("123-456-789/123");
       });
 
@@ -367,7 +370,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
           }),
         });
         renderComponent({ business });
-        fireEvent.click(screen.getByTestId("stepper-1"));
+        fireEvent.click(screen.getAllByRole("tab")[1]);
         expect(getInputElementByLabel("Tax pin").value).toEqual("1234");
       });
     });
@@ -380,16 +383,19 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
       formationData: generateFormationData({ formationFormData: createEmptyFormationFormData() }),
     });
     renderComponent({ business });
-    fireEvent.click(screen.getByTestId("stepper-1"));
-    expect(screen.getByTestId("eligibility-tab")).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("tab")[1]);
+    expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-    selectValueByLabel("Tax clearance certificate requesting agency", "newJerseyBoardOfPublicUtilities");
+    selectListBoxValueByLabel(
+      "Tax clearance certificate requesting agency",
+      LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name
+    );
     fillText("Business name", "Test Name");
     fillText("Address line1", "123 Test Road");
     fillText("Address line2", "Test Line 2");
     fillText("Address city", "Baltimore");
 
-    selectValueByTestId("addressState", "MD");
+    selectComboBoxValueByText("Address state", "MD");
     fillText("Address zip code", "21210");
     fillText("Tax id", "012345678901");
     fillText("Tax pin", "1234");
@@ -415,22 +421,25 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
       formationData: generateFormationData({ formationFormData: createEmptyFormationFormData() }),
     });
     renderComponent({ business });
-    fireEvent.click(screen.getByTestId("stepper-1"));
-    expect(screen.getByTestId("eligibility-tab")).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("tab")[1]);
+    expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-    selectValueByLabel("Tax clearance certificate requesting agency", "newJerseyBoardOfPublicUtilities");
+    selectListBoxValueByLabel(
+      "Tax clearance certificate requesting agency",
+      LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name
+    );
     fillText("Business name", "Test Name");
     fillText("Address line1", "123 Test Road");
     fillText("Address line2", "Test Line 2");
     fillText("Address city", "Baltimore");
 
-    selectValueByTestId("addressState", "MD");
+    selectComboBoxValueByText("Address state", "MD");
     fillText("Address zip code", "21210");
     fillText("Tax id", "012345678901");
     fillText("Tax pin", "1234");
 
-    fireEvent.click(screen.getByTestId("stepper-2"));
-    expect(screen.getByTestId("review-tab")).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("tab")[2]);
+    expect(screen.getAllByRole("tab")[2]).toHaveAttribute("aria-selected", "true");
     expect(currentBusiness().taxClearanceCertificateData).toEqual({
       requestingAgencyId: "newJerseyBoardOfPublicUtilities",
       businessName: "Test Name",
@@ -451,11 +460,12 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
       formationData: generateFormationData({ formationFormData: createEmptyFormationFormData() }),
     });
     renderComponent({ business });
-    fireEvent.click(screen.getByTestId("stepper-2"));
-    expect(screen.getByTestId("review-tab")).toBeInTheDocument();
-    expect(
-      within(screen.getByTestId("review-tab")).getByText(Config.taxClearanceCertificateStep3.mainTitleHeader)
-    ).toBeInTheDocument();
+    const reviewTab = screen.getAllByRole("tab")[2];
+    fireEvent.click(reviewTab);
+    expect(reviewTab).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      Config.taxClearanceCertificateStep3.mainTitleHeader
+    );
   });
 
   describe("renders user selected data on review tab", () => {
@@ -467,10 +477,10 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
         formationData: generateFormationData({ formationFormData: createEmptyFormationFormData() }),
       });
       renderComponent({ business });
-      fireEvent.click(screen.getByTestId("stepper-1"));
-      expect(screen.getByTestId("eligibility-tab")).toBeInTheDocument();
-      fireEvent.click(screen.getByTestId("stepper-2"));
-      expect(screen.getByTestId("review-tab")).toBeInTheDocument();
+      fireEvent.click(screen.getAllByRole("tab")[1]);
+      expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
+      fireEvent.click(screen.getAllByRole("tab")[2]);
+      expect(screen.getAllByRole("tab")[2]).toHaveAttribute("aria-selected", "true");
 
       expect(within(screen.getByTestId("requestingAgencyId")).getByText(notStartedText)).toBeInTheDocument();
       expect(within(screen.getByTestId("businessName")).getByText(notStartedText)).toBeInTheDocument();
@@ -487,17 +497,20 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
         formationData: generateFormationData({ formationFormData: createEmptyFormationFormData() }),
       });
       renderComponent({ business });
-      fireEvent.click(screen.getByTestId("stepper-1"));
-      expect(screen.getByTestId("eligibility-tab")).toBeInTheDocument();
+      fireEvent.click(screen.getAllByRole("tab")[1]);
+      expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectValueByLabel("Tax clearance certificate requesting agency", "newJerseyBoardOfPublicUtilities");
+      selectListBoxValueByLabel(
+        "Tax clearance certificate requesting agency",
+        LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name
+      );
       fillText("Address line2", "Test Line 2");
       fillText("Address city", "Baltimore");
 
-      selectValueByTestId("addressState", "MD");
+      selectComboBoxValueByText("Address state", "MD");
       fillText("Address zip code", "21210");
-      fireEvent.click(screen.getByTestId("stepper-2"));
-      expect(screen.getByTestId("review-tab")).toBeInTheDocument();
+      fireEvent.click(screen.getAllByRole("tab")[2]);
+      expect(screen.getAllByRole("tab")[2]).toHaveAttribute("aria-selected", "true");
 
       expect(within(screen.getByTestId("addressLabel")).getByText(notStartedText)).toBeInTheDocument();
     });
@@ -510,17 +523,20 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
         formationData: generateFormationData({ formationFormData: createEmptyFormationFormData() }),
       });
       renderComponent({ business });
-      fireEvent.click(screen.getByTestId("stepper-1"));
-      expect(screen.getByTestId("eligibility-tab")).toBeInTheDocument();
+      fireEvent.click(screen.getAllByRole("tab")[1]);
+      expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectValueByLabel("Tax clearance certificate requesting agency", "newJerseyBoardOfPublicUtilities");
+      selectListBoxValueByLabel(
+        "Tax clearance certificate requesting agency",
+        LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name
+      );
       fillText("Address line1", "123 Test Road");
       fillText("Address line2", "Test Line 2");
 
-      selectValueByTestId("addressState", "MD");
+      selectComboBoxValueByText("Address state", "MD");
       fillText("Address zip code", "21210");
-      fireEvent.click(screen.getByTestId("stepper-2"));
-      expect(screen.getByTestId("review-tab")).toBeInTheDocument();
+      fireEvent.click(screen.getAllByRole("tab")[2]);
+      expect(screen.getAllByRole("tab")[2]).toHaveAttribute("aria-selected", "true");
 
       expect(within(screen.getByTestId("addressLabel")).getByText(notStartedText)).toBeInTheDocument();
     });
@@ -533,16 +549,19 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
         formationData: generateFormationData({ formationFormData: createEmptyFormationFormData() }),
       });
       renderComponent({ business });
-      fireEvent.click(screen.getByTestId("stepper-1"));
-      expect(screen.getByTestId("eligibility-tab")).toBeInTheDocument();
+      fireEvent.click(screen.getAllByRole("tab")[1]);
+      expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectValueByLabel("Tax clearance certificate requesting agency", "newJerseyBoardOfPublicUtilities");
+      selectListBoxValueByLabel(
+        "Tax clearance certificate requesting agency",
+        LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name
+      );
       fillText("Address line1", "123 Test Road");
       fillText("Address line2", "Test Line 2");
       fillText("Address city", "Baltimore");
       fillText("Address zip code", "21210");
-      fireEvent.click(screen.getByTestId("stepper-2"));
-      expect(screen.getByTestId("review-tab")).toBeInTheDocument();
+      fireEvent.click(screen.getAllByRole("tab")[2]);
+      expect(screen.getAllByRole("tab")[2]).toHaveAttribute("aria-selected", "true");
 
       expect(within(screen.getByTestId("addressLabel")).getByText(notStartedText)).toBeInTheDocument();
     });
@@ -555,16 +574,19 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
         formationData: generateFormationData({ formationFormData: createEmptyFormationFormData() }),
       });
       renderComponent({ business });
-      fireEvent.click(screen.getByTestId("stepper-1"));
-      expect(screen.getByTestId("eligibility-tab")).toBeInTheDocument();
+      fireEvent.click(screen.getAllByRole("tab")[1]);
+      expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectValueByLabel("Tax clearance certificate requesting agency", "newJerseyBoardOfPublicUtilities");
+      selectListBoxValueByLabel(
+        "Tax clearance certificate requesting agency",
+        LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name
+      );
       fillText("Address line1", "123 Test Road");
       fillText("Address line2", "Test Line 2");
       fillText("Address city", "Baltimore");
-      selectValueByTestId("addressState", "MD");
-      fireEvent.click(screen.getByTestId("stepper-2"));
-      expect(screen.getByTestId("review-tab")).toBeInTheDocument();
+      selectComboBoxValueByText("Address state", "MD");
+      fireEvent.click(screen.getAllByRole("tab")[2]);
+      expect(screen.getAllByRole("tab")[2]).toHaveAttribute("aria-selected", "true");
 
       expect(within(screen.getByTestId("addressLabel")).getByText(notStartedText)).toBeInTheDocument();
     });
@@ -576,17 +598,20 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
         formationData: generateFormationData({ formationFormData: createEmptyFormationFormData() }),
       });
       renderComponent({ business });
-      fireEvent.click(screen.getByTestId("stepper-1"));
-      expect(screen.getByTestId("eligibility-tab")).toBeInTheDocument();
+      fireEvent.click(screen.getAllByRole("tab")[1]);
+      expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectValueByLabel("Tax clearance certificate requesting agency", "newJerseyBoardOfPublicUtilities");
+      selectListBoxValueByLabel(
+        "Tax clearance certificate requesting agency",
+        LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name
+      );
       fillText("Address line1", "123 Test Road");
       fillText("Address city", "Baltimore");
 
-      selectValueByTestId("addressState", "MD");
+      selectComboBoxValueByText("Address state", "MD");
       fillText("Address zip code", "21210");
-      fireEvent.click(screen.getByTestId("stepper-2"));
-      expect(screen.getByTestId("review-tab")).toBeInTheDocument();
+      fireEvent.click(screen.getAllByRole("tab")[2]);
+      expect(screen.getAllByRole("tab")[2]).toHaveAttribute("aria-selected", "true");
 
       const address = formatAddress({
         addressLine1: "123 Test Road",
@@ -607,17 +632,20 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
         formationData: generateFormationData({ formationFormData: createEmptyFormationFormData() }),
       });
       renderComponent({ business });
-      fireEvent.click(screen.getByTestId("stepper-1"));
-      expect(screen.getByTestId("eligibility-tab")).toBeInTheDocument();
+      fireEvent.click(screen.getAllByRole("tab")[1]);
+      expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectValueByLabel("Tax clearance certificate requesting agency", "newJerseyBoardOfPublicUtilities");
+      selectListBoxValueByLabel(
+        "Tax clearance certificate requesting agency",
+        LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name
+      );
       fillText("Business name", "Test Name");
       fillText("Entity id", "1234567890");
       fillText("Address line1", "123 Test Road");
       fillText("Address line2", "Test Line 2");
       fillText("Address city", "Baltimore");
 
-      selectValueByTestId("addressState", "MD");
+      selectComboBoxValueByText("Address state", "MD");
       fillText("Address zip code", "21210");
       fillText("Tax id", "012345678901");
       fillText("Tax pin", "1234");
@@ -630,8 +658,8 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
         addressZipCode: "21210",
       });
 
-      fireEvent.click(screen.getByTestId("stepper-2"));
-      expect(screen.getByTestId("review-tab")).toBeInTheDocument();
+      fireEvent.click(screen.getAllByRole("tab")[2]);
+      expect(screen.getAllByRole("tab")[2]).toHaveAttribute("aria-selected", "true");
 
       expect(
         within(screen.getByTestId("requestingAgencyId")).getByText(
@@ -655,9 +683,12 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
     const business = generateBusiness({ id: "Faraz" });
     const userData = generateUserDataForBusiness(business);
     renderComponent({ userData });
-    fireEvent.click(screen.getByTestId("stepper-2"));
-    expect(screen.getByTestId("review-tab")).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("next-button"));
+    fireEvent.click(screen.getAllByRole("tab")[2]);
+    expect(screen.getAllByRole("tab")[2]).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: Config.taxClearanceCertificateShared.saveButtonText })
+    );
     await waitFor(() => {
       expect(mockApi.postTaxClearanceCertificate).toHaveBeenCalledWith(userData);
     });
@@ -672,11 +703,14 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
       certificatePdfArray: [],
     });
     renderComponent({});
-    fireEvent.click(screen.getByTestId("stepper-2"));
-    fireEvent.click(screen.getByTestId("next-button"));
-
+    fireEvent.click(screen.getAllByRole("tab")[2]);
+    fireEvent.click(
+      screen.getByRole("button", { name: Config.taxClearanceCertificateShared.saveButtonText })
+    );
     await waitFor(() => {
-      expect(screen.getByTestId("download-page")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+        Config.taxClearanceCertificateDownload.headerTwoLabel
+      );
     });
     expect(mockCreateObjectURL).toHaveBeenLastCalledWith(expect.any(Blob));
     expect(screen.getByRole("link", { name: "Tax Clearance Certificate (PDF)" })).toHaveAttribute(
@@ -694,18 +728,18 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
     fireEvent.blur(screen.getByLabelText(label));
   };
 
-  const selectValueByTestId = (dataTestId: string, value: string): void => {
-    fireEvent.click(screen.getByTestId(dataTestId));
+  const selectComboBoxValueByText = (inputAriaLabel: string, value: string): void => {
+    fireEvent.click(screen.getByRole("combobox", { name: inputAriaLabel }));
     expect(screen.getByRole("listbox")).toBeInTheDocument();
     const listbox = within(screen.getByRole("listbox"));
-    fireEvent.click(listbox.getByTestId(value));
+    fireEvent.click(listbox.getByText(value));
   };
 
-  const selectValueByLabel = (label: string, value: string): void => {
+  const selectListBoxValueByLabel = (label: string, value: string): void => {
     expect(screen.getByLabelText(label)).toBeInTheDocument();
     fireEvent.mouseDown(screen.getByLabelText(label));
     expect(screen.getByRole("listbox")).toBeInTheDocument();
     const listbox = within(screen.getByRole("listbox"));
-    fireEvent.click(listbox.getByTestId(value));
+    fireEvent.click(listbox.getByText(value));
   };
 });

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateElement.test.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateElement.test.tsx
@@ -376,7 +376,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
     });
   });
 
-  it("saves userData when save and continue button is clicked on tab two", () => {
+  it("saves userData when save and continue button is clicked on tab two", async () => {
     const business = generateBusiness({
       taxClearanceCertificateData: undefined,
       profileData: emptyProfileData,
@@ -386,7 +386,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
     fireEvent.click(screen.getAllByRole("tab")[1]);
     expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-    selectListBoxValueByLabel(
+    await selectListBoxValueByLabel(
       "Tax clearance certificate requesting agency",
       LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name
     );
@@ -414,7 +414,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
     });
   });
 
-  it("saves userData when clicking from tab two to tab three", () => {
+  it("saves userData when clicking from tab two to tab three", async () => {
     const business = generateBusiness({
       taxClearanceCertificateData: undefined,
       profileData: emptyProfileData,
@@ -424,7 +424,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
     fireEvent.click(screen.getAllByRole("tab")[1]);
     expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-    selectListBoxValueByLabel(
+    await selectListBoxValueByLabel(
       "Tax clearance certificate requesting agency",
       LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name
     );
@@ -489,7 +489,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
       expect(within(screen.getByTestId("taxPinLabel")).getByText(notStartedText)).toBeInTheDocument();
     });
 
-    it("renders not started text when addressLine1 is not filled out", () => {
+    it("renders not started text when addressLine1 is not filled out", async () => {
       const notStartedText = Config.formation.general.notEntered;
       const business = generateBusiness({
         taxClearanceCertificateData: undefined,
@@ -500,7 +500,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
       fireEvent.click(screen.getAllByRole("tab")[1]);
       expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectListBoxValueByLabel(
+      await selectListBoxValueByLabel(
         "Tax clearance certificate requesting agency",
         LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name
       );
@@ -515,7 +515,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
       expect(within(screen.getByTestId("addressLabel")).getByText(notStartedText)).toBeInTheDocument();
     });
 
-    it("renders not started text when address city is not filled out", () => {
+    it("renders not started text when address city is not filled out", async () => {
       const notStartedText = Config.formation.general.notEntered;
       const business = generateBusiness({
         taxClearanceCertificateData: undefined,
@@ -526,7 +526,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
       fireEvent.click(screen.getAllByRole("tab")[1]);
       expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectListBoxValueByLabel(
+      await selectListBoxValueByLabel(
         "Tax clearance certificate requesting agency",
         LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name
       );
@@ -541,7 +541,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
       expect(within(screen.getByTestId("addressLabel")).getByText(notStartedText)).toBeInTheDocument();
     });
 
-    it("renders not started text when addressState is not filled out", () => {
+    it("renders not started text when addressState is not filled out", async () => {
       const notStartedText = Config.formation.general.notEntered;
       const business = generateBusiness({
         taxClearanceCertificateData: undefined,
@@ -552,7 +552,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
       fireEvent.click(screen.getAllByRole("tab")[1]);
       expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectListBoxValueByLabel(
+      await selectListBoxValueByLabel(
         "Tax clearance certificate requesting agency",
         LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name
       );
@@ -566,7 +566,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
       expect(within(screen.getByTestId("addressLabel")).getByText(notStartedText)).toBeInTheDocument();
     });
 
-    it("renders not started text when address zip code is not filled out", () => {
+    it("renders not started text when address zip code is not filled out", async () => {
       const notStartedText = Config.formation.general.notEntered;
       const business = generateBusiness({
         taxClearanceCertificateData: undefined,
@@ -577,7 +577,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
       fireEvent.click(screen.getAllByRole("tab")[1]);
       expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectListBoxValueByLabel(
+      await selectListBoxValueByLabel(
         "Tax clearance certificate requesting agency",
         LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name
       );
@@ -591,7 +591,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
       expect(within(screen.getByTestId("addressLabel")).getByText(notStartedText)).toBeInTheDocument();
     });
 
-    it("renders formatted address when everything except addressLine2 is filled out", () => {
+    it("renders formatted address when everything except addressLine2 is filled out", async () => {
       const business = generateBusiness({
         taxClearanceCertificateData: undefined,
         profileData: emptyProfileData,
@@ -601,7 +601,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
       fireEvent.click(screen.getAllByRole("tab")[1]);
       expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectListBoxValueByLabel(
+      await selectListBoxValueByLabel(
         "Tax clearance certificate requesting agency",
         LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name
       );
@@ -623,7 +623,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
       expect(within(screen.getByTestId("addressLabel")).getByText(address)).toBeInTheDocument();
     });
 
-    it("renders requesting agency text when all input is valid", () => {
+    it("renders requesting agency text when all input is valid", async () => {
       const business = generateBusiness({
         taxClearanceCertificateData: generateTaxClearanceCertificateData({
           requestingAgencyId: undefined,
@@ -635,7 +635,7 @@ describe("<AnyTimeActionTaxClearanceCertificateReviewElement />", () => {
       fireEvent.click(screen.getAllByRole("tab")[1]);
       expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectListBoxValueByLabel(
+      await selectListBoxValueByLabel(
         "Tax clearance certificate requesting agency",
         LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name
       );

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateElement.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateElement.tsx
@@ -169,7 +169,7 @@ export const AnytimeActionTaxClearanceCertificateElement = (props: Props): React
               onBack: (): void => {},
             }}
           >
-            <div className="min-height-38rem" data-testid="AnytimeActionTaxClearanceCertificateElement">
+            <div className="min-height-38rem">
               <div className="bg-base-extra-light margin-x-neg-4 margin-top-neg-4 radius-top-lg">
                 <div className="padding-y-4 margin-x-4 margin-bottom-2">
                   <Heading level={1}>{props.anytimeAction.name}</Heading>

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceDownload.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceDownload.tsx
@@ -15,7 +15,7 @@ export const TaxClearanceDownload = (props: Props): ReactElement => {
 
   return (
     <>
-      <div className="margin-y-3 margin-x-6" data-testid="download-page">
+      <div className="margin-y-3 margin-x-6">
         <div className="fdc fac ">
           <div className={"margin-top-3 margin-bottom-5"}>
             <img src={`/img/trophy-illustration.svg`} alt="" />

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceStepOne.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceStepOne.tsx
@@ -15,27 +15,25 @@ export const TaxClearanceStepOne = (props: Props): ReactElement => {
 
   return (
     <>
-      <div data-testid={"requirements-tab"}>
-        <Content>{Config.taxClearanceCertificateStep1.content}</Content>
-        <HorizontalLine />
-        <span className="h5-styling">{Config.taxClearanceCertificateStep1.issuingAgencyLabelText}: </span>
-        <span className="h6-styling">{Config.taxClearanceCertificateStep1.issuingAgencyText}</span>
-        <CtaContainer>
-          <ActionBarLayout>
-            <LiveChatHelpButton />
-            <PrimaryButton
-              isColor="primary"
-              onClick={(): void => {
-                props.setStepIndex(1);
-              }}
-              dataTestId="cta-primary-1"
-              isRightMarginRemoved={true}
-            >
-              {Config.taxClearanceCertificateStep1.continueButtonText}
-            </PrimaryButton>
-          </ActionBarLayout>
-        </CtaContainer>
-      </div>
+      <Content>{Config.taxClearanceCertificateStep1.content}</Content>
+      <HorizontalLine />
+      <span className="h5-styling">{Config.taxClearanceCertificateStep1.issuingAgencyLabelText}: </span>
+      <span className="h6-styling">{Config.taxClearanceCertificateStep1.issuingAgencyText}</span>
+      <CtaContainer>
+        <ActionBarLayout>
+          <LiveChatHelpButton />
+          <PrimaryButton
+            isColor="primary"
+            onClick={(): void => {
+              props.setStepIndex(1);
+            }}
+            dataTestId="cta-primary-1"
+            isRightMarginRemoved={true}
+          >
+            {Config.taxClearanceCertificateStep1.continueButtonText}
+          </PrimaryButton>
+        </ActionBarLayout>
+      </CtaContainer>
     </>
   );
 };

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceStepThree.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceStepThree.tsx
@@ -67,74 +67,72 @@ export const TaxClearanceStepThree = (props: Props): ReactElement => {
 
   return (
     <>
-      <div data-testid={"review-tab"}>
-        <ReviewSection
-          headingText={Config.taxClearanceCertificateStep3.mainTitleHeader}
-          editHandleButtonClick={() => props.setStepIndex(1)}
-          disableHorizontalLine
+      <ReviewSection
+        headingText={Config.taxClearanceCertificateStep3.mainTitleHeader}
+        editHandleButtonClick={() => props.setStepIndex(1)}
+        disableHorizontalLine
+      >
+        <ReviewSubSection
+          header={Config.taxClearanceCertificateStep3.firstSectionHeader}
+          marginOverride="margin-top-0"
         >
-          <ReviewSubSection
-            header={Config.taxClearanceCertificateStep3.firstSectionHeader}
-            marginOverride="margin-top-0"
-          >
-            <ReviewLineItem
-              label={Config.taxClearanceCertificateStep3.certificationReasonLabel}
-              value={requestingAgencyName}
-              dataTestId={"requestingAgencyId"}
-              noColonAfterLabel
-            />
-          </ReviewSubSection>
-          <hr className={"margin-y-3-override"} />
-          <ReviewSubSection
-            header={Config.taxClearanceCertificateStep3.secondSectionHeader}
-            marginOverride="margin-top-0"
-          >
-            <ReviewLineItem
-              label={Config.taxClearanceCertificateStep3.businessNameLabel}
-              value={business?.taxClearanceCertificateData?.businessName}
-              dataTestId={"businessName"}
-            />
-            <ReviewLineItem
-              label={Config.taxClearanceCertificateStep3.addressLabel}
-              value={addressValue}
-              dataTestId={"addressLabel"}
-            />
-            <ReviewLineItem
-              label={Config.taxClearanceCertificateStep3.stateTaxIdLabel}
-              value={business?.taxClearanceCertificateData?.taxId}
-              dataTestId={"stateTaxIdLabel"}
-            />
-            <ReviewLineItem
-              label={Config.taxClearanceCertificateStep3.taxPinLabel}
-              value={business?.taxClearanceCertificateData?.taxPin}
-              dataTestId={"taxPinLabel"}
-            />
-          </ReviewSubSection>
-        </ReviewSection>
-        <div className="margin-top-5">
-          <CtaContainer>
-            <ActionBarLayout>
-              <LiveChatHelpButton />
-              <div className="margin-top-2 mobile-lg:margin-top-0">
-                <SecondaryButton
-                  isColor="primary"
-                  onClick={() => props.setStepIndex(1)}
-                  dataTestId="previous-button"
-                >
-                  {Config.taxClearanceCertificateShared.backButtonText}
-                </SecondaryButton>
-              </div>
-              <PrimaryButton
+          <ReviewLineItem
+            label={Config.taxClearanceCertificateStep3.certificationReasonLabel}
+            value={requestingAgencyName}
+            dataTestId={"requestingAgencyId"}
+            noColonAfterLabel
+          />
+        </ReviewSubSection>
+        <hr className={"margin-y-3-override"} />
+        <ReviewSubSection
+          header={Config.taxClearanceCertificateStep3.secondSectionHeader}
+          marginOverride="margin-top-0"
+        >
+          <ReviewLineItem
+            label={Config.taxClearanceCertificateStep3.businessNameLabel}
+            value={business?.taxClearanceCertificateData?.businessName}
+            dataTestId={"businessName"}
+          />
+          <ReviewLineItem
+            label={Config.taxClearanceCertificateStep3.addressLabel}
+            value={addressValue}
+            dataTestId={"addressLabel"}
+          />
+          <ReviewLineItem
+            label={Config.taxClearanceCertificateStep3.stateTaxIdLabel}
+            value={business?.taxClearanceCertificateData?.taxId}
+            dataTestId={"stateTaxIdLabel"}
+          />
+          <ReviewLineItem
+            label={Config.taxClearanceCertificateStep3.taxPinLabel}
+            value={business?.taxClearanceCertificateData?.taxPin}
+            dataTestId={"taxPinLabel"}
+          />
+        </ReviewSubSection>
+      </ReviewSection>
+      <div className="margin-top-5">
+        <CtaContainer>
+          <ActionBarLayout>
+            <LiveChatHelpButton />
+            <div className="margin-top-2 mobile-lg:margin-top-0">
+              <SecondaryButton
                 isColor="primary"
-                onClick={handleButtonClick}
-                isRightMarginRemoved={true}
-                dataTestId="next-button"
+                onClick={() => props.setStepIndex(1)}
+                dataTestId="previous-button"
               >
-                {Config.taxClearanceCertificateShared.saveButtonText}
-              </PrimaryButton>
-            </ActionBarLayout>
-          </CtaContainer>
-        </div>
+                {Config.taxClearanceCertificateShared.backButtonText}
+              </SecondaryButton>
+            </div>
+            <PrimaryButton
+              isColor="primary"
+              onClick={handleButtonClick}
+              isRightMarginRemoved={true}
+              dataTestId="next-button"
+            >
+              {Config.taxClearanceCertificateShared.saveButtonText}
+            </PrimaryButton>
+          </ActionBarLayout>
+        </CtaContainer>
       </div>
     </>
   );

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceStepTwo.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceStepTwo.tsx
@@ -31,7 +31,7 @@ export const TaxClearanceStepTwo = (props: Props): ReactElement => {
 
   return (
     <>
-      <div data-testid={"eligibility-tab"}>
+      <div>
         <Heading level={2} styleVariant={"h3"}>
           {Config.taxClearanceCertificateStep2.requestingAgencySectionHeader}
         </Heading>
@@ -67,20 +67,11 @@ export const TaxClearanceStepTwo = (props: Props): ReactElement => {
         <ActionBarLayout>
           <LiveChatHelpButton />
           <div className="margin-top-2 mobile-lg:margin-top-0">
-            <SecondaryButton
-              isColor="primary"
-              onClick={() => props.setStepIndex(0)}
-              dataTestId="previous-button"
-            >
+            <SecondaryButton isColor="primary" onClick={() => props.setStepIndex(0)}>
               {Config.taxClearanceCertificateShared.backButtonText}
             </SecondaryButton>
           </div>
-          <PrimaryButton
-            isColor="primary"
-            onClick={handleSaveButtonClick}
-            isRightMarginRemoved={true}
-            dataTestId="next-button"
-          >
+          <PrimaryButton isColor="primary" onClick={handleSaveButtonClick} isRightMarginRemoved={true}>
             {Config.taxClearanceCertificateShared.saveButtonText}
           </PrimaryButton>
         </ActionBarLayout>


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#13772](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13772).

### Approach

This PR refactors the Tax Clearance Certificate test to replace data-testid usage with more accessible queries using getByRole, wherever applicable.
	•	Replaced data-testid selectors with getByRole or similar accessible queries.
	•	Updated relevant helper functions to support this transition.
	•	In areas like the Review page, where content updates dynamically and no semantic tags are available (e.g. just <div>s), data-testid usage is retained — which is the recommended practice for dynamic text blocks.
	•	Within the HorizontalStepper component, used getAllByRole("tab") to interact with the stepper tabs.
	•	⚠️ Note: This component currently has an incorrect aria-label, causing all steppers to reference “Formation Stepper Navigation”. A separate [bug ticket](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13984) has been created and prioritized to address this.
	
Note: I also replaced fireEvent with userEvent.
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
