### PR TITLE
feat: [AB#7751] tax clearance specific error messges

### DIFF
--- a/api/src/client/ApiTaxClearanceCertificateClient.test.ts
+++ b/api/src/client/ApiTaxClearanceCertificateClient.test.ts
@@ -1,7 +1,6 @@
 import {
   ApiTaxClearanceCertificateClient,
   FAILED_TAX_ID_AND_PIN_VALIDATION,
-  GENERIC_ERROR,
   INELIGIBLE_TAX_CLEARANCE_FORM,
   MISSING_FIELD,
   NATURAL_PROGRAM_ERROR,
@@ -174,6 +173,16 @@ describe("TaxClearanceCertificateClient", () => {
     spyOnLogError.mockRestore();
   });
 
+  it("throws error when error response is unknown", async () => {
+    const userData = generateUserData({});
+    mockAxios.post.mockRejectedValue({
+      response: { status: StatusCodes.INTERNAL_SERVER_ERROR },
+    });
+    await expect(
+      client.postTaxClearanceCertificate(userData, stubEncryptionDecryptionClient),
+    ).rejects.toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+  });
+
   it("returns INELIGIBLE_TAX_CLEARANCE_FORM error", async () => {
     const userData = generateUserData({});
     mockAxios.post.mockRejectedValue({
@@ -260,36 +269,6 @@ describe("TaxClearanceCertificateClient", () => {
       error: {
         message: TAX_ID_MISSING_FIELD_WITH_EXTRA_SPACE,
         type: "MISSING_FIELD",
-      },
-    });
-  });
-
-  it("returns GENERIC_ERROR for 500 status code", async () => {
-    const userData = generateUserData({});
-    mockAxios.post.mockRejectedValue({
-      response: { status: StatusCodes.INTERNAL_SERVER_ERROR },
-    });
-    expect(
-      await client.postTaxClearanceCertificate(userData, stubEncryptionDecryptionClient),
-    ).toEqual({
-      error: {
-        type: "GENERIC_ERROR",
-        message: GENERIC_ERROR,
-      },
-    });
-  });
-
-  it("returns GENERIC_ERROR for unknown errors", async () => {
-    const userData = generateUserData({});
-    mockAxios.post.mockRejectedValue({
-      response: undefined,
-    });
-    expect(
-      await client.postTaxClearanceCertificate(userData, stubEncryptionDecryptionClient),
-    ).toEqual({
-      error: {
-        type: "GENERIC_ERROR",
-        message: GENERIC_ERROR,
       },
     });
   });

--- a/api/src/client/ApiTaxClearanceCertificateClient.ts
+++ b/api/src/client/ApiTaxClearanceCertificateClient.ts
@@ -22,7 +22,6 @@ export const FAILED_TAX_ID_AND_PIN_VALIDATION =
 export const MISSING_FIELD =
   "Mandatory Field Missing. TaxpayerId, TaxpayerName, AddressLine1, City, State, Zip, Agency name, Rep Id and RepName are required.";
 export const NATURAL_PROGRAM_ERROR = "Error calling Natural Program. Please try again later.";
-export const GENERIC_ERROR = "Something went wrong. Try again later.";
 
 export const ApiTaxClearanceCertificateClient = (
   logWriter: LogWriterType,
@@ -140,14 +139,6 @@ export const ApiTaxClearanceCertificateClient = (
               },
             };
           }
-        }
-        if (response?.status === StatusCodes.INTERNAL_SERVER_ERROR || !response) {
-          return {
-            error: {
-              type: "GENERIC_ERROR",
-              message: GENERIC_ERROR,
-            },
-          };
         }
         logWriter.LogError(
           `Tax Clearance Certificate Client - Id:${logId} - Unexpected Error Response`,

--- a/content/src/fieldConfig/tax-clearance-certificate-step3.json
+++ b/content/src/fieldConfig/tax-clearance-certificate-step3.json
@@ -9,7 +9,7 @@
     "certificationReasonLabel": "What agency is requesting the Tax Clearance Certificate?",
     "secondSectionHeader": "Business Information",
     "stateTaxIdLabel": "NJ State Tax ID",
-    "errorTextGeneric": "We cannot find your business information. Check the information you've entered.",
+    "errorTextIneligible": "We cannot find your business information. Check the information you've entered.",
     "errorTextMissingField": "Your request was missing required fields. Ensure that all required fields are completed.",
     "errorTextSystem": "Something went wrong. Review your information and try again later.",
     "errorTextValidation": "Some of the entries in your submission were not valid. Review your information and try again."

--- a/content/src/fieldConfig/tax-clearance-certificate-step3.json
+++ b/content/src/fieldConfig/tax-clearance-certificate-step3.json
@@ -9,6 +9,9 @@
     "certificationReasonLabel": "What agency is requesting the Tax Clearance Certificate?",
     "secondSectionHeader": "Business Information",
     "stateTaxIdLabel": "NJ State Tax ID",
-    "genericTaxClearanceErrorText": "We cannot find your business information. Please check the information you've entered."
+    "errorTextGeneric": "We cannot find your business information. Check the information you've entered.",
+    "errorTextMissingField": "Your request was missing required fields. Ensure that all required fields are completed.",
+    "errorTextSystem": "Something went wrong. Review your information and try again later.",
+    "errorTextValidation": "Some of the entries in your submission were not valid. Review your information and try again."
   }
 }

--- a/shared/src/taxClearanceCertificate.ts
+++ b/shared/src/taxClearanceCertificate.ts
@@ -9,7 +9,7 @@ export type TaxClearanceCertificateResponseErrorType =
   | "NATURAL_PROGRAM_ERROR"
   | "TAX_ID_MISSING_FIELD"
   | "TAX_ID_MISSING_FIELD_WITH_EXTRA_SPACE"
-  | "GENERIC_ERROR";
+  | "SYSTEM_ERROR";
 
 export type TaxClearanceCertificateResponse = {
   error?: {

--- a/web/decap-config/collections/10-anytime-action.yml
+++ b/web/decap-config/collections/10-anytime-action.yml
@@ -289,8 +289,8 @@ collections:
                 }
               - { label: "Tax Pin Label", name: "taxPinLabel", widget: "string", required: true }
               - {
-                  label: "Generic Taxation API Error Text",
-                  name: "errorTextGeneric",
+                  label: "Ineligible Form Taxation API Error Text",
+                  name: "errorTextIneligible",
                   widget: "string",
                   required: true,
                 }

--- a/web/decap-config/collections/10-anytime-action.yml
+++ b/web/decap-config/collections/10-anytime-action.yml
@@ -245,12 +245,6 @@ collections:
             widget: object
             fields:
               - {
-                  label: "Generic Taxation API Error Text",
-                  name: "genericTaxClearanceErrorText",
-                  widget: "string",
-                  required: true,
-                }
-              - {
                   label: "Main Title Header",
                   name: "mainTitleHeader",
                   widget: "string",
@@ -294,6 +288,30 @@ collections:
                   required: true,
                 }
               - { label: "Tax Pin Label", name: "taxPinLabel", widget: "string", required: true }
+              - {
+                  label: "Generic Taxation API Error Text",
+                  name: "errorTextGeneric",
+                  widget: "string",
+                  required: true,
+                }
+              - {
+                  label: "Missing Field Taxation API Error Text",
+                  name: "errorTextMissingField",
+                  widget: "string",
+                  required: true,
+                }
+              - {
+                  label: "System Taxation API Error Text",
+                  name: "errorTextSystem",
+                  widget: "string",
+                  required: true,
+                }
+              - {
+                  label: "Validation Taxation API Error Text",
+                  name: "errorTextValidation",
+                  widget: "string",
+                  required: true,
+                }
       - label: "Tax Clearance Shared"
         name: "taxClearanceCertificate-shared"
         file: "content/src/fieldConfig/tax-clearance-certificate-shared.json"

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.test.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.test.tsx
@@ -34,7 +34,7 @@ describe("<AnytimeActionTaxClearanceCertificateAlert>", () => {
   describe.each([
     [
       "INELIGIBLE_TAX_CLEARANCE_FORM" as TaxClearanceCertificateResponseErrorType,
-      Config.taxClearanceCertificateStep3.errorTextGeneric,
+      Config.taxClearanceCertificateStep3.errorTextIneligible,
     ],
     [
       "FAILED_TAX_ID_AND_PIN_VALIDATION" as TaxClearanceCertificateResponseErrorType,
@@ -69,7 +69,7 @@ describe("<AnytimeActionTaxClearanceCertificateAlert>", () => {
         />,
       );
 
-      expect(screen.getByTestId("tax-clearance-error-alert")).toBeInTheDocument();
+      expect(screen.getByRole("alert")).toBeInTheDocument();
       expect(screen.getByText(expectedMessage)).toBeInTheDocument();
     });
   });

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.test.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.test.tsx
@@ -1,5 +1,6 @@
 import { AnytimeActionTaxClearanceCertificateAlert } from "@/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert";
 import { getMergedConfig } from "@/contexts/configContext";
+import { TaxClearanceCertificateResponseErrorType } from "@businessnjgovnavigator/shared";
 import { render, screen, within } from "@testing-library/react";
 
 const Config = getMergedConfig();
@@ -28,5 +29,48 @@ describe("<AnytimeActionTaxClearanceCertificateAlert>", () => {
   it("displays nothing if there are no errors", () => {
     render(<AnytimeActionTaxClearanceCertificateAlert fieldErrors={[]} />);
     expect(screen.queryByTestId("tax-clearance-error-alert")).not.toBeInTheDocument();
+  });
+
+  describe.each([
+    [
+      "INELIGIBLE_TAX_CLEARANCE_FORM" as TaxClearanceCertificateResponseErrorType,
+      Config.taxClearanceCertificateStep3.errorTextGeneric,
+    ],
+    [
+      "FAILED_TAX_ID_AND_PIN_VALIDATION" as TaxClearanceCertificateResponseErrorType,
+      Config.taxClearanceCertificateStep3.errorTextValidation,
+    ],
+    [
+      "MISSING_FIELD" as TaxClearanceCertificateResponseErrorType,
+      Config.taxClearanceCertificateStep3.errorTextMissingField,
+    ],
+    [
+      "TAX_ID_MISSING_FIELD" as TaxClearanceCertificateResponseErrorType,
+      Config.taxClearanceCertificateStep3.errorTextMissingField,
+    ],
+    [
+      "TAX_ID_MISSING_FIELD_WITH_EXTRA_SPACE" as TaxClearanceCertificateResponseErrorType,
+      Config.taxClearanceCertificateStep3.errorTextMissingField,
+    ],
+    [
+      "GENERIC_ERROR" as TaxClearanceCertificateResponseErrorType,
+      Config.taxClearanceCertificateStep3.errorTextSystem,
+    ],
+    [
+      "NATURAL_PROGRAM_ERROR" as TaxClearanceCertificateResponseErrorType,
+      Config.taxClearanceCertificateStep3.errorTextSystem,
+    ],
+  ])("when responseErrorType is %s", (errorType, expectedMessage) => {
+    it(`displays "${expectedMessage}"`, () => {
+      render(
+        <AnytimeActionTaxClearanceCertificateAlert
+          fieldErrors={[]}
+          responseErrorType={errorType}
+        />,
+      );
+
+      expect(screen.getByTestId("tax-clearance-error-alert")).toBeInTheDocument();
+      expect(screen.getByText(expectedMessage)).toBeInTheDocument();
+    });
   });
 });

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.tsx
@@ -52,6 +52,28 @@ export const AnytimeActionTaxClearanceCertificateAlert = (props: Props): ReactEl
 
   const hasErrors = props.fieldErrors.length > 0 || props.responseErrorType !== undefined;
 
+  const getTaxClearanceErrorMessage = (
+    errorType: TaxClearanceCertificateResponseErrorType,
+  ): string => {
+    if (errorType === "INELIGIBLE_TAX_CLEARANCE_FORM") {
+      return Config.taxClearanceCertificateStep3.errorTextGeneric;
+    }
+
+    if (errorType === "FAILED_TAX_ID_AND_PIN_VALIDATION") {
+      return Config.taxClearanceCertificateStep3.errorTextValidation;
+    }
+
+    if (
+      errorType === "MISSING_FIELD" ||
+      errorType === "TAX_ID_MISSING_FIELD" ||
+      errorType === "TAX_ID_MISSING_FIELD_WITH_EXTRA_SPACE"
+    ) {
+      return Config.taxClearanceCertificateStep3.errorTextMissingField;
+    }
+
+    return Config.taxClearanceCertificateStep3.errorTextSystem;
+  };
+
   return hasErrors ? (
     <Alert variant="error" dataTestid={"tax-clearance-error-alert"}>
       {props.fieldErrors.length > 0 && (
@@ -74,7 +96,7 @@ export const AnytimeActionTaxClearanceCertificateAlert = (props: Props): ReactEl
         </>
       )}
       {props.responseErrorType !== undefined && (
-        <div>{Config.taxClearanceCertificateStep3.genericTaxClearanceErrorText}</div>
+        <div>{getTaxClearanceErrorMessage(props.responseErrorType)}</div>
       )}
     </Alert>
   ) : (

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.tsx
@@ -56,7 +56,7 @@ export const AnytimeActionTaxClearanceCertificateAlert = (props: Props): ReactEl
     errorType: TaxClearanceCertificateResponseErrorType,
   ): string => {
     if (errorType === "INELIGIBLE_TAX_CLEARANCE_FORM") {
-      return Config.taxClearanceCertificateStep3.errorTextGeneric;
+      return Config.taxClearanceCertificateStep3.errorTextIneligible;
     }
 
     if (errorType === "FAILED_TAX_ID_AND_PIN_VALIDATION") {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Added specific human readable error messages for all possible error responses from the Tax API. 

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#7751](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7751).

### Approach

A `getTaxClearanceErrorMessage` function was added to `AnytimeActionTaxClearanceCertificateAlert.tsx`. All of the values returned from this function were added to CMS for easy future updates. Tests were added to assure appropriate error responses are shown. 

### Steps to Test

1. Run navigator and navigate to `localhost:3000`
2. Login to navigator
3. Select an up and running business
4. From the task dropdown on the dashboard select the option to Get Tax Clearance Certificate
5. Enter the values from `wiremock/.../tax-clearance-success.json`
6. Submit, and you should see the success screen
7. Repeat steps 4 and 5 but enter 'incorrect' information given in the various failed tax-clearance wiremocks
8. The appropriate error messages should show for each case (missing fields, validation, system error, and generic error)


## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden

