### PR TITLE
chore: [AB#0000] update serverless to include API_BASE_URL

### DIFF
--- a/api/serverless.ts
+++ b/api/serverless.ts
@@ -29,6 +29,7 @@ const cmsoAuthClientSecret = process.env.CMS_OAUTH_CLIENT_SECRET || "";
 const formationApiAccount = process.env.FORMATION_API_ACCOUNT || "";
 const formationApiKey = process.env.FORMATION_API_KEY || "";
 const formationApiBaseUrl = process.env.FORMATION_API_BASE_URL || "";
+const apiBaseUrl = process.env.API_BASE_URL || "";
 
 const gov2goRegApiKey = process.env.GOV2GO_REGISTRATION_API_KEY || "";
 const gov2goRegBaseUrl = process.env.GOV2GO_REGISTRATION_BASE_URL || "";
@@ -250,6 +251,7 @@ const serverlessConfiguration: AWS = {
       DYNAMICS_LICENSE_STATUS_URL: dynamicsLicenseStatusURL,
       DYNAMO_PORT: dynamoOfflinePort,
       FORMATION_API_ACCOUNT: formationApiAccount,
+      API_BASE_URL: apiBaseUrl,
       FORMATION_API_BASE_URL: formationApiBaseUrl,
       FORMATION_API_KEY: formationApiKey,
       GOV_DELIVERY_API_KEY: govDeliveryApiKey,

--- a/api/src/libs/healthCheck.ts
+++ b/api/src/libs/healthCheck.ts
@@ -15,9 +15,7 @@ const healthCheckEndPoints: Record<string, string> = {
   taxClearance: "tax-clearance",
 };
 
-const url = process.env.API_BASE_URL ?? "https://api.account.business.nj.gov";
-
-const healthCheck = async (type: string, logger: LogWriterType): Promise<Status> => {
+const healthCheck = async (type: string, url: string, logger: LogWriterType): Promise<Status> => {
   return axios
     .get(`${url}/health/${type}`)
     .then((response: AxiosResponse) => {
@@ -36,9 +34,14 @@ const healthCheck = async (type: string, logger: LogWriterType): Promise<Status>
 };
 
 export const runHealthChecks = async (logger: LogWriterType): Promise<StatusResult> => {
+  const url = process.env.API_BASE_URL;
+  if (!url) {
+    logger.LogError("Missing required environment variable: API_BASE_URL");
+    throw new Error("Missing required environment variable: API_BASE_URL");
+  }
   const results: Record<string, Status> = {};
   for (const type in healthCheckEndPoints) {
-    results[type] = await healthCheck(healthCheckEndPoints[type] ?? "", logger);
+    results[type] = await healthCheck(healthCheckEndPoints[type] ?? "", url, logger);
   }
   return results;
 };


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
This PR adds the `API_BASE_URL` environment variable to the Lambda configuration. Previously, the variable was missing, causing the Lambda to default to the fallback (production) API endpoint. With this change, each environment will now correctly use its respective API_BASE_URL, ensuring requests are routed appropriately in lower environments.
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#0000](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
