### PR TITLE
chore: add API_BASE_URL to process.env in jest config to fix local failing test

### DIFF
--- a/api/jest.config.ts
+++ b/api/jest.config.ts
@@ -1,6 +1,10 @@
 // eslint-disable-next-line no-restricted-imports
 import sharedConfig from "../jest.shared";
 
+process.env = Object.assign(process.env, {
+  API_BASE_URL: "someurl",
+});
+
 /** @type {import('jest').Config} */
 export default {
   ...sharedConfig,


### PR DESCRIPTION

<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

### Approach
Fixed an issue where health check tests were failing locally due to a missing environment variable. Updated the just.config file to ensure the necessary environment variable is set during local test runs.
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
