### PR TITLE
Remove ticket number requirement from pre-commit

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Define the regex pattern for commit messages
-COMMIT_MSG_REGEX="^(fix|feat|chore|docs|style|refactor|test): (\[AB#[0-9]+\] .+|spell check fixes)$"
+COMMIT_MSG_REGEX="^(fix|feat|chore|docs|style|refactor|test): (\[AB#[0-9]+\] )?.+$"
 COMMIT_MSG_FILE="$1"
 COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Removes the requirement to include a ticket number in the commit message.

### Ticket

n/a

### Approach

We have historically allowed engineers to make commits without including a ticket number. This work brings that back.

### Steps to Test

You should be able to make a commit without a ticket ID
EX: `feat: this is my commit`

If you do include a ticket number, we should still enforce the following
EX: `feat: [AB#1234] this is my commit`

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
