### PR TITLE
feat: [AB#7782] Fix profile tax pin init view

### DIFF
--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -507,7 +507,7 @@ const ProfilePage = (props: Props): ReactElement => {
 
         <ProfileField fieldName="taxPin">
           <TaxPin
-            dbBusinessTaxPin={business?.taxClearanceCertificateData?.taxPin}
+            dbBusinessTaxPin={business?.profileData?.taxPin}
             handleChangeOverride={showNeedsAccountModalForGuest()}
           />
         </ProfileField>
@@ -565,7 +565,7 @@ const ProfilePage = (props: Props): ReactElement => {
 
         <ProfileField fieldName="taxPin">
           <TaxPin
-            dbBusinessTaxPin={business?.taxClearanceCertificateData?.taxPin}
+            dbBusinessTaxPin={business?.profileData?.taxPin}
             handleChangeOverride={showNeedsAccountModalForGuest()}
           />
         </ProfileField>
@@ -796,7 +796,7 @@ const ProfilePage = (props: Props): ReactElement => {
 
         <ProfileField fieldName="taxPin">
           <TaxPin
-            dbBusinessTaxPin={business?.taxClearanceCertificateData?.taxPin}
+            dbBusinessTaxPin={business?.profileData?.taxPin}
             handleChangeOverride={showNeedsAccountModalForGuest()}
           />
         </ProfileField>
@@ -995,7 +995,7 @@ const ProfilePage = (props: Props): ReactElement => {
 
         <ProfileField fieldName="taxPin">
           <TaxPin
-            dbBusinessTaxPin={business?.taxClearanceCertificateData?.taxPin}
+            dbBusinessTaxPin={business?.profileData?.taxPin}
             handleChangeOverride={showNeedsAccountModalForGuest()}
           />
         </ProfileField>


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
PR #10367 accidentally introduced a bug that initialized whether to show/hide the profile tax pin based on the tax pin in tax clearance. It should instead be based on the pin in profile.

Will fast follow with a test, but I wanted to get this fixed before demo tomorrow.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This commit resolves #[7782](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7782).


### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

- New business
- Go to profile, reference numbers, fill in tax pin, hit save
- Should show password view, defaulting to the "Show" button
<img width="425" alt="image" src="https://github.com/user-attachments/assets/7c33dabd-3353-4c39-815d-5e3fa3447a4b" />


### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migxation file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Addxtions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
