### PR TITLE
fix: [AB#14067] add a label to the Requesting Agency dropdown and make it respond to click events

### DIFF
--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificate.test.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificate.test.tsx
@@ -3,10 +3,7 @@ import { getMergedConfig } from "@/contexts/configContext";
 import * as api from "@/lib/api-client/apiClient";
 import { formatAddress } from "@/lib/domain-logic/formatAddress";
 import { generateAnytimeActionTask } from "@/test/factories";
-import {
-  selectComboboxValueByTextClick,
-  selectComboboxValueByTextMouseDown,
-} from "@/test/helpers/helpers-testing-library-selectors";
+import { selectComboboxValueByTextClick } from "@/test/helpers/helpers-testing-library-selectors";
 import {
   currentBusiness,
   setupStatefulUserDataContext,
@@ -205,7 +202,7 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
       expect(secondTab).toHaveAttribute("aria-label", expect.stringContaining("State: Incomplete"));
       fireEvent.click(secondTab);
 
-      selectComboboxValueByTextMouseDown(
+      selectComboboxValueByTextClick(
         "Tax clearance certificate requesting agency",
         LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name,
       );
@@ -253,7 +250,7 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
 
       expect(secondTab).toHaveAttribute("aria-label", expect.stringContaining("State: Incomplete"));
 
-      selectComboboxValueByTextMouseDown(
+      selectComboboxValueByTextClick(
         "Tax clearance certificate requesting agency",
         LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name,
       );
@@ -266,7 +263,7 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
       expect(secondTab).toHaveAttribute("aria-label", expect.stringContaining("State: Incomplete"));
       fireEvent.click(secondTab);
 
-      selectComboboxValueByTextMouseDown(
+      selectComboboxValueByTextClick(
         "Tax clearance certificate requesting agency",
         LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name,
       );
@@ -560,7 +557,7 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
     fireEvent.click(screen.getAllByRole("tab")[1]);
     expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-    selectComboboxValueByTextMouseDown(
+    selectComboboxValueByTextClick(
       "Tax clearance certificate requesting agency",
       LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name,
     );
@@ -602,7 +599,7 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
     fireEvent.click(screen.getAllByRole("tab")[1]);
     expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-    selectComboboxValueByTextMouseDown(
+    selectComboboxValueByTextClick(
       "Tax clearance certificate requesting agency",
       LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name,
     );
@@ -692,7 +689,7 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
       fireEvent.click(screen.getAllByRole("tab")[1]);
       expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectComboboxValueByTextMouseDown(
+      selectComboboxValueByTextClick(
         "Tax clearance certificate requesting agency",
         LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name,
       );
@@ -720,7 +717,7 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
       fireEvent.click(screen.getAllByRole("tab")[1]);
       expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectComboboxValueByTextMouseDown(
+      selectComboboxValueByTextClick(
         "Tax clearance certificate requesting agency",
         LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name,
       );
@@ -748,7 +745,7 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
       fireEvent.click(screen.getAllByRole("tab")[1]);
       expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectComboboxValueByTextMouseDown(
+      selectComboboxValueByTextClick(
         "Tax clearance certificate requesting agency",
         LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name,
       );
@@ -775,7 +772,7 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
       fireEvent.click(screen.getAllByRole("tab")[1]);
       expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectComboboxValueByTextMouseDown(
+      selectComboboxValueByTextClick(
         "Tax clearance certificate requesting agency",
         LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name,
       );
@@ -801,7 +798,7 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
       fireEvent.click(screen.getAllByRole("tab")[1]);
       expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectComboboxValueByTextMouseDown(
+      selectComboboxValueByTextClick(
         "Tax clearance certificate requesting agency",
         LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name,
       );
@@ -835,7 +832,7 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
       fireEvent.click(screen.getAllByRole("tab")[1]);
       expect(screen.getAllByRole("tab")[1]).toHaveAttribute("aria-selected", "true");
 
-      selectComboboxValueByTextMouseDown(
+      selectComboboxValueByTextClick(
         "Tax clearance certificate requesting agency",
         LookupTaxClearanceCertificateAgenciesById("newJerseyBoardOfPublicUtilities").name,
       );

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/StateAgencyDropdown.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/StateAgencyDropdown.tsx
@@ -11,7 +11,7 @@ import {
   LookupTaxClearanceCertificateAgenciesById,
 } from "@businessnjgovnavigator/shared";
 import { FormControl, FormHelperText, MenuItem, Select, SelectChangeEvent } from "@mui/material";
-import { ReactElement, ReactNode, useContext } from "react";
+import { ReactElement, ReactNode, useContext, useState } from "react";
 
 interface Props {
   preventRefreshWhenUnmounted?: boolean;
@@ -46,14 +46,22 @@ export const StateAgencyDropdown = (props: Props): ReactElement => {
     return <>{value && LookupTaxClearanceCertificateAgenciesById(value).name}</>;
   };
 
+  const [isOpen, setIsOpen] = useState(false);
+
   return (
     <>
       <WithErrorBar hasError={isFormFieldInvalid} type="ALWAYS">
-        <Content className={"text-bold margin-bottom-05"}>
-          {Config.taxClearanceCertificateStep2.requestingAgencyLabel}
-        </Content>
+        <label htmlFor="tax-clearance-certificate-agency-dropdown">
+          <Content className={"text-bold margin-bottom-05"}>
+            {Config.taxClearanceCertificateStep2.requestingAgencyLabel}
+          </Content>
+        </label>
         <FormControl variant="outlined" fullWidth error={isFormFieldInvalid}>
           <Select
+            open={isOpen}
+            onOpen={() => setIsOpen(true)}
+            onClose={() => setIsOpen(false)}
+            onClick={() => setIsOpen(!isOpen)}
             fullWidth
             displayEmpty
             value={state.requestingAgencyId || ""}
@@ -62,6 +70,7 @@ export const StateAgencyDropdown = (props: Props): ReactElement => {
             renderValue={renderValue}
             inputProps={{
               "aria-label": "Tax clearance certificate requesting agency",
+              id: "tax-clearance-certificate-agency-dropdown",
             }}
             onBlur={performValidation}
           >

--- a/web/test/helpers/helpers-testing-library-selectors.ts
+++ b/web/test/helpers/helpers-testing-library-selectors.ts
@@ -25,19 +25,6 @@ export const selectDropdownByValue = (label: string, value: string): void => {
   fireEvent.click(listbox.getByTestId(value));
 };
 
-export const selectComboboxValueByTextMouseDown = (
-  comboboxLabel: string,
-  selectionText: string,
-): void => {
-  const combobox = screen.getByRole("combobox", { name: comboboxLabel });
-
-  fireEvent.mouseDown(combobox);
-
-  const listbox = screen.getByRole("listbox");
-  fireEvent.click(within(listbox).getByText(selectionText));
-  fireEvent.blur(combobox);
-};
-
 export const selectComboboxValueByTextClick = (
   comboboxLabel: string,
   selectionText: string,


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
Previously, the select dropdown for Requesting Agency in the tax clearance form only responded to `mouseDown` and did not respond to `click`, due to [choices made by Material UI, a component library we depend on](https://medium.com/@nickbreid_82849/how-to-fix-material-uis-select-component-not-responding-to-click-event-22b3b0ed3019). 

For users using a mouse the regular way, this difference was non-blocking, since an actual mouse will always fire `mouseDown` and `click` events together. However, this was obstructive for users of accessibility software (such as [rango](https://chromewebstore.google.com/detail/rango/lnemjdnjjofijemhdogofbpcedhgcpmb)) that rely on programmatic clicking, as they would be unable to click on the dropdown to open it.

It also forced us to create two different functions for testing this dropdown and the State dropdown, as the State one responds to `click` but not `mouseDown`. This PR removes the need for the extra function by making this Select component openable via click.

In addition, the WAVE extension (a web accessibility evaluation tool) caught that this dropdown was missing a form control label, so this PR adds and links the label.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14067](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14067).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

---
#### Clickability
See that the modified tests in `AnytimeActionTaxClearanceCertificate.test.tsx` pass, indicating that the dropdown is openable with programmatic click. 

Additionally, see these screenshots from running [rango](https://chromewebstore.google.com/detail/rango/lnemjdnjjofijemhdogofbpcedhgcpmb) on the page:

<details>
<summary>
Before (no letter annotations, indicating field is not detected as clickable)
</summary>
<img alt="Screenshot" src="https://github.com/user-attachments/assets/ebac26be-66df-4498-9ca6-b25c45b9c715" />
</details>


<details>
<summary>
After (letter annotations on the label, clickable by accessibility software)
</summary>
<img width="851" alt="Screenshot 2025-05-30 at 9 56 18 AM" src="https://github.com/user-attachments/assets/49b023ff-abc8-41db-a702-1399a01dc19c" />
</details>

---

#### Form label
See these screenshots from running WAVE on the page:
<details><summary>
Before (1 error, red tag icon by the dropdown):
</summary>
<img width="1506" alt="Screenshot 2025-05-29 at 4 38 58 PM" src="https://github.com/user-attachments/assets/41844117-e363-4180-96c5-d4161a9637ba" />
</details>

<details><summary>
After (0 errors, green tag icon by the dropdown):
</summary>
<img width="1505" alt="Screenshot 2025-05-29 at 4 38 33 PM" src="https://github.com/user-attachments/assets/afaee2d5-cc7b-4d5c-8e36-3aa43f952073" />
</details>

### Notes
This change also makes it so that clicking the label will also open the select dropdown. Clicking the label to interact with the form element is also[ how labels should work, per mdn web docs.](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/label)

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden