### PR TITLE
fix: [AB#7327] fix agentAddressCity validation

### DIFF
--- a/web/src/components/tasks/business-formation/contacts/RegisteredAgent.tsx
+++ b/web/src/components/tasks/business-formation/contacts/RegisteredAgent.tsx
@@ -37,7 +37,7 @@ export const RegisteredAgent = (): ReactElement => {
         agentUseBusinessAddress &&
         (agentOfficeAddressLine1 !== addressLine1 ||
           agentOfficeAddressLine2 !== addressLine2 ||
-          agentOfficeAddressCity !== addressMunicipality?.displayName ||
+          agentOfficeAddressCity !== addressMunicipality?.name ||
           agentOfficeAddressZipCode !== addressZipCode)
       ) {
         setFormationFormData({
@@ -112,7 +112,7 @@ export const RegisteredAgent = (): ReactElement => {
         ...state.formationFormData,
         agentOfficeAddressLine1: state.formationFormData.addressLine1,
         agentOfficeAddressLine2: state.formationFormData.addressLine2,
-        agentOfficeAddressCity: state.formationFormData.addressMunicipality?.displayName || "",
+        agentOfficeAddressCity: state.formationFormData.addressMunicipality?.name || "",
         agentOfficeAddressZipCode: state.formationFormData.addressZipCode,
         agentUseBusinessAddress: checked,
       });


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

There was a character limit error message appearing for the user in relation to the Office City field on the Registered Agent section of the Contacts tab on the Check Available Names and Form Your Business screen. The fix with the smallest overhead was to change the addressCity to show the `name` rather than `displayName`. Increasing the char limit on the validations was not possible because it would cause issues on the Department of Treasury side. 

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#7327](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7327).

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
