### PR TITLE
Add hashedTaxId as a global secondary index on business table

### DIFF
--- a/api/businesses-dynamodb-schema.json
+++ b/api/businesses-dynamodb-schema.json
@@ -20,6 +20,10 @@
     {
       "AttributeName": "encryptedTaxId",
       "AttributeType": "S"
+    },
+    {
+      "AttributeName": "hashedTaxId",
+      "AttributeType": "S"
     }
   ],
   "KeySchema": [
@@ -82,6 +86,22 @@
       "KeySchema": [
         {
           "AttributeName": "encryptedTaxId",
+          "KeyType": "HASH"
+        }
+      ],
+      "Projection": {
+        "ProjectionType": "ALL"
+      },
+      "ProvisionedThroughput": {
+        "ReadCapacityUnits": 25,
+        "WriteCapacityUnits": 25
+      }
+    },
+    {
+      "IndexName": "HashedTaxId",
+      "KeySchema": [
+        {
+          "AttributeName": "hashedTaxId",
           "KeyType": "HASH"
         }
       ],

--- a/api/src/db/DynamoBusinessDataClient.ts
+++ b/api/src/db/DynamoBusinessDataClient.ts
@@ -134,6 +134,7 @@ export const DynamoBusinessDataClient = (
         businessId: businessData.id,
         industry: businessData.profileData.industryId,
         encryptedTaxId: businessData.profileData.encryptedTaxId,
+        hashedTaxId: businessData.profileData.hashedTaxId,
         data: businessData,
         businessName: businessName === "" ? undefined : businessData.profileData.businessName,
         naicsCode: naicsCode === "" ? undefined : businessData.profileData.naicsCode,


### PR DESCRIPTION
## Description

In #10404 we added the ability to hash a piece of data, and using this functionality to hash the tax ID within the user's `profileData`. This work adds the `hashedTaxId` as a global secondary index on the business table so that DynamoDB can make queries to determine if a tax ID has been previously used.

### Ticket

This pull request resolves [#14310](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14310) a work item in service of completing [#7867](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7867).

### Approach

Updated the DynamoDB schema file used by Serverless to configure the business table.

### Steps to Test

After adding a tax ID in the profile, the hashed tax ID should be available in the user's profile data. When interacting with the database, `hashedTaxId` should appear as a secondary index on the business table.

screenshot from DynamoDBLocal GUI
![Screenshot 2025-05-26 at 10 52 30 PM](https://github.com/user-attachments/assets/e785df1c-6d94-44db-be2d-8c5cc64da627)

### Notes

We should remove `EncryptedTaxId` from the list of global secondary indices.

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
