### PR TITLE
fix: [AB#8150] information in the tax detail screen is not floating /…

### DIFF
--- a/web/src/pages/filings/[filingUrlSlug].tsx
+++ b/web/src/pages/filings/[filingUrlSlug].tsx
@@ -108,58 +108,60 @@ export const FilingElement = (props: {
           props.filing.frequency ||
           props.filing.agency === "New Jersey Division of Taxation") && (
           <Callout calloutType="conditional" showHeader={false}>
-            {props.filing.taxRates && (
-              <>
-                <span className="flex" data-testid="tax-rates">
-                  <Icon
-                    className="usa-icon--size-3 minw-3 margin-left-1 text-green margin-right-2"
-                    iconName="attach_money"
+            <div className="flex flex-column">
+              {props.filing.taxRates && (
+                <>
+                  <span className="flex margin-1" data-testid="tax-rates">
+                    <Icon
+                      className="usa-icon--size-3 minw-3 text-green margin-right-2"
+                      iconName="attach_money"
+                    />
+                    <Content>{`**${Config.filingDefaults.taxRateTitle}** &nbsp;&nbsp;${props.filing.taxRates}`}</Content>
+                  </span>
+                </>
+              )}
+              {props.filing.filingMethod && (
+                <span className="flex flex-row margin-1 " data-testid="filing-method">
+                  <img
+                    className="usa-icon--size-3 minw-3 margin-right-2"
+                    src={`/img/file-document-outline.svg`}
+                    alt=""
                   />
-                  <Content className="">{`**${Config.filingDefaults.taxRateTitle}** &nbsp;&nbsp;${props.filing.taxRates}`}</Content>
+                  <span className="flex flex-column ">
+                    <Content className="flex">{`**${
+                      Config.filingDefaults.filingMethod
+                    }** &nbsp;&nbsp;${taxFilingMethodMap[props.filing.filingMethod]}`}</Content>
+                    {props.filing.filingDetails && (
+                      <>
+                        {" "}
+                        <br />
+                        <Content data-testid="filing-details">{props.filing.filingDetails}</Content>
+                      </>
+                    )}
+                  </span>
                 </span>
-              </>
-            )}
-            {props.filing.filingMethod && (
-              <span className="flex flex-row margin-top-05" data-testid="filing-method">
-                <img
-                  className="usa-icon--size-3 minw-3 margin-1 margin-right-2"
-                  src={`/img/file-document-outline.svg`}
-                  alt=""
-                />
-                <span className="flex flex-column margin-top-1">
-                  <Content className="flex">{`**${
-                    Config.filingDefaults.filingMethod
-                  }** &nbsp;&nbsp;${taxFilingMethodMap[props.filing.filingMethod]}`}</Content>
-                  {props.filing.filingDetails && (
-                    <>
-                      {" "}
-                      <br />
-                      <Content data-testid="filing-details">{props.filing.filingDetails}</Content>
-                    </>
-                  )}
-                </span>
-              </span>
-            )}
-            {props.filing.frequency && (
-              <>
-                <span className="flex margin-top-05">
+              )}
+              {props.filing.frequency && (
+                <>
+                  <span className="flex margin-1">
+                    <Icon
+                      className="usa-icon--size-3 minw-3 text-green margin-right-2"
+                      iconName="event"
+                    />
+                    <Content>{`**${Config.filingDefaults.filingFrequency}** &nbsp;&nbsp;${props.filing.frequency}`}</Content>
+                  </span>
+                </>
+              )}
+              {props.filing.agency === "New Jersey Division of Taxation" && (
+                <span className="flex margin-1" data-testid="late-filing">
                   <Icon
-                    className="usa-icon--size-3 minw-3 margin-1 text-green margin-right-2"
-                    iconName="event"
+                    className="usa-icon--size-3 minw-3 text-green margin-right-2"
+                    iconName="cancel"
                   />
-                  <Content className="margin-top-1">{`**${Config.filingDefaults.filingFrequency}** &nbsp;&nbsp;${props.filing.frequency}`}</Content>
+                  <Content>{`**${Config.filingDefaults.lateFilingsTitle}** &nbsp;&nbsp;${Config.filingDefaults.lateFilingsMarkdown}`}</Content>
                 </span>
-              </>
-            )}
-            {props.filing.agency === "New Jersey Division of Taxation" && (
-              <span className="flex margin-top-05" data-testid="late-filing">
-                <Icon
-                  className="usa-icon--size-3 minw-3 margin-1 text-green margin-right-2"
-                  iconName="cancel"
-                />
-                <Content className="margin-top-1">{`**${Config.filingDefaults.lateFilingsTitle}** &nbsp;&nbsp;${Config.filingDefaults.lateFilingsMarkdown}`}</Content>
-              </span>
-            )}
+              )}
+            </div>
           </Callout>
         )}
 


### PR DESCRIPTION
… wrapping correctly

<!-- Please complete the following sections as necessary. -->

## Description

There was a bulleted list that wasn't appearing correctly in a callout in terms of wrapping that has been fixed to stack. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#8150](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8150).

### Approach

simple css fixes

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Go to tax calendar, 
get events via wiremock, 
click on any of the events
See the bulleted list at the bottom of the task on desktop and mobile

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
