### PR TITLE
feat: [AB#8605] add errLog for myNJSelf-Reg and test for fail path

### DIFF
--- a/api/src/client/MyNjSelfRegClient.test.ts
+++ b/api/src/client/MyNjSelfRegClient.test.ts
@@ -108,6 +108,18 @@ describe("MyNJSelfRegClient", () => {
     mockedAxios.mockRejectedValue(["E2109 This would duplicate an existing authorization"]);
     await expect(client.resume("some-id")).rejects.toEqual(new Error("DUPLICATE_SIGNUP"));
   });
+
+  it("logs and returns error on network failure", async () => {
+    const networkError = new Error("Network failure");
+    mockedAxios.mockRejectedValueOnce(networkError);
+
+    const logSpy = jest.spyOn(logger, "LogError");
+
+    const result = await client.grant(generateUser({}));
+
+    expect(result).toBe(networkError);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("myNJSelfRegError"), networkError);
+  });
 });
 
 const grantSuccessReponse =

--- a/api/src/client/MyNjSelfRegClient.ts
+++ b/api/src/client/MyNjSelfRegClient.ts
@@ -70,11 +70,7 @@ export const MyNJSelfRegClientFactory = (
         };
       })
       .catch((error) => {
-        if (process.env.NODE_ENV !== "test") {
-          console.log("error", error);
-        }
-        logger.LogError(`myNJ Self-Reg - Id:${logId} - Error: `, error);
-
+        logger.LogError(`myNJ Self-Reg - Id:${logId} - myNJSelfRegError: `, error);
         const myNJDuplicateErrors = ["E1048", "E1017", "E1059", "E2109"];
         if (error.length > 0 && myNJDuplicateErrors.includes(error[0].split(" ")[0])) {
           throw new Error("DUPLICATE_SIGNUP");


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
This change adds improved logging for myNJSelfRegError to enhance monitoring and observability of the myNJ login process. Robust logging is essential to make CloudWatch alerts more effective, enabling faster detection of login failures and improving site resilience.

Specifically, this prepares for CloudWatch metric and alarm creation to track drop-offs in user logins, addressing a key site performance concern.

Additionally, the test suite is updated to validate that network failures are properly logged with the myNJSelfRegError tag and that errors are correctly returned.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

- Updated api/src/client/MyNjSelfRegClient.ts to enhance error logging with a myNJSelfRegError identifier.

- Added a test in api/src/client/MyNjSelfRegClient.test.ts to validate error logging and handling on network failures.

- Update the logger in the fail path to include a 

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#8605](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8605).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
