### PR TITLE
feat: [AB#12793] Encrypt Tax Clearance ID and PIN

### DIFF
--- a/api/src/api/taxClearanceCertificateRouter.test.ts
+++ b/api/src/api/taxClearanceCertificateRouter.test.ts
@@ -1,5 +1,5 @@
 import { taxClearanceCertificateRouterFactory } from "@api/taxClearanceCertificateRouter";
-import { TaxClearanceCertificateClient } from "@domain/types";
+import { type EncryptionDecryptionClient, TaxClearanceCertificateClient } from "@domain/types";
 import { setupExpress } from "@libs/express";
 import { Express } from "express";
 import { StatusCodes } from "http-status-codes";
@@ -8,14 +8,24 @@ import request from "supertest";
 describe("taxClearanceCertificateRouterFactory", () => {
   let app: Express;
   let stubTaxClearanceCertificateClient: jest.Mocked<TaxClearanceCertificateClient>;
+  let stubEncryptionDecryptionClient: jest.Mocked<EncryptionDecryptionClient>;
 
   beforeEach(() => {
     jest.resetAllMocks();
     stubTaxClearanceCertificateClient = {
       postTaxClearanceCertificate: jest.fn(),
     };
+    stubEncryptionDecryptionClient = {
+      encryptValue: jest.fn(),
+      decryptValue: jest.fn(),
+    };
     app = setupExpress(false);
-    app.use(taxClearanceCertificateRouterFactory(stubTaxClearanceCertificateClient));
+    app.use(
+      taxClearanceCertificateRouterFactory(
+        stubTaxClearanceCertificateClient,
+        stubEncryptionDecryptionClient,
+      ),
+    );
   });
 
   it("returns a successful response", async () => {

--- a/api/src/api/taxClearanceCertificateRouter.ts
+++ b/api/src/api/taxClearanceCertificateRouter.ts
@@ -1,18 +1,22 @@
 import { ExpressRequestBody } from "@api/types";
-import { TaxClearanceCertificateClient } from "@domain/types";
+import { type EncryptionDecryptionClient, TaxClearanceCertificateClient } from "@domain/types";
 import { UserData } from "@shared/userData";
 import { Router } from "express";
 import { StatusCodes } from "http-status-codes";
 
 export const taxClearanceCertificateRouterFactory = (
   taxClearanceCertificateClient: TaxClearanceCertificateClient,
+  encryptionDecryptionClient: EncryptionDecryptionClient,
 ): Router => {
   const router = Router();
   router.post("/postTaxClearanceCertificate", async (req: ExpressRequestBody<UserData>, res) => {
     const userData = req.body;
 
     try {
-      const response = await taxClearanceCertificateClient.postTaxClearanceCertificate(userData);
+      const response = await taxClearanceCertificateClient.postTaxClearanceCertificate(
+        userData,
+        encryptionDecryptionClient,
+      );
       res.json(response);
     } catch (error) {
       res.status(StatusCodes.INTERNAL_SERVER_ERROR).json(error);

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -243,7 +243,10 @@ export const NO_ADDRESS_MATCH_ERROR = "NO_ADDRESS_MATCH";
 export const NO_MAIN_APPS_ERROR = "NO_MAIN_APPS";
 
 export interface TaxClearanceCertificateClient {
-  postTaxClearanceCertificate: (userData: UserData) => Promise<TaxClearanceCertificateResponse>;
+  postTaxClearanceCertificate: (
+    userData: UserData,
+    encryptionDecryptionClient: EncryptionDecryptionClient,
+  ) => Promise<TaxClearanceCertificateResponse>;
 }
 
 export interface XrayRegistrationStatusLookup {

--- a/api/src/domain/user/encryptFieldsFactory.test.ts
+++ b/api/src/domain/user/encryptFieldsFactory.test.ts
@@ -17,10 +17,10 @@ describe("encryptFieldsFactory", () => {
   const profileTaxPin = "1234";
   const taxClearanceTaxId = "111111111111";
   const taxClearanceTaxPin = "1111";
-  const encryptedProfileTaxId = "encrypted-profile-tax-id";
-  const encryptedProfileTaxPin = "encrypted-profile-tax-pin";
-  const encryptedTaxClearanceTaxId = "encrypted-tax-clearance-tax-id";
-  const encryptedTaxClearanceTaxPin = "encrypted-tax-clearance-tax-pin";
+  const encryptedProfileTaxId = "encrypted-123456789000";
+  const encryptedProfileTaxPin = "encrypted-1234";
+  const encryptedTaxClearanceTaxId = "encrypted-111111111111";
+  const encryptedTaxClearanceTaxPin = "encrypted-1111";
 
   const generateUnencryptedUserData = (
     profileDataOverrides = {},

--- a/api/src/domain/user/encryptFieldsFactory.test.ts
+++ b/api/src/domain/user/encryptFieldsFactory.test.ts
@@ -1,22 +1,89 @@
 import { EncryptionDecryptionClient, EncryptTaxId } from "@domain/types";
 import { encryptFieldsFactory } from "@domain/user/encryptFieldsFactory";
 import { modifyCurrentBusiness } from "@shared/domain-logic/modifyCurrentBusiness";
-import { generateBusiness, generateProfileData, generateUserDataForBusiness } from "@shared/test";
+import {
+  generateBusiness,
+  generateProfileData,
+  generateTaxClearanceCertificateData,
+  generateUserDataForBusiness,
+} from "@shared/test";
+import { UserData } from "@shared/userData";
 
 describe("encryptFieldsFactory", () => {
   let stubEncryptionDecryptionClient: jest.Mocked<EncryptionDecryptionClient>;
   let encryptTaxId: EncryptTaxId;
-  const numFieldsToEncrypt = 2;
-  const taxId = "123456789000";
-  const taxPin = "1234";
+  const numFieldsToEncrypt = 4;
+  const profileTaxId = "123456789000";
+  const profileTaxPin = "1234";
+  const taxClearanceTaxId = "111111111111";
+  const taxClearanceTaxPin = "1111";
+  const encryptedProfileTaxId = "encrypted-profile-tax-id";
+  const encryptedProfileTaxPin = "encrypted-profile-tax-pin";
+  const encryptedTaxClearanceTaxId = "encrypted-tax-clearance-tax-id";
+  const encryptedTaxClearanceTaxPin = "encrypted-tax-clearance-tax-pin";
+
+  const generateUnencryptedUserData = (
+    profileDataOverrides = {},
+    taxClearanceCertificateDataOverrides = {},
+  ): UserData => {
+    return generateUserDataForBusiness(
+      generateBusiness({
+        profileData: generateProfileData({
+          taxId: profileTaxId,
+          encryptedTaxId: undefined,
+          taxPin: profileTaxPin,
+          encryptedTaxPin: undefined,
+          ...profileDataOverrides,
+        }),
+        taxClearanceCertificateData: generateTaxClearanceCertificateData({
+          taxId: taxClearanceTaxId,
+          encryptedTaxId: undefined,
+          taxPin: taxClearanceTaxPin,
+          encryptedTaxPin: undefined,
+          ...taxClearanceCertificateDataOverrides,
+        }),
+      }),
+    );
+  };
+
+  const getExpectedEncryptedCurrentBusiness = (
+    userData: UserData,
+    profileDataOverrides = {},
+    taxClearanceCertificateDataOverrides = {},
+  ): UserData => {
+    const expectedUserData = modifyCurrentBusiness(userData, (business) => ({
+      ...business,
+      profileData: {
+        ...business.profileData,
+        taxId: "*******89000",
+        encryptedTaxId: encryptedProfileTaxId,
+        taxPin: "****",
+        encryptedTaxPin: encryptedProfileTaxPin,
+        ...profileDataOverrides,
+      },
+      taxClearanceCertificateData: business.taxClearanceCertificateData
+        ? {
+            ...business.taxClearanceCertificateData,
+            taxId: "*******11111",
+            encryptedTaxId: encryptedTaxClearanceTaxId,
+            taxPin: "****",
+            encryptedTaxPin: encryptedTaxClearanceTaxPin,
+            ...taxClearanceCertificateDataOverrides,
+          }
+        : undefined,
+    }));
+    return expectedUserData;
+  };
 
   beforeEach(async () => {
     jest.resetAllMocks();
     stubEncryptionDecryptionClient = {
       encryptValue: jest.fn((valueToBeEncrypted: string) => {
         const encryptedValues: { [key: string]: string } = {
-          "123456789000": "encrypted-tax-id",
-          "1234": "encrypted-tax-pin",
+          [profileTaxId]: encryptedProfileTaxId,
+          [profileTaxPin]: encryptedProfileTaxPin,
+          [taxClearanceTaxId]: encryptedTaxClearanceTaxId,
+          [taxClearanceTaxPin]: encryptedTaxClearanceTaxPin,
         };
         return Promise.resolve(encryptedValues[valueToBeEncrypted] ?? "unexpected value");
       }),
@@ -26,87 +93,115 @@ describe("encryptFieldsFactory", () => {
   });
 
   it("updates user by masking and encrypting tax id and tax pin", async () => {
-    const userData = generateUserDataForBusiness(
-      generateBusiness({
-        profileData: generateProfileData({
-          taxId: taxId,
-          encryptedTaxId: undefined,
-          taxPin: taxPin,
-          encryptedTaxPin: undefined,
-        }),
-      }),
-    );
+    const userData = generateUnencryptedUserData();
     const response = await encryptTaxId(userData);
-    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(taxId);
-    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(taxPin);
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(profileTaxId);
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(profileTaxPin);
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxId);
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxPin);
     expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledTimes(numFieldsToEncrypt);
 
-    const expectedUserData = modifyCurrentBusiness(userData, (business) => ({
-      ...business,
-      profileData: {
-        ...business.profileData,
-        taxId: "*******89000",
-        encryptedTaxId: "encrypted-tax-id",
-        taxPin: "****",
-        encryptedTaxPin: "encrypted-tax-pin",
-      },
-    }));
+    const expectedUserData = getExpectedEncryptedCurrentBusiness(userData);
     expect(response).toEqual(expectedUserData);
   });
 
-  it("does not encrypt tax id if it is already masked", async () => {
-    const userData = generateUserDataForBusiness(
-      generateBusiness({
-        profileData: generateProfileData({
-          taxId: "*******89000",
-          encryptedTaxId: "already-encrypted",
-          taxPin: taxPin,
-          encryptedTaxPin: undefined,
-        }),
-      }),
-    );
+  it("does not encrypt profile tax id if it is already masked", async () => {
+    const userData = generateUnencryptedUserData({
+      taxId: "*******89000",
+      encryptedTaxId: "already-encrypted",
+    });
     const response = await encryptTaxId(userData);
-    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(taxPin);
+    expect(stubEncryptionDecryptionClient.encryptValue).not.toHaveBeenCalledWith(profileTaxId);
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(profileTaxPin);
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxId);
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxPin);
     expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledTimes(
       numFieldsToEncrypt - 1,
     );
 
-    const expectedUserData = modifyCurrentBusiness(userData, (business) => ({
-      ...business,
-      profileData: {
-        ...business.profileData,
-        taxPin: "****",
-        encryptedTaxPin: "encrypted-tax-pin",
-      },
-    }));
+    const expectedUserData = getExpectedEncryptedCurrentBusiness(userData, {
+      taxId: "*******89000",
+      encryptedTaxId: "already-encrypted",
+    });
     expect(response).toEqual(expectedUserData);
   });
 
-  it("does not encrypt tax pin if it is already masked", async () => {
-    const userData = generateUserDataForBusiness(
-      generateBusiness({
-        profileData: generateProfileData({
-          taxId: taxId,
-          encryptedTaxId: undefined,
-          taxPin: "****",
-          encryptedTaxPin: "already-encrypted",
-        }),
-      }),
-    );
+  it("does not encrypt profile tax pin if it is already masked", async () => {
+    const userData = generateUnencryptedUserData({
+      taxPin: "****",
+      encryptedTaxPin: "already-encrypted",
+    });
     const response = await encryptTaxId(userData);
-    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(taxId);
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(profileTaxId);
+    expect(stubEncryptionDecryptionClient.encryptValue).not.toHaveBeenCalledWith(profileTaxPin);
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxId);
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxPin);
     expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledTimes(
       numFieldsToEncrypt - 1,
     );
 
-    const expectedUserData = modifyCurrentBusiness(userData, (business) => ({
-      ...business,
-      profileData: {
-        ...business.profileData,
+    const expectedUserData = getExpectedEncryptedCurrentBusiness(userData, {
+      taxPin: "****",
+      encryptedTaxPin: "already-encrypted",
+    });
+    expect(response).toEqual(expectedUserData);
+  });
+
+  it("does not encrypt tax clearance tax id if it is already masked", async () => {
+    const userData = generateUnencryptedUserData(
+      {},
+      {
         taxId: "*******89000",
-        encryptedTaxId: "encrypted-tax-id",
+        encryptedTaxId: "already-encrypted",
       },
-    }));
+    );
+    const response = await encryptTaxId(userData);
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(profileTaxId);
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(profileTaxPin);
+    expect(stubEncryptionDecryptionClient.encryptValue).not.toHaveBeenCalledWith(taxClearanceTaxId);
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxPin);
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledTimes(
+      numFieldsToEncrypt - 1,
+    );
+
+    const expectedUserData = getExpectedEncryptedCurrentBusiness(
+      userData,
+      {},
+      {
+        taxId: "*******89000",
+        encryptedTaxId: "already-encrypted",
+      },
+    );
+    expect(response).toEqual(expectedUserData);
+  });
+
+  it("does not encrypt tax clearance tax pin if it is already masked", async () => {
+    const userData = generateUnencryptedUserData(
+      {},
+      {
+        taxPin: "****",
+        encryptedTaxPin: "already-encrypted",
+      },
+    );
+    const response = await encryptTaxId(userData);
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(profileTaxId);
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(profileTaxPin);
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxId);
+    expect(stubEncryptionDecryptionClient.encryptValue).not.toHaveBeenCalledWith(
+      taxClearanceTaxPin,
+    );
+    expect(stubEncryptionDecryptionClient.encryptValue).toHaveBeenCalledTimes(
+      numFieldsToEncrypt - 1,
+    );
+
+    const expectedUserData = getExpectedEncryptedCurrentBusiness(
+      userData,
+      {},
+      {
+        taxPin: "****",
+        encryptedTaxPin: "already-encrypted",
+      },
+    );
     expect(response).toEqual(expectedUserData);
   });
 });

--- a/api/src/domain/user/encryptFieldsFactory.ts
+++ b/api/src/domain/user/encryptFieldsFactory.ts
@@ -72,7 +72,7 @@ const encryptProfileTaxPin = async (
   ) {
     return userData;
   }
-  const maskedTaxPin = maskingCharacter.repeat(4);
+  const maskedTaxPin = maskingCharacter.repeat(currentBusiness.profileData.taxPin.length);
   const encryptedTaxPin = await encryptionDecryptionClient.encryptValue(
     currentBusiness.profileData.taxPin as string,
   );

--- a/api/src/functions/express/app.ts
+++ b/api/src/functions/express/app.ts
@@ -413,7 +413,13 @@ app.use(
     dynamicsElevatorSafetyViolationsStatusClient,
   ),
 );
-app.use("/api", taxClearanceCertificateRouterFactory(taxClearanceCertificateClient));
+app.use(
+  "/api",
+  taxClearanceCertificateRouterFactory(
+    taxClearanceCertificateClient,
+    AWSEncryptionDecryptionClient,
+  ),
+);
 app.use("/api", fireSafetyRouterFactory(dynamicsFireSafetyClient));
 app.use(
   "/api",

--- a/shared/src/test/factories.ts
+++ b/shared/src/test/factories.ts
@@ -38,7 +38,12 @@ import {
 } from "../license";
 import { MunicipalityDetail } from "../municipality";
 import { OperatingPhaseId } from "../operatingPhase";
-import { BusinessPersona, IndustrySpecificData, ProfileData } from "../profileData";
+import {
+  BusinessPersona,
+  IndustrySpecificData,
+  maskingCharacter,
+  ProfileData,
+} from "../profileData";
 import { arrayOfSectors, SectorType } from "../sector";
 import { StateObject, arrayOfStateObjects as states } from "../states";
 import {
@@ -284,6 +289,7 @@ export const generateProfileData = (
   const id = `some-id-${randomInt()}`;
   const persona: BusinessPersona = randomElementFromArray(["STARTING", "OWNING", "FOREIGN"]);
   const industry = randomIndustry(canHavePermanentLocation);
+  const taxId = randomInt(12).toString();
 
   return {
     ...generateIndustrySpecificData({}),
@@ -297,11 +303,11 @@ export const generateProfileData = (
     dateOfFormation: getCurrentDateFormatted(defaultDateFormat),
     entityId: randomInt(10).toString(),
     employerId: randomInt(9).toString(),
-    taxId: randomInt(12).toString(),
+    taxId: maskingCharacter.repeat(7) + taxId.slice(-5),
     hashedTaxId: undefined,
-    encryptedTaxId: undefined,
-    taxPin: randomInt(4).toString(),
-    encryptedTaxPin: undefined,
+    encryptedTaxId: `encrypted-${taxId}`,
+    taxPin: maskingCharacter.repeat(4),
+    encryptedTaxPin: `encrypted-${randomInt(4)}`,
     notes: `some-notes-${randomInt()}`,
     ownershipTypeIds: [],
     documents: {
@@ -404,6 +410,7 @@ export const generateUnitedStatesStateDropdownOption = ({
 export const generateTaxClearanceCertificateData = (
   overrides: Partial<TaxClearanceCertificateData>,
 ): TaxClearanceCertificateData => {
+  const taxId = randomInt(12).toString();
   return {
     requestingAgencyId: randomElementFromArray(taxClearanceCertificateAgencies).id,
     businessName: `some-business-name-${randomInt()}`,
@@ -412,10 +419,10 @@ export const generateTaxClearanceCertificateData = (
     addressCity: `some-city-${randomInt()}`,
     addressState: generateUnitedStatesStateDropdownOption({}),
     addressZipCode: randomInt(5).toString(),
-    taxId: `${randomInt(12)}`,
-    encryptedTaxId: undefined,
-    taxPin: randomInt(4).toString(),
-    encryptedTaxPin: undefined,
+    taxId: maskingCharacter.repeat(7) + taxId.slice(-5),
+    encryptedTaxId: `encrypted-${taxId}`,
+    taxPin: maskingCharacter.repeat(4),
+    encryptedTaxPin: `encrypted-${randomInt(4)}`,
     ...overrides,
   };
 };

--- a/web/src/components/data-fields/TaxPin.test.tsx
+++ b/web/src/components/data-fields/TaxPin.test.tsx
@@ -1,4 +1,4 @@
-import { TaxPin } from "@/components/data-fields/TaxPin";
+import { TaxPin, Props as TaxPinProps } from "@/components/data-fields/TaxPin";
 import { getMergedConfig } from "@/contexts/configContext";
 import * as api from "@/lib/api-client/apiClient";
 import { currentProfileData, WithStatefulProfileData } from "@/test/mock/withStatefulProfileData";
@@ -35,12 +35,12 @@ const setLargeScreen = (value: boolean): void => {
   });
 };
 
-const renderComponent = (profileData: ProfileData): void => {
+const renderComponent = (profileData: ProfileData, fieldProps?: Partial<TaxPinProps>): void => {
   const business = generateBusiness({ profileData });
   render(
     <WithStatefulUserData initialUserData={generateUserDataForBusiness(business)}>
       <WithStatefulProfileData initialData={profileData}>
-        <TaxPin />
+        <TaxPin dbBusinessTaxPin={business.profileData.taxPin} {...fieldProps} />
       </WithStatefulProfileData>
       ,
     </WithStatefulUserData>,
@@ -113,6 +113,18 @@ describe("<TaxPin />", () => {
       taxPin: "****",
       encryptedTaxPin: "some-encrypted-value",
     });
+    expect(screen.getByLabelText("Tax pin")).toBeDisabled();
+  });
+
+  it("defaults to disabled if the database tax pin is masked, even if profileData tax pin is unmasked", () => {
+    renderComponent(
+      {
+        ...profileData,
+        taxPin: "1234",
+        encryptedTaxPin: "some-encrypted-value",
+      },
+      { dbBusinessTaxPin: "****" },
+    );
     expect(screen.getByLabelText("Tax pin")).toBeDisabled();
   });
 

--- a/web/src/components/data-fields/TaxPin.tsx
+++ b/web/src/components/data-fields/TaxPin.tsx
@@ -4,24 +4,23 @@ import { ConfigType } from "@/contexts/configContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { decryptValue } from "@/lib/api-client/apiClient";
 import { useConfig } from "@/lib/data-hooks/useConfig";
-import { useUserData } from "@/lib/data-hooks/useUserData";
 import { getProfileConfig } from "@/lib/domain-logic/getProfileConfig";
 import { MediaQueries } from "@/lib/PageSizes";
 import { getInitialShowHideStatus, isEncrypted } from "@/lib/utils/encryption";
 import { InputAdornment, useMediaQuery } from "@mui/material";
 import { ReactElement, useContext, useState } from "react";
 
-interface Props {
+export interface Props {
   handleChangeOverride?: (value: string) => void;
   inputWidth?: "full" | "default" | "reduced";
   required?: boolean;
   preventRefreshWhenUnmounted?: boolean;
+  dbBusinessTaxPin: string | undefined;
 }
 
 export const TaxPin = (props: Props): ReactElement => {
   const fieldName = "taxPin";
   const { Config } = useConfig();
-  const { business } = useUserData();
   const { state, setProfileData } = useContext(ProfileDataContext);
   const isTabletAndUp = useMediaQuery(MediaQueries.tabletAndUp);
   const taxPinIsEncrypted = isEncrypted(
@@ -29,7 +28,7 @@ export const TaxPin = (props: Props): ReactElement => {
     state.profileData.encryptedTaxPin,
   );
   const [showHideStatus, setShowHideStatus] = useState<ShowHideStatus>(
-    getInitialShowHideStatus(business?.profileData[fieldName]),
+    getInitialShowHideStatus(props.dbBusinessTaxPin),
   );
 
   const contentFromConfig: ConfigType["profileDefaults"]["fields"]["taxPin"]["default"] =

--- a/web/src/components/data-fields/tax-id/TaxId.test.tsx
+++ b/web/src/components/data-fields/tax-id/TaxId.test.tsx
@@ -1,4 +1,4 @@
-import { TaxId } from "@/components/data-fields/tax-id/TaxId";
+import { TaxId, Props as TaxIdProps } from "@/components/data-fields/tax-id/TaxId";
 import { getMergedConfig } from "@/contexts/configContext";
 import * as api from "@/lib/api-client/apiClient";
 import { currentProfileData, WithStatefulProfileData } from "@/test/mock/withStatefulProfileData";
@@ -35,13 +35,15 @@ const setLargeScreen = (value: boolean): void => {
   });
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const renderComponent = (profileData: ProfileData, fieldProps?: any): void => {
+const renderComponent = (profileData: ProfileData, fieldProps?: Partial<TaxIdProps>): void => {
   const business = generateBusiness({ profileData });
   render(
     <WithStatefulUserData initialUserData={generateUserDataForBusiness(business)}>
       <WithStatefulProfileData initialData={profileData}>
-        <TaxId {...fieldProps} />
+        <TaxId
+          dbBusinessTaxId={fieldProps ? fieldProps.dbBusinessTaxId : profileData.taxId}
+          {...fieldProps}
+        />
       </WithStatefulProfileData>
     </WithStatefulUserData>,
   );
@@ -148,6 +150,18 @@ describe("<TaxId />", () => {
         taxId: "********9000",
         encryptedTaxId: "some-encrypted-value",
       });
+      expect(screen.getByLabelText("Tax id")).toBeDisabled();
+    });
+
+    it("defaults to disabled if the database tax id is masked, even if profileData tax id is unmasked", () => {
+      renderComponent(
+        {
+          ...profileData,
+          taxId: "123456789000",
+          encryptedTaxId: "some-encrypted-value",
+        },
+        { dbBusinessTaxId: "********9000" },
+      );
       expect(screen.getByLabelText("Tax id")).toBeDisabled();
     });
 
@@ -367,6 +381,18 @@ describe("<TaxId />", () => {
       });
       expect(screen.getByLabelText("Tax id")).toBeDisabled();
       expect(screen.getByLabelText("Tax id location")).toBeDisabled();
+    });
+
+    it("defaults to disabled if the database tax id is masked, even if profileData tax id is unmasked", () => {
+      renderComponent(
+        {
+          ...profileData,
+          taxId: "123456789",
+          encryptedTaxId: "some-encrypted-value",
+        },
+        { dbBusinessTaxId: "*****6789" },
+      );
+      expect(screen.getByLabelText("Tax id")).toBeDisabled();
     });
 
     it("decrypts the tax id if tax id is a masked value", async () => {

--- a/web/src/components/data-fields/tax-id/TaxId.tsx
+++ b/web/src/components/data-fields/tax-id/TaxId.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { ProfileDataFieldProps } from "@/components/data-fields/ProfileDataField";
 import { SingleTaxId } from "@/components/data-fields/tax-id/SingleTaxId";
 import { SplitTaxId } from "@/components/data-fields/tax-id/SplitTaxId";
@@ -7,26 +5,25 @@ import { type ShowHideStatus, ShowHideToggleButton } from "@/components/ShowHide
 import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { decryptValue } from "@/lib/api-client/apiClient";
 import { useConfig } from "@/lib/data-hooks/useConfig";
-import { useUserData } from "@/lib/data-hooks/useUserData";
 import { MediaQueries } from "@/lib/PageSizes";
 import { getInitialShowHideStatus, isEncrypted } from "@/lib/utils/encryption";
 import { useMediaQuery } from "@mui/material";
 import { ReactElement, useContext, useRef, useState } from "react";
 
-interface Props
+export interface Props
   extends Omit<
     ProfileDataFieldProps,
     "fieldName" | "handleChange" | "onValidation" | "inputWidth"
   > {
   handleChangeOverride?: (value: string) => void;
   inputWidth?: "full" | "default" | "reduced";
+  dbBusinessTaxId: string | undefined;
 }
 
 export const TaxId = (props: Props): ReactElement => {
   const fieldName = "taxId";
 
   const isTabletAndUp = useMediaQuery(MediaQueries.tabletAndUp);
-  const { business } = useUserData();
   const { state, setProfileData } = useContext(ProfileDataContext);
   const { Config } = useConfig();
 
@@ -42,7 +39,7 @@ export const TaxId = (props: Props): ReactElement => {
 
   const taxIdIsEncrypted = isEncrypted(state.profileData.taxId, state.profileData.encryptedTaxId);
   const [taxIdDisplayStatus, setTaxIdDisplayStatus] = useState<ShowHideStatus>(
-    getInitialShowHideStatus(business?.profileData.taxId),
+    getInitialShowHideStatus(props.dbBusinessTaxId),
   );
 
   const getShowHideToggleButton = (toggleFunc?: (taxId: string) => void): ReactElement => {
@@ -86,10 +83,9 @@ export const TaxId = (props: Props): ReactElement => {
   };
 
   const additionalValidationIsValid = (value: string): boolean => {
-    if (!business) return true;
     if (
       !(value.length === 0 || value.length === 12) &&
-      (business.profileData.taxId !== value || props.required)
+      (props.dbBusinessTaxId !== value || props.required)
     ) {
       return false;
     }

--- a/web/src/components/filings-calendar/tax-access/TaxAccessStepTwo.test.tsx
+++ b/web/src/components/filings-calendar/tax-access/TaxAccessStepTwo.test.tsx
@@ -226,8 +226,8 @@ describe("<TaxAccessStepTwo />", () => {
       await waitFor(() => {
         return expect(currentBusiness().profileData.businessName).not.toEqual("zoom");
       });
-      expect(currentBusiness().profileData.taxId).toEqual("999888777666");
-      expect(currentBusiness().profileData.encryptedTaxId).toEqual("");
+      expect(currentBusiness().profileData.taxId).toEqual("*******77666");
+      expect(currentBusiness().profileData.encryptedTaxId).toEqual("encrypted-999888777666");
     });
 
     it("updates businessName on submit if tax filing is success", async () => {
@@ -255,8 +255,8 @@ describe("<TaxAccessStepTwo />", () => {
       await waitFor(() => {
         expect(currentBusiness().profileData.businessName).toEqual("zoom");
       });
-      expect(currentBusiness().profileData.taxId).toEqual("999888777666");
-      expect(currentBusiness().profileData.encryptedTaxId).toEqual("");
+      expect(currentBusiness().profileData.taxId).toEqual("*******77666");
+      expect(currentBusiness().profileData.encryptedTaxId).toEqual("encrypted-999888777666");
     });
 
     it("displays in-line error and alert when businessName field is empty and save button is clicked", async () => {
@@ -478,9 +478,8 @@ describe("<TaxAccessStepTwo />", () => {
       await waitFor(() => {
         return expect(currentBusiness().profileData.responsibleOwnerName).toEqual("zoom");
       });
-      await waitFor(() => {
-        return expect(currentBusiness().profileData.taxId).toEqual("123456789000");
-      });
+      expect(currentBusiness().profileData.taxId).toEqual("*******89000");
+      expect(currentBusiness().profileData.encryptedTaxId).toEqual("encrypted-123456789000");
     });
 
     it("displays in-line error and alert when responsibleOwnerName field is empty and save button is clicked", () => {

--- a/web/src/components/filings-calendar/tax-access/TaxAccessStepTwo.tsx
+++ b/web/src/components/filings-calendar/tax-access/TaxAccessStepTwo.tsx
@@ -309,6 +309,7 @@ export const TaxAccessStepTwo = (props: Props): ReactElement => {
               />
             </div>
             <TaxId
+              dbBusinessTaxId={business?.profileData.taxId}
               validationText={Config.taxAccess.failedTaxIdHelper}
               required
               inputWidth={"full"}

--- a/web/src/components/tasks/TaxInput.tsx
+++ b/web/src/components/tasks/TaxInput.tsx
@@ -148,6 +148,7 @@ export const TaxInput = (props: Props): ReactElement => {
           ) : (
             <>
               <TaxId
+                dbBusinessTaxId={business?.profileData.taxId}
                 required={isAuthenticated === IsAuthenticated.TRUE}
                 handleChangeOverride={getNeedsAccountModalFunction()}
               />

--- a/web/src/components/tasks/TaxTask.test.tsx
+++ b/web/src/components/tasks/TaxTask.test.tsx
@@ -157,7 +157,7 @@ describe("<TaxTask />", () => {
       fireEvent.change(screen.getByLabelText("Tax id"), { target: { value: "123456789123" } });
       fireEvent.click(screen.getByText(Config.taxId.saveButtonText));
       await waitFor(() => {
-        expect(currentBusiness().profileData.taxId).toEqual("123456789123");
+        expect(currentBusiness().profileData.taxId).toEqual("*******89123");
       });
     });
 
@@ -214,6 +214,7 @@ describe("<TaxTask />", () => {
       expect((screen.getByLabelText("Tax id") as HTMLInputElement).value).toEqual(
         "***-***-*89/123",
       );
+      expect(screen.getByLabelText("Tax id")).toBeDisabled();
     });
   });
 

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificate.test.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificate.test.tsx
@@ -569,10 +569,10 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
       addressCity: "Baltimore",
       addressState: { shortCode: "MD", name: "Maryland" },
       addressZipCode: "21210",
-      taxId: "012345678901",
-      encryptedTaxId: undefined,
-      taxPin: "1234",
-      encryptedTaxPin: undefined,
+      taxId: "*******78901",
+      encryptedTaxId: "encrypted-012345678901",
+      taxPin: "****",
+      encryptedTaxPin: "encrypted-1234",
     });
   });
 
@@ -610,10 +610,10 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
       addressCity: "Baltimore",
       addressState: { shortCode: "MD", name: "Maryland" },
       addressZipCode: "21210",
-      taxId: "012345678901",
-      encryptedTaxId: undefined,
-      taxPin: "1234",
-      encryptedTaxPin: undefined,
+      taxId: "*******78901",
+      encryptedTaxId: "encrypted-012345678901",
+      taxPin: "****",
+      encryptedTaxPin: "encrypted-1234",
     });
   });
 
@@ -850,9 +850,9 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
       expect(within(screen.getByTestId("businessName")).getByText("Test Name")).toBeInTheDocument();
       expect(within(screen.getByTestId("addressLabel")).getByText(address)).toBeInTheDocument();
       expect(
-        within(screen.getByTestId("stateTaxIdLabel")).getByText("012345678901"),
+        within(screen.getByTestId("stateTaxIdLabel")).getByText("*******78901"),
       ).toBeInTheDocument();
-      expect(within(screen.getByTestId("taxPinLabel")).getByText("1234")).toBeInTheDocument();
+      expect(within(screen.getByTestId("taxPinLabel")).getByText("****")).toBeInTheDocument();
     });
 
     describe("renders data when input is provided", () => {});

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/helpers.ts
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/helpers.ts
@@ -3,6 +3,14 @@ import { StateObject } from "@businessnjgovnavigator/shared/states";
 import { TaxClearanceCertificateData } from "@businessnjgovnavigator/shared/taxClearanceCertificate";
 import { Business } from "@businessnjgovnavigator/shared/userData";
 
+export const getInitialTaxId = (business: Business | undefined): string => {
+  return business?.taxClearanceCertificateData?.taxId || business?.profileData.taxId || "";
+};
+
+export const getInitialTaxPin = (business: Business | undefined): string => {
+  return business?.taxClearanceCertificateData?.taxPin || business?.profileData.taxPin || "";
+};
+
 export const getInitialData = (
   business: Business,
 ): {
@@ -43,12 +51,12 @@ export const getInitialData = (
     business?.taxClearanceCertificateData?.addressZipCode ||
     business.formationData.formationFormData.addressZipCode ||
     "";
-  const taxId = business?.taxClearanceCertificateData?.taxId || business.profileData.taxId || "";
+  const taxId = getInitialTaxId(business);
   const encryptedTaxId =
     business?.taxClearanceCertificateData?.encryptedTaxId ||
     business.profileData.encryptedTaxId ||
     undefined;
-  const taxPin = business?.taxClearanceCertificateData?.taxPin || business.profileData.taxPin || "";
+  const taxPin = getInitialTaxPin(business);
   const encryptedTaxPin =
     business?.taxClearanceCertificateData?.encryptedTaxPin ||
     business.profileData.encryptedTaxPin ||

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/CheckEligibility.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/CheckEligibility.tsx
@@ -10,7 +10,10 @@ import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
 import { ActionBarLayout } from "@/components/njwds-layout/ActionBarLayout";
 import { ProfileField } from "@/components/profile/ProfileField";
-import { getInitialTaxId } from "@/components/tasks/anytime-action/tax-clearance-certificate/helpers";
+import {
+  getInitialTaxId,
+  getInitialTaxPin,
+} from "@/components/tasks/anytime-action/tax-clearance-certificate/helpers";
 import { StateAgencyDropdown } from "@/components/tasks/anytime-action/tax-clearance-certificate/StateAgencyDropdown";
 import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { useAddressErrors } from "@/lib/data-hooks/useAddressErrors";
@@ -105,7 +108,7 @@ export const CheckEligibility = (props: Props): ReactElement => {
         <div>
           <ProfileField fieldName="taxPin" hideLine fullWidth>
             <TaxPin
-              dbBusinessTaxPin={business?.taxClearanceCertificateData?.taxPin}
+              dbBusinessTaxPin={getInitialTaxPin(business)}
               inputWidth="full"
               preventRefreshWhenUnmounted
               required

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/CheckEligibility.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/CheckEligibility.tsx
@@ -10,11 +10,13 @@ import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
 import { ActionBarLayout } from "@/components/njwds-layout/ActionBarLayout";
 import { ProfileField } from "@/components/profile/ProfileField";
+import { getInitialTaxId } from "@/components/tasks/anytime-action/tax-clearance-certificate/helpers";
 import { StateAgencyDropdown } from "@/components/tasks/anytime-action/tax-clearance-certificate/StateAgencyDropdown";
 import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { useAddressErrors } from "@/lib/data-hooks/useAddressErrors";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
+import { useUserData } from "@/lib/data-hooks/useUserData";
 import { FormEvent, ReactElement } from "react";
 
 interface Props {
@@ -55,6 +57,7 @@ export const CheckEligibility = (props: Props): ReactElement => {
     setIsValidState(!doesFieldHaveError("addressState"));
     setIsValidZipCode(!doesFieldHaveError("addressZipCode"));
   };
+  const { business } = useUserData();
 
   const handleSaveButtonClick = (): void => {
     props.onSave();
@@ -91,12 +94,22 @@ export const CheckEligibility = (props: Props): ReactElement => {
         </div>
         <div className="margin-y-2">
           <ProfileField fieldName="taxId" hideLine fullWidth>
-            <TaxId inputWidth="full" preventRefreshWhenUnmounted required />
+            <TaxId
+              dbBusinessTaxId={getInitialTaxId(business)}
+              inputWidth="full"
+              preventRefreshWhenUnmounted
+              required
+            />
           </ProfileField>
         </div>
         <div>
           <ProfileField fieldName="taxPin" hideLine fullWidth>
-            <TaxPin inputWidth="full" preventRefreshWhenUnmounted required />
+            <TaxPin
+              dbBusinessTaxPin={business?.taxClearanceCertificateData?.taxPin}
+              inputWidth="full"
+              preventRefreshWhenUnmounted
+              required
+            />
           </ProfileField>
         </div>
       </div>

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/Review.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/Review.tsx
@@ -109,7 +109,8 @@ export const Review = (props: Props): ReactElement => {
           />
           <ReviewLineItem
             label={Config.taxClearanceCertificateStep3.taxPinLabel}
-            value={business?.taxClearanceCertificateData?.taxPin}
+            // A masked tax pin is "****", which is not rendered as literal text in markdown.
+            value={business?.taxClearanceCertificateData?.taxPin?.replace("*", "&ast;")}
             dataTestId={"taxPinLabel"}
           />
         </ReviewSubSection>

--- a/web/src/lib/cms/previews/ProfileFieldsPreview.tsx
+++ b/web/src/lib/cms/previews/ProfileFieldsPreview.tsx
@@ -143,11 +143,11 @@ const ProfileFieldsPreview = (props: PreviewProps): ReactElement => {
 
           <hr className="margin-y-4" />
           <FieldLabelOnboarding fieldName="taxId" />
-          <TaxId />
+          <TaxId dbBusinessTaxId="" />
 
           <hr className="margin-y-4" />
           <FieldLabelOnboarding fieldName="taxPin" />
-          <TaxPin />
+          <TaxPin dbBusinessTaxPin="" />
 
           <hr className="margin-y-4" />
           <FieldLabelOnboarding fieldName="entityId" />

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -490,7 +490,10 @@ const ProfilePage = (props: Props): ReactElement => {
             {hasSubmittedTaxData ? (
               <DisabledTaxId />
             ) : (
-              <TaxId handleChangeOverride={showNeedsAccountModalForGuest()} />
+              <TaxId
+                dbBusinessTaxId={business?.profileData.taxId}
+                handleChangeOverride={showNeedsAccountModalForGuest()}
+              />
             )}
           </div>
           {business?.profileData.naicsCode && (
@@ -503,7 +506,10 @@ const ProfilePage = (props: Props): ReactElement => {
         </ProfileField>
 
         <ProfileField fieldName="taxPin">
-          <TaxPin handleChangeOverride={showNeedsAccountModalForGuest()} />
+          <TaxPin
+            dbBusinessTaxPin={business?.taxClearanceCertificateData?.taxPin}
+            handleChangeOverride={showNeedsAccountModalForGuest()}
+          />
         </ProfileField>
       </div>
     ),
@@ -549,13 +555,19 @@ const ProfilePage = (props: Props): ReactElement => {
             {hasSubmittedTaxData ? (
               <DisabledTaxId />
             ) : (
-              <TaxId handleChangeOverride={showNeedsAccountModalForGuest()} />
+              <TaxId
+                dbBusinessTaxId={business?.profileData.taxId}
+                handleChangeOverride={showNeedsAccountModalForGuest()}
+              />
             )}
           </div>
         </ProfileField>
 
         <ProfileField fieldName="taxPin">
-          <TaxPin handleChangeOverride={showNeedsAccountModalForGuest()} />
+          <TaxPin
+            dbBusinessTaxPin={business?.taxClearanceCertificateData?.taxPin}
+            handleChangeOverride={showNeedsAccountModalForGuest()}
+          />
         </ProfileField>
       </div>
     ),
@@ -774,13 +786,19 @@ const ProfilePage = (props: Props): ReactElement => {
             {hasSubmittedTaxData ? (
               <DisabledTaxId />
             ) : (
-              <TaxId handleChangeOverride={showNeedsAccountModalForGuest()} />
+              <TaxId
+                dbBusinessTaxId={business?.profileData.taxId}
+                handleChangeOverride={showNeedsAccountModalForGuest()}
+              />
             )}
           </div>
         </ProfileField>
 
         <ProfileField fieldName="taxPin">
-          <TaxPin handleChangeOverride={showNeedsAccountModalForGuest()} />
+          <TaxPin
+            dbBusinessTaxPin={business?.taxClearanceCertificateData?.taxPin}
+            handleChangeOverride={showNeedsAccountModalForGuest()}
+          />
         </ProfileField>
       </div>
     ),
@@ -967,13 +985,19 @@ const ProfilePage = (props: Props): ReactElement => {
             {hasSubmittedTaxData ? (
               <DisabledTaxId />
             ) : (
-              <TaxId handleChangeOverride={showNeedsAccountModalForGuest()} />
+              <TaxId
+                dbBusinessTaxId={business?.profileData.taxId}
+                handleChangeOverride={showNeedsAccountModalForGuest()}
+              />
             )}
           </div>
         </ProfileField>
 
         <ProfileField fieldName="taxPin">
-          <TaxPin handleChangeOverride={showNeedsAccountModalForGuest()} />
+          <TaxPin
+            dbBusinessTaxPin={business?.taxClearanceCertificateData?.taxPin}
+            handleChangeOverride={showNeedsAccountModalForGuest()}
+          />
         </ProfileField>
       </div>
     ),
@@ -1028,7 +1052,10 @@ const ProfilePage = (props: Props): ReactElement => {
             {hasSubmittedTaxData ? (
               <DisabledTaxId />
             ) : (
-              <TaxId handleChangeOverride={showNeedsAccountModalForGuest()} />
+              <TaxId
+                dbBusinessTaxId={business?.profileData.taxId}
+                handleChangeOverride={showNeedsAccountModalForGuest()}
+              />
             )}
           </div>
         </ProfileField>

--- a/web/stories/Molecules/textfields/OneEncryptedFieldTextField.stories.tsx
+++ b/web/stories/Molecules/textfields/OneEncryptedFieldTextField.stories.tsx
@@ -2,7 +2,10 @@ import { TaxId } from "@/components/data-fields/tax-id/TaxId";
 import { FieldLabelModal } from "@/components/field-labels/FieldLabelModal";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { ConfigContext, ConfigType, getMergedConfig } from "@/contexts/configContext";
-import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
+import {
+  createDataFormErrorMap,
+  DataFormErrorMapContext,
+} from "@/contexts/dataFormErrorMapContext";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
@@ -55,7 +58,7 @@ const Template = () => {
                   }}
                 />
               </div>
-              <TaxId required />
+              <TaxId dbBusinessTaxId="" required />
             </WithErrorBar>
 
             <WithErrorBar hasError type="ALWAYS" className="margin-top-2">
@@ -71,7 +74,12 @@ const Template = () => {
                   }}
                 />
               </div>
-              <TaxId validationText={config.taxAccess.failedTaxIdHelper} required error />
+              <TaxId
+                dbBusinessTaxId=""
+                validationText={config.taxAccess.failedTaxIdHelper}
+                required
+                error
+              />
             </WithErrorBar>
           </ProfileDataContext.Provider>
         </ConfigContext.Provider>

--- a/web/stories/Molecules/textfields/TwoEncryptedFieldTextField.stories.tsx
+++ b/web/stories/Molecules/textfields/TwoEncryptedFieldTextField.stories.tsx
@@ -2,7 +2,10 @@ import { TaxId } from "@/components/data-fields/tax-id/TaxId";
 import { FieldLabelModal } from "@/components/field-labels/FieldLabelModal";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { ConfigContext, ConfigType, getMergedConfig } from "@/contexts/configContext";
-import { createDataFormErrorMap, DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
+import {
+  createDataFormErrorMap,
+  DataFormErrorMapContext,
+} from "@/contexts/dataFormErrorMapContext";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
@@ -13,8 +16,9 @@ import { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 
 const Template = () => {
+  const taxId = "2";
   const [config, setConfig] = useState<ConfigType>(getMergedConfig());
-  const [profileData, setProfileData] = useState<ProfileData>(generateProfileData({ taxId: "2" }));
+  const [profileData, setProfileData] = useState<ProfileData>(generateProfileData({ taxId }));
   const { state: formContextState } = useFormContextHelper(createDataFormErrorMap());
 
   return (
@@ -52,7 +56,11 @@ const Template = () => {
                 headerNotBolded: "UnBoldedHeader Text",
               }}
             />
-            <TaxId validationText={config.taxAccess.failedTaxIdHelper} required />
+            <TaxId
+              dbBusinessTaxId={taxId}
+              validationText={config.taxAccess.failedTaxIdHelper}
+              required
+            />
 
             <WithErrorBar hasError type="ALWAYS" className="margin-top-2">
               <FieldLabelModal
@@ -65,7 +73,12 @@ const Template = () => {
                   headerNotBolded: "UnBoldedHeader Text",
                 }}
               />
-              <TaxId validationText={config.taxAccess.failedTaxIdHelper} required error />
+              <TaxId
+                dbBusinessTaxId={taxId}
+                validationText={config.taxAccess.failedTaxIdHelper}
+                required
+                error
+              />
             </WithErrorBar>
           </ProfileDataContext.Provider>
         </ConfigContext.Provider>

--- a/web/test/mock/mockEncryptFields.ts
+++ b/web/test/mock/mockEncryptFields.ts
@@ -1,0 +1,67 @@
+import {
+  getCurrentBusiness,
+  maskingCharacter,
+  modifyCurrentBusiness,
+} from "@businessnjgovnavigator/shared/index";
+import { type UserData } from "@businessnjgovnavigator/shared/userData";
+
+export const maskTaxId = (taxId: string): string => {
+  return taxId.length === 12
+    ? `${maskingCharacter.repeat(7)}${taxId.slice(7, taxId.length)}`
+    : `${maskingCharacter.repeat(5)}${taxId.slice(5, taxId.length)}`;
+};
+
+export const mockEncryptFields = (userData: UserData): UserData => {
+  const currentBusiness = getCurrentBusiness(userData);
+  return modifyCurrentBusiness(userData, (business) => ({
+    ...business,
+    profileData: {
+      ...business.profileData,
+      taxId:
+        !currentBusiness.profileData.taxId ||
+        currentBusiness.profileData.taxId?.includes(maskingCharacter)
+          ? currentBusiness.profileData.taxId
+          : maskTaxId(currentBusiness.profileData.taxId as string),
+      encryptedTaxId:
+        !currentBusiness.profileData.taxId ||
+        currentBusiness.profileData.taxId?.includes(maskingCharacter)
+          ? currentBusiness.profileData.encryptedTaxId
+          : `encrypted-${currentBusiness.profileData.taxId}`,
+      taxPin:
+        !currentBusiness.profileData.taxPin ||
+        currentBusiness.profileData.taxPin?.includes(maskingCharacter)
+          ? currentBusiness.profileData.taxPin
+          : maskingCharacter.repeat(currentBusiness.profileData.taxPin.length),
+      encryptedTaxPin:
+        !currentBusiness.profileData.taxPin ||
+        currentBusiness.profileData.taxPin?.includes(maskingCharacter)
+          ? currentBusiness.profileData.encryptedTaxPin
+          : `encrypted-${currentBusiness.profileData.taxPin}`,
+    },
+    taxClearanceCertificateData: business.taxClearanceCertificateData
+      ? {
+          ...business.taxClearanceCertificateData,
+          taxId:
+            !currentBusiness.taxClearanceCertificateData?.taxId ||
+            currentBusiness.taxClearanceCertificateData?.taxId?.includes(maskingCharacter)
+              ? currentBusiness.taxClearanceCertificateData?.taxId
+              : maskTaxId(currentBusiness.taxClearanceCertificateData?.taxId as string),
+          encryptedTaxId:
+            !currentBusiness.taxClearanceCertificateData?.taxId ||
+            currentBusiness.taxClearanceCertificateData?.taxId?.includes(maskingCharacter)
+              ? currentBusiness.taxClearanceCertificateData?.encryptedTaxId
+              : `encrypted-${currentBusiness.taxClearanceCertificateData?.taxId}`,
+          taxPin:
+            !currentBusiness.taxClearanceCertificateData?.taxPin ||
+            currentBusiness.taxClearanceCertificateData?.taxPin?.includes(maskingCharacter)
+              ? currentBusiness.taxClearanceCertificateData?.taxPin
+              : maskingCharacter.repeat(currentBusiness.taxClearanceCertificateData?.taxPin.length),
+          encryptedTaxPin:
+            !currentBusiness.taxClearanceCertificateData?.taxPin ||
+            currentBusiness.taxClearanceCertificateData?.taxPin?.includes(maskingCharacter)
+              ? currentBusiness.taxClearanceCertificateData?.encryptedTaxPin
+              : `encrypted-${currentBusiness.taxClearanceCertificateData?.taxPin}`,
+        }
+      : undefined,
+  }));
+};

--- a/web/test/mock/withStatefulData.tsx
+++ b/web/test/mock/withStatefulData.tsx
@@ -6,6 +6,7 @@ import { UpdateQueue } from "@/lib/types/types";
 import { UpdateQueueFactory } from "@/lib/UpdateQueue";
 import { isUserData } from "@/lib/utils/helpers";
 import { getLastCalledWith, getNumberOfMockCalls } from "@/test/helpers/helpers-utilities";
+import { mockEncryptFields } from "@/test/mock/mockEncryptFields";
 import { ProfileData } from "@businessnjgovnavigator/shared/profileData";
 import { UserData } from "@businessnjgovnavigator/shared/userData";
 import { createContext, ReactElement, ReactNode, useEffect, useState } from "react";
@@ -50,6 +51,10 @@ export const WithStatefulData = (spy: jest.Mock): ((props: StatefulDataProps) =>
       newData: GenericData | undefined,
       config?: { local?: boolean },
     ): Promise<void> => {
+      if (!config?.local && isUserData(genericData as UserData | ProfileData)) {
+        newData = mockEncryptFields(newData as UserData);
+      }
+
       spy(newData, config);
       setGenericData(newData);
       return Promise.resolve();

--- a/web/test/pages/profile/profile-owning.test.tsx
+++ b/web/test/pages/profile/profile-owning.test.tsx
@@ -127,9 +127,11 @@ describe("profile - owning existing business", () => {
   });
 
   it("updates the user data on save", async () => {
+    const initialTaxId = randomInt(9).toString();
     const business = generateBusinessForProfile({
       profileData: generateOwningProfileData({
-        taxId: randomInt(9).toString(),
+        taxId: `*****${initialTaxId.slice(-4)}`,
+        encryptedTaxId: `encrypted-${initialTaxId}`,
         industryId: "generic",
         legalStructureId: "limited-liability-company",
       }),
@@ -186,11 +188,13 @@ describe("profile - owning existing business", () => {
         ownershipTypeIds: ["veteran-owned", "woman-owned"],
         municipality: randomMunicipality,
         dateOfFormation,
-        taxId: "023456790123",
+        taxId: "*******90123",
+        encryptedTaxId: "encrypted-023456790123",
         entityId: "0234567890",
         employerId: "023456780",
         notes: "whats appppppp",
-        taxPin: "6666",
+        taxPin: "****",
+        encryptedTaxPin: "encrypted-6666",
         sectorId: "clean-energy",
       },
       formationData: {

--- a/web/test/pages/profile/profile-starting.test.tsx
+++ b/web/test/pages/profile/profile-starting.test.tsx
@@ -361,7 +361,8 @@ describe("profile - starting business", () => {
         sectorId: "retail-trade-and-ecommerce",
         homeBasedBusiness: true,
         municipality: randomMunicipality,
-        taxId: "023456790123",
+        taxId: "*******90123",
+        encryptedTaxId: "encrypted-023456790123",
         employerId: "023456780",
         notes: "whats appppppp",
       },
@@ -609,7 +610,8 @@ describe("profile - starting business", () => {
         profileData: generateProfileData({
           businessPersona: "STARTING",
           legalStructureId: "limited-liability-company",
-          taxId: "123456789",
+          taxId: "*****6789",
+          encryptedTaxId: "encrypted-123456789",
         }),
       });
 
@@ -656,7 +658,11 @@ describe("profile - starting business", () => {
               state: undefined,
               registeredISO: undefined,
             },
-            profileData: { ...businessWith9TaxId.profileData, taxId: "123456789123" },
+            profileData: {
+              ...businessWith9TaxId.profileData,
+              taxId: "*******89123",
+              encryptedTaxId: "encrypted-123456789123",
+            },
           });
         });
       });
@@ -676,7 +682,11 @@ describe("profile - starting business", () => {
               state: undefined,
               registeredISO: undefined,
             },
-            profileData: { ...businessWith9TaxId.profileData, taxId: "" },
+            profileData: {
+              ...businessWith9TaxId.profileData,
+              taxId: "",
+              encryptedTaxId: "encrypted-123456789", // Note that this does not clear the encryption
+            },
           });
         });
       });
@@ -687,7 +697,8 @@ describe("profile - starting business", () => {
         profileData: generateProfileData({
           businessPersona: "STARTING",
           legalStructureId: "limited-liability-company",
-          taxId: "123456789123",
+          taxId: "*******89123",
+          encryptedTaxId: "encrypted-123456789123",
         }),
       });
 
@@ -728,13 +739,17 @@ describe("profile - starting business", () => {
               state: undefined,
               registeredISO: undefined,
             },
-            profileData: { ...businessWith12TaxId.profileData, taxId: "666666666666" },
+            profileData: {
+              ...businessWith12TaxId.profileData,
+              taxId: "*******66666",
+              encryptedTaxId: "encrypted-666666666666",
+            },
           });
         });
       });
     });
 
-    describe("when the tax ID is initially 0  in length", () => {
+    describe("when the tax ID is initially 0 in length", () => {
       const businessWithEmptyTaxId = generateBusinessForProfile({
         profileData: generateProfileData({
           taxId: "",
@@ -780,7 +795,11 @@ describe("profile - starting business", () => {
               state: undefined,
               registeredISO: undefined,
             },
-            profileData: { ...businessWithEmptyTaxId.profileData, taxId: "123456789123" },
+            profileData: {
+              ...businessWithEmptyTaxId.profileData,
+              taxId: "*******89123",
+              encryptedTaxId: "encrypted-123456789123",
+            },
           });
         });
       });


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

Previously, the tax id and tax pin fields on tax clearance were stored as plain text. A prior PR had added the `encryptedTaxId` and `encryptedTaxPin` fields on tax clearance data, but they were not yet in use. Tax id and pin on the profile were already encrypted.

This PR updates the tax id and pin fields in tax clearance to also be encrypted. This involves:
- When the user saves tax clearance data, mask and encrypt the tax id and pin fields
- Decouple the `<TaxId/>` and `<TaxPin/>` components from the assumption that they are always pulling from the profile copy of tax id and tax pin
- Decrypt the encrypted tax id and pin before sending to the taxation API

After this, in both profile and tax clearance, all tax ids and pins should be masked and encrypted at rest while in the database. This PR also thus modifies tests to reflect this. I didn't bother to standardize every test especially if there is an existing precedent for that file, but for most tests, if e.g. the tax id is "actually" `123456789000`, the tax id should be `*******89000` and the encrypted tax id should be `encrypted-123456789000`.

Commit 1: Encrypt tax clearance on user save
Commit 2: Lift hardcoded `business?.profileData.taxId` and `business?.profileData.taxPin` out of TaxId and TaxPin components
Commit 3: Decrypt tax id and pin before sending to taxation API
Commit 4: Default test generated taxId and taxPins to encrypted, and encrypt on test user data post
Commit 5: Render `****` as literal non-markdown text

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves #[12793](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12793).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

#### Decoupling `<TaxId/>` and `<TaxPin/>` from profile data

I saw two possible approaches in how to decouple tax id and pin from profile data, and I went for the fewer-lines-changed one. I think this is more wonky and less clean, but preserves the existing pattern we have have since we probably chose it for reasons.

The central issue is that our generic frontend components (`<TaxId />`, `<UnitesStatesAddress />`) are tightly coupled to the data source (`business.profileData.taxId`, `business.formationData.formationFormData`) that they were first implemented for. `<AnytimeActionTaxClearanceCertificateElement />` currently handles this by creating empty `createEmptyProfileData()` and `emptyFormationAddressData`, and providing these via context providers to the generic `<TaxId />`, `<UnitesStatesAddress />` components. The empty profileData and formationAddressData local states are used as "scratchpad" local states to hold the current input value. Effectively, it creates the structure of local state that mimics profile, so `<TaxId />` can pretend it's using profile local state.

However, even if we mimic local state, `<TaxId />` and `<TaxPin />` were still coupled to read the database value (`business`) from profile, and we need it to correctly use the tax clearance value for encryption's stake. The `business` value definitely needs to be decoupled, and so I lifted that out of the component.

One could argue that it would be cleaner to also decouple `<TaxId />` and `<TaxPin />` from the assumption that it's reading from a "profile" local context-provided state. However, I figure that the wonkiness is a deliberate choice and compromise for now, and I don't have context on that decision or want to step over it with asking first. Open to any thoughts or it context that people might have here.

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

<details>
  <summary>Expand for screenshots</summary>
  
<img width="991" alt="749480 hideen" src="https://github.com/user-attachments/assets/1f6abc98-144d-462b-bcd0-9b350d3c7bcc" />
<img width="1032" alt="shown" src="https://github.com/user-attachments/assets/939b8c65-c85d-4a9f-9ab9-477039a5682e" />
<img width="1005" alt="749480 review" src="https://github.com/user-attachments/assets/096c8931-b7c4-4f1e-909f-610e84238eb6" />

</details>

1. In web/.env, set `FEATURE_TAX_CLEARANCE_CERTIFICATE=true`
2. In the dashboard anytime action dropdown, select the "Get a Tax Clearance Certificate"
3. In the step 2 "Check Eligibility", fill in everything, using `777-777-777/771` for the tax id and `3889` for the tax pin
4. Click "Save & Continue", or just click on the step 3 tab
5. The tax id and pin should show up masked in step 3 with `*`s
6. Clicking "Back", or on the step 2 tab, should go back to the previous step with tax id and pin hidden
7. Open the devtools network tab. Clicking show on tax id and pin should trigger a call to /decrypt on the first show for each field.
8. Going forward to step 3, clicking on "Save & Continue" all the way should give a success screen where you can download a pdf.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migxation file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Addxtions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
