### PR TITLE
chore: [AB#14662] implement kill switch mechanism for migration logic

### DIFF
--- a/api/.dependency-cruiser.js
+++ b/api/.dependency-cruiser.js
@@ -16,6 +16,10 @@ module.exports = {
     },
     {
       from: {},
+      to: { path: "@aws-sdk/client-ssm" },
+    },
+    {
+      from: {},
       to: { path: "@aws-sdk/util-dynamodb" },
     },
     {

--- a/api/businesses-dynamodb-schema.json
+++ b/api/businesses-dynamodb-schema.json
@@ -43,10 +43,6 @@
       ],
       "Projection": {
         "ProjectionType": "ALL"
-      },
-      "ProvisionedThroughput": {
-        "ReadCapacityUnits": 25,
-        "WriteCapacityUnits": 25
       }
     },
     {
@@ -59,10 +55,6 @@
       ],
       "Projection": {
         "ProjectionType": "ALL"
-      },
-      "ProvisionedThroughput": {
-        "ReadCapacityUnits": 25,
-        "WriteCapacityUnits": 25
       }
     },
     {
@@ -75,10 +67,6 @@
       ],
       "Projection": {
         "ProjectionType": "ALL"
-      },
-      "ProvisionedThroughput": {
-        "ReadCapacityUnits": 25,
-        "WriteCapacityUnits": 25
       }
     },
     {
@@ -91,10 +79,6 @@
       ],
       "Projection": {
         "ProjectionType": "ALL"
-      },
-      "ProvisionedThroughput": {
-        "ReadCapacityUnits": 25,
-        "WriteCapacityUnits": 25
       }
     },
     {
@@ -107,15 +91,7 @@
       ],
       "Projection": {
         "ProjectionType": "ALL"
-      },
-      "ProvisionedThroughput": {
-        "ReadCapacityUnits": 25,
-        "WriteCapacityUnits": 25
       }
     }
-  ],
-  "ProvisionedThroughput": {
-    "ReadCapacityUnits": 25,
-    "WriteCapacityUnits": 25
-  }
+  ]
 }

--- a/api/package.json
+++ b/api/package.json
@@ -31,6 +31,7 @@
     "@aws-sdk/client-cloudwatch-logs": "3.806.0",
     "@aws-sdk/client-dynamodb": "3.806.0",
     "@aws-sdk/client-s3": "3.806.0",
+    "@aws-sdk/client-ssm": "3.826.0",
     "@aws-sdk/lib-dynamodb": "3.806.0",
     "@aws-sdk/smithy-client": "3.374.0",
     "@aws-sdk/types": "3.804.0",

--- a/api/scripts/populateLocalDynamoDbWithMigrations.ts
+++ b/api/scripts/populateLocalDynamoDbWithMigrations.ts
@@ -33,7 +33,9 @@ const AWSTaxIDEncryptionClient = AWSCryptoFactory(AWS_CRYPTO_TAX_ID_ENCRYPTION_K
   purpose: AWS_CRYPTO_CONTEXT_TAX_ID_ENCRYPTION_PURPOSE,
   origin: AWS_CRYPTO_CONTEXT_ORIGIN,
 });
-
+const isKillSwitchOn = async (): Promise<boolean> => {
+  return false;
+}
 class BasicLogger {
   private id: string;
 
@@ -119,7 +121,12 @@ const run = async (): Promise<void> => {
     logger,
   );
   const businessesDataClient = DynamoBusinessDataClient(dynamoDb, BUSINESSES_TABLE, logger);
-  const dynamoDataClient = DynamoDataClient(userDataClient, businessesDataClient, logger);
+  const dynamoDataClient = DynamoDataClient(
+    userDataClient,
+    businessesDataClient,
+    logger,
+    isKillSwitchOn,
+  );
 
   await dynamoDataClient.migrateOutdatedVersionUsers();
 };

--- a/api/src/functions/express/app.ts
+++ b/api/src/functions/express/app.ts
@@ -72,6 +72,7 @@ import {
 } from "@functions/config";
 import { setupExpress } from "@libs/express";
 import { LogWriter } from "@libs/logWriter";
+import { isKillSwitchOn } from "@libs/ssmUtils";
 import bodyParser from "body-parser";
 import { StatusCodes } from "http-status-codes";
 import serverless from "serverless-http";
@@ -338,7 +339,12 @@ const userDataClient = DynamoUserDataClient(
   dataLogger,
 );
 const businessesDataClient = DynamoBusinessDataClient(dynamoDb, BUSINESSES_TABLE, dataLogger);
-const dynamoDataClient = DynamoDataClient(userDataClient, businessesDataClient, dataLogger);
+const dynamoDataClient = DynamoDataClient(
+  userDataClient,
+  businessesDataClient,
+  dataLogger,
+  isKillSwitchOn,
+);
 
 const taxFilingInterface = taxFilingsInterfaceFactory(taxFilingClient);
 

--- a/api/src/functions/updateKillSwitchParameter/app.ts
+++ b/api/src/functions/updateKillSwitchParameter/app.ts
@@ -1,0 +1,5 @@
+import { updateKillSwitch } from "@libs/ssmUtils";
+
+export const handler = async (): Promise<void> => {
+  await updateKillSwitch();
+};

--- a/api/src/functions/updateKillSwitchParameter/index.ts
+++ b/api/src/functions/updateKillSwitchParameter/index.ts
@@ -1,0 +1,16 @@
+import { FnType } from "@functions/fnType";
+import { handlerPath } from "@libs/handlerResolver";
+export default (vpcConfig: FnType["vpc"]): FnType => {
+  return {
+    handler: `${handlerPath(__dirname)}/app.handler`,
+    timeout: 10,
+    events: [
+      {
+        sns: {
+          arn: `arn:aws:sns:us-east-1:${process.env.AWS_ACCOUNT_ID}:bfs-navigator-${process.env.STAGE}-migrationLambda-Topic`,
+        },
+      },
+    ],
+    vpc: vpcConfig,
+  };
+};

--- a/api/src/libs/ssmUtils.ts
+++ b/api/src/libs/ssmUtils.ts
@@ -1,0 +1,53 @@
+import { GetParameterCommand, PutParameterCommand, SSMClient } from "@aws-sdk/client-ssm";
+
+const ssmClient = new SSMClient({});
+const parameterName = `/${process.env.STAGE}/feature-flag/users-migration/kill-switch`;
+
+let cache: {
+  value?: boolean;
+  expiresAt?: number;
+} = {};
+
+export const isKillSwitchOn = async (): Promise<boolean> => {
+  const now = Date.now();
+
+  if (cache.value !== undefined && cache.expiresAt && cache.expiresAt > now) {
+    return cache.value;
+  }
+  try {
+    const command = new GetParameterCommand({
+      Name: parameterName,
+      WithDecryption: true,
+    });
+
+    const response = await ssmClient.send(command);
+    const paramValue = response.Parameter?.Value ?? "false";
+    const boolValue = paramValue.toLowerCase() === "true";
+
+    cache = {
+      value: boolValue,
+      expiresAt: now + 30 * 1000,
+    };
+
+    return boolValue;
+  } catch (error) {
+    console.error("Failed to read kill switch parameter:", error);
+    return false;
+  }
+};
+
+export const updateKillSwitch = async (): Promise<void> => {
+  try {
+    const value = true;
+    const command = new PutParameterCommand({
+      Name: parameterName,
+      Value: value.toString(),
+      Type: "SecureString",
+      Overwrite: true,
+    });
+    await ssmClient.send(command);
+  } catch (error) {
+    console.error("Failed to update kill switch parameter:", error);
+    throw error;
+  }
+};

--- a/api/users-dynamodb-schema.json
+++ b/api/users-dynamodb-schema.json
@@ -26,16 +26,8 @@
       ],
       "Projection": {
         "ProjectionType": "ALL"
-      },
-      "ProvisionedThroughput": {
-        "ReadCapacityUnits": 1,
-        "WriteCapacityUnits": 1
       }
     }
   ],
-  "ProvisionedThroughput": {
-    "ReadCapacityUnits": 1,
-    "WriteCapacityUnits": 1
-  },
   "TableName": "users-table-dev"
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@aws-sdk/client-cloudwatch-logs": "3.806.0",
     "@aws-sdk/client-dynamodb": "3.806.0",
     "@aws-sdk/client-s3": "3.806.0",
+    "@aws-sdk/client-ssm": "3.826.0",
     "@aws-sdk/lib-dynamodb": "3.806.0",
     "@aws-sdk/protocol-http": "3.374.0",
     "@aws-sdk/s3-request-presigner": "3.806.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -998,6 +998,56 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/client-ssm@npm:3.826.0":
+  version: 3.826.0
+  resolution: "@aws-sdk/client-ssm@npm:3.826.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/core": 3.826.0
+    "@aws-sdk/credential-provider-node": 3.826.0
+    "@aws-sdk/middleware-host-header": 3.821.0
+    "@aws-sdk/middleware-logger": 3.821.0
+    "@aws-sdk/middleware-recursion-detection": 3.821.0
+    "@aws-sdk/middleware-user-agent": 3.826.0
+    "@aws-sdk/region-config-resolver": 3.821.0
+    "@aws-sdk/types": 3.821.0
+    "@aws-sdk/util-endpoints": 3.821.0
+    "@aws-sdk/util-user-agent-browser": 3.821.0
+    "@aws-sdk/util-user-agent-node": 3.826.0
+    "@smithy/config-resolver": ^4.1.4
+    "@smithy/core": ^3.5.3
+    "@smithy/fetch-http-handler": ^5.0.4
+    "@smithy/hash-node": ^4.0.4
+    "@smithy/invalid-dependency": ^4.0.4
+    "@smithy/middleware-content-length": ^4.0.4
+    "@smithy/middleware-endpoint": ^4.1.11
+    "@smithy/middleware-retry": ^4.1.12
+    "@smithy/middleware-serde": ^4.0.8
+    "@smithy/middleware-stack": ^4.0.4
+    "@smithy/node-config-provider": ^4.1.3
+    "@smithy/node-http-handler": ^4.0.6
+    "@smithy/protocol-http": ^5.1.2
+    "@smithy/smithy-client": ^4.4.3
+    "@smithy/types": ^4.3.1
+    "@smithy/url-parser": ^4.0.4
+    "@smithy/util-base64": ^4.0.0
+    "@smithy/util-body-length-browser": ^4.0.0
+    "@smithy/util-body-length-node": ^4.0.0
+    "@smithy/util-defaults-mode-browser": ^4.0.19
+    "@smithy/util-defaults-mode-node": ^4.0.19
+    "@smithy/util-endpoints": ^3.0.6
+    "@smithy/util-middleware": ^4.0.4
+    "@smithy/util-retry": ^4.0.5
+    "@smithy/util-utf8": ^4.0.0
+    "@smithy/util-waiter": ^4.0.5
+    "@types/uuid": ^9.0.1
+    tslib: ^2.6.2
+    uuid: ^9.0.1
+  checksum: 5ab39288fdcf9212a2425258b145ba609773f5d33cae448d7b4bb293eb8467cb8ed02abfa1bd68f3036cbb1cac8c812153453e7842d0f05c707c26a46bcc9cf2
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/client-sso-oidc@npm:3.529.1":
   version: 3.529.1
   resolution: "@aws-sdk/client-sso-oidc@npm:3.529.1"
@@ -1329,6 +1379,52 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/client-sso@npm:3.826.0":
+  version: 3.826.0
+  resolution: "@aws-sdk/client-sso@npm:3.826.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/core": 3.826.0
+    "@aws-sdk/middleware-host-header": 3.821.0
+    "@aws-sdk/middleware-logger": 3.821.0
+    "@aws-sdk/middleware-recursion-detection": 3.821.0
+    "@aws-sdk/middleware-user-agent": 3.826.0
+    "@aws-sdk/region-config-resolver": 3.821.0
+    "@aws-sdk/types": 3.821.0
+    "@aws-sdk/util-endpoints": 3.821.0
+    "@aws-sdk/util-user-agent-browser": 3.821.0
+    "@aws-sdk/util-user-agent-node": 3.826.0
+    "@smithy/config-resolver": ^4.1.4
+    "@smithy/core": ^3.5.3
+    "@smithy/fetch-http-handler": ^5.0.4
+    "@smithy/hash-node": ^4.0.4
+    "@smithy/invalid-dependency": ^4.0.4
+    "@smithy/middleware-content-length": ^4.0.4
+    "@smithy/middleware-endpoint": ^4.1.11
+    "@smithy/middleware-retry": ^4.1.12
+    "@smithy/middleware-serde": ^4.0.8
+    "@smithy/middleware-stack": ^4.0.4
+    "@smithy/node-config-provider": ^4.1.3
+    "@smithy/node-http-handler": ^4.0.6
+    "@smithy/protocol-http": ^5.1.2
+    "@smithy/smithy-client": ^4.4.3
+    "@smithy/types": ^4.3.1
+    "@smithy/url-parser": ^4.0.4
+    "@smithy/util-base64": ^4.0.0
+    "@smithy/util-body-length-browser": ^4.0.0
+    "@smithy/util-body-length-node": ^4.0.0
+    "@smithy/util-defaults-mode-browser": ^4.0.19
+    "@smithy/util-defaults-mode-node": ^4.0.19
+    "@smithy/util-endpoints": ^3.0.6
+    "@smithy/util-middleware": ^4.0.4
+    "@smithy/util-retry": ^4.0.5
+    "@smithy/util-utf8": ^4.0.0
+    tslib: ^2.6.2
+  checksum: 2c472935676118c4b4fd5f75a39bd6107fb8f6518c62a6b1f4acff51b9996e96e1c4396e8b3345159e3dcc175d5d1058393fc13d028bbb61e8d2944d7e0ef963
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/client-sts@npm:3.529.1":
   version: 3.529.1
   resolution: "@aws-sdk/client-sts@npm:3.529.1"
@@ -1543,6 +1639,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/core@npm:3.826.0":
+  version: 3.826.0
+  resolution: "@aws-sdk/core@npm:3.826.0"
+  dependencies:
+    "@aws-sdk/types": 3.821.0
+    "@aws-sdk/xml-builder": 3.821.0
+    "@smithy/core": ^3.5.3
+    "@smithy/node-config-provider": ^4.1.3
+    "@smithy/property-provider": ^4.0.4
+    "@smithy/protocol-http": ^5.1.2
+    "@smithy/signature-v4": ^5.1.2
+    "@smithy/smithy-client": ^4.4.3
+    "@smithy/types": ^4.3.1
+    "@smithy/util-base64": ^4.0.0
+    "@smithy/util-body-length-browser": ^4.0.0
+    "@smithy/util-middleware": ^4.0.4
+    "@smithy/util-utf8": ^4.0.0
+    fast-xml-parser: 4.4.1
+    tslib: ^2.6.2
+  checksum: 9e46a3c904ae8f690008e4cc71409fba676914ede6dede3924cc9381daaf4a3c6ba1b98514ec37b2d2e387411a3e94dba4e0e5b4a0dcb2369fbca803e9465fdd
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-env@npm:3.523.0":
   version: 3.523.0
   resolution: "@aws-sdk/credential-provider-env@npm:3.523.0"
@@ -1590,6 +1709,19 @@ __metadata:
     "@smithy/types": ^4.2.0
     tslib: ^2.6.2
   checksum: 163b5defc7b93c50a9a32ae6caa51e6b3a7da443150641e0dad379ffee656a75a968d193af70c5aa88a20edb119546a76bbdf558f77412ddb076f5ddaf53ba28
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-env@npm:3.826.0":
+  version: 3.826.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.826.0"
+  dependencies:
+    "@aws-sdk/core": 3.826.0
+    "@aws-sdk/types": 3.821.0
+    "@smithy/property-provider": ^4.0.4
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: ee336310c20cdf60dcce01f9073787286cda52800d102b323b41d9eedc701aa22cdd9aef1c4fb467d765fcb6cf957c87a835a8c431ac98ce8954e8df7f433305
   languageName: node
   linkType: hard
 
@@ -1660,6 +1792,24 @@ __metadata:
     "@smithy/util-stream": ^4.2.0
     tslib: ^2.6.2
   checksum: 54766e1da7068cdd9da395a12c9ff9b90e6fb8bfec8a8d84459af90b66c9c4bd149fffa0d31120a44e29802850d6d690ed7f57bdbb3cffd1488ba1b66d837e69
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-http@npm:3.826.0":
+  version: 3.826.0
+  resolution: "@aws-sdk/credential-provider-http@npm:3.826.0"
+  dependencies:
+    "@aws-sdk/core": 3.826.0
+    "@aws-sdk/types": 3.821.0
+    "@smithy/fetch-http-handler": ^5.0.4
+    "@smithy/node-http-handler": ^4.0.6
+    "@smithy/property-provider": ^4.0.4
+    "@smithy/protocol-http": ^5.1.2
+    "@smithy/smithy-client": ^4.4.3
+    "@smithy/types": ^4.3.1
+    "@smithy/util-stream": ^4.2.2
+    tslib: ^2.6.2
+  checksum: 3fa44637b42b33d35ad03bdd690bd3e6d86999547d3a9862e580a3ead1e997d85283845d9c5e878d5df830e01eab7a12b6e9facd10bff1fe00757447e43b4eaf
   languageName: node
   linkType: hard
 
@@ -1746,6 +1896,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-ini@npm:3.826.0":
+  version: 3.826.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.826.0"
+  dependencies:
+    "@aws-sdk/core": 3.826.0
+    "@aws-sdk/credential-provider-env": 3.826.0
+    "@aws-sdk/credential-provider-http": 3.826.0
+    "@aws-sdk/credential-provider-process": 3.826.0
+    "@aws-sdk/credential-provider-sso": 3.826.0
+    "@aws-sdk/credential-provider-web-identity": 3.826.0
+    "@aws-sdk/nested-clients": 3.826.0
+    "@aws-sdk/types": 3.821.0
+    "@smithy/credential-provider-imds": ^4.0.6
+    "@smithy/property-provider": ^4.0.4
+    "@smithy/shared-ini-file-loader": ^4.0.4
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: b939286ecc2bd61738285371e613429ed06b161481a00c5c865eb1972adc822eff79488142c35601be663bc596a2aff14f769385b06454c0d5527474fd14b706
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-node@npm:3.529.1":
   version: 3.529.1
   resolution: "@aws-sdk/credential-provider-node@npm:3.529.1"
@@ -1826,6 +1997,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-node@npm:3.826.0":
+  version: 3.826.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.826.0"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.826.0
+    "@aws-sdk/credential-provider-http": 3.826.0
+    "@aws-sdk/credential-provider-ini": 3.826.0
+    "@aws-sdk/credential-provider-process": 3.826.0
+    "@aws-sdk/credential-provider-sso": 3.826.0
+    "@aws-sdk/credential-provider-web-identity": 3.826.0
+    "@aws-sdk/types": 3.821.0
+    "@smithy/credential-provider-imds": ^4.0.6
+    "@smithy/property-provider": ^4.0.4
+    "@smithy/shared-ini-file-loader": ^4.0.4
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: b6c18b89d5100a7931947bac9c148971d68327438592f909d7f6f0b2b29d81df14999786b182a146c0ae98fa851aeba466036fb8f56e9e5132a8786728d45891
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-process@npm:3.523.0":
   version: 3.523.0
   resolution: "@aws-sdk/credential-provider-process@npm:3.523.0"
@@ -1877,6 +2068,20 @@ __metadata:
     "@smithy/types": ^4.2.0
     tslib: ^2.6.2
   checksum: b10f214a4059e2c9ca2ec9d8162083bf6332f2035f83375693858fb58506235d338b8db3a87b2b91a86ff4816bd48dbc09dd416066b51fd4bc046005f4e1afec
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:3.826.0":
+  version: 3.826.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.826.0"
+  dependencies:
+    "@aws-sdk/core": 3.826.0
+    "@aws-sdk/types": 3.821.0
+    "@smithy/property-provider": ^4.0.4
+    "@smithy/shared-ini-file-loader": ^4.0.4
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: a063c0c7e62232afe5c756797b7b6254c18aaba546a342107985e61d459c41f5d4666f225c2e57efd8eb15dfd41a00957826b09ad3d7467c502b315884cd7715
   languageName: node
   linkType: hard
 
@@ -1942,6 +2147,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-sso@npm:3.826.0":
+  version: 3.826.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.826.0"
+  dependencies:
+    "@aws-sdk/client-sso": 3.826.0
+    "@aws-sdk/core": 3.826.0
+    "@aws-sdk/token-providers": 3.826.0
+    "@aws-sdk/types": 3.821.0
+    "@smithy/property-provider": ^4.0.4
+    "@smithy/shared-ini-file-loader": ^4.0.4
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: cd406a5ae2809c92f137af555312aef84f60fd24bd3d67983c19a19ce8bf52df68bd97d0ab7c34b7bf8482b246e795ef750be9b3742a98fc8e3dd2913ff09166
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-web-identity@npm:3.529.1":
   version: 3.529.1
   resolution: "@aws-sdk/credential-provider-web-identity@npm:3.529.1"
@@ -1995,6 +2216,20 @@ __metadata:
     "@smithy/types": ^4.2.0
     tslib: ^2.6.2
   checksum: a7aa9bb95a86c5fb68ecfb202aa755210ca893f8a8f496439b99dee1f8a37721094ea27858728dddb4bd011ec0875e905a7940f7dc202bb988c1541165f94dbd
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:3.826.0":
+  version: 3.826.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.826.0"
+  dependencies:
+    "@aws-sdk/core": 3.826.0
+    "@aws-sdk/nested-clients": 3.826.0
+    "@aws-sdk/types": 3.821.0
+    "@smithy/property-provider": ^4.0.4
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: 54cc15a16547acb2a405f22d5417254faeb97b9d581c66f2dd64525ea44055614b5fb01c32132375bff20017c0b37dfe48183c73c6e4917f4dc68a9ba6875214
   languageName: node
   linkType: hard
 
@@ -2143,6 +2378,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-host-header@npm:3.821.0":
+  version: 3.821.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.821.0"
+  dependencies:
+    "@aws-sdk/types": 3.821.0
+    "@smithy/protocol-http": ^5.1.2
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: b626412b0ccb169542311230d0c16e62c21179802e2d6041b5305b3da02de7c3ea352c892162d416ab0fc92e6cc5fbfbf14671b0dd0c54a36cf33efa91a7fd1e
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-location-constraint@npm:3.804.0":
   version: 3.804.0
   resolution: "@aws-sdk/middleware-location-constraint@npm:3.804.0"
@@ -2198,6 +2445,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-logger@npm:3.821.0":
+  version: 3.821.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.821.0"
+  dependencies:
+    "@aws-sdk/types": 3.821.0
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: 1f287c7a9a1cff4413070ff84459c41102dcf063b8cbc90efb67e8ab23beebd9c3814c7e2d59166027520d8f91aaaee39ab66aa53bae129327e509b95ab24085
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-recursion-detection@npm:3.523.0":
   version: 3.523.0
   resolution: "@aws-sdk/middleware-recursion-detection@npm:3.523.0"
@@ -2243,6 +2501,18 @@ __metadata:
     "@smithy/types": ^4.2.0
     tslib: ^2.6.2
   checksum: e762ca615372584ec4fea95b50f4476457edd36c8b433238df8c6c7143ae91da17fe1d3209eca425e89e799a73879e76510121d9235975c46d644e37a17e5350
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-recursion-detection@npm:3.821.0":
+  version: 3.821.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.821.0"
+  dependencies:
+    "@aws-sdk/types": 3.821.0
+    "@smithy/protocol-http": ^5.1.2
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: 8abb4c2df2c30507b12d6e002f7d99cac09309b350f07094e4b540b3036dd1d2b073b79882fc6819b15f50837e40e5f05a3bd8547964a7a146a210355d39a85f
   languageName: node
   linkType: hard
 
@@ -2335,6 +2605,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-user-agent@npm:3.826.0":
+  version: 3.826.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.826.0"
+  dependencies:
+    "@aws-sdk/core": 3.826.0
+    "@aws-sdk/types": 3.821.0
+    "@aws-sdk/util-endpoints": 3.821.0
+    "@smithy/core": ^3.5.3
+    "@smithy/protocol-http": ^5.1.2
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: af20f791b6af956b6f150df4bb6aa39b5de3997972ad693668f1fb7e49a242473899cc723b7155e05202d6b5e70fc474e70005cf0f14b9df189b72f5915eb81c
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/nested-clients@npm:3.806.0":
   version: 3.806.0
   resolution: "@aws-sdk/nested-clients@npm:3.806.0"
@@ -2378,6 +2663,52 @@ __metadata:
     "@smithy/util-utf8": ^4.0.0
     tslib: ^2.6.2
   checksum: 2302bc893eef87a8af3f1491432c4672cbbcc37088e06c882b9f42c339639d7908225e960cfee9937ece244b0868ca8a1a628b9156c1a28404cef0d81564382c
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/nested-clients@npm:3.826.0":
+  version: 3.826.0
+  resolution: "@aws-sdk/nested-clients@npm:3.826.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/core": 3.826.0
+    "@aws-sdk/middleware-host-header": 3.821.0
+    "@aws-sdk/middleware-logger": 3.821.0
+    "@aws-sdk/middleware-recursion-detection": 3.821.0
+    "@aws-sdk/middleware-user-agent": 3.826.0
+    "@aws-sdk/region-config-resolver": 3.821.0
+    "@aws-sdk/types": 3.821.0
+    "@aws-sdk/util-endpoints": 3.821.0
+    "@aws-sdk/util-user-agent-browser": 3.821.0
+    "@aws-sdk/util-user-agent-node": 3.826.0
+    "@smithy/config-resolver": ^4.1.4
+    "@smithy/core": ^3.5.3
+    "@smithy/fetch-http-handler": ^5.0.4
+    "@smithy/hash-node": ^4.0.4
+    "@smithy/invalid-dependency": ^4.0.4
+    "@smithy/middleware-content-length": ^4.0.4
+    "@smithy/middleware-endpoint": ^4.1.11
+    "@smithy/middleware-retry": ^4.1.12
+    "@smithy/middleware-serde": ^4.0.8
+    "@smithy/middleware-stack": ^4.0.4
+    "@smithy/node-config-provider": ^4.1.3
+    "@smithy/node-http-handler": ^4.0.6
+    "@smithy/protocol-http": ^5.1.2
+    "@smithy/smithy-client": ^4.4.3
+    "@smithy/types": ^4.3.1
+    "@smithy/url-parser": ^4.0.4
+    "@smithy/util-base64": ^4.0.0
+    "@smithy/util-body-length-browser": ^4.0.0
+    "@smithy/util-body-length-node": ^4.0.0
+    "@smithy/util-defaults-mode-browser": ^4.0.19
+    "@smithy/util-defaults-mode-node": ^4.0.19
+    "@smithy/util-endpoints": ^3.0.6
+    "@smithy/util-middleware": ^4.0.4
+    "@smithy/util-retry": ^4.0.5
+    "@smithy/util-utf8": ^4.0.0
+    tslib: ^2.6.2
+  checksum: 7dd12d4b39c1c47a25f437dcaa3a17945b1c746c2adee7113d2ea837adc37c1dde51f43439808235b973793053bfa82e63ea34913fd7a6674594d9dbdf6ac764
   languageName: node
   linkType: hard
 
@@ -2444,6 +2775,20 @@ __metadata:
     "@smithy/util-middleware": ^4.0.2
     tslib: ^2.6.2
   checksum: f1f8cbac14e70afa65d30ac089ac0d1ab28f218463b9eb657e12c9da0075bd00cabf6fb926ec901ea8c468b61b2940b170a6bac6bcab6cb6a491f717940db188
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/region-config-resolver@npm:3.821.0":
+  version: 3.821.0
+  resolution: "@aws-sdk/region-config-resolver@npm:3.821.0"
+  dependencies:
+    "@aws-sdk/types": 3.821.0
+    "@smithy/node-config-provider": ^4.1.3
+    "@smithy/types": ^4.3.1
+    "@smithy/util-config-provider": ^4.0.0
+    "@smithy/util-middleware": ^4.0.4
+    tslib: ^2.6.2
+  checksum: e3688c64180308ef3db8347b13402f5d261d9d033c9c7e912746630c519d30f123e8a89cac87fc0314e798aa2edacf0a01d6fb901a14ca0e3d179058959dcc2f
   languageName: node
   linkType: hard
 
@@ -2545,6 +2890,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/token-providers@npm:3.826.0":
+  version: 3.826.0
+  resolution: "@aws-sdk/token-providers@npm:3.826.0"
+  dependencies:
+    "@aws-sdk/core": 3.826.0
+    "@aws-sdk/nested-clients": 3.826.0
+    "@aws-sdk/types": 3.821.0
+    "@smithy/property-provider": ^4.0.4
+    "@smithy/shared-ini-file-loader": ^4.0.4
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: eb747de5d8726557bdae9b1412b576d30f4d94b3cd48c2f4d19824aa78a0d48e3f95cc3ce3d0f2df089497571506145b142ea1af8a35174a7563978b294977ae
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/types@npm:3.387.0":
   version: 3.387.0
   resolution: "@aws-sdk/types@npm:3.387.0"
@@ -2602,6 +2962,16 @@ __metadata:
     "@smithy/types": ^4.2.0
     tslib: ^2.6.2
   checksum: 6e15b214b96e3f1a158ad5144093cd6cbc765984b8ddc00492e2274218b00d43921aaf1340c8a75dd1878c981528257663c053c28d7a47146620122af4f45cca
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:3.821.0":
+  version: 3.821.0
+  resolution: "@aws-sdk/types@npm:3.821.0"
+  dependencies:
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: 999e0344b0eea74b5d423b9cc562ae6b00c5c1e3fb7d1f6f86e81cbdb0dfa948cc574cc5ab4e9e875043d559904128807f3e95119b97123a8cc37dd5471f6c35
   languageName: node
   linkType: hard
 
@@ -2703,6 +3073,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/util-endpoints@npm:3.821.0":
+  version: 3.821.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.821.0"
+  dependencies:
+    "@aws-sdk/types": 3.821.0
+    "@smithy/types": ^4.3.1
+    "@smithy/util-endpoints": ^3.0.6
+    tslib: ^2.6.2
+  checksum: e9e9dcd8dad4b0a79a2689af337a3dfe2a64f65b510b1fd60d1b38300a725f0cac435e81857467db757708045142ebd5b61bb1565764810ad37740a447ac358d
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-format-url@npm:3.804.0":
   version: 3.804.0
   resolution: "@aws-sdk/util-format-url@npm:3.804.0"
@@ -2769,6 +3151,18 @@ __metadata:
     bowser: ^2.11.0
     tslib: ^2.6.2
   checksum: 6216ac4936631696c596a57a762683575b173efca7af5a8bb805402c6527e8caa0b5f75b3da3f73e354581f04dd19a5e5d09bca7c2f55c7c2b8fba61086f4e86
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-browser@npm:3.821.0":
+  version: 3.821.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.821.0"
+  dependencies:
+    "@aws-sdk/types": 3.821.0
+    "@smithy/types": ^4.3.1
+    bowser: ^2.11.0
+    tslib: ^2.6.2
+  checksum: 8817cc00dcc032af0a7e270dd9954b7b5f598448d8804a430456276ef560a6b4781aea4ad84377fddff3684417ac4e5925de5574d9a8b0f08832002948c4a508
   languageName: node
   linkType: hard
 
@@ -2842,6 +3236,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/util-user-agent-node@npm:3.826.0":
+  version: 3.826.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.826.0"
+  dependencies:
+    "@aws-sdk/middleware-user-agent": 3.826.0
+    "@aws-sdk/types": 3.821.0
+    "@smithy/node-config-provider": ^4.1.3
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  peerDependencies:
+    aws-crt: ">=1.0.0"
+  peerDependenciesMeta:
+    aws-crt:
+      optional: true
+  checksum: 61d2378ba0e76319cab1d9a97870663263a6d9659351bafc6ce321c85c67f1aaccf52839c216fab853a6c888648db355cfa59b673669a5328cb6f78348bec677
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-utf8-browser@npm:^3.0.0":
   version: 3.259.0
   resolution: "@aws-sdk/util-utf8-browser@npm:3.259.0"
@@ -2858,6 +3270,16 @@ __metadata:
     "@smithy/types": ^4.2.0
     tslib: ^2.6.2
   checksum: 4b7500d0c8e18cb6d8fde350094e7ae55d76c4f1d92e67f390cbc2455e591dda4be0f4f464b379c550a939d1611ab518b505d16b8c0fb8c2455404172015db74
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/xml-builder@npm:3.821.0":
+  version: 3.821.0
+  resolution: "@aws-sdk/xml-builder@npm:3.821.0"
+  dependencies:
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: f6ee1e5f5336afeb72e2b5e712593d1dcaa626729d0a12941c32e14136308b8729b225d4c75e7b6606bc17eeb79ea28076212aced93cc6460fefb9b712b07e28
   languageName: node
   linkType: hard
 
@@ -4398,6 +4820,7 @@ __metadata:
     "@aws-sdk/client-cognito-identity-provider": ^3.777.0
     "@aws-sdk/client-dynamodb": 3.806.0
     "@aws-sdk/client-s3": 3.806.0
+    "@aws-sdk/client-ssm": 3.826.0
     "@aws-sdk/lib-dynamodb": 3.806.0
     "@aws-sdk/smithy-client": 3.374.0
     "@aws-sdk/types": 3.804.0
@@ -4486,6 +4909,7 @@ __metadata:
     "@aws-sdk/client-cognito-identity-provider": ^3.777.0
     "@aws-sdk/client-dynamodb": 3.806.0
     "@aws-sdk/client-s3": 3.806.0
+    "@aws-sdk/client-ssm": 3.826.0
     "@aws-sdk/lib-dynamodb": 3.806.0
     "@aws-sdk/protocol-http": 3.374.0
     "@aws-sdk/s3-request-presigner": 3.806.0
@@ -9179,6 +9603,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/abort-controller@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@smithy/abort-controller@npm:4.0.4"
+  dependencies:
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: 50e646633160f16d4d131c4a5612a352bca8ee652acfefc811389307756b791d0e0cee1459eeba4662e09b57e9f78681bb6c24d180d76e605126281fa52c20fb
+  languageName: node
+  linkType: hard
+
 "@smithy/chunked-blob-reader-native@npm:^4.0.0":
   version: 4.0.0
   resolution: "@smithy/chunked-blob-reader-native@npm:4.0.0"
@@ -9237,6 +9671,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/config-resolver@npm:^4.1.4":
+  version: 4.1.4
+  resolution: "@smithy/config-resolver@npm:4.1.4"
+  dependencies:
+    "@smithy/node-config-provider": ^4.1.3
+    "@smithy/types": ^4.3.1
+    "@smithy/util-config-provider": ^4.0.0
+    "@smithy/util-middleware": ^4.0.4
+    tslib: ^2.6.2
+  checksum: d3c3b7017377ae30839d3bc684fca7ff58c41c2ca71dd067931aff61f0c570b09cf35e47fde660488c7e1ecc8e1abf720bd41f380b9a91ea302fbd7c7f1b85fb
+  languageName: node
+  linkType: hard
+
 "@smithy/core@npm:^1.3.5":
   version: 1.4.2
   resolution: "@smithy/core@npm:1.4.2"
@@ -9285,6 +9732,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/core@npm:^3.5.3":
+  version: 3.5.3
+  resolution: "@smithy/core@npm:3.5.3"
+  dependencies:
+    "@smithy/middleware-serde": ^4.0.8
+    "@smithy/protocol-http": ^5.1.2
+    "@smithy/types": ^4.3.1
+    "@smithy/util-base64": ^4.0.0
+    "@smithy/util-body-length-browser": ^4.0.0
+    "@smithy/util-middleware": ^4.0.4
+    "@smithy/util-stream": ^4.2.2
+    "@smithy/util-utf8": ^4.0.0
+    tslib: ^2.6.2
+  checksum: ae1d9393683e07ccff7ff1dcb7bfdaced42d71e4030094f4e43aaed8dba424e2389e60229805f34443cf60a6a05976c17d09f1b995464a87cf2e5774ead55474
+  languageName: node
+  linkType: hard
+
 "@smithy/credential-provider-imds@npm:^2.2.3, @smithy/credential-provider-imds@npm:^2.3.0":
   version: 2.3.0
   resolution: "@smithy/credential-provider-imds@npm:2.3.0"
@@ -9321,6 +9785,19 @@ __metadata:
     "@smithy/url-parser": ^4.0.2
     tslib: ^2.6.2
   checksum: a82e51787fa8b7dd7ed2dcd9a3760caf9c5b006701e5a765da57e75cced7923a92b3434fbefafe1d12b4b87a9c3d82aa6fb613656b6898c8cf1d4d4023897cd3
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "@smithy/credential-provider-imds@npm:4.0.6"
+  dependencies:
+    "@smithy/node-config-provider": ^4.1.3
+    "@smithy/property-provider": ^4.0.4
+    "@smithy/types": ^4.3.1
+    "@smithy/url-parser": ^4.0.4
+    tslib: ^2.6.2
+  checksum: 380ada77c7cc7f6e11ee4246a335799cd855b43df07469164ca7ccaeecd1eb8e037adf0b870e57578de7f82bb1f77e5d534c55ed3aa44491fcef55809b5d1d5c
   languageName: node
   linkType: hard
 
@@ -9499,6 +9976,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/fetch-http-handler@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "@smithy/fetch-http-handler@npm:5.0.4"
+  dependencies:
+    "@smithy/protocol-http": ^5.1.2
+    "@smithy/querystring-builder": ^4.0.4
+    "@smithy/types": ^4.3.1
+    "@smithy/util-base64": ^4.0.0
+    tslib: ^2.6.2
+  checksum: 3afb020d42e50d6bb446ceb8efe0cb33a05b449a15156459eea5717860e785f56a9166eb08455b7c1fd3af277bbca4b708e4d8cccda37519f44aa4990e3f50d4
+  languageName: node
+  linkType: hard
+
 "@smithy/hash-blob-browser@npm:^4.0.2":
   version: 4.0.2
   resolution: "@smithy/hash-blob-browser@npm:4.0.2"
@@ -9547,6 +10037,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/hash-node@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@smithy/hash-node@npm:4.0.4"
+  dependencies:
+    "@smithy/types": ^4.3.1
+    "@smithy/util-buffer-from": ^4.0.0
+    "@smithy/util-utf8": ^4.0.0
+    tslib: ^2.6.2
+  checksum: 2fd8a1036b9d6d2948249ad41a97b5801b918948ab1f8041b2b2482848570e8b417eeea7810f959376325e9ab33890775025b34a58305355b84ca8bff1417481
+  languageName: node
+  linkType: hard
+
 "@smithy/hash-stream-node@npm:^4.0.2":
   version: 4.0.2
   resolution: "@smithy/hash-stream-node@npm:4.0.2"
@@ -9585,6 +10087,16 @@ __metadata:
     "@smithy/types": ^4.2.0
     tslib: ^2.6.2
   checksum: 96ea5e6c02c112e78655bf5538e13bca5ba374692db3e1ac73683143d0f2183958c1b8cbf4c1ed4d1357f45174f338a255352ad6d7e83fdf2601c1cb6ff73997
+  languageName: node
+  linkType: hard
+
+"@smithy/invalid-dependency@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@smithy/invalid-dependency@npm:4.0.4"
+  dependencies:
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: 6d6f53558cb252e2070e4830a18c0c72ad486308378d6eab2a185d63f5a0492ffbdff27dbea59f79e2d48477af2295e80d6314becf9ea3215827be8bb6690b07
   languageName: node
   linkType: hard
 
@@ -9679,6 +10191,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-content-length@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@smithy/middleware-content-length@npm:4.0.4"
+  dependencies:
+    "@smithy/protocol-http": ^5.1.2
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: 251e47fbb7df19a8c39719f96dfd9e00252fc33733d2585898b7e5a37e85056052de1559d3c62b9daf493e2293b574ac2e92e17806777cadc9b733f1aab42294
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-endpoint@npm:^2.4.4, @smithy/middleware-endpoint@npm:^2.5.1":
   version: 2.5.1
   resolution: "@smithy/middleware-endpoint@npm:2.5.1"
@@ -9707,6 +10230,22 @@ __metadata:
     "@smithy/util-middleware": ^3.0.11
     tslib: ^2.6.2
   checksum: 6ca10e433e7bb10ad5b33c31b08abfbec4aaefce22c8c82f6742a6254b93b8b0dbddd5d4b9b4bea4d938a2ff890351f93c06801ddf2288829ede3e92ef6a2cb5
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-endpoint@npm:^4.1.11":
+  version: 4.1.11
+  resolution: "@smithy/middleware-endpoint@npm:4.1.11"
+  dependencies:
+    "@smithy/core": ^3.5.3
+    "@smithy/middleware-serde": ^4.0.8
+    "@smithy/node-config-provider": ^4.1.3
+    "@smithy/shared-ini-file-loader": ^4.0.4
+    "@smithy/types": ^4.3.1
+    "@smithy/url-parser": ^4.0.4
+    "@smithy/util-middleware": ^4.0.4
+    tslib: ^2.6.2
+  checksum: dea73669a74afcf74a0fcb8d6a12b940d41c1cafed005244e228eb30c2c60af3b9b69bdd11943078d98eb1de15052fd7335099cb073d84f67f61ce97fbe8688a
   languageName: node
   linkType: hard
 
@@ -9760,6 +10299,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-retry@npm:^4.1.12":
+  version: 4.1.12
+  resolution: "@smithy/middleware-retry@npm:4.1.12"
+  dependencies:
+    "@smithy/node-config-provider": ^4.1.3
+    "@smithy/protocol-http": ^5.1.2
+    "@smithy/service-error-classification": ^4.0.5
+    "@smithy/smithy-client": ^4.4.3
+    "@smithy/types": ^4.3.1
+    "@smithy/util-middleware": ^4.0.4
+    "@smithy/util-retry": ^4.0.5
+    tslib: ^2.6.2
+    uuid: ^9.0.1
+  checksum: 401d97e2b9e2d62220215ec98f9b7299b9a8aed909b3ae9a5e0c29993087fdfe22464a17bb980eb72c027c1a056d365159102ddd9c06c8045a1a6f0be441f1dd
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-retry@npm:^4.1.4":
   version: 4.1.5
   resolution: "@smithy/middleware-retry@npm:4.1.5"
@@ -9807,6 +10363,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-serde@npm:^4.0.8":
+  version: 4.0.8
+  resolution: "@smithy/middleware-serde@npm:4.0.8"
+  dependencies:
+    "@smithy/protocol-http": ^5.1.2
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: 1c78cf584bf82c2ed80d55694945d63b5d3bdaf0c4dea1a35ff33b201d939e9ee5afbfb01c6725c9cbc0d9efb3ee50703970d177a9d20dba545e7e7ba3c0a3f5
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-stack@npm:^1.1.0":
   version: 1.1.0
   resolution: "@smithy/middleware-stack@npm:1.1.0"
@@ -9846,6 +10413,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-stack@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@smithy/middleware-stack@npm:4.0.4"
+  dependencies:
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: c0b4e057d438fbc900435a4bcae68308bc17361968ebe828d43b4f78d826711e5d196ea2fc3ef86525169508d885979e459db0d46918ae00a2bb5dc8a5bd6796
+  languageName: node
+  linkType: hard
+
 "@smithy/node-config-provider@npm:^2.2.4, @smithy/node-config-provider@npm:^2.3.0":
   version: 2.3.0
   resolution: "@smithy/node-config-provider@npm:2.3.0"
@@ -9879,6 +10456,18 @@ __metadata:
     "@smithy/types": ^4.2.0
     tslib: ^2.6.2
   checksum: cdae4d1bb9df6c0db06e532fa5c2bf369da3bd2442a7e26e04dced0f8130e89cbc30434ce75b4b0917c0d1a858349d9f796a7150237ad63e7c97faef0e9a6020
+  languageName: node
+  linkType: hard
+
+"@smithy/node-config-provider@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "@smithy/node-config-provider@npm:4.1.3"
+  dependencies:
+    "@smithy/property-provider": ^4.0.4
+    "@smithy/shared-ini-file-loader": ^4.0.4
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: c1260719f567b64e979e54698356ffd49f26d82e5eaafc60741588257df6016bbf7d2e26cba902ff900058e5e47e985287fdcb7ab1acdf6534b7cd50252e3856
   languageName: node
   linkType: hard
 
@@ -9934,6 +10523,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/node-http-handler@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "@smithy/node-http-handler@npm:4.0.6"
+  dependencies:
+    "@smithy/abort-controller": ^4.0.4
+    "@smithy/protocol-http": ^5.1.2
+    "@smithy/querystring-builder": ^4.0.4
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: b0505a812182f29e4ff254f4710a476e0dd9a869248b5c9972ddaaf0c1bef9dc980682947826d5a24c3b54c635ad6a1d7ac6460e61ac99da8becc4ecda55e768
+  languageName: node
+  linkType: hard
+
 "@smithy/property-provider@npm:^2.1.3, @smithy/property-provider@npm:^2.2.0":
   version: 2.2.0
   resolution: "@smithy/property-provider@npm:2.2.0"
@@ -9961,6 +10563,16 @@ __metadata:
     "@smithy/types": ^4.2.0
     tslib: ^2.6.2
   checksum: 3038ce031036d3d055bb1c9401f30bea7f1410b2db1d0cd3565cd25f7f374f18a67792930b2e3d0f73c2b1fcbfb23d3bfbd110197f1fd15d0acaa778719fa267
+  languageName: node
+  linkType: hard
+
+"@smithy/property-provider@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@smithy/property-provider@npm:4.0.4"
+  dependencies:
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: 1cd552792897e43c1d4cf91edac0956a8a8d6a7ba588e46532644ae5aca535ec0fb33e3aa71c73f325632b72cd1b8f26732525a6723f74c54238026432b0118e
   languageName: node
   linkType: hard
 
@@ -10001,6 +10613,16 @@ __metadata:
     "@smithy/types": ^4.2.0
     tslib: ^2.6.2
   checksum: 091e8c129411c2072e640aa6a8440fdcfd265fc7b4aef3ff52f419c24dc5f8e34009f03fc810a87a49c7e66d0bf4636b4fbd76a84be563a97b41e9c927f90337
+  languageName: node
+  linkType: hard
+
+"@smithy/protocol-http@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "@smithy/protocol-http@npm:5.1.2"
+  dependencies:
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: 48dbb715956f7089f3422c6c875fd5c6c901bb55363091905f749bba4bac03c40bf11e63dcc92c9b5de058305c60513e987e1fd7550e585c9e2a98e7355676c8
   languageName: node
   linkType: hard
 
@@ -10048,6 +10670,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/querystring-builder@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@smithy/querystring-builder@npm:4.0.4"
+  dependencies:
+    "@smithy/types": ^4.3.1
+    "@smithy/util-uri-escape": ^4.0.0
+    tslib: ^2.6.2
+  checksum: e521cd60294aebabb11386f4db7925095ca7dcdd1eda1904ad3443aa65c992a74e7d57b24018c3e141320bcc8b8928a24b8a14c4328bc7176bdb1eac15f6655b
+  languageName: node
+  linkType: hard
+
 "@smithy/querystring-parser@npm:^1.1.0":
   version: 1.1.0
   resolution: "@smithy/querystring-parser@npm:1.1.0"
@@ -10088,6 +10721,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/querystring-parser@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@smithy/querystring-parser@npm:4.0.4"
+  dependencies:
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: ebe874dfec44ec3d6ff63f9570cac7c18f5b1b2fb3d6a72722adb9d24bb891970fbbabb18d15b8ce46902cc5f21f1751218794f3ff2e110865804d822f4b83a0
+  languageName: node
+  linkType: hard
+
 "@smithy/service-error-classification@npm:^2.1.5":
   version: 2.1.5
   resolution: "@smithy/service-error-classification@npm:2.1.5"
@@ -10112,6 +10755,15 @@ __metadata:
   dependencies:
     "@smithy/types": ^4.2.0
   checksum: 6fa7a20dafca3e0a03d69ac0dc83749a2cc04061af4c7b8a06e8fbdff4050325536cfbe299cf0bbfc9a9cc0b2541fc22cfe923ae45a8bddce64d83927990253d
+  languageName: node
+  linkType: hard
+
+"@smithy/service-error-classification@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "@smithy/service-error-classification@npm:4.0.5"
+  dependencies:
+    "@smithy/types": ^4.3.1
+  checksum: c93c0fbcd7f094a8652ecfa0b1281621bb49b93eae36b94330c4990436666e53e9a3a9dc57915b79e79f731f801e18873256c06f7fb091b3b7e64d23fdb33960
   languageName: node
   linkType: hard
 
@@ -10142,6 +10794,16 @@ __metadata:
     "@smithy/types": ^4.2.0
     tslib: ^2.6.2
   checksum: d6304d06c3e7e252a29197fae37f827b5924dbf98e1473adebc398256cdde67f14c9afa8b0ffc2b914cbf9d257c2417f5d0ebede95f824814d1c11077e1d1721
+  languageName: node
+  linkType: hard
+
+"@smithy/shared-ini-file-loader@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@smithy/shared-ini-file-loader@npm:4.0.4"
+  dependencies:
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: b9405d3fea03cb7d1b031a41d7a91581eaaf47a5e6322c7bf2c57e27bcf8af403eea68c46a9c878a31af8a1f08fa803fce3d253c55b3318548fc93d61b0e56e8
   languageName: node
   linkType: hard
 
@@ -10189,6 +10851,22 @@ __metadata:
     "@smithy/util-utf8": ^4.0.0
     tslib: ^2.6.2
   checksum: 302741d0779c419ef13be6fd303476d1544c9ad6b531e40d7883941b72817f1e36342474b5fe1cde177b38d1b8cd89d0da59eb3b41fa1ab719e7988b3cf35155
+  languageName: node
+  linkType: hard
+
+"@smithy/signature-v4@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "@smithy/signature-v4@npm:5.1.2"
+  dependencies:
+    "@smithy/is-array-buffer": ^4.0.0
+    "@smithy/protocol-http": ^5.1.2
+    "@smithy/types": ^4.3.1
+    "@smithy/util-hex-encoding": ^4.0.0
+    "@smithy/util-middleware": ^4.0.4
+    "@smithy/util-uri-escape": ^4.0.0
+    "@smithy/util-utf8": ^4.0.0
+    tslib: ^2.6.2
+  checksum: b8acbdd600279be860650b8c99ea443b653f0a980a9aceb7cdf8bf0f017d0376a4aac9bef738c24aa0c2f12b3ae1984bf1ed5d99235f64a9ff41a7fcd851b531
   languageName: node
   linkType: hard
 
@@ -10248,6 +10926,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/smithy-client@npm:^4.4.3":
+  version: 4.4.3
+  resolution: "@smithy/smithy-client@npm:4.4.3"
+  dependencies:
+    "@smithy/core": ^3.5.3
+    "@smithy/middleware-endpoint": ^4.1.11
+    "@smithy/middleware-stack": ^4.0.4
+    "@smithy/protocol-http": ^5.1.2
+    "@smithy/types": ^4.3.1
+    "@smithy/util-stream": ^4.2.2
+    tslib: ^2.6.2
+  checksum: 72ceab6f5cd4d908d0e11c8d1437699b9d83aa398704bf9ccd5536305d8d990023484b5b0129027654aaf6d9ebdb89c4fc536c4349e0bdc4b10463c774a21f6a
+  languageName: node
+  linkType: hard
+
 "@smithy/types@npm:^1.2.0":
   version: 1.2.0
   resolution: "@smithy/types@npm:1.2.0"
@@ -10281,6 +10974,15 @@ __metadata:
   dependencies:
     tslib: ^2.6.2
   checksum: 296b2122144a4edacbecf6baec138c6d4abb838b98823dbb8b94e90e89a0e1c13cf3a7bbd82900b4a229ebe58dac9cd516fc4a6ddf39b1e5190c91cce64c25a5
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "@smithy/types@npm:4.3.1"
+  dependencies:
+    tslib: ^2.6.2
+  checksum: 45f2e15cec06eefb6a2470346c65ec927e56ab1757eee5ab1c431f703a9b350b331679e1f60105a1529ecb9cdb953104883942e655701fb4710bbaf566ec0bc6
   languageName: node
   linkType: hard
 
@@ -10325,6 +11027,17 @@ __metadata:
     "@smithy/types": ^4.2.0
     tslib: ^2.6.2
   checksum: a193c8d215756d5ee0f4fc52262f3aebba2c71a1f21e309f2d36fae79b1575379fd084383c1f159473879e72ea158650bcfa25048815378880867929fade24f1
+  languageName: node
+  linkType: hard
+
+"@smithy/url-parser@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@smithy/url-parser@npm:4.0.4"
+  dependencies:
+    "@smithy/querystring-parser": ^4.0.4
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: 1d3df1c58809f424af00396f987607ec9ebb0840625e4353af6dcd6baf480db8dd080b2f01ed41598ff18681ab2fcecab37f18f4c253fcbdd71eab2fab049400
   languageName: node
   linkType: hard
 
@@ -10531,6 +11244,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-defaults-mode-browser@npm:^4.0.19":
+  version: 4.0.19
+  resolution: "@smithy/util-defaults-mode-browser@npm:4.0.19"
+  dependencies:
+    "@smithy/property-provider": ^4.0.4
+    "@smithy/smithy-client": ^4.4.3
+    "@smithy/types": ^4.3.1
+    bowser: ^2.11.0
+    tslib: ^2.6.2
+  checksum: 2e523365df792b6e8615a5f6030dde5b6aeda84f149d694bbc6b2a3f9a44d29e6ac447ee50d5e69349e6c9f318b0559874790c20c5b300253f7dea41ac1bd5b0
+  languageName: node
+  linkType: hard
+
 "@smithy/util-defaults-mode-node@npm:^2.2.3":
   version: 2.3.1
   resolution: "@smithy/util-defaults-mode-node@npm:2.3.1"
@@ -10576,6 +11302,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-defaults-mode-node@npm:^4.0.19":
+  version: 4.0.19
+  resolution: "@smithy/util-defaults-mode-node@npm:4.0.19"
+  dependencies:
+    "@smithy/config-resolver": ^4.1.4
+    "@smithy/credential-provider-imds": ^4.0.6
+    "@smithy/node-config-provider": ^4.1.3
+    "@smithy/property-provider": ^4.0.4
+    "@smithy/smithy-client": ^4.4.3
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: 7e76598b9af449bc412d8184c1539c4dfe1997090ccc16fb95a9c66ddf362a6e31feb8eb3e7ad7252d9d4361b5a8e34bff1e203f774818c581fbf526f4833015
+  languageName: node
+  linkType: hard
+
 "@smithy/util-endpoints@npm:^1.1.4":
   version: 1.2.0
   resolution: "@smithy/util-endpoints@npm:1.2.0"
@@ -10606,6 +11347,17 @@ __metadata:
     "@smithy/types": ^4.2.0
     tslib: ^2.6.2
   checksum: cec9cbd8e951b683f8b7f6bd83153014ff8df50ec3bd4f281c31b55c6b8ca4f02c129efdb7834c5b59794e1430333b33bb427ced50a012245d3c8be4219a16e5
+  languageName: node
+  linkType: hard
+
+"@smithy/util-endpoints@npm:^3.0.6":
+  version: 3.0.6
+  resolution: "@smithy/util-endpoints@npm:3.0.6"
+  dependencies:
+    "@smithy/node-config-provider": ^4.1.3
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: 185c096db895f5bfabc05f1500d3428761fc4d450e998d6bf269879f7fc3f6fd770c1ed5a2de395a6b5300197bd40748a5b06c74b91ff01c9c499a25f2ba827e
   languageName: node
   linkType: hard
 
@@ -10684,6 +11436,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-middleware@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@smithy/util-middleware@npm:4.0.4"
+  dependencies:
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: 6cfdec16f03cc963e78d888a0ef349c0d80645775e9933a88c4615fbd5a683a8230997f89372e2597bd956bc05df5adc41de6524fa8c0cc93fb7150d6530a03b
+  languageName: node
+  linkType: hard
+
 "@smithy/util-retry@npm:^2.1.3, @smithy/util-retry@npm:^2.2.0":
   version: 2.2.0
   resolution: "@smithy/util-retry@npm:2.2.0"
@@ -10714,6 +11476,17 @@ __metadata:
     "@smithy/types": ^4.2.0
     tslib: ^2.6.2
   checksum: 9cabe7f127729dcd93ef1fd9d5f47d5efe958cac534b51310fdfcfee6c1be2d6146a9c8f5f3bb4ba46d8be95e22d2b5b47de4dc15ab17b3c24b352ba063be0b5
+  languageName: node
+  linkType: hard
+
+"@smithy/util-retry@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "@smithy/util-retry@npm:4.0.5"
+  dependencies:
+    "@smithy/service-error-classification": ^4.0.5
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: 2027f792a76591f2c761fa322ed50a95d40c6ef457f6d044f6b64694e037fcf549bf56e750a4f36a1460a0a6b05c6690f911733d66b40b4c84f8fcfe69bd931d
   languageName: node
   linkType: hard
 
@@ -10778,6 +11551,22 @@ __metadata:
     "@smithy/util-utf8": ^4.0.0
     tslib: ^2.6.2
   checksum: b392f9464b2e93078e010d8f8e9a6bdb14633ea79eb050e5adcce143721ea2386447e5c565469d636029415d7466e7886c5367750b1d10033a8534ab23121404
+  languageName: node
+  linkType: hard
+
+"@smithy/util-stream@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "@smithy/util-stream@npm:4.2.2"
+  dependencies:
+    "@smithy/fetch-http-handler": ^5.0.4
+    "@smithy/node-http-handler": ^4.0.6
+    "@smithy/types": ^4.3.1
+    "@smithy/util-base64": ^4.0.0
+    "@smithy/util-buffer-from": ^4.0.0
+    "@smithy/util-hex-encoding": ^4.0.0
+    "@smithy/util-utf8": ^4.0.0
+    tslib: ^2.6.2
+  checksum: 52b7c38ccf397536c882fd15453ca4c214618e045fcd96b049e79829f9c5be06a526f3672e88f1f578fa730debead264ce53e6fc3b18f43d8e6079a24ba7bbb0
   languageName: node
   linkType: hard
 
@@ -10886,6 +11675,17 @@ __metadata:
     "@smithy/types": ^4.2.0
     tslib: ^2.6.2
   checksum: 90611e62bc70ae03c4de672cdf34f2beb8ac54bfa76ff22b5acbcb4302d9ba7207541a9e5a0145028c8d8aa99e6b276cad300b1a7d2af675661ff942401f5ddb
+  languageName: node
+  linkType: hard
+
+"@smithy/util-waiter@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "@smithy/util-waiter@npm:4.0.5"
+  dependencies:
+    "@smithy/abort-controller": ^4.0.4
+    "@smithy/types": ^4.3.1
+    tslib: ^2.6.2
+  checksum: 6fa635c78093d4512aa569338af4d36bfb7c2982ac53a0bfb83f3c90cc483df05bc05450cabab57e0e1a1348efd2a469ce711b0e90d9f7a9c8b19f51dfa3d880
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
This PR introduces a kill switch mechanism to the Migration Lambda to allow us to halt record processing in the event of unexpected cost overruns or operational risks.

As part of our migration effort, we are switching from provisioned to on-demand capacity for our DynamoDB tables, which gives us flexibility but also increases the risk of unbounded costs if something goes wrong (e.g., large scans, retries, or runaway processes).
Additionally, large-scale record migrations introduce the potential for:
- Unexpected cost spikes from unthrottled read/write activity.
- Lambda throttling or retries, especially under load.
- Infinite or runaway processing loops, particularly if logic errors lead to repeated record processing
To mitigate these risks, we are implementing a kill switch that allows us to quickly stop the migration process without a redeploy. 
**Terraform Additions**
As part of this effort, we have also added a CloudWatch alarm that monitors the SNS topic used to trigger the kill switch. This alarm will notify us when a message is published to the topic (i.e., when the kill switch is invoked), ensuring visibility into when and why migration processing is halted.
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14662](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14662).

### Approach

- A stage-specific kill switch flag, e.g `/testing/feature-flag/users-migration/kill-switch` is stored as a boolean value in AWS SSM Parameter Store.
- The Existing Migration Lambda: `migrateUsersVersion`  checks the value of this parameter at runtime before processing records.
- If the flag is set to true, the Lambda logs a warning and exits without processing any records.
- A separate Lambda function: `updateKillSwitchParameter` is introduced to toggle this flag (e.g., set it to true to stop processing).
- This update Lambda is triggered via an SNS topic, allowing automated systems or alerts to activate the kill switch programmatically.
- To further limit risk, a MAX_SAFE_MIGRATION_COUNT constant caps the number of records processed in a single run (e.g., 5,000).
This ensures that even if the kill switch fails or is slow to activate, we avoid runaway migrations and unbounded costs in a single Lambda invocation

This allows us to remotely and dynamically stop migrations without requiring a redeploy or manual code changes

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
