### PR TITLE
chore: [AB#8506] enable public movers license reinstatement

### DIFF
--- a/content/src/anytime-action-license-reinstatements/moving-warehouse.md
+++ b/content/src/anytime-action-license-reinstatements/moving-warehouse.md
@@ -9,7 +9,7 @@ notesMd: >-
 
   4.17: making SME revisions, will need another SME review
 id: moving-warehouse
-licenseName: ""
+licenseName: "Public Movers and Warehousemen"
 name: Reinstate Your Public Movers and/or Warehousemen License
 urlSlug: moving-warehouse
 summaryDescriptionMd: If your license expired less than 30 days ago, [you can


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->


## Description

By adding the license name, we enable users to access the reinstatement task through the anytime actions dropdown, as seen here.
<img width="636" alt="Screenshot 2025-06-03 at 3 17 23 PM" src="https://github.com/user-attachments/assets/2986ed92-90d5-4f7f-ba0d-6f8d20aef9a4" />

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#8506](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8506).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

To test, create an up and running business and go to https://localhost:3000/mgmt/modifyBusiness and add an EXPIRED Public Movers and Warehousemen license. You should then see the reinstatement task in the anytime actions list.
### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
