### PR TITLE
feat: [AB#12793] Fix password view bug in tax task (separate from profile or tax clearance)

### DIFF
--- a/web/src/components/tasks/TaxInput.tsx
+++ b/web/src/components/tasks/TaxInput.tsx
@@ -148,6 +148,7 @@ export const TaxInput = (props: Props): ReactElement => {
           ) : (
             <>
               <TaxId
+                key={business?.profileData.taxId}
                 dbBusinessTaxId={business?.profileData.taxId}
                 required={isAuthenticated === IsAuthenticated.TRUE}
                 handleChangeOverride={getNeedsAccountModalFunction()}

--- a/web/src/components/tasks/TaxTask.test.tsx
+++ b/web/src/components/tasks/TaxTask.test.tsx
@@ -159,6 +159,11 @@ describe("<TaxTask />", () => {
       await waitFor(() => {
         expect(currentBusiness().profileData.taxId).toEqual("*******89123");
       });
+      expect(screen.getByLabelText("Tax id")).toBeDisabled();
+      expect((screen.getByLabelText("Tax id") as HTMLInputElement).type).toEqual("password");
+      expect((screen.getByLabelText("Tax id") as HTMLInputElement).value).toEqual(
+        "***-***-*89/123",
+      );
     });
 
     it("shows error on length validation failure", () => {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

Bug was introduced in https://github.com/newjersey/navigator.business.nj.gov/pull/10273#discussion_r2076164682. Turns out there is a situation where we update `business` without unmounting! See https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12793#13715563 for noticing the bug.

Added a test to enforce this behavior.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves #[12793](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12793).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

Previously, 
- enter as poppy
- select business structure
- dashboard task "Register Your Business for State Taxes and Employer Purposes"
- fill in tax id, click save
- you get this weird thing:
<img width="503" alt="image" src="https://github.com/user-attachments/assets/74f7e4a5-4962-44eb-8494-a7f19574db62" />

Now, it correctly sets to hidden password view on save
<img width="544" alt="image" src="https://github.com/user-attachments/assets/eada3297-b41c-472e-a066-79c7dcb66cba" />


### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migxation file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Addxtions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
