### PR TITLE
fix: [AB#14891] callout icon bullets will show without needing body text

### DIFF
--- a/web/src/components/njwds-extended/callout/Callout.test.tsx
+++ b/web/src/components/njwds-extended/callout/Callout.test.tsx
@@ -167,5 +167,30 @@ describe("Callout Component", () => {
       const emailLink = screen.getByRole("link", { name: email });
       expect(emailLink).toHaveAttribute("href", `mailto:${email}`);
     });
+
+    it("should render a combination of all icon types correctly without needing body text", () => {
+      const { amount, filingType, phone, email } = TEST_DATA.mixedData;
+
+      render(
+        <Callout
+          calloutType="quickReference"
+          amountIconText={amount}
+          filingTypeIconText={filingType}
+          phoneIconText={phone}
+          emailIconText={email}
+          showHeader
+          headerText="soemthing"
+        />,
+      );
+
+      expect(screen.getByText(amount)).toBeInTheDocument();
+      expect(screen.getByText(filingType)).toBeInTheDocument();
+
+      const phoneLink = screen.getByRole("link", { name: phone });
+      expect(phoneLink).toHaveAttribute("href", `tel:${phone}`);
+
+      const emailLink = screen.getByRole("link", { name: email });
+      expect(emailLink).toHaveAttribute("href", `mailto:${email}`);
+    });
   });
 });

--- a/web/src/components/njwds-extended/callout/CalloutLayout.tsx
+++ b/web/src/components/njwds-extended/callout/CalloutLayout.tsx
@@ -33,12 +33,10 @@ export const CalloutLayout = (props: CalloutLayoutProps): ReactElement => {
           )}
           <span className="text-bold">{props.headingText}</span>
         </div>
-        {props.children && (
-          <div className="margin-top-105">
-            <div>{props.children}</div>
-            <IconTextList items={props.iconItems} />
-          </div>
-        )}
+        <div className="margin-top-105">
+          <div>{props.children}</div>
+          <IconTextList items={props.iconItems} />
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

We were having an issue where the callout component required body text to use the bulleted icon text attributes. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14891](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14891).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

run the app
run the cms proxy
go into tasks, add a callout block to markdown field
<img width="1350" alt="image" src="https://github.com/user-attachments/assets/807be8ac-8a6a-4413-ad0f-991da892c932" />
Make it a quick reference callout

see that if you add header text and then add to any of the bottom attributes (the ones with Icon links)

that they render without needing body copy. 



<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
