### PR TITLE
chore: [AB#7782] Tax Id Prefactor for Tax Pin

### DIFF
--- a/api/src/api/decryptionRouter.test.ts
+++ b/api/src/api/decryptionRouter.test.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { taxDecryptionRouterFactory } from "@api/taxDecryptionRouter";
+import { decryptionRouterFactory } from "@api/decryptionRouter";
 import { EncryptionDecryptionClient } from "@domain/types";
 import { setupExpress } from "@libs/express";
 import { Express } from "express";
 import request from "supertest";
 
-describe("taxDecryptionRouter", () => {
+describe("decryptionRouter", () => {
   let app: Express;
   let stubEncryptionDecryptionClient: jest.Mocked<EncryptionDecryptionClient>;
 
@@ -22,7 +22,7 @@ describe("taxDecryptionRouter", () => {
     };
 
     app = setupExpress(false);
-    app.use(taxDecryptionRouterFactory(stubEncryptionDecryptionClient));
+    app.use(decryptionRouterFactory(stubEncryptionDecryptionClient));
   });
 
   afterAll(async () => {
@@ -32,8 +32,8 @@ describe("taxDecryptionRouter", () => {
   });
 
   describe("/decrypt", () => {
-    it("decrypts tax id", async () => {
-      const response = await request(app).post(`/decrypt`).send({ encryptedTaxId: "sample-value" });
+    it("decrypts value", async () => {
+      const response = await request(app).post(`/decrypt`).send({ encryptedValue: "sample-value" });
       expect(response.body).toEqual("decrypted sample-value");
     });
   });

--- a/api/src/api/decryptionRouter.ts
+++ b/api/src/api/decryptionRouter.ts
@@ -2,16 +2,16 @@ import { EncryptionDecryptionClient } from "@domain/types";
 import { Router } from "express";
 import { StatusCodes } from "http-status-codes";
 
-export const taxDecryptionRouterFactory = (
+export const decryptionRouterFactory = (
   encryptionDecryptionClient: EncryptionDecryptionClient,
 ): Router => {
   const router = Router();
 
   router.post("/decrypt", async (req, res) => {
-    const { encryptedTaxId } = req.body;
+    const { encryptedValue } = req.body;
     try {
-      const plainTextTaxId = await encryptionDecryptionClient.decryptValue(encryptedTaxId);
-      res.json(plainTextTaxId);
+      const plainTextValue = await encryptionDecryptionClient.decryptValue(encryptedValue);
+      res.json(plainTextValue);
     } catch (error) {
       res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ error });
     }

--- a/api/src/client/AwsEncryptionDecryptionFactory.ts
+++ b/api/src/client/AwsEncryptionDecryptionFactory.ts
@@ -21,17 +21,17 @@ export const AWSEncryptionDecryptionFactory = (
 
   const decoder = new TextDecoder();
 
-  const encryptValue = async (plainTextTaxId: string): Promise<string> => {
-    const { result } = await encrypt(keyring, plainTextTaxId, {
+  const encryptValue = async (plainTextValue: string): Promise<string> => {
+    const { result } = await encrypt(keyring, plainTextValue, {
       encryptionContext: context,
     });
-    const base64TaxId = toBase64(result);
-    return base64TaxId;
+    const base64Value = toBase64(result);
+    return base64Value;
   };
 
-  const decryptValue = async (encryptedTaxId: string): Promise<string> => {
-    const bufferedTaxId = fromBase64(encryptedTaxId);
-    const { plaintext, messageHeader } = await decrypt(keyring, bufferedTaxId);
+  const decryptValue = async (encryptedValue: string): Promise<string> => {
+    const bufferedValue = fromBase64(encryptedValue);
+    const { plaintext, messageHeader } = await decrypt(keyring, bufferedValue);
 
     const { encryptionContext } = messageHeader;
 
@@ -41,8 +41,8 @@ export const AWSEncryptionDecryptionFactory = (
       }
     }
 
-    const decodedTaxId = decoder.decode(plaintext);
-    return decodedTaxId;
+    const decodedValue = decoder.decode(plaintext);
+    return decodedValue;
   };
 
   return { encryptValue, decryptValue };

--- a/api/src/functions/express/app.ts
+++ b/api/src/functions/express/app.ts
@@ -1,3 +1,4 @@
+import { decryptionRouterFactory } from "@api/decryptionRouter";
 import { elevatorSafetyRouterFactory } from "@api/elevatorSafetyRouter";
 import { emergencyTripPermitRouterFactory } from "@api/emergencyTripPermitRouter";
 import { fireSafetyRouterFactory } from "@api/fireSafetyRouter";
@@ -7,7 +8,6 @@ import { housingRouterFactory } from "@api/housingRouter";
 import { licenseStatusRouterFactory } from "@api/licenseStatusRouter";
 import { selfRegRouterFactory } from "@api/selfRegRouter";
 import { taxClearanceCertificateRouterFactory } from "@api/taxClearanceCertificateRouter";
-import { taxDecryptionRouterFactory } from "@api/taxDecryptionRouter";
 import { userRouterFactory } from "@api/userRouter";
 import { xrayRegistrationRouterFactory } from "@api/xrayRegistrationRouter";
 import { AbcEmergencyTripPermitClient } from "@client/AbcEmergencyTripPermitClient";
@@ -424,7 +424,7 @@ app.use(
   "/api/taxFilings",
   taxFilingRouterFactory(dynamoDataClient, taxFilingInterface, AWSEncryptionDecryptionClient),
 );
-app.use("/api", taxDecryptionRouterFactory(AWSEncryptionDecryptionClient));
+app.use("/api", decryptionRouterFactory(AWSEncryptionDecryptionClient));
 app.use(
   "/health",
   healthCheckRouterFactory(

--- a/content/src/fieldConfig/tax-id.json
+++ b/content/src/fieldConfig/tax-id.json
@@ -1,5 +1,5 @@
 {
-  "tax": {
+  "taxId": {
     "descriptionText": "Save your 12-digit New Jersey Tax ID below to discover State grants, loans, and certifications your business may be eligible for.",
     "saveButtonText": "Save",
     "showButtonText": "Show",

--- a/web/decap-config/collections/06-tasks.yml
+++ b/web/decap-config/collections/06-tasks.yml
@@ -1012,7 +1012,7 @@ collections:
     files:
       - label: "Tax ID Input Section"
         name: "tax-input-section"
-        file: content/src/fieldConfig/tax.json
+        file: content/src/fieldConfig/tax-id.json
         editor:
           preview: true
         fields:

--- a/web/src/components/ShowHideToggleButton.tsx
+++ b/web/src/components/ShowHideToggleButton.tsx
@@ -2,8 +2,10 @@ import { ButtonIcon } from "@/components/ButtonIcon";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { ReactElement } from "react";
 
+export type ShowHideStatus = "text-view" | "password-view";
+
 interface Props {
-  status: "text-view" | "password-view";
+  status: ShowHideStatus;
   toggle: () => Promise<void>;
   hideText: string;
   showText: string;

--- a/web/src/components/data-fields/tax-id/DisabledTaxId.test.tsx
+++ b/web/src/components/data-fields/tax-id/DisabledTaxId.test.tsx
@@ -57,7 +57,7 @@ describe("<DisabledTaxId />", () => {
       taxId: "********9000",
       encryptedTaxId: "some-encrypted-value",
     });
-    fireEvent.click(screen.getByText(Config.tax.showButtonText));
+    fireEvent.click(screen.getByText(Config.taxId.showButtonText));
     expect(mockApi.decryptValue).toHaveBeenCalledWith({ encryptedValue: "some-encrypted-value" });
     await waitFor(() => {
       expect(screen.getByTestId("disabled-taxid")).toHaveTextContent("123-456-789/000");
@@ -71,13 +71,13 @@ describe("<DisabledTaxId />", () => {
       taxId: "********9000",
       encryptedTaxId: "some-encrypted-value",
     });
-    expect(screen.queryByText(Config.tax.hideButtonText)).not.toBeInTheDocument();
+    expect(screen.queryByText(Config.taxId.hideButtonText)).not.toBeInTheDocument();
     expect(screen.getByTestId("disabled-tax-id-value")).toHaveTextContent("****-****-****");
-    fireEvent.click(screen.getByText(Config.tax.showButtonText));
+    fireEvent.click(screen.getByText(Config.taxId.showButtonText));
     await waitFor(() => {
-      expect(screen.getByText(Config.tax.hideButtonText)).toBeInTheDocument();
+      expect(screen.getByText(Config.taxId.hideButtonText)).toBeInTheDocument();
     });
-    expect(screen.queryByText(Config.tax.showButtonText)).not.toBeInTheDocument();
+    expect(screen.queryByText(Config.taxId.showButtonText)).not.toBeInTheDocument();
   });
 
   it("toggles between mobile hide and show text", async () => {
@@ -88,11 +88,11 @@ describe("<DisabledTaxId />", () => {
       taxId: "********9000",
       encryptedTaxId: "some-encrypted-value",
     });
-    expect(screen.queryByText(Config.tax.hideButtonTextMobile)).not.toBeInTheDocument();
-    fireEvent.click(screen.getByText(Config.tax.showButtonTextMobile));
+    expect(screen.queryByText(Config.taxId.hideButtonTextMobile)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText(Config.taxId.showButtonTextMobile));
     await waitFor(() => {
-      expect(screen.getByText(Config.tax.hideButtonTextMobile)).toBeInTheDocument();
+      expect(screen.getByText(Config.taxId.hideButtonTextMobile)).toBeInTheDocument();
     });
-    expect(screen.queryByText(Config.tax.showButtonTextMobile)).not.toBeInTheDocument();
+    expect(screen.queryByText(Config.taxId.showButtonTextMobile)).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/data-fields/tax-id/DisabledTaxId.test.tsx
+++ b/web/src/components/data-fields/tax-id/DisabledTaxId.test.tsx
@@ -10,7 +10,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 jest.mock("@mui/material", () => mockMaterialUI());
 jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
 jest.mock("@/lib/api-client/apiClient", () => ({
-  decryptTaxId: jest.fn(),
+  decryptValue: jest.fn(),
 }));
 const mockApi = api as jest.Mocked<typeof api>;
 
@@ -51,21 +51,21 @@ describe("<DisabledTaxId />", () => {
   });
 
   it("decrypts the tax id if tax id is a masked value", async () => {
-    mockApi.decryptTaxId.mockResolvedValue("123456789000");
+    mockApi.decryptValue.mockResolvedValue("123456789000");
     renderComponent({
       ...profileData,
       taxId: "********9000",
       encryptedTaxId: "some-encrypted-value",
     });
     fireEvent.click(screen.getByText(Config.tax.showButtonText));
-    expect(mockApi.decryptTaxId).toHaveBeenCalledWith({ encryptedTaxId: "some-encrypted-value" });
+    expect(mockApi.decryptValue).toHaveBeenCalledWith({ encryptedValue: "some-encrypted-value" });
     await waitFor(() => {
       expect(screen.getByTestId("disabled-taxid")).toHaveTextContent("123-456-789/000");
     });
   });
 
   it("toggles between hide and show text", async () => {
-    mockApi.decryptTaxId.mockResolvedValue("123456789000");
+    mockApi.decryptValue.mockResolvedValue("123456789000");
     renderComponent({
       ...profileData,
       taxId: "********9000",
@@ -81,7 +81,7 @@ describe("<DisabledTaxId />", () => {
   });
 
   it("toggles between mobile hide and show text", async () => {
-    mockApi.decryptTaxId.mockResolvedValue("123456789000");
+    mockApi.decryptValue.mockResolvedValue("123456789000");
     setLargeScreen(false);
     renderComponent({
       ...profileData,

--- a/web/src/components/data-fields/tax-id/DisabledTaxId.tsx
+++ b/web/src/components/data-fields/tax-id/DisabledTaxId.tsx
@@ -45,11 +45,11 @@ export const DisabledTaxId = (props: Props): ReactElement => {
       <ShowHideToggleButton
         status={taxIdDisplayStatus}
         toggle={updateTaxIdDisplay}
-        showText={Config.tax.showButtonText}
-        hideText={Config.tax.hideButtonText}
+        showText={Config.taxId.showButtonText}
+        hideText={Config.taxId.hideButtonText}
         useOverrideText={!isTabletAndUp}
-        showOverrideText={Config.tax.showButtonTextMobile}
-        hideOverrideText={Config.tax.hideButtonTextMobile}
+        showOverrideText={Config.taxId.showButtonTextMobile}
+        hideOverrideText={Config.taxId.hideButtonTextMobile}
       />
     );
   };

--- a/web/src/components/data-fields/tax-id/DisabledTaxId.tsx
+++ b/web/src/components/data-fields/tax-id/DisabledTaxId.tsx
@@ -2,7 +2,7 @@
 
 import { type ShowHideStatus, ShowHideToggleButton } from "@/components/ShowHideToggleButton";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { decryptTaxId } from "@/lib/api-client/apiClient";
+import { decryptValue } from "@/lib/api-client/apiClient";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { formatTaxId } from "@/lib/domain-logic/formatTaxId";
 import { MediaQueries } from "@/lib/PageSizes";
@@ -60,8 +60,8 @@ export const DisabledTaxId = (props: Props): ReactElement => {
   };
 
   const getDecryptedTaxId = async (): Promise<string> => {
-    return decryptTaxId({
-      encryptedTaxId: state.profileData.encryptedTaxId as string,
+    return decryptValue({
+      encryptedValue: state.profileData.encryptedTaxId as string,
     });
   };
 

--- a/web/src/components/data-fields/tax-id/SingleTaxId.tsx
+++ b/web/src/components/data-fields/tax-id/SingleTaxId.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { GenericTextField } from "@/components/GenericTextField";
+import { ShowHideStatus } from "@/components/ShowHideToggleButton";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { ProfileDataFieldProps } from "@/components/data-fields/ProfileDataField";
-import { TaxIdDisplayStatus } from "@/components/data-fields/tax-id/TaxIdHelpers";
 import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { MediaQueries } from "@/lib/PageSizes";
@@ -19,7 +19,7 @@ interface Props
   > {
   handleChangeOverride?: (value: string) => void;
   getShowHideToggleButton: () => ReactElement;
-  taxIdDisplayStatus: TaxIdDisplayStatus;
+  taxIdDisplayStatus: ShowHideStatus;
 }
 export const SingleTaxId = ({
   handleChangeOverride,

--- a/web/src/components/data-fields/tax-id/SplitTaxId.tsx
+++ b/web/src/components/data-fields/tax-id/SplitTaxId.tsx
@@ -5,8 +5,8 @@ import {
   TaxIdFormContext,
   taxIdFormContextErrorMap,
 } from "@/components/data-fields/tax-id/TaxIdFormContext";
-import { TaxIdDisplayStatus } from "@/components/data-fields/tax-id/TaxIdHelpers";
 import { GenericTextField } from "@/components/GenericTextField";
+import { ShowHideStatus } from "@/components/ShowHideToggleButton";
 import { ConfigType } from "@/contexts/configContext";
 import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
@@ -26,7 +26,7 @@ interface Props
   > {
   handleChangeOverride?: (value: string) => void;
   getShowHideToggleButton: (toggleFunc?: (taxId: string) => void) => ReactElement;
-  taxIdDisplayStatus: TaxIdDisplayStatus;
+  taxIdDisplayStatus: ShowHideStatus;
 }
 export const SplitTaxId = ({
   handleChangeOverride,

--- a/web/src/components/data-fields/tax-id/TaxId.test.tsx
+++ b/web/src/components/data-fields/tax-id/TaxId.test.tsx
@@ -130,7 +130,7 @@ describe("<TaxId />", () => {
         ...profileData,
         taxId: "",
       });
-      expect(screen.getByText(Config.tax.hideButtonText)).toBeInTheDocument();
+      expect(screen.getByText(Config.taxId.hideButtonText)).toBeInTheDocument();
     });
 
     it("disables the field if the encrypted tax id is populated and tax id is masked", () => {
@@ -149,7 +149,7 @@ describe("<TaxId />", () => {
         taxId: "********9000",
         encryptedTaxId: "some-encrypted-value",
       });
-      fireEvent.click(screen.getByText(Config.tax.showButtonText));
+      fireEvent.click(screen.getByText(Config.taxId.showButtonText));
       expect(mockApi.decryptValue).toHaveBeenCalledWith({ encryptedValue: "some-encrypted-value" });
       await waitFor(() => {
         expect((screen.getByLabelText("Tax id") as HTMLInputElement).value).toEqual(
@@ -165,17 +165,17 @@ describe("<TaxId />", () => {
         taxId: "*******89000",
         encryptedTaxId: "some-encrypted-value",
       });
-      fireEvent.click(screen.getByText(Config.tax.showButtonText));
+      fireEvent.click(screen.getByText(Config.taxId.showButtonText));
       await waitFor(() => {
         expect((screen.getByLabelText("Tax id") as HTMLInputElement).value).toEqual(
           "123-456-789/000",
         );
       });
-      fireEvent.click(screen.getByText(Config.tax.hideButtonText));
+      fireEvent.click(screen.getByText(Config.taxId.hideButtonText));
       await waitFor(() => {
         expect(currentProfileData().taxId).toEqual("123456789000");
       });
-      fireEvent.click(screen.getByText(Config.tax.showButtonText));
+      fireEvent.click(screen.getByText(Config.taxId.showButtonText));
       expect(mockApi.decryptValue).toHaveBeenCalledTimes(1);
     });
 
@@ -187,7 +187,7 @@ describe("<TaxId />", () => {
         encryptedTaxId: "some-encrypted-value",
       });
       expect((screen.getByLabelText("Tax id") as HTMLInputElement).type).toEqual("password");
-      fireEvent.click(screen.getByText(Config.tax.showButtonText));
+      fireEvent.click(screen.getByText(Config.taxId.showButtonText));
       await waitFor(() => {
         expect((screen.getByLabelText("Tax id") as HTMLInputElement).type).toEqual("text");
       });
@@ -199,7 +199,7 @@ describe("<TaxId />", () => {
         taxId: "1233456789000",
       });
       expect((screen.getByLabelText("Tax id") as HTMLInputElement).type).toEqual("text");
-      fireEvent.click(screen.getByText(Config.tax.hideButtonText));
+      fireEvent.click(screen.getByText(Config.taxId.hideButtonText));
       expect((screen.getByLabelText("Tax id") as HTMLInputElement).type).toEqual("password");
     });
 
@@ -210,12 +210,12 @@ describe("<TaxId />", () => {
         taxId: "********9000",
         encryptedTaxId: "some-encrypted-value",
       });
-      expect(screen.queryByText(Config.tax.hideButtonText)).not.toBeInTheDocument();
-      fireEvent.click(screen.getByText(Config.tax.showButtonText));
+      expect(screen.queryByText(Config.taxId.hideButtonText)).not.toBeInTheDocument();
+      fireEvent.click(screen.getByText(Config.taxId.showButtonText));
       await waitFor(() => {
-        expect(screen.getByText(Config.tax.hideButtonText)).toBeInTheDocument();
+        expect(screen.getByText(Config.taxId.hideButtonText)).toBeInTheDocument();
       });
-      expect(screen.queryByText(Config.tax.showButtonText)).not.toBeInTheDocument();
+      expect(screen.queryByText(Config.taxId.showButtonText)).not.toBeInTheDocument();
     });
 
     it("toggles between mobile hide and show text", async () => {
@@ -226,12 +226,12 @@ describe("<TaxId />", () => {
         taxId: "********9000",
         encryptedTaxId: "some-encrypted-value",
       });
-      expect(screen.queryByText(Config.tax.hideButtonTextMobile)).not.toBeInTheDocument();
-      fireEvent.click(screen.getByText(Config.tax.showButtonTextMobile));
+      expect(screen.queryByText(Config.taxId.hideButtonTextMobile)).not.toBeInTheDocument();
+      fireEvent.click(screen.getByText(Config.taxId.showButtonTextMobile));
       await waitFor(() => {
-        expect(screen.getByText(Config.tax.hideButtonTextMobile)).toBeInTheDocument();
+        expect(screen.getByText(Config.taxId.hideButtonTextMobile)).toBeInTheDocument();
       });
-      expect(screen.queryByText(Config.tax.showButtonTextMobile)).not.toBeInTheDocument();
+      expect(screen.queryByText(Config.taxId.showButtonTextMobile)).not.toBeInTheDocument();
     });
   });
 
@@ -367,7 +367,7 @@ describe("<TaxId />", () => {
         taxId: "*****6789",
         encryptedTaxId: "some-encrypted-value",
       });
-      fireEvent.click(screen.getByText(Config.tax.showButtonText));
+      fireEvent.click(screen.getByText(Config.taxId.showButtonText));
       expect(mockApi.decryptValue).toHaveBeenCalledWith({ encryptedValue: "some-encrypted-value" });
       await waitFor(() => {
         expect((screen.getByLabelText("Tax id") as HTMLInputElement).value).toEqual("123-456-789");
@@ -381,15 +381,15 @@ describe("<TaxId />", () => {
         taxId: "*****6789",
         encryptedTaxId: "some-encrypted-value",
       });
-      fireEvent.click(screen.getByText(Config.tax.showButtonText));
+      fireEvent.click(screen.getByText(Config.taxId.showButtonText));
       await waitFor(() => {
         expect((screen.getByLabelText("Tax id") as HTMLInputElement).value).toEqual("123-456-789");
       });
-      fireEvent.click(screen.getByText(Config.tax.hideButtonText));
+      fireEvent.click(screen.getByText(Config.taxId.hideButtonText));
       await waitFor(() => {
         expect(currentProfileData().taxId).toEqual("123456789");
       });
-      fireEvent.click(screen.getByText(Config.tax.showButtonText));
+      fireEvent.click(screen.getByText(Config.taxId.showButtonText));
       expect(mockApi.decryptValue).toHaveBeenCalledTimes(1);
     });
 
@@ -401,7 +401,7 @@ describe("<TaxId />", () => {
         encryptedTaxId: "some-encrypted-value",
       });
       expect((screen.getByLabelText("Tax id") as HTMLInputElement).type).toEqual("password");
-      fireEvent.click(screen.getByText(Config.tax.showButtonText));
+      fireEvent.click(screen.getByText(Config.taxId.showButtonText));
       await waitFor(() => {
         expect((screen.getByLabelText("Tax id") as HTMLInputElement).type).toEqual("text");
       });
@@ -413,7 +413,7 @@ describe("<TaxId />", () => {
         taxId: "123456789",
       });
       expect((screen.getByLabelText("Tax id") as HTMLInputElement).type).toEqual("text");
-      fireEvent.click(screen.getByText(Config.tax.hideButtonText));
+      fireEvent.click(screen.getByText(Config.taxId.hideButtonText));
       expect((screen.getByLabelText("Tax id") as HTMLInputElement).type).toEqual("password");
     });
 
@@ -424,12 +424,12 @@ describe("<TaxId />", () => {
         taxId: "*****6789",
         encryptedTaxId: "some-encrypted-value",
       });
-      expect(screen.queryByText(Config.tax.hideButtonText)).not.toBeInTheDocument();
-      fireEvent.click(screen.getByText(Config.tax.showButtonText));
+      expect(screen.queryByText(Config.taxId.hideButtonText)).not.toBeInTheDocument();
+      fireEvent.click(screen.getByText(Config.taxId.showButtonText));
       await waitFor(() => {
-        expect(screen.getByText(Config.tax.hideButtonText)).toBeInTheDocument();
+        expect(screen.getByText(Config.taxId.hideButtonText)).toBeInTheDocument();
       });
-      expect(screen.queryByText(Config.tax.showButtonText)).not.toBeInTheDocument();
+      expect(screen.queryByText(Config.taxId.showButtonText)).not.toBeInTheDocument();
     });
 
     it("toggles between mobile hide and show text", async () => {
@@ -440,12 +440,12 @@ describe("<TaxId />", () => {
         taxId: "*****6789",
         encryptedTaxId: "some-encrypted-value",
       });
-      expect(screen.queryByText(Config.tax.hideButtonTextMobile)).not.toBeInTheDocument();
-      fireEvent.click(screen.getByText(Config.tax.showButtonTextMobile));
+      expect(screen.queryByText(Config.taxId.hideButtonTextMobile)).not.toBeInTheDocument();
+      fireEvent.click(screen.getByText(Config.taxId.showButtonTextMobile));
       await waitFor(() => {
-        expect(screen.getByText(Config.tax.hideButtonTextMobile)).toBeInTheDocument();
+        expect(screen.getByText(Config.taxId.hideButtonTextMobile)).toBeInTheDocument();
       });
-      expect(screen.queryByText(Config.tax.showButtonTextMobile)).not.toBeInTheDocument();
+      expect(screen.queryByText(Config.taxId.showButtonTextMobile)).not.toBeInTheDocument();
     });
   });
 });

--- a/web/src/components/data-fields/tax-id/TaxId.test.tsx
+++ b/web/src/components/data-fields/tax-id/TaxId.test.tsx
@@ -10,7 +10,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 jest.mock("@mui/material", () => mockMaterialUI());
 jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
 jest.mock("@/lib/api-client/apiClient", () => ({
-  decryptTaxId: jest.fn(),
+  decryptValue: jest.fn(),
 }));
 const mockApi = api as jest.Mocked<typeof api>;
 
@@ -143,14 +143,14 @@ describe("<TaxId />", () => {
     });
 
     it("decrypts the tax id if tax id is a masked value", async () => {
-      mockApi.decryptTaxId.mockResolvedValue("123456789000");
+      mockApi.decryptValue.mockResolvedValue("123456789000");
       renderComponent({
         ...profileData,
         taxId: "********9000",
         encryptedTaxId: "some-encrypted-value",
       });
       fireEvent.click(screen.getByText(Config.tax.showButtonText));
-      expect(mockApi.decryptTaxId).toHaveBeenCalledWith({ encryptedTaxId: "some-encrypted-value" });
+      expect(mockApi.decryptValue).toHaveBeenCalledWith({ encryptedValue: "some-encrypted-value" });
       await waitFor(() => {
         expect((screen.getByLabelText("Tax id") as HTMLInputElement).value).toEqual(
           "123-456-789/000",
@@ -159,7 +159,7 @@ describe("<TaxId />", () => {
     });
 
     it("doesn't decrypt if the tax id in current profile data is an unmasked value", async () => {
-      mockApi.decryptTaxId.mockResolvedValue("123456789000");
+      mockApi.decryptValue.mockResolvedValue("123456789000");
       renderComponent({
         ...profileData,
         taxId: "*******89000",
@@ -176,11 +176,11 @@ describe("<TaxId />", () => {
         expect(currentProfileData().taxId).toEqual("123456789000");
       });
       fireEvent.click(screen.getByText(Config.tax.showButtonText));
-      expect(mockApi.decryptTaxId).toHaveBeenCalledTimes(1);
+      expect(mockApi.decryptValue).toHaveBeenCalledTimes(1);
     });
 
     it("changes the tax id input type to text when show is clicked", async () => {
-      mockApi.decryptTaxId.mockResolvedValue("123456789000");
+      mockApi.decryptValue.mockResolvedValue("123456789000");
       renderComponent({
         ...profileData,
         taxId: "********9000",
@@ -204,7 +204,7 @@ describe("<TaxId />", () => {
     });
 
     it("toggles between hide and show text", async () => {
-      mockApi.decryptTaxId.mockResolvedValue("123456789000");
+      mockApi.decryptValue.mockResolvedValue("123456789000");
       renderComponent({
         ...profileData,
         taxId: "********9000",
@@ -219,7 +219,7 @@ describe("<TaxId />", () => {
     });
 
     it("toggles between mobile hide and show text", async () => {
-      mockApi.decryptTaxId.mockResolvedValue("123456789000");
+      mockApi.decryptValue.mockResolvedValue("123456789000");
       setLargeScreen(false);
       renderComponent({
         ...profileData,
@@ -361,21 +361,21 @@ describe("<TaxId />", () => {
     });
 
     it("decrypts the tax id if tax id is a masked value", async () => {
-      mockApi.decryptTaxId.mockResolvedValue("123456789");
+      mockApi.decryptValue.mockResolvedValue("123456789");
       renderComponent({
         ...profileData,
         taxId: "*****6789",
         encryptedTaxId: "some-encrypted-value",
       });
       fireEvent.click(screen.getByText(Config.tax.showButtonText));
-      expect(mockApi.decryptTaxId).toHaveBeenCalledWith({ encryptedTaxId: "some-encrypted-value" });
+      expect(mockApi.decryptValue).toHaveBeenCalledWith({ encryptedValue: "some-encrypted-value" });
       await waitFor(() => {
         expect((screen.getByLabelText("Tax id") as HTMLInputElement).value).toEqual("123-456-789");
       });
     });
 
     it("doesn't decrypt if the tax id in current profile data is an unmasked value", async () => {
-      mockApi.decryptTaxId.mockResolvedValue("123456789");
+      mockApi.decryptValue.mockResolvedValue("123456789");
       renderComponent({
         ...profileData,
         taxId: "*****6789",
@@ -390,11 +390,11 @@ describe("<TaxId />", () => {
         expect(currentProfileData().taxId).toEqual("123456789");
       });
       fireEvent.click(screen.getByText(Config.tax.showButtonText));
-      expect(mockApi.decryptTaxId).toHaveBeenCalledTimes(1);
+      expect(mockApi.decryptValue).toHaveBeenCalledTimes(1);
     });
 
     it("changes the tax id input type to text when show is clicked", async () => {
-      mockApi.decryptTaxId.mockResolvedValue("123456789");
+      mockApi.decryptValue.mockResolvedValue("123456789");
       renderComponent({
         ...profileData,
         taxId: "*****6789",
@@ -418,7 +418,7 @@ describe("<TaxId />", () => {
     });
 
     it("toggles between hide and show text", async () => {
-      mockApi.decryptTaxId.mockResolvedValue("123456789000");
+      mockApi.decryptValue.mockResolvedValue("123456789000");
       renderComponent({
         ...profileData,
         taxId: "*****6789",
@@ -433,7 +433,7 @@ describe("<TaxId />", () => {
     });
 
     it("toggles between mobile hide and show text", async () => {
-      mockApi.decryptTaxId.mockResolvedValue("123456789000");
+      mockApi.decryptValue.mockResolvedValue("123456789000");
       setLargeScreen(false);
       renderComponent({
         ...profileData,

--- a/web/src/components/data-fields/tax-id/TaxId.tsx
+++ b/web/src/components/data-fields/tax-id/TaxId.tsx
@@ -5,7 +5,7 @@ import { SingleTaxId } from "@/components/data-fields/tax-id/SingleTaxId";
 import { SplitTaxId } from "@/components/data-fields/tax-id/SplitTaxId";
 import { type ShowHideStatus, ShowHideToggleButton } from "@/components/ShowHideToggleButton";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
-import { decryptTaxId } from "@/lib/api-client/apiClient";
+import { decryptValue } from "@/lib/api-client/apiClient";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { MediaQueries } from "@/lib/PageSizes";
@@ -67,8 +67,8 @@ export const TaxId = (props: Props): ReactElement => {
   };
 
   const getDecryptedTaxId = async (): Promise<string> => {
-    return decryptTaxId({
-      encryptedTaxId: state.profileData.encryptedTaxId as string,
+    return decryptValue({
+      encryptedValue: state.profileData.encryptedTaxId as string,
     });
   };
 

--- a/web/src/components/data-fields/tax-id/TaxId.tsx
+++ b/web/src/components/data-fields/tax-id/TaxId.tsx
@@ -57,11 +57,11 @@ export const TaxId = (props: Props): ReactElement => {
       <ShowHideToggleButton
         status={taxIdDisplayStatus}
         toggle={taxIdToggle(toggleFunc)}
-        showText={Config.tax.showButtonText}
-        hideText={Config.tax.hideButtonText}
+        showText={Config.taxId.showButtonText}
+        hideText={Config.taxId.hideButtonText}
         useOverrideText={!isTabletAndUp}
-        showOverrideText={Config.tax.showButtonTextMobile}
-        hideOverrideText={Config.tax.hideButtonTextMobile}
+        showOverrideText={Config.taxId.showButtonTextMobile}
+        hideOverrideText={Config.taxId.hideButtonTextMobile}
       />
     );
   };

--- a/web/src/components/data-fields/tax-id/TaxId.tsx
+++ b/web/src/components/data-fields/tax-id/TaxId.tsx
@@ -3,13 +3,13 @@
 import { ProfileDataFieldProps } from "@/components/data-fields/ProfileDataField";
 import { SingleTaxId } from "@/components/data-fields/tax-id/SingleTaxId";
 import { SplitTaxId } from "@/components/data-fields/tax-id/SplitTaxId";
-import { EncryptionStatus, TaxIdDisplayStatus } from "@/components/data-fields/tax-id/TaxIdHelpers";
-import { ShowHideToggleButton } from "@/components/ShowHideToggleButton";
+import { type ShowHideStatus, ShowHideToggleButton } from "@/components/ShowHideToggleButton";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { decryptTaxId } from "@/lib/api-client/apiClient";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { MediaQueries } from "@/lib/PageSizes";
+import { getInitialShowHideStatus, isEncrypted } from "@/lib/utils/encryption";
 import { maskingCharacter } from "@businessnjgovnavigator/shared";
 import { useMediaQuery } from "@mui/material";
 import { ReactElement, useContext, useEffect, useRef, useState } from "react";
@@ -41,20 +41,9 @@ export const TaxId = (props: Props): ReactElement => {
 
   const initialType = useRef<"FULL" | "SPLIT">(getFieldType());
 
-  const taxIdInitialDisplay = (): TaxIdDisplayStatus => {
-    if (
-      state.profileData.taxId &&
-      state.profileData.taxId.includes(maskingCharacter) &&
-      state.profileData.encryptedTaxId
-    ) {
-      return "password-view";
-    } else {
-      return "text-view";
-    }
-  };
-
-  const [taxIdDisplayStatus, setTaxIdDisplayStatus] = useState<TaxIdDisplayStatus>(
-    taxIdInitialDisplay(),
+  const taxIdIsEncrypted = isEncrypted(state.profileData.taxId, state.profileData.encryptedTaxId);
+  const [taxIdDisplayStatus, setTaxIdDisplayStatus] = useState<ShowHideStatus>(
+    getInitialShowHideStatus(taxIdIsEncrypted),
   );
 
   useEffect(() => {
@@ -64,29 +53,17 @@ export const TaxId = (props: Props): ReactElement => {
   }, [business?.profileData.taxId]);
 
   const getShowHideToggleButton = (toggleFunc?: (taxId: string) => void): ReactElement => {
-    return ShowHideToggleButton({
-      status: taxIdDisplayStatus,
-      toggle: taxIdToggle(toggleFunc),
-      showText: Config.tax.showButtonText,
-      hideText: Config.tax.hideButtonText,
-      useOverrideText: !isTabletAndUp,
-      showOverrideText: Config.tax.showButtonTextMobile,
-      hideOverrideText: Config.tax.hideButtonTextMobile,
-    });
-  };
-
-  const getTaxIdEncryptionStatus = (): EncryptionStatus => {
-    if (!state.profileData.taxId) {
-      return;
-    }
-    if (!state.profileData.taxId.includes(maskingCharacter) && state.profileData.encryptedTaxId) {
-      return "decrypted";
-    } else if (
-      state.profileData.taxId.includes(maskingCharacter) &&
-      state.profileData.encryptedTaxId
-    ) {
-      return "encrypted";
-    }
+    return (
+      <ShowHideToggleButton
+        status={taxIdDisplayStatus}
+        toggle={taxIdToggle(toggleFunc)}
+        showText={Config.tax.showButtonText}
+        hideText={Config.tax.hideButtonText}
+        useOverrideText={!isTabletAndUp}
+        showOverrideText={Config.tax.showButtonTextMobile}
+        hideOverrideText={Config.tax.hideButtonTextMobile}
+      />
+    );
   };
 
   const getDecryptedTaxId = async (): Promise<string> => {
@@ -105,9 +82,9 @@ export const TaxId = (props: Props): ReactElement => {
     if (!state.profileData.taxId) {
       return;
     }
-    const encryptionStatus = getTaxIdEncryptionStatus();
+
     if (taxIdDisplayStatus === "password-view") {
-      if (encryptionStatus === "encrypted") {
+      if (taxIdIsEncrypted) {
         await getDecryptedTaxId().then((decryptedTaxId) => {
           setProfileData({ ...state.profileData, taxId: decryptedTaxId });
           toggleFunc && toggleFunc(decryptedTaxId);

--- a/web/src/components/data-fields/tax-id/TaxIdHelpers.ts
+++ b/web/src/components/data-fields/tax-id/TaxIdHelpers.ts
@@ -1,2 +1,0 @@
-export type TaxIdDisplayStatus = "text-view" | "password-view";
-export type EncryptionStatus = "decrypted" | "encrypted" | undefined;

--- a/web/src/components/tasks/TaxInput.tsx
+++ b/web/src/components/tasks/TaxInput.tsx
@@ -47,8 +47,8 @@ export const TaxInput = (props: Props): ReactElement => {
 
   const saveButtonText =
     isAuthenticated === IsAuthenticated.FALSE
-      ? `Register & ${Config.tax.saveButtonText}`
-      : Config.tax.saveButtonText;
+      ? `Register & ${Config.taxId.saveButtonText}`
+      : Config.taxId.saveButtonText;
 
   useEffect(() => {
     if (!business) return;
@@ -93,10 +93,12 @@ export const TaxInput = (props: Props): ReactElement => {
 
   const DisabledElement = (props: { children: ReactNode }): ReactElement => (
     <div className={`flex ${isTabletAndUp ? "flex-row" : "flex-column margin-right-2"} no-wrap`}>
-      <div className={`${isTabletAndUp ? "padding-right-1" : ""}`}>{Config.tax.lockedPreText}</div>
+      <div className={`${isTabletAndUp ? "padding-right-1" : ""}`}>
+        {Config.taxId.lockedPreText}
+      </div>
       <div>{props.children}</div>
       <div className={`${isTabletAndUp ? "padding-left-1" : ""} margin-right-1`}>
-        {Config.tax.lockedPostText}
+        {Config.taxId.lockedPostText}
       </div>
       <div className={"text-wrap margin-bottom-1"}>
         <ArrowTooltip title={Config.profileDefaults.default.lockedFieldTooltipText}>

--- a/web/src/components/tasks/TaxTask.test.tsx
+++ b/web/src/components/tasks/TaxTask.test.tsx
@@ -71,7 +71,7 @@ describe("<TaxTask />", () => {
     expect(screen.getByText("some content here")).toBeInTheDocument();
     expect(screen.getByText("more content")).toBeInTheDocument();
     expect(screen.queryByText("${taxInputComponent}")).not.toBeInTheDocument();
-    expect(screen.getByText(Config.tax.descriptionText)).toBeInTheDocument();
+    expect(screen.getByText(Config.taxId.descriptionText)).toBeInTheDocument();
   });
 
   it("renders CTA button", () => {
@@ -99,8 +99,8 @@ describe("<TaxTask />", () => {
       </WithStatefulBusiness>,
     );
     expect(screen.queryByLabelText("Tax id")).not.toBeInTheDocument();
-    expect(screen.getByTestId("disabled-taxid")).toHaveTextContent(Config.tax.lockedPostText);
-    expect(screen.getByTestId("disabled-taxid")).toHaveTextContent(Config.tax.lockedPreText);
+    expect(screen.getByTestId("disabled-taxid")).toHaveTextContent(Config.taxId.lockedPostText);
+    expect(screen.getByTestId("disabled-taxid")).toHaveTextContent(Config.taxId.lockedPreText);
     expect(screen.getByTestId("disabled-tax-id-value")).toHaveTextContent("****-****-****");
   });
 
@@ -127,7 +127,7 @@ describe("<TaxTask />", () => {
 
     it("shows the save button text for an authenticated user", async () => {
       renderPage();
-      expect(screen.getByText(Config.tax.saveButtonText)).toBeInTheDocument();
+      expect(screen.getByText(Config.taxId.saveButtonText)).toBeInTheDocument();
     });
 
     it("updates the progress of the task to TO_DO if there is a pre-existing 9 digit tax id", async () => {
@@ -155,7 +155,7 @@ describe("<TaxTask />", () => {
     it("enters and saves Tax ID", async () => {
       renderPage();
       fireEvent.change(screen.getByLabelText("Tax id"), { target: { value: "123456789123" } });
-      fireEvent.click(screen.getByText(Config.tax.saveButtonText));
+      fireEvent.click(screen.getByText(Config.taxId.saveButtonText));
       await waitFor(() => {
         expect(currentBusiness().profileData.taxId).toEqual("123456789123");
       });
@@ -170,7 +170,7 @@ describe("<TaxTask />", () => {
         },
       );
       fireEvent.change(screen.getByLabelText("Tax id"), { target: { value: "123123123" } });
-      fireEvent.click(screen.getByText(Config.tax.saveButtonText));
+      fireEvent.click(screen.getByText(Config.taxId.saveButtonText));
       expect(screen.getByText(expectedErrorMessage)).toBeInTheDocument();
       expect(userDataWasNotUpdated()).toBe(true);
     });
@@ -178,7 +178,7 @@ describe("<TaxTask />", () => {
     it("sets task status to COMPLETED on save", async () => {
       renderPage();
       fireEvent.change(screen.getByLabelText("Tax id"), { target: { value: "123456789123" } });
-      fireEvent.click(screen.getByText(Config.tax.saveButtonText));
+      fireEvent.click(screen.getByText(Config.taxId.saveButtonText));
       await waitFor(() => {
         expect(currentBusiness().taskProgress[taskId]).toEqual("COMPLETED");
       });
@@ -242,12 +242,12 @@ describe("<TaxTask />", () => {
 
     it("prepends register to the Save button", async () => {
       renderPage();
-      expect(screen.getByText(`Register & ${Config.tax.saveButtonText}`)).toBeInTheDocument();
+      expect(screen.getByText(`Register & ${Config.taxId.saveButtonText}`)).toBeInTheDocument();
     });
 
     it("opens Needs Account modal on save button click", async () => {
       renderPage();
-      fireEvent.click(screen.getByText(`Register & ${Config.tax.saveButtonText}`));
+      fireEvent.click(screen.getByText(`Register & ${Config.taxId.saveButtonText}`));
       await waitFor(() => {
         return expect(setShowNeedsAccountModal).toHaveBeenCalledWith(true);
       });

--- a/web/src/components/tasks/TaxTask.tsx
+++ b/web/src/components/tasks/TaxTask.tsx
@@ -26,7 +26,7 @@ export const TaxTask = (props: Props): ReactElement => {
       <UnlockedBy task={props.task} />
       <Content>{preInputContent}</Content>
       <div className="margin-left-3ch margin-top-1">
-        <Content>{Config.tax.descriptionText}</Content>
+        <Content>{Config.taxId.descriptionText}</Content>
         <TaxDisclaimer legalStructureId={business?.profileData.legalStructureId} />
         <TaxInput task={props.task} />
       </div>

--- a/web/src/contexts/configContext.ts
+++ b/web/src/contexts/configContext.ts
@@ -43,7 +43,7 @@ import * as TaxClearanceCertificateShared from "@businessnjgovnavigator/content/
 import * as TaxClearanceCertificateStep1 from "@businessnjgovnavigator/content/fieldConfig/tax-clearance-certificate-step1.json";
 import * as TaxClearanceCertificateStep2 from "@businessnjgovnavigator/content/fieldConfig/tax-clearance-certificate-step2.json";
 import * as TaxClearanceCertificateStep3 from "@businessnjgovnavigator/content/fieldConfig/tax-clearance-certificate-step3.json";
-import * as Tax from "@businessnjgovnavigator/content/fieldConfig/tax.json";
+import * as TaxId from "@businessnjgovnavigator/content/fieldConfig/tax-id.json";
 import * as XrayRegistration from "@businessnjgovnavigator/content/fieldConfig/x-ray-registration.json";
 import * as CalloutAlerts from "@businessnjgovnavigator/content/mappings/callout-alerts.json";
 import * as PageMetadata from "@businessnjgovnavigator/content/page-metadata/page-metadata.json";
@@ -65,7 +65,7 @@ const merged = JSON.parse(
       NexusDbaFormation,
       NaicsCode,
       Ein,
-      Tax,
+      TaxId,
       CannabisLicenseEligibilityModal,
       FormationInterimSuccessPage,
       FormationSuccessPage,
@@ -121,7 +121,7 @@ export type ConfigType = typeof ConfigOriginal &
   typeof NexusDbaFormation &
   typeof NaicsCode &
   typeof Ein &
-  typeof Tax &
+  typeof TaxId &
   typeof CannabisLicenseEligibilityModal &
   typeof FormationInterimSuccessPage &
   typeof FormationSuccessPage &
@@ -175,7 +175,7 @@ export const getMergedConfig = (): ConfigType => {
     NexusDbaFormation,
     NaicsCode,
     Ein,
-    Tax,
+    TaxId,
     CannabisLicenseEligibilityModal,
     FormationInterimSuccessPage,
     FormationSuccessPage,

--- a/web/src/lib/api-client/apiClient.ts
+++ b/web/src/lib/api-client/apiClient.ts
@@ -113,7 +113,7 @@ export const postTaxFilingsLookup = (props: {
   return post(`/taxFilings/lookup`, props);
 };
 
-export const decryptTaxId = (props: { encryptedTaxId: string }): Promise<string> => {
+export const decryptValue = (props: { encryptedValue: string }): Promise<string> => {
   return post(`/decrypt`, props);
 };
 

--- a/web/src/lib/cms/previews/TaxInputPreview.tsx
+++ b/web/src/lib/cms/previews/TaxInputPreview.tsx
@@ -19,7 +19,7 @@ const TaxInputPreview = (props: PreviewProps): ReactElement => {
   return (
     <ConfigContext.Provider value={{ config, setOverrides: setConfig }}>
       <div className="cms" ref={ref} style={{ margin: 40, pointerEvents: "none" }}>
-        <Content>{config.tax.descriptionText}</Content>
+        <Content>{config.taxId.descriptionText}</Content>
         <TaxInput task={task} />
 
         <hr className="margin-y-6" />

--- a/web/src/lib/utils/encryption.test.ts
+++ b/web/src/lib/utils/encryption.test.ts
@@ -1,0 +1,15 @@
+import { isEncrypted } from "@/lib/utils/encryption";
+
+describe("isEncrypted", () => {
+  it.each([
+    { maskedValue: undefined, encryptedValue: "AgV4o/o1RbwN", expected: undefined },
+    { maskedValue: "777", encryptedValue: undefined, expected: undefined },
+    { maskedValue: "777", encryptedValue: "AgV4o/o1RbwN", expected: false },
+    { maskedValue: "*77", encryptedValue: "AgV4o/o1RbwN", expected: true },
+  ])(
+    `should return $expected when maskedValue is $maskedValue and encryptedValue is $encryptedValue`,
+    ({ maskedValue, encryptedValue, expected }) => {
+      expect(isEncrypted(maskedValue, encryptedValue)).toEqual(expected);
+    }
+  );
+});

--- a/web/src/lib/utils/encryption.test.ts
+++ b/web/src/lib/utils/encryption.test.ts
@@ -10,6 +10,6 @@ describe("isEncrypted", () => {
     `should return $expected when maskedValue is $maskedValue and encryptedValue is $encryptedValue`,
     ({ maskedValue, encryptedValue, expected }) => {
       expect(isEncrypted(maskedValue, encryptedValue)).toEqual(expected);
-    }
+    },
   );
 });

--- a/web/src/lib/utils/encryption.ts
+++ b/web/src/lib/utils/encryption.ts
@@ -3,7 +3,7 @@ import { maskingCharacter } from "@businessnjgovnavigator/shared";
 
 export const isEncrypted = (
   maskedValue: string | undefined,
-  encryptedValue: string | undefined
+  encryptedValue: string | undefined,
 ): boolean | undefined => {
   if (maskedValue === undefined || !encryptedValue) {
     return;

--- a/web/src/lib/utils/encryption.ts
+++ b/web/src/lib/utils/encryption.ts
@@ -1,0 +1,16 @@
+import { ShowHideStatus } from "@/components/ShowHideToggleButton";
+import { maskingCharacter } from "@businessnjgovnavigator/shared";
+
+export const isEncrypted = (
+  maskedValue: string | undefined,
+  encryptedValue: string | undefined
+): boolean | undefined => {
+  if (maskedValue === undefined || !encryptedValue) {
+    return;
+  }
+  return maskedValue.includes(maskingCharacter);
+};
+
+export const getInitialShowHideStatus = (isEncrypted: boolean | undefined): ShowHideStatus => {
+  return isEncrypted ? "password-view" : "text-view";
+};


### PR DESCRIPTION
## Description

#[7782](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7782) involves encrypting and building show/hide functionality for the tax pin component. 

Commit 1: refactors the tax id components to pull out and more generically name common functions that would be reused for the tax pin component. 
- Moves and renames `TaxIdDisplayStatus` to more generically be in `ShowHideToggleButton.tsx`
- Pulls out `getTaxIdEncryptionStatus` -> `isEncrypted`
- Pulls out `taxIdInitialDisplay` -> `getInitialShowHideStatus`

Commit 2: renames names around `AWSEncryptionDecryptionFactory`, the `/api/decrypt` endpoint, and the apiClient call to the endpoint to more generically refer to encryption and decryption without specifying `tax`. Does not touch anything higher-level than that, e.g. `getDecryptedTaxId` on the front or `getTaxId` on the back.

Commit 3: renames CMS `tax.json` -> `tax-id.json` in anticipation of one for tax-pin

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This commit contributes to #[7782](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7782).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migxation file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Addxtions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarde