### PR TITLE
Revert "chore: correct .prettierrc syntax and simplify Markdown formatting rules"

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -15,17 +15,13 @@
     {
       "files": ["*.yml", "*.yaml"],
       "options": {
-        "singleQuote": false,
-        "quoteProps": "preserve"
+        "singleQuote": false
       }
     },
     {
       "files": ["*.md"],
       "options": {
-        "proseWrap": "preserve",
-        "embeddedLanguageFormatting": "auto",
-        "quoteProps": "as-needed",
-        "singleQuote": false
+        "proseWrap": "preserve"
       }
     }
   ]

--- a/web/decap-config/config-base.yml
+++ b/web/decap-config/config-base.yml
@@ -18,6 +18,3 @@ slug:
   encoding: "ascii"
   clean_accents: true
   sanitize_replacement: "_"
-yaml:
-  outputStringStyle: "QUOTE_ALL_STRINGS"
-  outputIndentation: "FIXED_2_SPACES"


### PR DESCRIPTION
Reverts newjersey/navigator.business.nj.gov#10314