### PR TITLE
feat: [AB#14643] making error anchor link switch back to 2nd step

### DIFF
--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificate.test.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificate.test.tsx
@@ -169,6 +169,23 @@ describe("<AnyTimeActionTaxClearanceCertificate />", () => {
       expect(secondTab).toHaveAttribute("aria-selected", "true");
     });
 
+    it("renders back to tab two after clicking on a field error in the alert box", async () => {
+      renderComponent({});
+      const secondTab = screen.getByRole("tab", { name: /Check Eligibility Step/ });
+      fireEvent.click(secondTab);
+      fillText("Tax pin", "");
+
+      expect(screen.getByTestId("tax-clearance-error-alert")).toBeInTheDocument();
+
+      const thirdTab = screen.getByRole("tab", { name: /Review Step/ });
+      fireEvent.click(thirdTab);
+
+      const fieldErrorLink = screen.getByRole("link", { name: /Tax PIN/ });
+      fireEvent.click(fieldErrorLink);
+
+      expect(secondTab).toHaveAttribute("aria-selected", "true");
+    });
+
     it("renders tab one as complete when on tab two", () => {
       const business = generateBusinessWithEmptyTaxClearanceData();
       renderComponent({ business });

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.test.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.test.tsx
@@ -7,7 +7,12 @@ const Config = getMergedConfig();
 
 describe("<AnytimeActionTaxClearanceCertificateAlert>", () => {
   it("displays single field text in header if there is only one error", () => {
-    render(<AnytimeActionTaxClearanceCertificateAlert fieldErrors={["entityId"]} />);
+    render(
+      <AnytimeActionTaxClearanceCertificateAlert
+        fieldErrors={["entityId"]}
+        setStepIndex={() => {}}
+      />,
+    );
     const profileAlert = screen.getByTestId("tax-clearance-error-alert");
     expect(
       within(profileAlert).getByText(Config.taxClearanceCertificateShared.singularErrorText),
@@ -18,6 +23,7 @@ describe("<AnytimeActionTaxClearanceCertificateAlert>", () => {
     render(
       <AnytimeActionTaxClearanceCertificateAlert
         fieldErrors={["requestingAgencyId", "entityId"]}
+        setStepIndex={() => {}}
       />,
     );
     const profileAlert = screen.getByTestId("tax-clearance-error-alert");
@@ -27,7 +33,7 @@ describe("<AnytimeActionTaxClearanceCertificateAlert>", () => {
   });
 
   it("displays nothing if there are no errors", () => {
-    render(<AnytimeActionTaxClearanceCertificateAlert fieldErrors={[]} />);
+    render(<AnytimeActionTaxClearanceCertificateAlert fieldErrors={[]} setStepIndex={() => {}} />);
     expect(screen.queryByTestId("tax-clearance-error-alert")).not.toBeInTheDocument();
   });
 
@@ -66,6 +72,7 @@ describe("<AnytimeActionTaxClearanceCertificateAlert>", () => {
         <AnytimeActionTaxClearanceCertificateAlert
           fieldErrors={[]}
           responseErrorType={errorType}
+          setStepIndex={() => {}}
         />,
       );
 

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.tsx
@@ -9,6 +9,7 @@ import { ReactElement } from "react";
 interface Props {
   fieldErrors: string[];
   responseErrorType?: TaxClearanceCertificateResponseErrorType;
+  setStepIndex: (step: number) => void;
 }
 
 export const AnytimeActionTaxClearanceCertificateAlert = (props: Props): ReactElement | null => {
@@ -94,7 +95,14 @@ export const AnytimeActionTaxClearanceCertificateAlert = (props: Props): ReactEl
           <ul>
             {fieldErrors.map((id) => (
               <li key={`${id}`} id={`label-${id}`}>
-                <a href={`#question-${id}`}>{getLabel(id)}</a>
+                <a
+                  onClick={() => {
+                    props.setStepIndex(1);
+                  }}
+                  href={`#question-${id}`}
+                >
+                  {getLabel(id)}
+                </a>
               </li>
             ))}
           </ul>

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceSteps.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceSteps.tsx
@@ -121,6 +121,7 @@ export const TaxClearanceSteps = (props: Props): ReactElement => {
       ) : (
         <>
           <AnytimeActionTaxClearanceCertificateAlert
+            setStepIndex={setStepIndex}
             fieldErrors={props.getInvalidFieldIds()}
             responseErrorType={responseErrorType}
           />
@@ -128,6 +129,7 @@ export const TaxClearanceSteps = (props: Props): ReactElement => {
             steps={stepperSteps}
             currentStep={stepIndex}
             onStepClicked={onStepClick}
+            suppressRefocusBehavior={props.getInvalidFieldIds().length > 0}
           />
           {stepsComponents[stepIndex].component}
         </>

--- a/web/src/lib/cms/previews/AnytimeActionTaxClearancePreview.tsx
+++ b/web/src/lib/cms/previews/AnytimeActionTaxClearancePreview.tsx
@@ -49,6 +49,7 @@ const AnytimeActionTaxClearancePreview = (props: PreviewProps): ReactElement => 
             <AnytimeActionTaxClearanceCertificateAlert
               fieldErrors={[]}
               responseErrorType={"INELIGIBLE_TAX_CLEARANCE_FORM"}
+              setStepIndex={() => {}}
             />
             <Heading level={2}>Anytime Action Step 3</Heading>
             <AnytimeActionTaxClearanceCertificate
@@ -60,9 +61,15 @@ const AnytimeActionTaxClearancePreview = (props: PreviewProps): ReactElement => 
         {tab === "shared" && (
           <>
             <Heading level={2}>Singular Field Error</Heading>
-            <AnytimeActionTaxClearanceCertificateAlert fieldErrors={[taxClearanceFields[0]]} />
+            <AnytimeActionTaxClearanceCertificateAlert
+              fieldErrors={[taxClearanceFields[0]]}
+              setStepIndex={() => {}}
+            />
             <Heading level={2}>Multiple Field Errors</Heading>
-            <AnytimeActionTaxClearanceCertificateAlert fieldErrors={taxClearanceFields} />
+            <AnytimeActionTaxClearanceCertificateAlert
+              fieldErrors={taxClearanceFields}
+              setStepIndex={() => {}}
+            />
             <Heading level={2}>Anytime Action Task Screen</Heading>
             <AnytimeActionTaxClearanceCertificate
               anytimeAction={taxClearanceAnytimeAction}


### PR DESCRIPTION
## Description

Clicking the anchor links in the error alert box should jump to the field that has the error (in screenshot below, this link should take the user to the Business Name field). But when a user clicks the link from the third step of the tax clearance form, the field is not on the page, so the link has no effect.

<img width="831" alt="Screenshot 2025-06-11 at 12 11 46 PM" src="https://github.com/user-attachments/assets/325a3311-a704-4e4c-8d32-3ed22169ae07" />
This PR makes sure that the form switches to the 2nd step before jumping to the field. 

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14643](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14643).

### Approach

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes
The stepper by default has refocus behavior the scrolls the page up to the stepper when switching between steps. For the desired behavior here (jumping to the field), we have to suppress the refocus behavior so that it doesn't scroll back up after jumping. I decided to suppress it whenever there are field errors on the form, but this does make it so that it won't refocus when changing steps in general (and not just when clicking the error link). 

I considered adding more state so that we could turn off refocus specifically for clicking the error link, but I couldn't quite figure out how to do that, as the following code doesn't really work in React: 

```
  const setStepIndexWithoutRefocusingStepper = (step: number): void => {
    setSuppressStepperRefocus(true);
    setStepIndex(step);
    setSuppressStepperRefocus(false);
  };
```

Because state updates are batched, even if `suppressStepperRefocus` has been set to `true` while calling `setStepIndex`, the value of `suppressStepperRefocus` does not affect the behavior of the stepper component on the page because that component has not been re-rendered before `setStepIndex` runs. If anyone has any ideas I'd appreciate it! But in the meantime I think this more general condition for suppressStepperRefocus works as a crude approximation, even if it disables the stepper refocus behavior for a few more cases than we want it to (e.g. clicking the step icons or footer buttons when a field has an error).

---

Adding a note that I explored this refocusing issue with James from OOI and he summarized the problem like so:

The HorizontalStepper component currently calls `scrollToTopOfElement(ref, { focus: true })` whenever the `stepIndex` prop changes. This allows for simpler implementations of Stepper components that always begin each step at the top of the container, but means that we have no ability to control element focus whenever the step is changing, like in this case, when I want to focus the first errored element of a form step.

Changing the behavior of HorizontalStepper to instead scroll to the top whenever the `onStepClicked` handler is called allows parent component to control the focus in circumstances other than when the user directly interacts with the stepper's step buttons. However, since existing usages of `HorizontalStepper` already depend on its existing functionality (e.g. they expect the refocus to occur when a "Next" or "Back" button in a different component is clicked) changing this behavior would cause regressions unless we refactored the HorizontalStepper to accept a `ref` prop for more manual management of stepper focus.

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
