### PR TITLE
feat: [AB#14471] update returnToLink when showing sign-in/register modal on tax clearance steps

### DIFF
--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceSteps.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceSteps.tsx
@@ -9,6 +9,8 @@ import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { TaxClearanceCertificateDataContext } from "@/contexts/taxClearanceCertificateDataContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
+import { useUserData } from "@/lib/data-hooks/useUserData";
+import { ROUTES } from "@/lib/domain-logic/routes";
 import { StepperStep } from "@/lib/types/types";
 import analytics from "@/lib/utils/analytics";
 import { TaxClearanceCertificateResponseErrorType } from "@businessnjgovnavigator/shared";
@@ -26,7 +28,7 @@ interface Props {
 export const TaxClearanceSteps = (props: Props): ReactElement => {
   const { Config } = useConfig();
   const { state: taxClearanceCertificateData } = useContext(TaxClearanceCertificateDataContext);
-
+  const { updateQueue } = useUserData();
   const [stepIndex, setStepIndex] = useState(props.CMS_ONLY_stepIndex ?? 0);
 
   const { isAuthenticated, setShowNeedsAccountModal } = useContext(NeedsAccountContext);
@@ -46,6 +48,7 @@ export const TaxClearanceSteps = (props: Props): ReactElement => {
 
   const onStepClick = (step: number): void => {
     if (isAuthenticated === IsAuthenticated.FALSE) {
+      updateQueue?.queuePreferences({ returnToLink: ROUTES.taxClearanceCertificate }).update();
       setShowNeedsAccountModal(true);
     } else {
       if (step === 2) {

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/Requirements.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/Requirements.tsx
@@ -7,6 +7,8 @@ import { ActionBarLayout } from "@/components/njwds-layout/ActionBarLayout";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
+import { useUserData } from "@/lib/data-hooks/useUserData";
+import { ROUTES } from "@/lib/domain-logic/routes";
 import analytics from "@/lib/utils/analytics";
 import { ReactElement, useContext } from "react";
 
@@ -17,9 +19,11 @@ interface Props {
 export const Requirements = (props: Props): ReactElement => {
   const { Config } = useConfig();
   const { isAuthenticated, setShowNeedsAccountModal } = useContext(NeedsAccountContext);
+  const { updateQueue } = useUserData();
 
   const onContinueClick = (): void => {
     if (isAuthenticated === IsAuthenticated.FALSE) {
+      updateQueue?.queuePreferences({ returnToLink: ROUTES.taxClearanceCertificate }).update();
       setShowNeedsAccountModal(true);
     } else {
       analytics.event.tax_clearance.click.switch_to_step_two();

--- a/web/src/lib/auth/signinHelper.test.ts
+++ b/web/src/lib/auth/signinHelper.test.ts
@@ -109,7 +109,7 @@ describe("SigninHelper", () => {
       expect(mockSetRegistrationStatus).toHaveBeenCalledWith("IN_PROGRESS");
     });
 
-    it("does not use a returnToLink if path is account-setup", async () => {
+    it("posts userData to api self-reg with current pathname included when returnToLink is empty", async () => {
       const business = generateBusiness({
         preferences: generatePreferences({ returnToLink: "" }),
       });
@@ -137,7 +137,7 @@ describe("SigninHelper", () => {
       });
     });
 
-    it("posts userData to api self-reg with current pathname included when returnToLink is empty", async () => {
+    it("does not use a returnToLink if path is account-setup", async () => {
       fakeRouter = { replace: mockPush, asPath: ROUTES.accountSetup };
       const business = generateBusiness({
         preferences: generatePreferences({ returnToLink: "" }),

--- a/web/src/lib/auth/signinHelper.ts
+++ b/web/src/lib/auth/signinHelper.ts
@@ -52,9 +52,9 @@ export const onSelfRegister = ({
   }
   setRegistrationStatus("IN_PROGRESS");
 
-  const route = router.asPath?.includes(ROUTES.accountSetup)
-    ? ""
-    : getCurrentBusiness(userData).preferences.returnToLink || router.asPath || "";
+  const { returnToLink } = getCurrentBusiness(userData).preferences;
+  const fallback = router.asPath?.includes(ROUTES.accountSetup) ? "" : router.asPath || "";
+  const route = returnToLink || fallback;
 
   api
     .postSelfReg({

--- a/web/src/lib/domain-logic/routes.ts
+++ b/web/src/lib/domain-logic/routes.ts
@@ -14,6 +14,7 @@ export const ROUTES = {
   starterKits: "/starter-kits",
   login: "/login",
   njeda: "/njeda",
+  taxClearanceCertificate: "/actions/tax-clearance-certificate-apply",
 };
 
 export interface QUERY_PARAMS_VALUES {


### PR DESCRIPTION

<!-- Please complete the following sections as necessary. -->

## Description

This adds a returnToLink to the business preferences when a guest user tries to move forward with Tax Clearance steps and are prompted with a sign-in modal.

Note that the returnToLink functionality only works when the guest user *registers* an account, not when they sign in with an existing account, because it is tied to their business data which gets replaced if they log in with an existing user.

This PR also addresses a bug with the returnToLink logic in the signinHelper, where the redirect won't work if the user passes through the account setup page - which occurs in this flow. Now, the returnToLink should be correctly passed to the postSelfReg api call.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14471](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14471).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
