### PR TITLE
fix: [AB#14382] remove domestic-employer as option for permits tests

### DIFF
--- a/web/test/pages/profile/profile-starting.test.tsx
+++ b/web/test/pages/profile/profile-starting.test.tsx
@@ -1105,7 +1105,7 @@ describe("profile - starting business", () => {
     renderPage({
       business: generateBusinessForProfile({
         profileData: generateProfileData({
-          industryId: randomNonHomeBasedIndustry(),
+          industryId: randomNonHomeBasedIndustry(["domestic-employer"]),
           businessPersona: "STARTING",
         }),
       }),
@@ -1123,11 +1123,12 @@ describe("profile - starting business", () => {
   it("does not show the home-based question if not applicable to industry", () => {
     const business = generateBusinessForProfile({
       profileData: generateProfileData({
-        industryId: randomNonHomeBasedIndustry(),
+        industryId: randomNonHomeBasedIndustry(["domestic-employer"]),
         businessPersona: "STARTING",
       }),
     });
     renderPage({ business });
+    chooseTab("permits");
 
     expect(
       screen.queryByText(Config.profileDefaults.fields.homeBasedBusiness.default.description),


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

The test `shows the home-based question when user changes to applicable industry, even before saving` in `web/test/pages/profile/profile-starting.test.tsx` was flaking randomly giving the error that `Unable to find an element by: [data-testid="permits"]`. This was occurring because this generator `randomNonHomeBasedIndustry()` includes the industry `domestic-employer`. If `domestic-employer` is the industry, the `Permits` tab will not display, and therefore could not be found. 

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14382](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14382).

### Approach

Add `domestic-employer` to the list of excluded ID's in the generator: `randomNonHomeBasedIndustry(["domestic-employer"])`

### Steps to Test

Run this test with this random seed: 
`RANDOM_SEED=4rvlg4ocojg yarn run -- jest -i web/test/pages/profile/profile-starting.test.tsx -t "shows the home-based question when user changes to applicable industry, even before saving"`

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
