### PR TITLE
fix: [AB#14979] prevent 'details?.toJSON is not a function' error

### DIFF
--- a/api/src/libs/logWriter.ts
+++ b/api/src/libs/logWriter.ts
@@ -59,7 +59,8 @@ export const LogWriter = (groupName: string, logStream: string, region?: string)
 
   const LogError = async (message: string, details?: AxiosError): Promise<void> => {
     try {
-      console.error(`${message} - ${JSON.stringify(details?.toJSON())}`);
+      const jsonDetails = typeof details?.toJSON === "function" ? details.toJSON() : details;
+      console.error(`${message} - ${JSON.stringify(jsonDetails)}`);
       winston.error(message, details);
       await FlushLog();
     } catch (error) {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

In the case that the `details` object does not have a `toJSON` method, this should prevent the `console.error` line from throwing an error and obscuring potentially useful details about the error being logged.


### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request is a part of a fix needed for [#14979](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14979).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

I'm not sure if the way that we do `JSON.stringify(details?.toJSON())` is necessary. I was being cautious here but maybe we can just remove the toJSON call entirely and just do `JSON.stringify(details)`?

Not all Javascript objects implement a `.toJSON()` method, but it seems like we want to use this `.toJSON()` method to make sure we serialize the object as intended. But looking into [the documentation for `JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify), I see this paragraph:

> If the value has a `toJSON()` method, it's responsible to define what data will be serialized. Instead of the object being serialized, the value returned by the toJSON() method when called will be serialized. JSON.stringify() calls toJSON with one parameter, the `key`, which has the same semantic as the `key` parameter of the replacer function:
> - if this object is a property value, the property name
> - if it is in an array, the index in the array, as a string
> - if JSON.stringify() was directly called on this object, an empty string

I don't totally understand this last part and am not sure if the replacer function is relevant for us, but it seems like if it exists, it will be called by `JSON.stringify` anyway.

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
