### PR TITLE
Add logic to show error when requesting tax clearance certificate if tax ID is in use

### DIFF
--- a/api/jest-dynalite-config.js
+++ b/api/jest-dynalite-config.js
@@ -70,6 +70,10 @@ module.exports = {
           AttributeName: "encryptedTaxId",
           AttributeType: "S",
         },
+        {
+          AttributeName: "hashedTaxId",
+          AttributeType: "S",
+        },
       ],
       KeySchema: [
         {
@@ -140,6 +144,22 @@ module.exports = {
           ProvisionedThroughput: {
             ReadCapacityUnits: 1,
             WriteCapacityUnits: 1,
+          },
+        },
+        {
+          IndexName: "HashedTaxId",
+          KeySchema: [
+            {
+              AttributeName: "hashedTaxId",
+              KeyType: "HASH",
+            },
+          ],
+          Projection: {
+            ProjectionType: "ALL",
+          },
+          ProvisionedThroughput: {
+            ReadCapacityUnits: 25,
+            WriteCapacityUnits: 25,
           },
         },
         {

--- a/api/src/api/externalEndpointRouter.test.ts
+++ b/api/src/api/externalEndpointRouter.test.ts
@@ -46,6 +46,7 @@ describe("externalEndpointRouter", () => {
       findByEmail: jest.fn(),
       findUserByBusinessName: jest.fn(),
       findUsersByBusinessNamePrefix: jest.fn(),
+      findBusinessesByHashedTaxId: jest.fn(),
     };
     stubAddNewsletter = jest.fn();
     stubAddToUserTesting = jest.fn();

--- a/api/src/api/formationRouter.test.ts
+++ b/api/src/api/formationRouter.test.ts
@@ -65,6 +65,7 @@ describe("formationRouter", () => {
       findByEmail: jest.fn(),
       findUserByBusinessName: jest.fn(),
       findUsersByBusinessNamePrefix: jest.fn(),
+      findBusinessesByHashedTaxId: jest.fn(),
     };
     app = setupExpress(false);
     app.use(

--- a/api/src/api/licenseStatusRouter.test.ts
+++ b/api/src/api/licenseStatusRouter.test.ts
@@ -38,6 +38,7 @@ describe("licenseStatusRouter", () => {
       findByEmail: jest.fn(),
       findUserByBusinessName: jest.fn(),
       findUsersByBusinessNamePrefix: jest.fn(),
+      findBusinessesByHashedTaxId: jest.fn(),
     };
     stubDynamoDataClient.put.mockImplementation((userData) => {
       return Promise.resolve(userData);

--- a/api/src/api/selfRegRouter.test.ts
+++ b/api/src/api/selfRegRouter.test.ts
@@ -24,6 +24,7 @@ describe("selfRegRouter", () => {
       findByEmail: jest.fn(),
       findUserByBusinessName: jest.fn(),
       findUsersByBusinessNamePrefix: jest.fn(),
+      findBusinessesByHashedTaxId: jest.fn(),
     };
 
     stubSelfRegClient = {

--- a/api/src/api/taxClearanceCertificateRouter.ts
+++ b/api/src/api/taxClearanceCertificateRouter.ts
@@ -1,5 +1,5 @@
 import { ExpressRequestBody } from "@api/types";
-import { type CryptoClient, TaxClearanceCertificateClient } from "@domain/types";
+import { type CryptoClient, DatabaseClient, TaxClearanceCertificateClient } from "@domain/types";
 import { UserData } from "@shared/userData";
 import { Router } from "express";
 import { StatusCodes } from "http-status-codes";
@@ -7,6 +7,7 @@ import { StatusCodes } from "http-status-codes";
 export const taxClearanceCertificateRouterFactory = (
   taxClearanceCertificateClient: TaxClearanceCertificateClient,
   cryptoClient: CryptoClient,
+  databaseClient: DatabaseClient,
 ): Router => {
   const router = Router();
   router.post("/postTaxClearanceCertificate", async (req: ExpressRequestBody<UserData>, res) => {
@@ -16,6 +17,7 @@ export const taxClearanceCertificateRouterFactory = (
       const response = await taxClearanceCertificateClient.postTaxClearanceCertificate(
         userData,
         cryptoClient,
+        databaseClient,
       );
       res.json(response);
     } catch (error) {

--- a/api/src/api/taxFilingRouter.test.ts
+++ b/api/src/api/taxFilingRouter.test.ts
@@ -46,6 +46,7 @@ describe("taxFilingRouter", () => {
       findByEmail: jest.fn(),
       findUserByBusinessName: jest.fn(),
       findUsersByBusinessNamePrefix: jest.fn(),
+      findBusinessesByHashedTaxId: jest.fn(),
     };
     apiTaxFilingClient = {
       lookup: jest.fn(),

--- a/api/src/api/userRouter.test.ts
+++ b/api/src/api/userRouter.test.ts
@@ -87,6 +87,7 @@ describe("userRouter", () => {
       findByEmail: jest.fn(),
       findUserByBusinessName: jest.fn(),
       findUsersByBusinessNamePrefix: jest.fn(),
+      findBusinessesByHashedTaxId: jest.fn(),
     };
     stubUpdateLicenseStatus = jest.fn();
     stubUpdateRoadmapSidebarCards = jest.fn();

--- a/api/src/api/xrayRegistrationRouter.test.ts
+++ b/api/src/api/xrayRegistrationRouter.test.ts
@@ -37,6 +37,7 @@ describe("xrayRegistrationRouter", () => {
       migrateOutdatedVersionUsers: jest.fn(),
       findUserByBusinessName: jest.fn(),
       findUsersByBusinessNamePrefix: jest.fn(),
+      findBusinessesByHashedTaxId: jest.fn(),
     };
     stubDynamoDataClient.put.mockImplementation((userData) => {
       return Promise.resolve(userData);

--- a/api/src/db/DynamoBusinessDataClient.ts
+++ b/api/src/db/DynamoBusinessDataClient.ts
@@ -109,6 +109,12 @@ export const DynamoBusinessDataClient = (
     });
   };
 
+  const findAllByHashedTaxId = (hashedTaxId: string): Promise<Business[]> => {
+    return findAllBusinessesByIndex("HashedTaxId", "hashedTaxId = :hashedTaxId", {
+      ":hashedTaxId": { S: hashedTaxId },
+    });
+  };
+
   const get = (businessId: string): Promise<Business> => {
     const params = {
       TableName: tableName,
@@ -173,5 +179,6 @@ export const DynamoBusinessDataClient = (
     findAllByIndustry,
     findAllByNAICSCode,
     findBusinessesByNamePrefix,
+    findAllByHashedTaxId,
   };
 };

--- a/api/src/db/DynamoDataClient.ts
+++ b/api/src/db/DynamoDataClient.ts
@@ -1,6 +1,6 @@
 import { BusinessesDataClient, DatabaseClient, UserDataClient } from "@domain/types";
 import { LogWriterType } from "@libs/logWriter";
-import { CURRENT_VERSION, UserData } from "@shared/userData";
+import { Business, CURRENT_VERSION, UserData } from "@shared/userData";
 import { chunk } from "lodash";
 
 export const DynamoDataClient = (
@@ -147,6 +147,26 @@ export const DynamoDataClient = (
       throw new Error(errorMessage);
     }
   };
+
+  const findBusinessesByHashedTaxId = async (hashedTaxId: string): Promise<Business[]> => {
+    const truncatedValue = `"${hashedTaxId.slice(0, 10)}..."`;
+
+    try {
+      const businesses = await businessesDataClient.findAllByHashedTaxId(hashedTaxId);
+      if (!businesses || businesses.length === 0) {
+        logger.LogInfo(`No Businesses found with hashedTaxId: ${truncatedValue}`);
+        return [];
+      }
+      return businesses;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      logger.LogError(
+        `Failed to get Businesses with hashedTaxId matching ${truncatedValue}: ${errorMessage}`,
+      );
+      throw new Error(errorMessage);
+    }
+  };
+
   return {
     migrateOutdatedVersionUsers,
     get,
@@ -154,5 +174,6 @@ export const DynamoDataClient = (
     findByEmail,
     findUserByBusinessName,
     findUsersByBusinessNamePrefix,
+    findBusinessesByHashedTaxId,
   };
 };

--- a/api/src/db/migrations/migrations.ts
+++ b/api/src/db/migrations/migrations.ts
@@ -163,6 +163,7 @@ import { migrate_v159_to_v160 } from "@db/migrations/v160_add_xray_registration_
 import { migrate_v160_to_v161 } from "@db/migrations/v161_add_encrypted_tax_pin";
 import { migrate_v161_to_v162 } from "@db/migrations/v162_add_hashed_taxid_to_userdata";
 import { migrate_v162_to_v163 } from "@db/migrations/v163_waste_transport_to_waste_data";
+import { migrate_v163_to_v164 } from "@db/migrations/v164_track_tax_clearance_primary_business";
 
 import { MigrationClients } from "@db/migrations/types";
 
@@ -333,6 +334,7 @@ export const Migrations: MigrationFunction[] = [
   migrate_v160_to_v161,
   migrate_v161_to_v162,
   migrate_v162_to_v163,
+  migrate_v163_to_v164,
 ];
 
-export { generatev163UserData as CURRENT_GENERATOR } from "@db/migrations/v163_waste_transport_to_waste_data";
+export { generatev164UserData as CURRENT_GENERATOR } from "@db/migrations/v164_track_tax_clearance_primary_business";

--- a/api/src/db/migrations/v164_track_tax_clearance_primary_business.ts
+++ b/api/src/db/migrations/v164_track_tax_clearance_primary_business.ts
@@ -1,0 +1,1029 @@
+import { type MigrationClients } from "@db/migrations/types";
+import { v163Business, v163UserData } from "@db/migrations/v163_waste_transport_to_waste_data";
+
+import { randomInt } from "@shared/intHelpers";
+
+export const migrate_v163_to_v164 = async (
+  v163Data: v163UserData,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _?: MigrationClients,
+): Promise<v164UserData> => {
+  const businesses = Object.values(v163Data.businesses);
+  const newBusinesses = [];
+  for (const business of businesses) {
+    newBusinesses.push(await migrate_v163Business_to_v164Business(business));
+  }
+  return {
+    ...v163Data,
+    businesses: Object.fromEntries(
+      newBusinesses.map((currBusiness: v164Business) => [currBusiness.id, currBusiness]),
+    ),
+    version: 164,
+  } as v164UserData;
+};
+
+export const migrate_v163Business_to_v164Business = async (
+  business: v163Business,
+): Promise<v164Business> => {
+  const newBusiness = {
+    ...business,
+    taxClearanceCertificateData: {
+      ...business.taxClearanceCertificateData,
+      hasPreviouslyReceivedCertificate: undefined,
+      lastUpdatedISO: undefined,
+    },
+    version: 164,
+  } as v164Business;
+
+  return newBusiness;
+};
+
+export interface v164IndustrySpecificData {
+  liquorLicense: boolean;
+  requiresCpa: boolean;
+  homeBasedBusiness: boolean | undefined;
+  providesStaffingService: boolean;
+  certifiedInteriorDesigner: boolean;
+  realEstateAppraisalManagement: boolean;
+  cannabisLicenseType: v164CannabisLicenseType;
+  cannabisMicrobusiness: boolean | undefined;
+  constructionRenovationPlan: boolean | undefined;
+  carService: v164CarServiceType | undefined;
+  interstateTransport: boolean;
+  interstateLogistics: boolean | undefined;
+  interstateMoving: boolean | undefined;
+  isChildcareForSixOrMore: boolean | undefined;
+  petCareHousing: boolean | undefined;
+  willSellPetCareItems: boolean | undefined;
+  constructionType: v164ConstructionType;
+  residentialConstructionType: v164ResidentialConstructionType;
+  employmentPersonnelServiceType: v164EmploymentAndPersonnelServicesType;
+  employmentPlacementType: v164EmploymentPlacementType;
+  carnivalRideOwningBusiness: boolean | undefined;
+  propertyLeaseType: v164PropertyLeaseType;
+  hasThreeOrMoreRentalUnits: boolean | undefined;
+  travelingCircusOrCarnivalOwningBusiness: boolean | undefined;
+  vacantPropertyOwner: boolean | undefined;
+}
+
+export type v164PropertyLeaseType = "SHORT_TERM_RENTAL" | "LONG_TERM_RENTAL" | "BOTH" | undefined;
+
+// ---------------- v164 types ----------------
+type v164TaskProgress = "TO_DO" | "COMPLETED";
+type v164OnboardingFormProgress = "UNSTARTED" | "COMPLETED";
+type v164ABExperience = "ExperienceA" | "ExperienceB";
+
+export interface v164UserData {
+  user: v164BusinessUser;
+  version: number;
+  lastUpdatedISO: string;
+  dateCreatedISO: string;
+  versionWhenCreated: number;
+  businesses: Record<string, v164Business>;
+  currentBusinessId: string;
+}
+
+export interface v164Business {
+  id: string;
+  dateCreatedISO: string;
+  lastUpdatedISO: string;
+  profileData: v164ProfileData;
+  onboardingFormProgress: v164OnboardingFormProgress;
+  taskProgress: Record<string, v164TaskProgress>;
+  taskItemChecklist: Record<string, boolean>;
+  licenseData: v164LicenseData | undefined;
+  preferences: v164Preferences;
+  taxFilingData: v164TaxFilingData;
+  formationData: v164FormationData;
+  environmentData: v164EnvironmentData | undefined;
+  xrayRegistrationData: v164XrayData | undefined;
+  taxClearanceCertificateData: v164TaxClearanceCertificateData | undefined;
+  version: number;
+  versionWhenCreated: number;
+  userId: string;
+}
+
+export interface v164ProfileData extends v164IndustrySpecificData {
+  businessPersona: v164BusinessPersona;
+  businessName: string;
+  responsibleOwnerName: string;
+  tradeName: string;
+  industryId: string | undefined;
+  legalStructureId: string | undefined;
+  municipality: v164Municipality | undefined;
+  dateOfFormation: string | undefined;
+  entityId: string | undefined;
+  employerId: string | undefined;
+  taxId: string | undefined;
+  hashedTaxId: string | undefined;
+  encryptedTaxId: string | undefined;
+  notes: string;
+  documents: v164ProfileDocuments;
+  ownershipTypeIds: string[];
+  existingEmployees: string | undefined;
+  taxPin: string | undefined;
+  encryptedTaxPin: string | undefined;
+  sectorId: string | undefined;
+  naicsCode: string;
+  foreignBusinessTypeIds: v164ForeignBusinessTypeId[];
+  nexusDbaName: string;
+  operatingPhase: v164OperatingPhase;
+  nonEssentialRadioAnswers: Record<string, boolean | undefined>;
+  elevatorOwningBusiness: boolean | undefined;
+  communityAffairsAddress?: v164CommunityAffairsAddress;
+  plannedRenovationQuestion: boolean | undefined;
+  raffleBingoGames: boolean | undefined;
+  businessOpenMoreThanTwoYears: boolean | undefined;
+}
+
+export type v164CommunityAffairsAddress = {
+  streetAddress1: string;
+  streetAddress2?: string;
+  municipality: v164Municipality;
+};
+
+type v164BusinessUser = {
+  name?: string;
+  email: string;
+  id: string;
+  receiveNewsletter: boolean;
+  userTesting: boolean;
+  externalStatus: v164ExternalStatus;
+  myNJUserKey?: string;
+  intercomHash?: string;
+  abExperience: v164ABExperience;
+  accountCreationSource: string;
+  contactSharingWithAccountCreationPartner: boolean;
+};
+
+interface v164ProfileDocuments {
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+}
+
+type v164BusinessPersona = "STARTING" | "OWNING" | "FOREIGN" | undefined;
+type v164OperatingPhase =
+  | "GUEST_MODE"
+  | "NEEDS_TO_FORM"
+  | "NEEDS_BUSINESS_STRUCTURE"
+  | "FORMED"
+  | "UP_AND_RUNNING"
+  | "UP_AND_RUNNING_OWNING"
+  | "REMOTE_SELLER_WORKER"
+  | undefined;
+
+export type v164CannabisLicenseType = "CONDITIONAL" | "ANNUAL" | undefined;
+export type v164CarServiceType = "STANDARD" | "HIGH_CAPACITY" | "BOTH" | undefined;
+export type v164ConstructionType = "RESIDENTIAL" | "COMMERCIAL_OR_INDUSTRIAL" | "BOTH" | undefined;
+export type v164ResidentialConstructionType =
+  | "NEW_HOME_CONSTRUCTION"
+  | "HOME_RENOVATIONS"
+  | "BOTH"
+  | undefined;
+export type v164EmploymentAndPersonnelServicesType = "JOB_SEEKERS" | "EMPLOYERS" | undefined;
+export type v164EmploymentPlacementType = "TEMPORARY" | "PERMANENT" | "BOTH" | undefined;
+
+type v164ForeignBusinessTypeId =
+  | "employeeOrContractorInNJ"
+  | "officeInNJ"
+  | "propertyInNJ"
+  | "companyOperatedVehiclesInNJ"
+  | "employeesInNJ"
+  | "revenueInNJ"
+  | "transactionsInNJ"
+  | "none";
+
+type v164Municipality = {
+  name: string;
+  displayName: string;
+  county: string;
+  id: string;
+};
+
+type v164TaxFilingState = "SUCCESS" | "FAILED" | "UNREGISTERED" | "PENDING" | "API_ERROR";
+type v164TaxFilingErrorFields = "businessName" | "formFailure";
+
+type v164TaxFilingData = {
+  state?: v164TaxFilingState;
+  lastUpdatedISO?: string;
+  registeredISO?: string;
+  errorField?: v164TaxFilingErrorFields;
+  businessName?: string;
+  filings: v164TaxFilingCalendarEvent[];
+};
+
+export type v164CalendarEvent = {
+  readonly dueDate: string; // YYYY-MM-DD
+  readonly calendarEventType: "TAX-FILING" | "LICENSE";
+};
+
+export interface v164TaxFilingCalendarEvent extends v164CalendarEvent {
+  readonly identifier: string;
+  readonly calendarEventType: "TAX-FILING";
+}
+
+export type v164LicenseSearchAddress = {
+  addressLine1: string;
+  addressLine2: string;
+  zipCode: string;
+};
+
+export interface v164LicenseSearchNameAndAddress extends v164LicenseSearchAddress {
+  name: string;
+}
+
+type v164LicenseDetails = {
+  nameAndAddress: v164LicenseSearchNameAndAddress;
+  licenseStatus: v164LicenseStatus;
+  expirationDateISO: string | undefined;
+  lastUpdatedISO: string;
+  checklistItems: v164LicenseStatusItem[];
+};
+
+const v164taskIdLicenseNameMapping = {
+  "apply-for-shop-license": "Cosmetology and Hairstyling-Shop",
+  "appraiser-license": "Real Estate Appraisers-Appraisal Management Company",
+  "architect-license": "Architecture-Certificate of Authorization",
+  "health-club-registration": "Health Club Services",
+  "home-health-aide-license": "Health Care Services",
+  "hvac-license": "HVACR-HVACR CE Sponsor",
+  "landscape-architect-license": "Landscape Architecture-Certificate of Authorization",
+  "license-massage-therapy": "Massage and Bodywork Therapy-Massage and Bodywork Employer",
+  "moving-company-license": "Public Movers and Warehousemen-Public Mover and Warehouseman",
+  "pharmacy-license": "Pharmacy-Pharmacy",
+  "public-accountant-license": "Accountancy-Firm Registration",
+  "register-accounting-firm": "Accountancy-Firm Registration",
+  "register-consumer-affairs": "Home Improvement Contractors-Home Improvement Contractor",
+  "ticket-broker-reseller-registration": "Ticket Brokers",
+  "telemarketing-license": "Telemarketers",
+} as const;
+
+type v164LicenseTaskID = keyof typeof v164taskIdLicenseNameMapping;
+
+export type v164LicenseName = (typeof v164taskIdLicenseNameMapping)[v164LicenseTaskID];
+
+type v164Licenses = Partial<Record<v164LicenseName, v164LicenseDetails>>;
+
+type v164LicenseData = {
+  lastUpdatedISO: string;
+  licenses?: v164Licenses;
+};
+
+type v164Preferences = {
+  roadmapOpenSections: v164SectionType[];
+  roadmapOpenSteps: number[];
+  hiddenFundingIds: string[];
+  hiddenCertificationIds: string[];
+  visibleSidebarCards: string[];
+  isCalendarFullView: boolean;
+  returnToLink: string;
+  isHideableRoadmapOpen: boolean;
+  phaseNewlyChanged: boolean;
+  isNonProfitFromFunding?: boolean;
+};
+
+type v164LicenseStatusItem = {
+  title: string;
+  status: v164CheckoffStatus;
+};
+
+type v164CheckoffStatus = "ACTIVE" | "PENDING" | "UNKNOWN";
+
+type v164LicenseStatus =
+  | "ACTIVE"
+  | "PENDING"
+  | "UNKNOWN"
+  | "EXPIRED"
+  | "BARRED"
+  | "OUT_OF_BUSINESS"
+  | "REINSTATEMENT_PENDING"
+  | "CLOSED"
+  | "DELETED"
+  | "DENIED"
+  | "VOLUNTARY_SURRENDER"
+  | "WITHDRAWN";
+
+const v164LicenseStatuses: v164LicenseStatus[] = [
+  "ACTIVE",
+  "PENDING",
+  "UNKNOWN",
+  "EXPIRED",
+  "BARRED",
+  "OUT_OF_BUSINESS",
+  "REINSTATEMENT_PENDING",
+  "CLOSED",
+  "DELETED",
+  "DENIED",
+  "VOLUNTARY_SURRENDER",
+  "WITHDRAWN",
+];
+
+const v164SectionNames = ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"] as const;
+type v164SectionType = (typeof v164SectionNames)[number];
+
+type v164ExternalStatus = {
+  newsletter?: v164NewsletterResponse;
+  userTesting?: v164UserTestingResponse;
+};
+
+interface v164NewsletterResponse {
+  success?: boolean;
+  status: v164NewsletterStatus;
+}
+
+interface v164UserTestingResponse {
+  success?: boolean;
+  status: v164UserTestingStatus;
+}
+
+type v164NewsletterStatus = (typeof newsletterStatusList)[number];
+
+const externalStatusList = ["SUCCESS", "IN_PROGRESS", "CONNECTION_ERROR"] as const;
+
+const userTestingStatusList = [...externalStatusList] as const;
+
+type v164UserTestingStatus = (typeof userTestingStatusList)[number];
+
+const newsletterStatusList = [
+  ...externalStatusList,
+  "EMAIL_ERROR",
+  "TOPIC_ERROR",
+  "RESPONSE_WARNING",
+  "RESPONSE_ERROR",
+  "RESPONSE_FAIL",
+  "QUESTION_WARNING",
+] as const;
+
+type v164NameAvailabilityStatus =
+  | "AVAILABLE"
+  | "DESIGNATOR_ERROR"
+  | "SPECIAL_CHARACTER_ERROR"
+  | "UNAVAILABLE"
+  | "RESTRICTED_ERROR"
+  | undefined;
+
+interface v164NameAvailabilityResponse {
+  status: v164NameAvailabilityStatus;
+  similarNames: string[];
+  invalidWord?: string;
+}
+
+interface v164NameAvailability extends v164NameAvailabilityResponse {
+  lastUpdatedTimeStamp: string;
+}
+
+interface v164FormationData {
+  formationFormData: v164FormationFormData;
+  businessNameAvailability: v164NameAvailability | undefined;
+  dbaBusinessNameAvailability: v164NameAvailability | undefined;
+  formationResponse: v164FormationSubmitResponse | undefined;
+  getFilingResponse: v164GetFilingResponse | undefined;
+  completedFilingPayment: boolean;
+  lastVisitedPageIndex: number;
+}
+
+type v164InFormInBylaws = "IN_BYLAWS" | "IN_FORM" | undefined;
+
+interface v164FormationFormData extends v164FormationAddress {
+  readonly businessName: string;
+  readonly businessSuffix: v164BusinessSuffix | undefined;
+  readonly businessTotalStock: string;
+  readonly businessStartDate: string; // YYYY-MM-DD
+  readonly businessPurpose: string;
+  readonly withdrawals: string;
+  readonly combinedInvestment: string;
+  readonly dissolution: string;
+  readonly canCreateLimitedPartner: boolean | undefined;
+  readonly createLimitedPartnerTerms: string;
+  readonly canGetDistribution: boolean | undefined;
+  readonly getDistributionTerms: string;
+  readonly canMakeDistribution: boolean | undefined;
+  readonly makeDistributionTerms: string;
+  readonly hasNonprofitBoardMembers: boolean | undefined;
+  readonly nonprofitBoardMemberQualificationsSpecified: v164InFormInBylaws;
+  readonly nonprofitBoardMemberQualificationsTerms: string;
+  readonly nonprofitBoardMemberRightsSpecified: v164InFormInBylaws;
+  readonly nonprofitBoardMemberRightsTerms: string;
+  readonly nonprofitTrusteesMethodSpecified: v164InFormInBylaws;
+  readonly nonprofitTrusteesMethodTerms: string;
+  readonly nonprofitAssetDistributionSpecified: v164InFormInBylaws;
+  readonly nonprofitAssetDistributionTerms: string;
+  readonly additionalProvisions: string[] | undefined;
+  readonly agentNumberOrManual: "NUMBER" | "MANUAL_ENTRY";
+  readonly agentNumber: string;
+  readonly agentName: string;
+  readonly agentEmail: string;
+  readonly agentOfficeAddressLine1: string;
+  readonly agentOfficeAddressLine2: string;
+  readonly agentOfficeAddressCity: string;
+  readonly agentOfficeAddressZipCode: string;
+  readonly agentUseAccountInfo: boolean;
+  readonly agentUseBusinessAddress: boolean;
+  readonly members: v164FormationMember[] | undefined;
+  readonly incorporators: v164FormationIncorporator[] | undefined;
+  readonly signers: v164FormationSigner[] | undefined;
+  readonly paymentType: v164PaymentType;
+  readonly annualReportNotification: boolean;
+  readonly corpWatchNotification: boolean;
+  readonly officialFormationDocument: boolean;
+  readonly certificateOfStanding: boolean;
+  readonly certifiedCopyOfFormationDocument: boolean;
+  readonly contactFirstName: string;
+  readonly contactLastName: string;
+  readonly contactPhoneNumber: string;
+  readonly foreignStateOfFormation: v164StateObject | undefined;
+  readonly foreignDateOfFormation: string | undefined; // YYYY-MM-DD
+  readonly foreignGoodStandingFile: v164ForeignGoodStandingFileObject | undefined;
+  readonly legalType: string;
+  readonly willPracticeLaw: boolean | undefined;
+  readonly isVeteranNonprofit: boolean | undefined;
+}
+
+type v164ForeignGoodStandingFileObject = {
+  Extension: "PDF" | "PNG";
+  Content: string;
+};
+
+type v164StateObject = {
+  shortCode: string;
+  name: string;
+};
+
+interface v164FormationAddress {
+  readonly addressLine1: string;
+  readonly addressLine2: string;
+  readonly addressCity?: string;
+  readonly addressState?: v164StateObject;
+  readonly addressMunicipality?: v164Municipality;
+  readonly addressProvince?: string;
+  readonly addressZipCode: string;
+  readonly addressCountry: string;
+  readonly businessLocationType: v164FormationBusinessLocationType | undefined;
+}
+
+type v164FormationBusinessLocationType = "US" | "INTL" | "NJ";
+
+type v164SignerTitle =
+  | "Authorized Representative"
+  | "Authorized Partner"
+  | "Incorporator"
+  | "General Partner"
+  | "President"
+  | "Vice-President"
+  | "Chairman of the Board"
+  | "CEO";
+
+interface v164FormationSigner {
+  readonly name: string;
+  readonly signature: boolean;
+  readonly title: v164SignerTitle;
+}
+
+interface v164FormationIncorporator extends v164FormationSigner, v164FormationAddress {}
+
+interface v164FormationMember extends v164FormationAddress {
+  readonly name: string;
+}
+
+type v164PaymentType = "CC" | "ACH" | undefined;
+
+const llcBusinessSuffix = [
+  "LLC",
+  "L.L.C.",
+  "LTD LIABILITY CO",
+  "LTD LIABILITY CO.",
+  "LTD LIABILITY COMPANY",
+  "LIMITED LIABILITY CO",
+  "LIMITED LIABILITY CO.",
+  "LIMITED LIABILITY COMPANY",
+] as const;
+
+const llpBusinessSuffix = [
+  "Limited Liability Partnership",
+  "LLP",
+  "L.L.P.",
+  "Registered Limited Liability Partnership",
+  "RLLP",
+  "R.L.L.P.",
+] as const;
+
+export const lpBusinessSuffix = ["LIMITED PARTNERSHIP", "LP", "L.P."] as const;
+
+const corpBusinessSuffix = [
+  "Corporation",
+  "Incorporated",
+  "Company",
+  "LTD",
+  "CO",
+  "CO.",
+  "CORP",
+  "CORP.",
+  "INC",
+  "INC.",
+] as const;
+
+export const nonprofitBusinessSuffix = [
+  "A NJ NONPROFIT CORPORATION",
+  "CORPORATION",
+  "INCORPORATED",
+  "CORP",
+  "CORP.",
+  "INC",
+  "INC.",
+] as const;
+
+const foreignCorpBusinessSuffix = [...corpBusinessSuffix, "P.C.", "P.A."] as const;
+
+export const AllBusinessSuffixes = [
+  ...llcBusinessSuffix,
+  ...llpBusinessSuffix,
+  ...lpBusinessSuffix,
+  ...corpBusinessSuffix,
+  ...foreignCorpBusinessSuffix,
+  ...nonprofitBusinessSuffix,
+] as const;
+
+type v164BusinessSuffix = (typeof AllBusinessSuffixes)[number];
+
+type v164FormationSubmitResponse = {
+  success: boolean;
+  token: string | undefined;
+  formationId: string | undefined;
+  redirect: string | undefined;
+  errors: v164FormationSubmitError[];
+  lastUpdatedISO: string | undefined;
+};
+
+type v164FormationSubmitError = {
+  field: string;
+  type: "FIELD" | "UNKNOWN" | "RESPONSE";
+  message: string;
+};
+
+type v164GetFilingResponse = {
+  success: boolean;
+  entityId: string;
+  transactionDate: string;
+  confirmationNumber: string;
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+};
+
+export type v164EnvironmentData = {
+  waste?: v164WasteData;
+  land?: v164LandData;
+  air?: v164AirData;
+};
+
+export type v164MediaArea = keyof v164EnvironmentData;
+export type v164QuestionnaireFieldIds =
+  | v164WasteQuestionnaireFieldIds
+  | v164LandQuestionnaireFieldIds
+  | v164AirQuestionnaireFieldIds;
+export type v164Questionnaire = Record<v164QuestionnaireFieldIds, boolean>;
+export type v164QuestionnaireConfig = Record<v164QuestionnaireFieldIds, string>;
+
+export type v164WasteData = {
+  questionnaireData: v164WasteQuestionnaireData;
+  submitted: boolean;
+};
+
+export type v164WasteQuestionnaireFieldIds =
+  | "transportWaste"
+  | "hazardousMedicalWaste"
+  | "compostWaste"
+  | "treatProcessWaste"
+  | "constructionDebris"
+  | "noWaste";
+
+export type v164WasteQuestionnaireData = Record<v164WasteQuestionnaireFieldIds, boolean>;
+
+export type v164LandData = {
+  questionnaireData: v164LandQuestionnaireData;
+  submitted: boolean;
+};
+
+export type v164LandQuestionnaireFieldIds =
+  | "takeOverExistingBiz"
+  | "propertyAssessment"
+  | "constructionActivities"
+  | "siteImprovementWasteLands"
+  | "noLand";
+
+export type v164LandQuestionnaireData = Record<v164LandQuestionnaireFieldIds, boolean>;
+
+export type v164AirData = {
+  questionnaireData: v164AirQuestionnaireData;
+  submitted: boolean;
+};
+
+export type v164AirQuestionnaireFieldIds =
+  | "emitPollutants"
+  | "emitEmissions"
+  | "constructionActivities"
+  | "noAir";
+
+export type v164AirQuestionnaireData = Record<v164AirQuestionnaireFieldIds, boolean>;
+
+export type v164TaxClearanceCertificateData = {
+  requestingAgencyId: string | undefined;
+  businessName: string | undefined;
+  addressLine1: string | undefined;
+  addressLine2: string | undefined;
+  addressCity: string | undefined;
+  addressState?: v164StateObject | undefined;
+  addressZipCode: string | undefined;
+  taxId: string | undefined;
+  taxPin: string | undefined;
+  hasPreviouslyReceivedCertificate: boolean | undefined;
+  lastUpdatedISO: string | undefined;
+};
+
+export type v164XrayData = {
+  facilityDetails?: v164FacilityDetails;
+  machines?: v164MachineDetails[];
+  status?: v164XrayRegistrationStatus;
+  expirationDate?: string;
+  deactivationDate?: string;
+};
+
+export type v164FacilityDetails = {
+  businessName: string;
+  addressLine1: string;
+  addressLine2?: string;
+  addressZipCode: string;
+};
+
+export type v164MachineDetails = {
+  name?: string;
+  registrationNumber?: string;
+  roomId?: string;
+  registrationCategory?: string;
+  manufacturer?: string;
+  modelNumber?: string;
+  serialNumber?: string;
+  annualFee?: number;
+};
+
+export type v164XrayRegistrationStatusResponse = {
+  machines: v164MachineDetails[];
+  status: v164XrayRegistrationStatus;
+  expirationDate?: string;
+  deactivationDate?: string;
+};
+
+export type v164XrayRegistrationStatus = "ACTIVE" | "EXPIRED" | "INACTIVE";
+
+// ---------------- v164 generators ----------------
+
+export const generatev164UserData = (overrides: Partial<v164UserData>): v164UserData => {
+  return {
+    user: generatev164BusinessUser({}),
+    version: 164,
+    lastUpdatedISO: "",
+    dateCreatedISO: "",
+    versionWhenCreated: 141,
+    businesses: {
+      "123": generatev164Business({ id: "123" }),
+    },
+    currentBusinessId: "",
+    ...overrides,
+  };
+};
+
+export const generatev164BusinessUser = (
+  overrides: Partial<v164BusinessUser>,
+): v164BusinessUser => {
+  return {
+    name: `some-name-${randomInt()}`,
+    email: `some-email-${randomInt()}@example.com`,
+    id: `some-id-${randomInt()}`,
+    receiveNewsletter: false,
+    userTesting: false,
+    externalStatus: {
+      userTesting: {
+        success: true,
+        status: "SUCCESS",
+      },
+    },
+    myNJUserKey: undefined,
+    intercomHash: undefined,
+    abExperience: "ExperienceA",
+    accountCreationSource: `some-source-${randomInt()}`,
+    contactSharingWithAccountCreationPartner: false,
+    ...overrides,
+  };
+};
+
+export const generatev164Business = (overrides: Partial<v164Business>): v164Business => {
+  const profileData = generatev164ProfileData({});
+
+  return {
+    id: `some-id-${randomInt()}`,
+    dateCreatedISO: "",
+    lastUpdatedISO: "",
+    profileData: profileData,
+    preferences: generatev164Preferences({}),
+    formationData: generatev164FormationData({}, profileData.legalStructureId ?? ""),
+    onboardingFormProgress: "UNSTARTED",
+    taxClearanceCertificateData: generatev164TaxClearanceCertificateData({}),
+    taskProgress: {
+      "business-structure": "TO_DO",
+    },
+    taskItemChecklist: {
+      "general-dvob": false,
+    },
+    licenseData: undefined,
+    taxFilingData: generatev164TaxFilingData({}),
+    environmentData: undefined,
+    xrayRegistrationData: undefined,
+    userId: `some-id-${randomInt()}`,
+    version: 164,
+    versionWhenCreated: -1,
+    ...overrides,
+  };
+};
+
+export const generatev164ProfileData = (overrides: Partial<v164ProfileData>): v164ProfileData => {
+  const id = `some-id-${randomInt()}`;
+  const persona = randomInt() % 2 ? "STARTING" : "OWNING";
+  return {
+    ...generatev164IndustrySpecificData({}),
+    businessPersona: persona,
+    businessName: `some-business-name-${randomInt()}`,
+    industryId: "restaurant",
+    legalStructureId: "limited-liability-partnership",
+    dateOfFormation: undefined,
+    entityId: randomInt(10).toString(),
+    employerId: randomInt(9).toString(),
+    taxId: randomInt() % 2 ? randomInt(9).toString() : randomInt(12).toString(),
+    hashedTaxId: `some-hashed-tax-id`,
+    encryptedTaxId: `some-encrypted-tax-id`,
+    notes: `some-notes-${randomInt()}`,
+    existingEmployees: randomInt(7).toString(),
+    naicsCode: randomInt(6).toString(),
+    nexusDbaName: "undefined",
+    operatingPhase: "NEEDS_TO_FORM",
+    ownershipTypeIds: [],
+    documents: {
+      certifiedDoc: `${id}/certifiedDoc-${randomInt()}.pdf`,
+      formationDoc: `${id}/formationDoc-${randomInt()}.pdf`,
+      standingDoc: `${id}/standingDoc-${randomInt()}.pdf`,
+    },
+    taxPin: randomInt(4).toString(),
+    encryptedTaxPin: `some-encrypted-tax-pin`,
+    sectorId: undefined,
+    foreignBusinessTypeIds: [],
+    municipality: undefined,
+    responsibleOwnerName: `some-owner-name-${randomInt()}`,
+    tradeName: `some-trade-name-${randomInt()}`,
+    elevatorOwningBusiness: undefined,
+    nonEssentialRadioAnswers: {},
+    plannedRenovationQuestion: undefined,
+    communityAffairsAddress: undefined,
+    raffleBingoGames: undefined,
+    businessOpenMoreThanTwoYears: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev164IndustrySpecificData = (
+  overrides: Partial<v164IndustrySpecificData>,
+): v164IndustrySpecificData => {
+  return {
+    liquorLicense: false,
+    requiresCpa: false,
+    homeBasedBusiness: false,
+    cannabisLicenseType: undefined,
+    cannabisMicrobusiness: undefined,
+    constructionRenovationPlan: undefined,
+    providesStaffingService: false,
+    certifiedInteriorDesigner: false,
+    realEstateAppraisalManagement: false,
+    carService: undefined,
+    interstateTransport: false,
+    isChildcareForSixOrMore: undefined,
+    willSellPetCareItems: undefined,
+    petCareHousing: undefined,
+    interstateLogistics: undefined,
+    interstateMoving: undefined,
+    constructionType: undefined,
+    residentialConstructionType: undefined,
+    employmentPersonnelServiceType: undefined,
+    employmentPlacementType: undefined,
+    carnivalRideOwningBusiness: undefined,
+    propertyLeaseType: undefined,
+    hasThreeOrMoreRentalUnits: undefined,
+    travelingCircusOrCarnivalOwningBusiness: undefined,
+    vacantPropertyOwner: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev164Preferences = (overrides: Partial<v164Preferences>): v164Preferences => {
+  return {
+    roadmapOpenSections: ["PLAN", "START"],
+    roadmapOpenSteps: [],
+    hiddenCertificationIds: [],
+    hiddenFundingIds: [],
+    visibleSidebarCards: [],
+    returnToLink: "",
+    isCalendarFullView: true,
+    isHideableRoadmapOpen: false,
+    phaseNewlyChanged: false,
+    isNonProfitFromFunding: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev164FormationData = (
+  overrides: Partial<v164FormationData>,
+  legalStructureId: string,
+): v164FormationData => {
+  return {
+    formationFormData: generatev164FormationFormData({}, legalStructureId),
+    formationResponse: undefined,
+    getFilingResponse: undefined,
+    completedFilingPayment: false,
+    businessNameAvailability: undefined,
+    lastVisitedPageIndex: 0,
+    dbaBusinessNameAvailability: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev164FormationFormData = (
+  overrides: Partial<v164FormationFormData>,
+  legalStructureId: string,
+): v164FormationFormData => {
+  const isCorp = legalStructureId
+    ? ["s-corporation", "c-corporation"].includes(legalStructureId)
+    : false;
+
+  return <v164FormationFormData>{
+    businessName: `some-business-name-${randomInt()}`,
+    businessSuffix: "LLC",
+    businessTotalStock: isCorp ? randomInt().toString() : "",
+    businessStartDate: new Date(Date.now()).toISOString().split("T")[0],
+    businessPurpose: `some-purpose-${randomInt()}`,
+    addressLine1: `some-members-address-1-${randomInt()}`,
+    addressLine2: `some-members-address-2-${randomInt()}`,
+    addressCity: `some-members-address-city-${randomInt()}`,
+    addressState: { shortCode: "123", name: "new-jersey" },
+    addressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    addressCountry: `some-county`,
+    addressMunicipality: generatev164Municipality({}),
+    addressProvince: "",
+    withdrawals: `some-withdrawals-text-${randomInt()}`,
+    combinedInvestment: `some-combinedInvestment-text-${randomInt()}`,
+    dissolution: `some-dissolution-text-${randomInt()}`,
+    canCreateLimitedPartner: !!(randomInt() % 2),
+    createLimitedPartnerTerms: `some-createLimitedPartnerTerms-text-${randomInt()}`,
+    canGetDistribution: !!(randomInt() % 2),
+    getDistributionTerms: `some-getDistributionTerms-text-${randomInt()}`,
+    canMakeDistribution: !!(randomInt() % 2),
+    makeDistributionTerms: `make-getDistributionTerms-text-${randomInt()}`,
+    hasNonprofitBoardMembers: true,
+    nonprofitBoardMemberQualificationsSpecified: "IN_BYLAWS",
+    nonprofitBoardMemberQualificationsTerms: "",
+    nonprofitBoardMemberRightsSpecified: "IN_BYLAWS",
+    nonprofitBoardMemberRightsTerms: "",
+    nonprofitTrusteesMethodSpecified: "IN_BYLAWS",
+    nonprofitTrusteesMethodTerms: "",
+    nonprofitAssetDistributionSpecified: "IN_BYLAWS",
+    nonprofitAssetDistributionTerms: "",
+    provisions: [],
+    agentNumberOrManual: randomInt() % 2 ? "NUMBER" : "MANUAL_ENTRY",
+    agentNumber: `some-agent-number-${randomInt()}`,
+    agentName: `some-agent-name-${randomInt()}`,
+    agentEmail: `some-agent-email-${randomInt()}`,
+    agentOfficeAddressLine1: `some-agent-office-address-1-${randomInt()}`,
+    agentOfficeAddressLine2: `some-agent-office-address-2-${randomInt()}`,
+    agentOfficeAddressCity: `some-agent-office-address-city-${randomInt()}`,
+    agentOfficeAddressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    agentUseAccountInfo: !!(randomInt() % 2),
+    agentUseBusinessAddress: !!(randomInt() % 2),
+    signers: [],
+    members:
+      legalStructureId === "limited-liability-partnership" ? [] : [generatev164FormationMember({})],
+    incorporators: undefined,
+    paymentType: randomInt() % 2 ? "ACH" : "CC",
+    annualReportNotification: !!(randomInt() % 2),
+    corpWatchNotification: !!(randomInt() % 2),
+    officialFormationDocument: !!(randomInt() % 2),
+    certificateOfStanding: !!(randomInt() % 2),
+    certifiedCopyOfFormationDocument: !!(randomInt() % 2),
+    contactFirstName: `some-contact-first-name-${randomInt()}`,
+    contactLastName: `some-contact-last-name-${randomInt()}`,
+    contactPhoneNumber: `some-contact-phone-number-${randomInt()}`,
+    foreignStateOfFormation: undefined,
+    foreignDateOfFormation: undefined,
+    foreignGoodStandingFile: undefined,
+    willPracticeLaw: false,
+    isVeteranNonprofit: false,
+    legalType: "",
+    additionalProvisions: undefined,
+    businessLocationType: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev164Municipality = (
+  overrides: Partial<v164Municipality>,
+): v164Municipality => {
+  return {
+    displayName: `some-display-name-${randomInt()}`,
+    name: `some-name-${randomInt()}`,
+    county: `some-county-${randomInt()}`,
+    id: `some-id-${randomInt()}`,
+    ...overrides,
+  };
+};
+
+export const generatev164FormationMember = (
+  overrides: Partial<v164FormationMember>,
+): v164FormationMember => {
+  return {
+    name: `some-name`,
+    addressLine1: `some-members-address-1-${randomInt()}`,
+    addressLine2: `some-members-address-2-${randomInt()}`,
+    addressCity: `some-members-address-city-${randomInt()}`,
+    addressState: { shortCode: "123", name: "new-jersey" },
+    addressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    addressCountry: `some-county`,
+    businessLocationType: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev164TaxFilingData = (
+  overrides: Partial<v164TaxFilingData>,
+): v164TaxFilingData => {
+  return {
+    state: undefined,
+    businessName: undefined,
+    errorField: undefined,
+    lastUpdatedISO: undefined,
+    registeredISO: undefined,
+    filings: [],
+    ...overrides,
+  };
+};
+
+export const generatev164LicenseDetails = (
+  overrides: Partial<v164LicenseDetails>,
+): v164LicenseDetails => {
+  return {
+    nameAndAddress: generatev164LicenseSearchNameAndAddress({}),
+    licenseStatus: getRandomv164LicenseStatus(),
+    expirationDateISO: "some-expiration-iso",
+    lastUpdatedISO: "some-last-updated",
+    checklistItems: [generatev164LicenseStatusItem()],
+    ...overrides,
+  };
+};
+
+const generatev164LicenseSearchNameAndAddress = (
+  overrides: Partial<v164LicenseSearchNameAndAddress>,
+): v164LicenseSearchNameAndAddress => {
+  return {
+    name: `some-name`,
+    addressLine1: `some-members-address-1-${randomInt()}`,
+    addressLine2: `some-members-address-2-${randomInt()}`,
+    zipCode: `some-agent-office-zipcode-${randomInt()}`,
+    ...overrides,
+  };
+};
+
+const generatev164LicenseStatusItem = (): v164LicenseStatusItem => {
+  return {
+    title: `some-title-${randomInt()}`,
+    status: "ACTIVE",
+  };
+};
+
+export const getRandomv164LicenseStatus = (): v164LicenseStatus => {
+  const randomIndex = Math.floor(Math.random() * v164LicenseStatuses.length);
+  return v164LicenseStatuses[randomIndex];
+};
+
+export const generatev164TaxClearanceCertificateData = (
+  overrides: Partial<v164TaxClearanceCertificateData>,
+): v164TaxClearanceCertificateData => {
+  return {
+    requestingAgencyId: "",
+    businessName: `some-business-name-${randomInt()}`,
+    addressLine1: `some-address-1-${randomInt()}`,
+    addressLine2: `some-address-2-${randomInt()}`,
+    addressCity: `some-city-${randomInt()}`,
+    addressState: undefined,
+    addressZipCode: randomInt(5).toString(),
+    taxId: `${randomInt(12)}`,
+    taxPin: randomInt(4).toString(),
+    hasPreviouslyReceivedCertificate: undefined,
+    lastUpdatedISO: "",
+    ...overrides,
+  };
+};

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -46,6 +46,7 @@ export interface DatabaseClient {
   findByEmail: (email: string) => Promise<UserData | undefined>;
   findUserByBusinessName: (businessName: string) => Promise<UserData | undefined>;
   findUsersByBusinessNamePrefix: (prefix: string) => Promise<UserData[]>;
+  findBusinessesByHashedTaxId: (hashedTaxId: string) => Promise<Business[]>;
 }
 
 export interface UserDataClient {
@@ -70,6 +71,7 @@ export interface BusinessesDataClient {
   findAllByIndustry: (industry: string) => Promise<Business[]>;
   findBusinessesByNamePrefix: (prefix: string) => Promise<Business[]>;
   findByEncryptedTaxId: (encryptedTaxId: string) => Promise<Business | undefined>;
+  findAllByHashedTaxId: (hashedTaxId: string) => Promise<Business[]>;
 }
 
 export interface BusinessNameClient {
@@ -247,6 +249,7 @@ export interface TaxClearanceCertificateClient {
   postTaxClearanceCertificate: (
     userData: UserData,
     cryptoClient: CryptoClient,
+    databaseClient: DatabaseClient,
   ) => Promise<TaxClearanceCertificateResponse>;
 }
 

--- a/api/src/functions/express/app.ts
+++ b/api/src/functions/express/app.ts
@@ -430,7 +430,11 @@ app.use(
 );
 app.use(
   "/api",
-  taxClearanceCertificateRouterFactory(taxClearanceCertificateClient, AWSTaxIDEncryptionClient),
+  taxClearanceCertificateRouterFactory(
+    taxClearanceCertificateClient,
+    AWSTaxIDEncryptionClient,
+    dynamoDataClient,
+  ),
 );
 app.use("/api", fireSafetyRouterFactory(dynamicsFireSafetyClient));
 app.use(

--- a/content/src/fieldConfig/tax-clearance-certificate-step3.json
+++ b/content/src/fieldConfig/tax-clearance-certificate-step3.json
@@ -12,6 +12,7 @@
     "errorTextIneligible": "We cannot find your business information. Check the information you've entered.",
     "errorTextMissingField": "Your request was missing required fields. Ensure that all required fields are completed.",
     "errorTextSystem": "Something went wrong. Review your information and try again later.",
-    "errorTextValidation": "Some of the entries in your submission were not valid. Review your information and try again."
+    "errorTextValidation": "Some of the entries in your submission were not valid. Review your information and try again.",
+    "errorTextPreviouslyReceivedCertificate": "**Tax ID is in use by another business account.** \n\nReturn to the \"Check Eligibility\" step to confirm your tax ID."
   }
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -33,6 +33,7 @@ export * from "./states";
 export * from "./stringHelpers";
 export * from "./taskAgency";
 export * from "./taxClearanceCertificate";
+export * from "./taxClearanceCertificateResponse";
 export * from "./taxFiling";
 export * from "./test";
 export * from "./userData";

--- a/shared/src/taxClearanceCertificate.ts
+++ b/shared/src/taxClearanceCertificate.ts
@@ -2,23 +2,6 @@ import { orderBy } from "lodash";
 import taxClearanceCertificateAgenciesJSON from "../../content/src/mappings/taxClearanceCertificateIssuingAgencies.json";
 import { StateObject } from "./states";
 
-export type TaxClearanceCertificateResponseErrorType =
-  | "INELIGIBLE_TAX_CLEARANCE_FORM"
-  | "FAILED_TAX_ID_AND_PIN_VALIDATION"
-  | "MISSING_FIELD"
-  | "NATURAL_PROGRAM_ERROR"
-  | "TAX_ID_MISSING_FIELD"
-  | "TAX_ID_MISSING_FIELD_WITH_EXTRA_SPACE"
-  | "SYSTEM_ERROR";
-
-export type TaxClearanceCertificateResponse = {
-  error?: {
-    type: TaxClearanceCertificateResponseErrorType;
-    message: string;
-  };
-  certificatePdfArray?: number[];
-};
-
 export const taxClearanceCertificateAgencies: TaxClearanceCertificateAgency[] =
   taxClearanceCertificateAgenciesJSON.arrayOfTaxClearanceCertificateIssuingAgencies;
 
@@ -42,6 +25,8 @@ export const emptyTaxClearanceCertificateData: TaxClearanceCertificateData = {
   encryptedTaxId: "",
   taxPin: "",
   encryptedTaxPin: "",
+  hasPreviouslyReceivedCertificate: false,
+  lastUpdatedISO: undefined,
 };
 
 export type TaxClearanceCertificateData = {
@@ -56,6 +41,8 @@ export type TaxClearanceCertificateData = {
   encryptedTaxId: string | undefined;
   taxPin: string | undefined;
   encryptedTaxPin: string | undefined;
+  hasPreviouslyReceivedCertificate: boolean | undefined;
+  lastUpdatedISO: string | undefined;
 };
 
 export const LookupTaxClearanceCertificateAgenciesById = (

--- a/shared/src/taxClearanceCertificateResponse.ts
+++ b/shared/src/taxClearanceCertificateResponse.ts
@@ -1,0 +1,25 @@
+import { UserData } from "./userData";
+
+export type TaxClearanceCertificateResponseErrorType =
+  | "INELIGIBLE_TAX_CLEARANCE_FORM"
+  | "FAILED_TAX_ID_AND_PIN_VALIDATION"
+  | "MISSING_FIELD"
+  | "NATURAL_PROGRAM_ERROR"
+  | "TAX_ID_MISSING_FIELD"
+  | "TAX_ID_MISSING_FIELD_WITH_EXTRA_SPACE"
+  | "SYSTEM_ERROR"
+  | "TAX_ID_IN_USE_BY_ANOTHER_BUSINESS_ACCOUNT";
+
+type ErrorResponse = {
+  error: {
+    type: TaxClearanceCertificateResponseErrorType;
+    message: string;
+  };
+};
+
+type SuccessResponse = {
+  userData: UserData;
+  certificatePdfArray: number[];
+};
+
+export type TaxClearanceCertificateResponse = ErrorResponse | SuccessResponse;

--- a/shared/src/test/factories.ts
+++ b/shared/src/test/factories.ts
@@ -423,6 +423,8 @@ export const generateTaxClearanceCertificateData = (
     encryptedTaxId: `encrypted-${taxId}`,
     taxPin: maskingCharacter.repeat(4),
     encryptedTaxPin: `encrypted-${randomInt(4)}`,
+    hasPreviouslyReceivedCertificate: false,
+    lastUpdatedISO: getCurrentDateISOString(),
     ...overrides,
   };
 };
@@ -532,7 +534,9 @@ export const generateXrayRegistrationData = (overrides: Partial<XrayData>): Xray
 };
 
 export const generateBusiness = (overrides: Partial<Business>): Business => {
-  const profileData = overrides.profileData ?? generateProfileData({});
+  const taxId = maskingCharacter.repeat(7) + randomInt(12).toString().slice(-5);
+  const taxPin = maskingCharacter.repeat(4);
+  const profileData = overrides.profileData ?? generateProfileData({ taxId, taxPin });
   const formationData: FormationData = publicFilingLegalTypes.includes(
     profileData.legalStructureId as PublicFilingLegalType,
   )
@@ -557,7 +561,7 @@ export const generateBusiness = (overrides: Partial<Business>): Business => {
     licenseData: generateLicenseData({}),
     preferences: generatePreferences({}),
     taxFilingData: generateTaxFilingData({}),
-    taxClearanceCertificateData: generateTaxClearanceCertificateData({}),
+    taxClearanceCertificateData: generateTaxClearanceCertificateData({ taxId, taxPin }),
     environmentData: generateEnvironmentData({}),
     xrayRegistrationData: undefined,
     version: CURRENT_VERSION,

--- a/shared/src/userData.ts
+++ b/shared/src/userData.ts
@@ -38,7 +38,7 @@ export interface Business {
   readonly userId: string;
 }
 
-export const CURRENT_VERSION = 163;
+export const CURRENT_VERSION = 164;
 
 export const createEmptyBusiness = ({
   userId,

--- a/web/decap-config/collections/10-anytime-action.yml
+++ b/web/decap-config/collections/10-anytime-action.yml
@@ -312,6 +312,12 @@ collections:
                   widget: "string",
                   required: true,
                 }
+              - {
+                  label: "Tax ID In Use By Another Business - Error Text",
+                  name: "errorTextPreviouslyReceivedCertificate",
+                  widget: "string",
+                  required: true,
+                }
       - label: "Tax Clearance Shared"
         name: "taxClearanceCertificate-shared"
         file: "content/src/fieldConfig/tax-clearance-certificate-shared.json"

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificate.test.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificate.test.tsx
@@ -23,6 +23,7 @@ import {
   generateProfileData,
   generateTaxClearanceCertificateData,
   generateUnitedStatesStateDropdownOption,
+  generateUserData,
   generateUserDataForBusiness,
   getTaxClearanceCertificateAgencies,
   LookupTaxClearanceCertificateAgenciesById,
@@ -73,7 +74,7 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
   }): void => {
     render(
       <WithStatefulUserData
-        initialUserData={userData || generateUserDataForBusiness(business || generateBusiness({}))}
+        initialUserData={userData ?? generateUserDataForBusiness(business ?? generateBusiness({}))}
       >
         <AnytimeActionTaxClearanceCertificate anytimeAction={anytimeAction} />
       </WithStatefulUserData>,
@@ -583,6 +584,8 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
       encryptedTaxId: "encrypted-012345678901",
       taxPin: "****",
       encryptedTaxPin: "encrypted-1234",
+      hasPreviouslyReceivedCertificate: false,
+      lastUpdatedISO: undefined,
     });
   });
 
@@ -624,6 +627,8 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
       encryptedTaxId: "encrypted-012345678901",
       taxPin: "****",
       encryptedTaxPin: "encrypted-1234",
+      hasPreviouslyReceivedCertificate: false,
+      lastUpdatedISO: undefined,
     });
   });
 
@@ -971,6 +976,7 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
   it("makes the api post request", async () => {
     mockApi.postTaxClearanceCertificate.mockResolvedValue({
       certificatePdfArray: [],
+      userData: generateUserData({}),
     });
     window.URL.createObjectURL = jest.fn();
     const business = generateBusiness({ id: "Faraz" });
@@ -983,7 +989,14 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
       screen.getByRole("button", { name: Config.taxClearanceCertificateShared.saveButtonText }),
     );
     await waitFor(() => {
-      expect(mockApi.postTaxClearanceCertificate).toHaveBeenCalledWith(userData);
+      const currentBusiness: Business = {
+        ...userData.businesses[userData.currentBusinessId],
+        lastUpdatedISO: expect.any(String),
+      };
+      expect(mockApi.postTaxClearanceCertificate).toHaveBeenCalledWith({
+        ...userData,
+        businesses: { ...userData.businesses, [currentBusiness.id]: currentBusiness },
+      });
     });
   });
 
@@ -994,6 +1007,7 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
     window.URL.createObjectURL = mockCreateObjectURL;
     mockApi.postTaxClearanceCertificate.mockResolvedValue({
       certificatePdfArray: [],
+      userData: generateUserData({}),
     });
     renderComponent({});
     fireEvent.click(screen.getAllByRole("tab")[2]);

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificate.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificate.tsx
@@ -81,10 +81,18 @@ export const AnytimeActionTaxClearanceCertificate = (props: Props): ReactElement
   };
 
   const saveTaxClearanceCertificateData = (): void => {
+    if (!business) {
+      return;
+    }
     updateQueue
       ?.queueBusiness({
         ...updateQueue.currentBusiness(),
         taxClearanceCertificateData,
+        profileData: {
+          ...business.profileData,
+          taxId: taxClearanceCertificateData.taxId,
+        },
+        lastUpdatedISO: new Date(Date.now()).toISOString(),
       })
       .update();
   };
@@ -103,6 +111,8 @@ export const AnytimeActionTaxClearanceCertificate = (props: Props): ReactElement
         encryptedTaxId,
         taxPin,
         encryptedTaxPin,
+        hasPreviouslyReceivedCertificate,
+        lastUpdatedISO,
       } = getInitialData(business);
 
       setTaxClearanceCertificateData({
@@ -117,6 +127,8 @@ export const AnytimeActionTaxClearanceCertificate = (props: Props): ReactElement
         encryptedTaxId,
         taxPin,
         encryptedTaxPin,
+        hasPreviouslyReceivedCertificate,
+        lastUpdatedISO,
       });
 
       setProfileData({

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.tsx
@@ -1,3 +1,4 @@
+import { Content } from "@/components/Content";
 import { Alert } from "@/components/njwds-extended/Alert";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { getProfileConfig } from "@/lib/domain-logic/getProfileConfig";
@@ -71,6 +72,10 @@ export const AnytimeActionTaxClearanceCertificateAlert = (props: Props): ReactEl
       return Config.taxClearanceCertificateStep3.errorTextMissingField;
     }
 
+    if (errorType === "TAX_ID_IN_USE_BY_ANOTHER_BUSINESS_ACCOUNT") {
+      return Config.taxClearanceCertificateStep3.errorTextPreviouslyReceivedCertificate;
+    }
+
     return Config.taxClearanceCertificateStep3.errorTextSystem;
   };
 
@@ -96,7 +101,9 @@ export const AnytimeActionTaxClearanceCertificateAlert = (props: Props): ReactEl
         </>
       )}
       {props.responseErrorType !== undefined && (
-        <div>{getTaxClearanceErrorMessage(props.responseErrorType)}</div>
+        <div>
+          <Content>{getTaxClearanceErrorMessage(props.responseErrorType)}</Content>
+        </div>
       )}
     </Alert>
   ) : (

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/helpers.ts
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/helpers.ts
@@ -25,6 +25,8 @@ export const getInitialData = (
   encryptedTaxId: string | undefined;
   taxPin: string;
   encryptedTaxPin: string | undefined;
+  hasPreviouslyReceivedCertificate: boolean;
+  lastUpdatedISO: string | undefined;
 } => {
   const requestingAgencyId = business.taxClearanceCertificateData?.requestingAgencyId || "";
   const businessName =
@@ -74,6 +76,9 @@ export const getInitialData = (
     encryptedTaxId,
     taxPin,
     encryptedTaxPin,
+    hasPreviouslyReceivedCertificate:
+      business.taxClearanceCertificateData?.hasPreviouslyReceivedCertificate ?? false,
+    lastUpdatedISO: business.taxClearanceCertificateData?.lastUpdatedISO,
   };
 };
 

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/Review.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/Review.tsx
@@ -32,8 +32,9 @@ interface Props {
 }
 export const Review = (props: Props): ReactElement => {
   const { Config } = useConfig();
-  const { business, userData } = useUserData();
   const { doesRequiredFieldHaveError } = useAddressErrors();
+  const { userData, business, updateQueue } = useUserData();
+
   const requestingAgencyName = LookupTaxClearanceCertificateAgenciesById(
     business?.taxClearanceCertificateData?.requestingAgencyId,
   ).name;
@@ -123,8 +124,7 @@ export const Review = (props: Props): ReactElement => {
 
     try {
       const taxClearanceResponse = await api.postTaxClearanceCertificate(userData);
-
-      if (taxClearanceResponse.error) {
+      if ("error" in taxClearanceResponse) {
         analytics.event.tax_clearance.submit.validation_error();
         props.setResponseErrorType(taxClearanceResponse.error.type);
         return;
@@ -143,6 +143,8 @@ export const Review = (props: Props): ReactElement => {
           },
         );
         props.setCertificatePdfBlob(blob);
+        props.setResponseErrorType(undefined);
+        updateQueue?.queue(taxClearanceResponse.userData).update();
       }
     } catch {
       analytics.event.tax_clearance.submit.validation_error();


### PR DESCRIPTION


<!-- Please complete the following sections as necessary. -->

## Description

Prevents multiple businesses with the same tax ID from receiving tax clearance certificates by adding validation to check if any business with the same hashed tax ID has previously received a certificate.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14314](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14314).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

Testing the tax ID hashing from the business profile:
 - Create a business
 - Set the tax ID in the business profile
 - The system will automatically hash the tax ID
 - You can verify the hashed tax ID is set by checking the business data in DynamoDB

Testing the tax ID hashing from the tax clearance form:
 - Create a business
 - Set the tax ID by going to tax clearance and entering it in the Check Eligibility step, then clicking "Save & Continue"
 - The system will automatically hash the tax ID
 - You can verify the hashed tax ID is set by checking the business data in DynamoDB

Testing the validation against previous requests:
- Create a business and request a tax clearance certificate (use tax ID: 777777777771 and tax pin: 3389 for successful wiremock response)
- Create another business with the same tax ID and attempt to request a certificate (should fail with `TAX_ID_IN_USE_BY_ANOTHER_BUSINESS_ACCOUNT` error from the backend)
- Verify that an error alert appears on the front end when you attempt the request.



### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
