### PR TITLE
chore: [AB#12854] split yaml into multiple files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ web/fundings.csv
 # Python
 .venv/
 **/__pycache__/
+
+# yaml file generated from yarn build
+web/public/mgmt/config.yml

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "build": "yarn verify:node && yarn workspaces foreach -ptvi run build",
+    "build": "yarn verify:node && yarn decap:build-config && yarn workspaces foreach -ptvi run build",
     "build:clean": "yarn clean && yarn build",
     "clean": "yarn workspaces foreach -v run clean",
     "cms:proxy": "yarn dlx decap-server",
+    "decap:build-config": "yarn prettier:yamlInput && yarn dlx tsx scripts/merge-decap-config.ts && yarn prettier:yamlOutput",
     "dependency-check": "yarn workspaces foreach -v run dependency-check",
     "dynamo": "DYNAMO_ENDPOINT=http://localhost:8000 dynamodb-admin",
     "invokeNewsletter": "yarn workspace @businessnjgovnavigator/api invokeNewsletter",
@@ -17,6 +18,8 @@
     "lint:staged": "lint-staged",
     "prepare": "husky",
     "prettier": "prettier --write . --ignore-path=./.eslintignore",
+    "prettier:yamlInput": "prettier -w \"web/decap-config/**/*.{yml,yaml}\"",
+    "prettier:yamlOutput": "prettier -w web/public/mgmt/config.yml",
     "prettier:check": "prettier --check . --ignore-path=./.eslintignore",
     "spellcheck": "yarn workspaces foreach -v run spellcheck",
     "start:dev": "yarn workspaces foreach -ptvi run dev",
@@ -252,7 +255,7 @@
       "eslint --fix",
       "prettier --write"
     ],
-    "*.{css,md,scss,yml}": "prettier --write"
+    "*.{css,md,scss,yml,yaml}": "prettier --write"
   },
   "release": {
     "baseBranch": "main",

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -2,6 +2,14 @@
 const config = {
   printWidth: 110,
   endOfLine: "auto",
+  overrides: [
+    {
+      files: ["*.yml", "*.yaml"],
+      options: {
+        singleQuote: false,
+      },
+    },
+  ],
 };
 
 export default config;

--- a/scripts/merge-decap-config.ts
+++ b/scripts/merge-decap-config.ts
@@ -1,0 +1,38 @@
+import * as fs from "fs";
+import * as yaml from "js-yaml";
+import * as path from "path";
+
+const baseConfigPath = "web/decap-config/config-base.yml";
+const collectionsDir = "web/decap-config/collections";
+const outputPath = "web/public/mgmt/config.yml";
+
+interface CollectionEntry {
+  name: string;
+  [key: string]: unknown;
+}
+
+interface DecapConfig {
+  [key: string]: unknown;
+  collections?: CollectionEntry[];
+}
+
+// Load base config
+const base = yaml.load(fs.readFileSync(baseConfigPath, "utf8")) as DecapConfig;
+
+// Merge all collections
+const files = fs.readdirSync(collectionsDir).filter((f) => f.endsWith(".yml"));
+const collections: CollectionEntry[] = files.flatMap((file) => {
+  const fullPath = path.join(collectionsDir, file);
+  const content = yaml.load(fs.readFileSync(fullPath, "utf8")) as {
+    collections?: CollectionEntry[];
+  };
+  return content.collections || [];
+});
+
+base.collections = collections;
+
+// Output merged config with double quotes
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, yaml.dump(base), "utf8");
+
+console.log(`✅ Decap CMS config built: ${outputPath}`);

--- a/web/decap-config/collections/00_allCollections.yml
+++ b/web/decap-config/collections/00_allCollections.yml
@@ -1,24 +1,3 @@
-backend:
-  name: github
-  repo: newjersey/navigator.business.nj.gov
-  branch: content-repo
-  base_url: https://522jjs5e28.execute-api.us-east-1.amazonaws.com
-  auth_endpoint: /dev/api/cms/auth
-  use_graphql: true
-  squash_merges: true
-  commit_messages:
-    create: "chore: creating {{collection}} {{slug}}"
-    update: "chore: updating {{collection}} {{slug}}"
-publish_mode: editorial_workflow
-local_backend: true
-media_folder: web/public/img
-logo_url: https://dev.navigator.business.nj.gov/img/Navigator-logo.svg
-public_folder: web/public
-slug:
-  encoding: "ascii"
-  clean_accents: true
-  sanitize_replacement: "_"
-
 collections:
   - name: "business-formation-label"
     label: "🟥 BUSINESS FORMATION"

--- a/web/decap-config/config-base.yml
+++ b/web/decap-config/config-base.yml
@@ -1,0 +1,20 @@
+backend:
+  name: github
+  repo: newjersey/navigator.business.nj.gov
+  branch: content-repo
+  base_url: https://522jjs5e28.execute-api.us-east-1.amazonaws.com
+  auth_endpoint: /dev/api/cms/auth
+  use_graphql: true
+  squash_merges: true
+  commit_messages:
+    create: "chore: creating {{collection}} {{slug}}"
+    update: "chore: updating {{collection}} {{slug}}"
+publish_mode: editorial_workflow
+local_backend: true
+media_folder: web/public/img
+logo_url: https://dev.navigator.business.nj.gov/img/Navigator-logo.svg
+public_folder: web/public
+slug:
+  encoding: "ascii"
+  clean_accents: true
+  sanitize_replacement: "_"

--- a/web/package.json
+++ b/web/package.json
@@ -41,7 +41,18 @@
   },
   "prettier": {
     "printWidth": 110,
-    "endOfLine": "auto"
+    "endOfLine": "auto",
+    "overrides": [
+      {
+        "files": [
+          "*.yml",
+          "*.yaml"
+        ],
+        "options": {
+          "singleQuote": false
+        }
+      }
+    ]
   },
   "dependencies": {
     "@aws-crypto/sha256-browser": "5.2.0",


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

NOTE: Before merging, I need to rebase with Main and move everything from the public/config.yml file to the individual .yml files in the decap folder.

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->
https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12854/


### Approach
This PR adds a script that merges YAML config files for the CMS.
	•	It takes a config-base.yaml file and combines it with the .yaml files in the collections/ folder.
	•	The result is a single file: web/public/mgmt/config.yml, which is used by the CMS.

The collection files need to start with a two-digit number like 00 or 01. This controls the order they appear in the CMS sidebar. Without this, the sidebar can show things in a random or confusing order.

We also added Prettier scripts to format:
	1.	The input YAML files
	2.	The final output file

To run everything (merge and format), just run yarn build. This is now part of the regular build process.

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes
I plan to break out the collections into individual files after this commit it in main. This will reduce the risk of unintentionally removing a field.

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
