### PR TITLE
fix: [AB#14779] fix flaking test by hardcoding current time

### DIFF
--- a/api/src/client/ApiTaxClearanceCertificateClient.test.ts
+++ b/api/src/client/ApiTaxClearanceCertificateClient.test.ts
@@ -210,6 +210,10 @@ describe("TaxClearanceCertificateClient", () => {
   });
 
   it("returns certificate pdf array and updated user data", async () => {
+    const NOW = "2000-01-01T10:00:00.000Z";
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(NOW));
+
     mockAxios.post.mockResolvedValue({ data: { certificate: [11, 22] } });
     const result = await client.postTaxClearanceCertificate(
       userData,
@@ -226,6 +230,8 @@ describe("TaxClearanceCertificateClient", () => {
       certificatePdfArray: [11, 22],
       userData: expectedUserData,
     });
+
+    jest.useRealTimers();
   });
 
   it("fires error log when error response is returned", async () => {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
Discovered that this test in `api/src/client/ApiTaxClearanceCertificateClient.test.ts` would occasionally fail due to a 0.001 second difference between a timestamp when the function was called and the timestamp when a result was mocked.

See this example: https://app.circleci.com/pipelines/github/newjersey/navigator.business.nj.gov/38111/workflows/7c1fb9b9-263a-4532-8784-07a11a18c19e/jobs/184521/parallel-runs/6/steps/6-109

Running it locally, I saw that it would fail sometimes but pass most of the time. By hardcoding the current time with jest, we ensure that this test will never fail due to a timing issue.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14779](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14779).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
