### PR TITLE
feat: [AB#14384] Add certifications and funding accordion details

### DIFF
--- a/web/src/components/data-fields/non-essential-questions/CertificationsAndFundingNonEssentialQuestions.test.tsx
+++ b/web/src/components/data-fields/non-essential-questions/CertificationsAndFundingNonEssentialQuestions.test.tsx
@@ -1,0 +1,100 @@
+import { CertificationsAndFundingNonEssentialQuestions } from "@/components/data-fields/non-essential-questions/CertificationsAndFundingNonEssentialQuestions";
+import {
+  createDataFormErrorMap,
+  DataFormErrorMapContext,
+} from "@/contexts/dataFormErrorMapContext";
+import { ProfileDataContext } from "@/contexts/profileDataContext";
+import { getFlow } from "@/lib/utils/helpers";
+import { useMockBusiness } from "@/test/mock/mockUseUserData";
+import { generateBusinessForProfile } from "@/test/pages/profile/profile-helpers";
+import { OperatingPhaseId } from "@businessnjgovnavigator/shared/operatingPhase";
+import { ProfileData } from "@businessnjgovnavigator/shared/profileData";
+import { generateProfileData } from "@businessnjgovnavigator/shared/test";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
+
+describe("CertificationsAndFundingNonEssentialQuestions", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const renderComponent = (profileData: ProfileData): void => {
+    render(
+      <DataFormErrorMapContext.Provider
+        value={{
+          fieldStates: createDataFormErrorMap(),
+          runValidations: false,
+          reducer: () => {},
+        }}
+      >
+        <ProfileDataContext.Provider
+          value={{
+            state: {
+              profileData: profileData,
+              flow: getFlow(profileData),
+            },
+            setProfileData: (): void => {},
+            onBack: (): void => {},
+          }}
+        >
+          <CertificationsAndFundingNonEssentialQuestions />
+        </ProfileDataContext.Provider>
+      </DataFormErrorMapContext.Provider>,
+    );
+  };
+
+  it("only shows municipality questions for starting businesses", () => {
+    const profileData = generateProfileData({
+      operatingPhase: OperatingPhaseId.GUEST_MODE,
+    });
+
+    useMockBusiness(generateBusinessForProfile({ profileData: profileData }));
+    renderComponent(profileData);
+
+    expect(
+      screen.getByRole("combobox", {
+        name: "Location",
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("combobox", {
+        name: "Ownership",
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("textbox", {
+        name: "Existing employees",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows all questions for operating businesses", () => {
+    const profileData = generateProfileData({
+      operatingPhase: OperatingPhaseId.GUEST_MODE_OWNING,
+    });
+
+    useMockBusiness(generateBusinessForProfile({ profileData: profileData }));
+    renderComponent(profileData);
+
+    expect(
+      screen.getByRole("combobox", {
+        name: "Location",
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("combobox", {
+        name: "Ownership",
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("textbox", {
+        name: "Existing employees",
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/data-fields/non-essential-questions/CertificationsAndFundingNonEssentialQuestions.tsx
+++ b/web/src/components/data-fields/non-essential-questions/CertificationsAndFundingNonEssentialQuestions.tsx
@@ -1,0 +1,60 @@
+import { CannabisLocationAlert } from "@/components/CannabisLocationAlert";
+import { ExistingEmployees } from "@/components/data-fields/ExistingEmployees";
+import { MunicipalityField } from "@/components/data-fields/MunicipalityField";
+import { Ownership } from "@/components/data-fields/Ownership";
+import { shouldLockMunicipality } from "@/components/profile/profileDisplayLogicHelpers";
+import { ProfileField } from "@/components/profile/ProfileField";
+import { ProfileDataContext } from "@/contexts/profileDataContext";
+import { useUserData } from "@/lib/data-hooks/useUserData";
+import { LookupOperatingPhaseById } from "@businessnjgovnavigator/shared/operatingPhase";
+import { ReactElement, useContext } from "react";
+
+export const CertificationsAndFundingNonEssentialQuestions = (props: {
+  showCannabisAlert?: boolean;
+}): ReactElement => {
+  const { business } = useUserData();
+  const { state: profileDataState } = useContext(ProfileDataContext);
+  const profileData = profileDataState.profileData;
+  const isOwningBusiness = profileData.businessPersona === "OWNING";
+
+  return (
+    <>
+      <div className={"padding-bottom-1"}>
+        <ProfileField
+          fieldName="municipality"
+          locked={shouldLockMunicipality(profileData, business)}
+          hideLine
+        >
+          {props.showCannabisAlert && <CannabisLocationAlert industryId={profileData.industryId} />}
+          <MunicipalityField />
+        </ProfileField>
+      </div>
+
+      <div className={"padding-bottom-1"}>
+        <ProfileField
+          fieldName="ownershipTypeIds"
+          isVisible={
+            LookupOperatingPhaseById(business?.profileData.operatingPhase)
+              .displayCompanyDemographicProfileFields || isOwningBusiness
+          }
+          hideLine
+        >
+          <Ownership />
+        </ProfileField>
+      </div>
+
+      <div className={"padding-bottom-1"}>
+        <ProfileField
+          fieldName="existingEmployees"
+          isVisible={
+            LookupOperatingPhaseById(business?.profileData.operatingPhase)
+              .displayCompanyDemographicProfileFields || isOwningBusiness
+          }
+          hideLine
+        >
+          <ExistingEmployees />
+        </ProfileField>
+      </div>
+    </>
+  );
+};

--- a/web/src/components/profile/PersonalizeYourTasksTab.tsx
+++ b/web/src/components/profile/PersonalizeYourTasksTab.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@/components/Content";
 import { DateOfFormation } from "@/components/data-fields/DateOfFormation";
+import { CertificationsAndFundingNonEssentialQuestions } from "@/components/data-fields/non-essential-questions/CertificationsAndFundingNonEssentialQuestions";
 import { IndustryBasedNonEssentialQuestionsSection } from "@/components/data-fields/non-essential-questions/IndustryBasedNonEssentialQuestionsSection";
 import { LocationBasedNonEssentialQuestions } from "@/components/data-fields/non-essential-questions/LocationBasedNonEssentialQuestions";
 import { Heading } from "@/components/njwds-extended/Heading";
@@ -97,7 +98,14 @@ export const PersonalizeYourTasksTab = (props: Props): ReactElement => {
           headerText={Config.profileDefaults.default.filterCertificationsAndFundingHeader}
           description={Config.profileDefaults.default.filterCertificationsAndFundingSubText}
         />
-        <AccordionDetails sx={{ marginLeft: 6 }}>FILTER CERTIFICATIONS DETAILS</AccordionDetails>
+        <AccordionDetails sx={{ marginLeft: 6 }}>
+          <CertificationsAndFundingNonEssentialQuestions
+            showCannabisAlert={
+              profileData.businessPersona === "STARTING" ||
+              profileData.businessPersona === "FOREIGN"
+            }
+          />
+        </AccordionDetails>
       </Accordion>
       <hr className="margin-y-4" />
       <Accordion>

--- a/web/src/components/profile/profileDisplayLogicHelpers.test.ts
+++ b/web/src/components/profile/profileDisplayLogicHelpers.test.ts
@@ -2,10 +2,12 @@ import {
   displayElevatorQuestion,
   displayHomedBaseBusinessQuestion,
   displayPlannedRenovationQuestion,
+  shouldLockMunicipality,
 } from "@/components/profile/profileDisplayLogicHelpers";
 import { NexusBusinessTypeIds } from "@businessnjgovnavigator/shared/domain-logic/businessPersonaHelpers";
 import { getIndustries } from "@businessnjgovnavigator/shared/industry";
 import { createEmptyProfileData } from "@businessnjgovnavigator/shared/profileData";
+import { generateMunicipality } from "@businessnjgovnavigator/shared/test";
 import {
   generateBusiness,
   generateProfileData,
@@ -111,6 +113,50 @@ describe("profileDisplayLogicHelpers", () => {
         }),
       });
       expect(displayElevatorQuestion(business.profileData, business)).toBe(true);
+    });
+  });
+
+  describe("shouldLockMunicipality", () => {
+    it("returns false if user hasn't submitted tax filing", () => {
+      const business = generateBusiness({
+        profileData: generateProfileData({
+          municipality: generateMunicipality({}),
+        }),
+        taxFilingData: {
+          state: "UNREGISTERED",
+          filings: [],
+        },
+      });
+
+      expect(shouldLockMunicipality(business.profileData, business)).toBe(false);
+    });
+
+    it("returns false if user has has submitted tax filing and has not selected municipality", () => {
+      const business = generateBusiness({
+        profileData: generateProfileData({
+          municipality: undefined,
+        }),
+        taxFilingData: {
+          state: "SUCCESS",
+          filings: [],
+        },
+      });
+
+      expect(shouldLockMunicipality(business.profileData, business)).toBe(false);
+    });
+
+    it("returns true if user has has submitted tax filing and selected municipality", () => {
+      const business = generateBusiness({
+        profileData: generateProfileData({
+          municipality: generateMunicipality({}),
+        }),
+        taxFilingData: {
+          state: "SUCCESS",
+          filings: [],
+        },
+      });
+
+      expect(shouldLockMunicipality(business.profileData, business)).toBe(true);
     });
   });
 });

--- a/web/src/components/profile/profileDisplayLogicHelpers.ts
+++ b/web/src/components/profile/profileDisplayLogicHelpers.ts
@@ -38,3 +38,7 @@ export const displayElevatorQuestion = (profileData: ProfileData, business?: Bus
   if (!business) return false;
   return profileData.homeBasedBusiness === false && profileData.businessPersona === "STARTING";
 };
+
+export const shouldLockMunicipality = (profileData: ProfileData, business?: Business): boolean => {
+  return !!profileData.municipality && business?.taxFilingData.state === "SUCCESS";
+};

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -1,21 +1,18 @@
-import { CannabisLocationAlert } from "@/components/CannabisLocationAlert";
 import { BusinessName } from "@/components/data-fields/BusinessName";
 import { BusinessStructure } from "@/components/data-fields/BusinessStructure";
 import { DateOfFormation } from "@/components/data-fields/DateOfFormation";
 import { EmployerId } from "@/components/data-fields/EmployerId";
 import { EntityId } from "@/components/data-fields/EntityId";
-import { ExistingEmployees } from "@/components/data-fields/ExistingEmployees";
 import { ForeignBusinessTypeField } from "@/components/data-fields/ForeignBusinessTypeField";
 import { Industry } from "@/components/data-fields/Industry";
-import { MunicipalityField } from "@/components/data-fields/MunicipalityField";
 import { NaicsCode } from "@/components/data-fields/NaicsCode";
 import { NexusBusinessNameField } from "@/components/data-fields/NexusBusinessNameField";
 import { NexusDBANameField } from "@/components/data-fields/NexusDBANameField";
+import { CertificationsAndFundingNonEssentialQuestions } from "@/components/data-fields/non-essential-questions/CertificationsAndFundingNonEssentialQuestions";
 import { IndustryBasedNonEssentialQuestionsSection } from "@/components/data-fields/non-essential-questions/IndustryBasedNonEssentialQuestionsSection";
 import { LocationBasedNonEssentialQuestions } from "@/components/data-fields/non-essential-questions/LocationBasedNonEssentialQuestions";
 import { NonEssentialQuestionForPersonas } from "@/components/data-fields/non-essential-questions/nonEssentialQuestionsHelpers";
 import { Notes } from "@/components/data-fields/Notes";
-import { Ownership } from "@/components/data-fields/Ownership";
 import { RaffleBingoGamesQuestion } from "@/components/data-fields/RaffleBingoGamesQuestion";
 import { ResponsibleOwnerName } from "@/components/data-fields/ResponsibleOwnerName";
 import { Sectors } from "@/components/data-fields/Sectors";
@@ -87,7 +84,6 @@ import {
 } from "@businessnjgovnavigator/shared";
 import { formatDate } from "@businessnjgovnavigator/shared/dateHelpers";
 import { isStartingBusiness } from "@businessnjgovnavigator/shared/domain-logic/businessPersonaHelpers";
-import { nexusLocationInNewJersey } from "@businessnjgovnavigator/shared/domain-logic/nexusLocationInNewJersey";
 import deepEqual from "fast-deep-equal/es6/react";
 import { GetStaticPropsResult } from "next";
 import { NextSeo } from "next-seo";
@@ -296,10 +292,6 @@ const ProfilePage = (props: Props): ReactElement => {
     profileData.operatingPhase,
   ).displayProfileOpportunityAlert;
 
-  const shouldLockMunicipality = (): boolean => {
-    return !!profileData.municipality && business?.taxFilingData.state === "SUCCESS";
-  };
-
   const displayRaffleBingoGameQuestion = (): boolean => {
     if (!business) return false;
     return profileData.legalStructureId === "nonprofit";
@@ -362,14 +354,7 @@ const ProfilePage = (props: Props): ReactElement => {
           <DateOfFormation futureAllowed />
         </ProfileField>
 
-        <ProfileField
-          fieldName="municipality"
-          isVisible={nexusLocationInNewJersey(profileData)}
-          locked={shouldLockMunicipality()}
-        >
-          <CannabisLocationAlert industryId={business?.profileData.industryId} />
-          <MunicipalityField />
-        </ProfileField>
+        <CertificationsAndFundingNonEssentialQuestions showCannabisAlert />
       </div>
     ),
     permits: (
@@ -580,30 +565,7 @@ const ProfilePage = (props: Props): ReactElement => {
           <DateOfFormation futureAllowed />
         </ProfileField>
 
-        <ProfileField fieldName="municipality" locked={shouldLockMunicipality()}>
-          <CannabisLocationAlert industryId={business?.profileData.industryId} />
-          <MunicipalityField />
-        </ProfileField>
-
-        <ProfileField
-          fieldName="ownershipTypeIds"
-          isVisible={
-            LookupOperatingPhaseById(business?.profileData.operatingPhase)
-              .displayCompanyDemographicProfileFields
-          }
-        >
-          <Ownership />
-        </ProfileField>
-
-        <ProfileField
-          fieldName="existingEmployees"
-          isVisible={
-            LookupOperatingPhaseById(business?.profileData.operatingPhase)
-              .displayCompanyDemographicProfileFields
-          }
-        >
-          <ExistingEmployees />
-        </ProfileField>
+        <CertificationsAndFundingNonEssentialQuestions showCannabisAlert />
       </div>
     ),
     permits: (
@@ -746,17 +708,7 @@ const ProfilePage = (props: Props): ReactElement => {
           <DateOfFormation futureAllowed={false} />
         </ProfileField>
 
-        <ProfileField fieldName="municipality" locked={shouldLockMunicipality()}>
-          <MunicipalityField />
-        </ProfileField>
-
-        <ProfileField fieldName="ownershipTypeIds">
-          <Ownership />
-        </ProfileField>
-
-        <ProfileField fieldName="existingEmployees">
-          <ExistingEmployees />
-        </ProfileField>
+        <CertificationsAndFundingNonEssentialQuestions />
       </div>
     ),
     permits: (


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Adds certifications and fundings questions to Personalize My Tasks accordion

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14384](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14384).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

1. Go through onboarding and navigate to the profile, and click Personalize My Tasks
2. Click on the Certificatiosn and Funding Accordion
3. If you are a starting business, you should only see the municipality question
4. If you are an operating business, you should see all three questions

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
