### PR TITLE
feat: [AB#13891] handle tax clearance input errors on submit

### DIFF
--- a/web/src/components/data-fields/address/AddressLines1And2.tsx
+++ b/web/src/components/data-fields/address/AddressLines1And2.tsx
@@ -6,6 +6,7 @@ import { ReactElement } from "react";
 interface Props {
   onValidation: () => void;
   isFullWidth?: boolean;
+  isAddressLine1Invalid?: boolean;
 }
 export const AddressLines1And2 = (props: Props): ReactElement => {
   const { Config } = useConfig();
@@ -26,6 +27,7 @@ export const AddressLines1And2 = (props: Props): ReactElement => {
           className={"margin-bottom-2"}
           errorBarType="ALWAYS"
           onValidation={props.onValidation}
+          error={props.isAddressLine1Invalid}
         />
       </div>
       <div

--- a/web/src/components/data-fields/address/AddressTextField.tsx
+++ b/web/src/components/data-fields/address/AddressTextField.tsx
@@ -11,6 +11,7 @@ export interface Props extends Omit<GenericTextFieldProps, "value" | "error" | "
   label?: string;
   secondaryLabel?: string;
   errorBarType: "ALWAYS" | "MOBILE-ONLY" | "DESKTOP-ONLY" | "NEVER";
+  error?: boolean;
 }
 
 export const AddressTextField = ({ className, ...props }: Props): ReactElement => {
@@ -22,7 +23,7 @@ export const AddressTextField = ({ className, ...props }: Props): ReactElement =
     setAddressData((prevAddressData) => ({ ...prevAddressData, [props.fieldName]: value }));
   };
 
-  const hasError = doesFieldHaveError(props.fieldName);
+  const hasError = props.error || doesFieldHaveError(props.fieldName);
 
   return (
     <WithErrorBar className={className ?? ""} hasError={hasError} type={props.errorBarType}>

--- a/web/src/components/data-fields/address/UnitesStatesAddress.tsx
+++ b/web/src/components/data-fields/address/UnitesStatesAddress.tsx
@@ -4,8 +4,10 @@ import { ModifiedContent } from "@/components/ModifiedContent";
 import { StateDropdown } from "@/components/StateDropdown";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { AddressContext } from "@/contexts/addressContext";
+import { DataFormErrorMap } from "@/contexts/dataFormErrorMapContext";
 import { useAddressErrors } from "@/lib/data-hooks/useAddressErrors";
 import { useConfig } from "@/lib/data-hooks/useConfig";
+import { FormContextType } from "@/lib/types/types";
 import { StateObject } from "@businessnjgovnavigator/shared/states";
 import { ReactElement, useContext } from "react";
 
@@ -13,6 +15,7 @@ interface Props {
   onValidation: () => void;
   isFullWidth?: boolean;
   excludeNJ?: boolean | true;
+  dataFormErrorMap?: FormContextType<DataFormErrorMap, unknown>;
 }
 
 export const UnitesStatesAddress = (props: Props): ReactElement => {
@@ -20,29 +23,55 @@ export const UnitesStatesAddress = (props: Props): ReactElement => {
   const { doSomeFieldsHaveError, doesFieldHaveError, getFieldErrorLabel } = useAddressErrors();
   const { state, setAddressData } = useContext(AddressContext);
 
+  const isAddressLine1Invalid =
+    props.dataFormErrorMap?.fieldStates?.["addressLine1"]?.invalid ?? false;
+  const isAddressCityInvalid =
+    props.dataFormErrorMap?.fieldStates?.["addressCity"]?.invalid ?? false;
+  const isAddressStateInvalid =
+    props.dataFormErrorMap?.fieldStates?.["addressState"]?.invalid ?? false;
+  const isAddressZipCodeInvalid =
+    props.dataFormErrorMap?.fieldStates?.["addressZipCode"]?.invalid ?? false;
+
   return (
     <>
-      <AddressLines1And2 onValidation={props.onValidation} isFullWidth={props.isFullWidth} />
+      <AddressLines1And2
+        onValidation={props.onValidation}
+        isFullWidth={props.isFullWidth}
+        isAddressLine1Invalid={isAddressLine1Invalid}
+      />
       <div className={`${props.isFullWidth ? "" : "text-field-width-default"}`}>
         <WithErrorBar
-          hasError={doSomeFieldsHaveError(["addressCity", "addressState", "addressZipCode"])}
+          hasError={
+            doSomeFieldsHaveError(["addressCity", "addressState", "addressZipCode"]) ||
+            isAddressCityInvalid ||
+            isAddressStateInvalid ||
+            isAddressZipCodeInvalid
+          }
           type="DESKTOP-ONLY"
         >
           <div className="grid-row tablet:grid-gap-2">
             <div className="grid-col-12 tablet:grid-col-6">
-              <WithErrorBar hasError={doesFieldHaveError("addressCity")} type="MOBILE-ONLY">
+              <WithErrorBar
+                hasError={doesFieldHaveError("addressCity") || isAddressCityInvalid}
+                type="MOBILE-ONLY"
+              >
                 <AddressTextField
                   label={Config.formation.fields.addressCity.label}
                   fieldName="addressCity"
                   validationText={getFieldErrorLabel("addressCity")}
                   errorBarType="ALWAYS"
                   onValidation={props.onValidation}
+                  error={isAddressCityInvalid}
                 />
               </WithErrorBar>
             </div>
             <div className="grid-col-12 tablet:grid-col-6 margin-top-2 tablet:margin-top-0">
               <WithErrorBar
-                hasError={doSomeFieldsHaveError(["addressState", "addressZipCode"])}
+                hasError={
+                  doSomeFieldsHaveError(["addressState", "addressZipCode"]) ||
+                  isAddressStateInvalid ||
+                  isAddressZipCodeInvalid
+                }
                 type="MOBILE-ONLY"
               >
                 <div className="grid-row grid-gap tablet:grid-gap-2">
@@ -59,13 +88,13 @@ export const UnitesStatesAddress = (props: Props): ReactElement => {
                       <StateDropdown
                         fieldName="addressState"
                         value={state.formationAddressData.addressState?.name}
-                        validationText={Config.formation.fields.foreignStateOfFormation.error}
+                        validationText={Config.formation.fields.addressState.error}
                         onSelect={(value: StateObject | undefined): void => {
                           setAddressData((prevAddressData) => {
                             return { ...prevAddressData, addressState: value };
                           });
                         }}
-                        error={doesFieldHaveError("addressState")}
+                        error={doesFieldHaveError("addressState") || isAddressStateInvalid}
                         disabled={false}
                         onValidation={props.onValidation}
                         excludeNJ={props.excludeNJ}
@@ -84,6 +113,7 @@ export const UnitesStatesAddress = (props: Props): ReactElement => {
                         validationText={getFieldErrorLabel("addressZipCode")}
                         fieldName={"addressZipCode"}
                         onValidation={props.onValidation}
+                        error={isAddressZipCodeInvalid}
                       />
                     </div>
                   </div>

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificate.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificate.tsx
@@ -12,7 +12,7 @@ import { TaxClearanceCertificateDataContext } from "@/contexts/taxClearanceCerti
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { AnytimeActionLicenseReinstatement, AnytimeActionTask } from "@/lib/types/types";
-import { getFlow, scrollToTop, useMountEffectWhenDefined } from "@/lib/utils/helpers";
+import { getFlow, useMountEffectWhenDefined } from "@/lib/utils/helpers";
 import { emptyTaxClearanceCertificateData } from "@businessnjgovnavigator/shared";
 import {
   emptyFormationAddressData,
@@ -32,9 +32,13 @@ export const AnytimeActionTaxClearanceCertificate = (props: Props): ReactElement
   const [taxClearanceCertificateData, setTaxClearanceCertificateData] = useState(
     emptyTaxClearanceCertificateData,
   );
+
   const [formationAddressData, setAddressData] =
     useState<FormationAddress>(emptyFormationAddressData);
   const [profileData, setProfileData] = useState<ProfileData>(emptyProfileData);
+  const [certificatePdfBlob, setCertificatePdfBlob] = useState<Blob | undefined>(
+    props.CMS_ONLY_certificatePdfBlob || undefined,
+  );
 
   const setAddress: Dispatch<SetStateAction<FormationAddress>> = (action) => {
     setAddressData((prevAddress) => {
@@ -136,23 +140,12 @@ export const AnytimeActionTaxClearanceCertificate = (props: Props): ReactElement
   }, business);
 
   const {
-    FormFuncWrapper,
+    FormFuncWrapper: formFuncWrapper,
     isValid,
     getInvalidFieldIds,
     onSubmit,
     state: formContextState,
   } = useFormContextHelper(createDataFormErrorMap());
-
-  FormFuncWrapper(
-    async (): Promise<void> => {
-      if (!business || !isValid()) {
-        scrollToTop();
-        return;
-      }
-      scrollToTop();
-    },
-    () => {},
-  );
 
   return (
     <DataFormErrorMapContext.Provider value={formContextState}>
@@ -184,15 +177,18 @@ export const AnytimeActionTaxClearanceCertificate = (props: Props): ReactElement
                   <Heading level={1}>{props.anytimeAction.name}</Heading>
                 </div>
               </div>
-              <TaxClearanceSteps
-                taxClearanceCertificateData={taxClearanceCertificateData}
-                certificatePdfBlob={props.CMS_ONLY_certificatePdfBlob}
-                saveTaxClearanceCertificateData={saveTaxClearanceCertificateData}
-                isValid={isValid}
-                getInvalidFieldIds={getInvalidFieldIds}
-                onSubmit={onSubmit}
-                CMS_ONLY_stepIndex={props.CMS_ONLY_stepIndex}
-              />
+              <form onSubmit={onSubmit}>
+                <TaxClearanceSteps
+                  taxClearanceCertificateData={taxClearanceCertificateData}
+                  certificatePdfBlob={certificatePdfBlob}
+                  setCertificatePdfBlob={setCertificatePdfBlob}
+                  saveTaxClearanceCertificateData={saveTaxClearanceCertificateData}
+                  isValid={isValid}
+                  getInvalidFieldIds={getInvalidFieldIds}
+                  CMS_ONLY_stepIndex={props.CMS_ONLY_stepIndex}
+                  formFuncWrapper={formFuncWrapper}
+                />
+              </form>
             </div>
           </AddressContext.Provider>
         </ProfileDataContext.Provider>

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceSteps.test.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceSteps.test.tsx
@@ -24,6 +24,8 @@ describe("TaxClearanceSteps", () => {
     isValid: jest.fn().mockReturnValue(true),
     getInvalidFieldIds: jest.fn().mockReturnValue([]),
     onSubmit: jest.fn(),
+    setCertificatePdfBlob: jest.fn(),
+    formFuncWrapper: jest.fn(),
   };
 
   beforeEach(() => {

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/helpers.ts
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/helpers.ts
@@ -91,3 +91,18 @@ export const getAllFieldsNonEmpty = (
     (taxClearanceCertificateData.taxPin ?? "").trim() !== ""
   );
 };
+
+export const isAnyFieldEmpty = (
+  taxClearanceCertificateData: TaxClearanceCertificateData,
+): boolean => {
+  return (
+    (taxClearanceCertificateData.requestingAgencyId ?? "").trim() === "" ||
+    (taxClearanceCertificateData.businessName ?? "").trim() === "" ||
+    (taxClearanceCertificateData.addressLine1 ?? "").trim() === "" ||
+    (taxClearanceCertificateData.addressCity ?? "").trim() === "" ||
+    taxClearanceCertificateData.addressState === undefined ||
+    (taxClearanceCertificateData.addressZipCode ?? "").trim() === "" ||
+    (taxClearanceCertificateData.taxId ?? "").trim() === "" ||
+    (taxClearanceCertificateData.taxPin ?? "").trim() === ""
+  );
+};

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/CheckEligibility.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/CheckEligibility.tsx
@@ -21,18 +21,19 @@ import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import analytics from "@/lib/utils/analytics";
-import { FormEvent, ReactElement } from "react";
+import { ReactElement, useContext } from "react";
 
 interface Props {
   setStepIndex: (step: number) => void;
-  onSave: (event?: FormEvent<HTMLFormElement>) => void;
-  onSubmit: (event?: FormEvent<HTMLFormElement>) => void;
+  saveTaxClearanceCertificateData: () => void;
 }
 
 export const CheckEligibility = (props: Props): ReactElement => {
+  const dataFormErrorMap = useContext(DataFormErrorMapContext);
+
   const { Config } = useConfig();
 
-  const { doesFieldHaveError } = useAddressErrors();
+  const { doesRequiredFieldHaveError, doesFieldHaveError } = useAddressErrors();
   const { setIsValid: setIsValidAddressLine1 } = useFormContextFieldHelpers(
     "addressLine1",
     DataFormErrorMapContext,
@@ -55,18 +56,18 @@ export const CheckEligibility = (props: Props): ReactElement => {
   );
 
   const onValidation = (): void => {
-    setIsValidAddressLine1(!doesFieldHaveError("addressLine1"));
+    setIsValidAddressLine1(!doesRequiredFieldHaveError("addressLine1"));
     setIsValidAddressLine2(!doesFieldHaveError("addressLine2"));
-    setIsValidCity(!doesFieldHaveError("addressCity"));
-    setIsValidState(!doesFieldHaveError("addressState"));
-    setIsValidZipCode(!doesFieldHaveError("addressZipCode"));
+    setIsValidCity(!doesRequiredFieldHaveError("addressCity"));
+    setIsValidState(!doesRequiredFieldHaveError("addressState"));
+    setIsValidZipCode(!doesRequiredFieldHaveError("addressZipCode"));
   };
   const { business } = useUserData();
 
   const handleSaveButtonClick = (): void => {
     analytics.event.tax_clearance.click.switch_to_step_three();
-    props.onSave();
-    props.onSubmit();
+    props.saveTaxClearanceCertificateData();
+    props.setStepIndex(2);
   };
 
   const handleBackButtonClick = (): void => {
@@ -100,7 +101,11 @@ export const CheckEligibility = (props: Props): ReactElement => {
           </ProfileField>
         </div>
         <div className="margin-y-2">
-          <UnitesStatesAddress onValidation={onValidation} isFullWidth />
+          <UnitesStatesAddress
+            onValidation={onValidation}
+            dataFormErrorMap={dataFormErrorMap}
+            isFullWidth
+          />
         </div>
         <div className="margin-y-2">
           <ProfileField fieldName="taxId" hideLine fullWidth>

--- a/web/src/lib/data-hooks/useAddressErrors.tsx
+++ b/web/src/lib/data-hooks/useAddressErrors.tsx
@@ -7,6 +7,7 @@ type AddressErrorsResponse = {
   doesFieldHaveError: (field: FieldsForAddressErrorHandling) => boolean;
   doSomeFieldsHaveError: (fields: AddressFields[]) => boolean;
   getFieldErrorLabel: (field: AddressFields) => string;
+  doesRequiredFieldHaveError: (field: AddressFields) => boolean;
 };
 
 export const useAddressErrors = (): AddressErrorsResponse => {
@@ -22,6 +23,15 @@ export const useAddressErrors = (): AddressErrorsResponse => {
     "addressCountry",
     "addressProvince",
   ]);
+
+  // use for onBlur validation
+  const doesRequiredFieldHaveError = (field: FieldsForAddressErrorHandling): boolean => {
+    return (
+      doesFieldHaveError(field) ||
+      state.formationAddressData[field] === "" ||
+      state.formationAddressData[field] === undefined
+    );
+  };
 
   const doesFieldHaveError = (field: FieldsForAddressErrorHandling): boolean => {
     if (!validatedFields.has(field)) {
@@ -56,5 +66,6 @@ export const useAddressErrors = (): AddressErrorsResponse => {
     doesFieldHaveError,
     doSomeFieldsHaveError,
     getFieldErrorLabel,
+    doesRequiredFieldHaveError,
   };
 };


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#13891](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13891).

### Approach
This PR addresses two key issues related to form validation and submission:
	1.	Address Field Validation on Blur:
The address input field was not triggering validation on blur, resulting in missing error feedback. This has been resolved by updating the logic to properly mark the field as invalid when the user leaves the input empty. An associated alert is also displayed to inform the user of the required field.
	2.	Form Submission Guard:
Validation has been added to the final tab’s submit button to ensure all required fields are populated before making the API call. This ensures that even if a user does not trigger a blur event on an input, the form will still validate and prevent submission when any required field is empty.

These updates ensure a more robust and user-friendly validation flow across both individual input interactions and overall form submission.
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
