### PR TITLE
fix: [AB#14795] fix test flaking due to invalid NJ zipcode

### DIFF
--- a/shared/src/test/factories.ts
+++ b/shared/src/test/factories.ts
@@ -411,14 +411,15 @@ export const generateTaxClearanceCertificateData = (
   overrides: Partial<TaxClearanceCertificateData>,
 ): TaxClearanceCertificateData => {
   const taxId = randomInt(12).toString();
+  const addressState = generateUnitedStatesStateDropdownOption({});
   return {
     requestingAgencyId: randomElementFromArray(taxClearanceCertificateAgencies).id,
     businessName: `some-business-name-${randomInt()}`,
     addressLine1: `some-address-1-${randomInt()}`,
     addressLine2: `some-address-2-${randomInt()}`,
     addressCity: `some-city-${randomInt()}`,
-    addressState: generateUnitedStatesStateDropdownOption({}),
-    addressZipCode: randomInt(5).toString(),
+    addressState,
+    addressZipCode: addressState.shortCode === "NJ" ? generateNjZipCode() : randomInt(5).toString(),
     taxId: maskingCharacter.repeat(7) + taxId.slice(-5),
     encryptedTaxId: `encrypted-${taxId}`,
     taxPin: maskingCharacter.repeat(4),
@@ -685,4 +686,8 @@ export const generateEmergencyTripPermitApplicationData = (
     vehicleYear: `${randomInt(4)}`,
     ...overrides,
   };
+};
+
+export const generateNjZipCode = (): string => {
+  return `0${randomIntFromInterval("7", "8")}${randomInt(3)}`;
 };


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
A unit test related to #10441 was found failing [on CircleCI occasionally](https://app.circleci.com/pipelines/github/newjersey/navigator.business.nj.gov/38215/workflows/f2707c90-4185-4576-a9f1-452870358b79/jobs/184916). The test expects that there won't be an error alert box on the screen after firing all the actions, but because `generateTaxClearanceCertificateData` sometimes chooses the state NJ along with a non-NJ zipcode (not beginning in 07 or 08), the error alert box remains on the screen.



### Ticket


This pull request resolves [#14795](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14795).

### Approach

I think another way of fixing this flaky test could be using a more specific query on the page — instead of looking for an element with `"tax-clearance-error-alert"` as the id, we could check that there's no element with the error text `"This business is not currently eligible for this certificate."`, as that is more precisely what we want to test. If we think that is preferable I can add try to add that in here as well.

This approach fixes taxClearanceCertificateData so that it will always be valid to the frontend, which might be better in general, if any future tests have to do with error handling.

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
