### PR TITLE
Skip salt decrypt

### DIFF
--- a/api/src/client/AwsCryptoFactory.ts
+++ b/api/src/client/AwsCryptoFactory.ts
@@ -74,14 +74,15 @@ export const AWSCryptoFactory = (
       throw new Error("Salt must be provided");
     }
 
-    const decryptedSalt = await decryptValue(encryptedHashingSalt);
+    // const decryptedSalt = await decryptValue(encryptedHashingSalt);
     const iterations = _iterationsOverride || 100000;
 
     try {
       const hash = await new Promise<string>((resolve, reject) => {
         cryptoUtils.pbkdf2(
           normalizedString,
-          decryptedSalt,
+          // decryptedSalt,
+          encryptedHashingSalt,
           iterations,
           64,
           "sha3-512",


### PR DESCRIPTION
## Description

Storing the salt as an environment variable is causing issues with Serverless deploy. We need to come up with a better solution.

Skipping salt decrypt for now in lower environments.

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
