### PR TITLE
feat: [AB#13626] Lock Fields in Tax Clearance

### DIFF
--- a/web/src/components/profile/ProfileAddressLockedFields.tsx
+++ b/web/src/components/profile/ProfileAddressLockedFields.tsx
@@ -3,16 +3,22 @@ import { Icon } from "@/components/njwds/Icon";
 import { AddressContext } from "@/contexts/addressContext";
 import { getMergedConfig } from "@/contexts/configContext";
 import { useUserData } from "@/lib/data-hooks/useUserData";
+import { FormationBusinessLocationType } from "@businessnjgovnavigator/shared/formationData";
 import { ReactElement, ReactNode, useContext } from "react";
 
-export const ProfileAddressLockedFields = (): ReactElement => {
+interface Props {
+  businessLocation?: FormationBusinessLocationType;
+}
+
+export const ProfileAddressLockedFields = (props: Props): ReactElement => {
   const { state } = useContext(AddressContext);
   const { business } = useUserData();
 
   const Config = getMergedConfig();
 
   const displayAddress = (): ReactNode => {
-    const businessLocation = business?.formationData.formationFormData.businessLocationType;
+    const businessLocation =
+      props.businessLocation || business?.formationData.formationFormData.businessLocationType;
     switch (businessLocation) {
       case "NJ":
         return (


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Lock BusinessName, Address, and TaxId fields if business has formed. 

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#13626](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13626).

### Approach

Essentially copying over existing logic from Profile page

### Steps to Test

1. Enter as a starting business
2. Go through formation (enter business name and address in this step)
3. Confirm that Address and BusinessName are locked in the tax clearance anytime action
4. Go to the tax calendar, and enter the taxId to confirm tax calendar
5. Go back to Tax Clearance and confirm that the TaxId is locked

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden

