### PR TITLE
chore: [AB#0000] add warning to existing ts disable usages

### DIFF
--- a/api/src/db/dynamoUserDataMigration.test.ts
+++ b/api/src/db/dynamoUserDataMigration.test.ts
@@ -1,3 +1,4 @@
+// We should try not to do this; if you do need to disable typescript please include a comment justifying why.
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-var-requires */

--- a/web/cypress/e2e/dashboard.spec.ts
+++ b/web/cypress/e2e/dashboard.spec.ts
@@ -25,6 +25,7 @@ describe("Dashboard [feature] [all] [group2]", () => {
       if (Cypress._.isArray(size)) {
         cy.viewport(size[0], size[1]);
       } else {
+        // We should try not to do this; if you do need to disable typescript please include a comment justifying why.
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         cy.viewport(size);

--- a/web/src/components/njwds-extended/FileInput.tsx
+++ b/web/src/components/njwds-extended/FileInput.tsx
@@ -149,6 +149,7 @@ export const FileInput = ({
       if (fileInputElement) {
         dT.items.add(file);
         fileInputElement.files = dT.files;
+        // We should try not to do this; if you do need to disable typescript please include a comment justifying why.
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         fileInputElement.dispatchEvent(new Event("change", { target: { files: [file] } }));

--- a/web/src/components/profile/ProfileErrorAlert.tsx
+++ b/web/src/components/profile/ProfileErrorAlert.tsx
@@ -15,6 +15,7 @@ export const ProfileErrorAlert = (props: Props): ReactElement | null => {
   const displayProfileErrorAlert = (): boolean => props.fieldErrors.length > 0;
 
   const getLabel = (field: string): string => {
+    // We should try not to do this; if you do need to disable typescript please include a comment justifying why.
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     const formationLabel = Config.formation.fields[field]?.label;

--- a/web/src/lib/auth/sessionHelper.ts
+++ b/web/src/lib/auth/sessionHelper.ts
@@ -84,6 +84,7 @@ export const triggerSignOut = async (): Promise<void> => {
 };
 
 export const triggerSignIn = async (): Promise<void> => {
+  // We should try not to do this; if you do need to disable typescript please include a comment justifying why.
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   configureAmplify();

--- a/web/src/lib/static/admin/findDeadLinks.test.ts
+++ b/web/src/lib/static/admin/findDeadLinks.test.ts
@@ -1,3 +1,4 @@
+// We should try not to do this; if you do need to disable typescript please include a comment justifying why.
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 

--- a/web/src/lib/static/mockHelpers.ts
+++ b/web/src/lib/static/mockHelpers.ts
@@ -7,6 +7,7 @@ export const mockReadDirReturn = ({
   value: string[];
   mockedFs: jest.Mocked<typeof fs>;
 }): void => {
+  // We should try not to do this; if you do need to disable typescript please include a comment justifying why.
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   mockedFs.readdirSync.mockReturnValue(value);
@@ -18,6 +19,7 @@ export const mockReadDirReturnOnce = ({
   value: string[];
   mockedFs: jest.Mocked<typeof fs>;
 }): void => {
+  // We should try not to do this; if you do need to disable typescript please include a comment justifying why.
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   mockedFs.readdirSync.mockReturnValueOnce(value);

--- a/web/src/pages/account-setup.tsx
+++ b/web/src/pages/account-setup.tsx
@@ -91,6 +91,7 @@ const AccountSetupPage = (): ReactElement => {
     }
   }, [router]);
 
+  // We should try not to do this; if you do need to disable typescript please include a comment justifying why.
   /* eslint-disable @typescript-eslint/ban-ts-comment */
   const parseAndSendAnalyticsEvent = (source: string): void => {
     const possibleAnalyticsEvents = Object.keys(analytics.event);

--- a/web/test/pages/cms.test.tsx
+++ b/web/test/pages/cms.test.tsx
@@ -13,6 +13,7 @@ describe("cms", () => {
         "utf8"
       );
 
+      // We should try not to do this; if you do need to disable typescript please include a comment justifying why.
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       const mergedConfig = getMergedConfig().default;


### PR DESCRIPTION
## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

Existing usages of `ban-ts` without justifying comments seem to have facilitated unintentional propagation of disables in the codebase, see [this discussion](https://njcio.slack.com/archives/C04J8MTJNS2/p1745266548347089?thread_ts=1745266544.420649&cid=C04J8MTJNS2). Added comments to existing usages as a warning not to propagate.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#0000](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
