### PR TITLE
fix: [AB#14182] capitalization contextual info issue for content repo

### DIFF
--- a/web/src/lib/cms/fields/writeoncereadonlynospacefield.tsx
+++ b/web/src/lib/cms/fields/writeoncereadonlynospacefield.tsx
@@ -52,7 +52,7 @@ class WriteOnceReadOnlyNoSpaceControl extends Component<
 
   handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     this.setState({ _sel: e.target.selectionStart });
-    this.props.onChange(e.target.value.trim());
+    this.props.onChange(e.target.value.trim().toLowerCase());
   };
 
   render(): ReactElement {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

this is an impromptu bug that came as a result of a content person putting capitals in an ID, 

This broke our system because the ID had capital letters but the file name (which is suppose to match the ID) did not. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14182](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14182).

### Approach

I decided to make it so ID's from the content side are forced to be lower case as well. 

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Go to the cms locally and try to type in capital letters into the ID field and see that you can't (it automatically lower cases them)

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

I could have taken the opposite approach and tried to get the filenames to save with uppercase letters but I didn't for a few reasons. 

1) I think this is easier
2) I think decap might controll that so it may be harder to manipulate
3) our file names will be more consistent which is generally better

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
