### PR TITLE
feat: [AB#14933] unlink taxId function in Dev

### DIFF
--- a/api/src/api/taxClearanceCertificateRouter.test.ts
+++ b/api/src/api/taxClearanceCertificateRouter.test.ts
@@ -17,6 +17,7 @@ describe("taxClearanceCertificateRouterFactory", () => {
     stubTaxClearanceCertificateClient = {
       postTaxClearanceCertificate: jest.fn(),
       health: jest.fn(),
+      unlinkTaxId: jest.fn(),
     };
     stubCryptoClient = {
       encryptValue: jest.fn(),
@@ -56,6 +57,22 @@ describe("taxClearanceCertificateRouterFactory", () => {
   it("throws a server error", async () => {
     stubTaxClearanceCertificateClient.postTaxClearanceCertificate.mockRejectedValue("some value");
     const response = await request(app).post(`/postTaxClearanceCertificate`);
+    expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(response.body).toEqual("some value");
+  });
+
+  it("unlink TaxId returns a successful response", async () => {
+    stubTaxClearanceCertificateClient.unlinkTaxId.mockResolvedValue({
+      success: true,
+    });
+    const response = await request(app).post(`/unlinkTaxId`);
+    expect(response.status).toEqual(StatusCodes.OK);
+    expect(response.body).toEqual({ success: true });
+  });
+
+  it("unlink TaxId throws a server error", async () => {
+    stubTaxClearanceCertificateClient.unlinkTaxId.mockRejectedValue("some value");
+    const response = await request(app).post(`/unlinkTaxId`);
     expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
     expect(response.body).toEqual("some value");
   });

--- a/api/src/api/taxClearanceCertificateRouter.ts
+++ b/api/src/api/taxClearanceCertificateRouter.ts
@@ -24,5 +24,15 @@ export const taxClearanceCertificateRouterFactory = (
       res.status(StatusCodes.INTERNAL_SERVER_ERROR).json(error);
     }
   });
+  router.post("/unlinkTaxId", async (req: ExpressRequestBody<UserData>, res) => {
+    const userData = req.body;
+
+    try {
+      const response = await taxClearanceCertificateClient.unlinkTaxId(userData, databaseClient);
+      res.json(response);
+    } catch (error) {
+      res.status(StatusCodes.INTERNAL_SERVER_ERROR).json(error);
+    }
+  });
   return router;
 };

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -2,6 +2,7 @@
 import {
   FacilityDetails,
   TaxClearanceCertificateResponse,
+  UnlinkTaxIdResponse,
   XrayRegistrationEntry,
   XrayRegistrationStatusResponse,
 } from "@businessnjgovnavigator/shared";
@@ -252,6 +253,7 @@ export interface TaxClearanceCertificateClient {
     databaseClient: DatabaseClient,
   ) => Promise<TaxClearanceCertificateResponse>;
   health: () => Promise<HealthCheckMetadata>;
+  unlinkTaxId: (userData: UserData, databaseClient: DatabaseClient) => Promise<UnlinkTaxIdResponse>;
 }
 
 export interface XrayRegistrationStatusLookup {

--- a/shared/src/taxClearanceCertificateResponse.ts
+++ b/shared/src/taxClearanceCertificateResponse.ts
@@ -22,4 +22,11 @@ type SuccessResponse = {
   certificatePdfArray: number[];
 };
 
+export interface UnlinkTaxIdResponse {
+  success: boolean;
+  error?: {
+    message: string;
+  };
+}
+
 export type TaxClearanceCertificateResponse = ErrorResponse | SuccessResponse;

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@/components/Content";
 import { Alert } from "@/components/njwds-extended/Alert";
+import { DevOnlyUnlinkTaxIdButton } from "@/components/tasks/anytime-action/tax-clearance-certificate/DevOnlyUnlinkTaxIdButton";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { getProfileConfig } from "@/lib/domain-logic/getProfileConfig";
 import { ProfileContentField } from "@/lib/types/types";
@@ -9,6 +10,7 @@ import { ReactElement } from "react";
 interface Props {
   fieldErrors: string[];
   responseErrorType?: TaxClearanceCertificateResponseErrorType;
+  setResponseErrorType?: (errorType: TaxClearanceCertificateResponseErrorType | undefined) => void;
   setStepIndex: (step: number) => void;
 }
 
@@ -111,6 +113,9 @@ export const AnytimeActionTaxClearanceCertificateAlert = (props: Props): ReactEl
         <div data-testid="tax-clearance-response-error">
           <Content>{getTaxClearanceErrorMessage(props.responseErrorType)}</Content>
         </div>
+      )}
+      {props.responseErrorType === "TAX_ID_IN_USE_BY_ANOTHER_BUSINESS_ACCOUNT" && (
+        <DevOnlyUnlinkTaxIdButton setResponseErrorType={props.setResponseErrorType} />
       )}
     </Alert>
   ) : (

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/DevOnlyUnlinkTaxIdButton.test.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/DevOnlyUnlinkTaxIdButton.test.tsx
@@ -1,0 +1,30 @@
+import { DevOnlyUnlinkTaxIdButton } from "@/components/tasks/anytime-action/tax-clearance-certificate/DevOnlyUnlinkTaxIdButton";
+import { TaxClearanceCertificateResponseErrorType } from "@businessnjgovnavigator/shared";
+import { render, screen } from "@testing-library/react";
+
+const mockErrorSettor: (errorType: TaxClearanceCertificateResponseErrorType | undefined) => void =
+  jest.fn();
+
+describe("<DevOnlyUnlinkTaxIdButton />", () => {
+  const originalEnvironment = process.env.STAGE;
+
+  afterEach(() => {
+    process.env.STAGE = originalEnvironment;
+  });
+
+  it("is rendered in a non-prod env", () => {
+    process.env.STAGE = "dev";
+    render(<DevOnlyUnlinkTaxIdButton setResponseErrorType={mockErrorSettor} />);
+
+    const button = screen.getByRole("button", { name: "Unlink Tax ID" });
+    expect(button).toBeInTheDocument();
+  });
+
+  it("is not rendered in a prod env", () => {
+    process.env.STAGE = "prod";
+    render(<DevOnlyUnlinkTaxIdButton setResponseErrorType={mockErrorSettor} />);
+
+    const button = screen.queryByRole("button", { name: "Unlink Tax ID" });
+    expect(button).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/DevOnlyUnlinkTaxIdButton.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/DevOnlyUnlinkTaxIdButton.tsx
@@ -1,0 +1,41 @@
+import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
+import * as api from "@/lib/api-client/apiClient";
+import { useUserData } from "@/lib/data-hooks/useUserData";
+import {
+  TaxClearanceCertificateResponseErrorType,
+  UnlinkTaxIdResponse,
+} from "@businessnjgovnavigator/shared";
+import { ReactElement } from "react";
+
+interface Props {
+  setResponseErrorType?: (errorType: TaxClearanceCertificateResponseErrorType | undefined) => void;
+}
+
+export const DevOnlyUnlinkTaxIdButton = (props: Props): ReactElement => {
+  const isUnlinkButtonEnabled = process.env.STAGE !== "prod";
+  const { userData, refresh } = useUserData();
+
+  const unlinkTaxId = async (): Promise<void> => {
+    if (!userData) return;
+    const res: UnlinkTaxIdResponse = await api.unlinkTaxId(userData);
+
+    if (res.success) {
+      refresh();
+      props.setResponseErrorType !== undefined && props.setResponseErrorType(undefined);
+    }
+  };
+
+  return (
+    <>
+      {isUnlinkButtonEnabled ? (
+        <div className="margin-y-2">
+          <PrimaryButton isColor="accent-cooler" onClick={unlinkTaxId}>
+            Unlink Tax ID
+          </PrimaryButton>
+        </div>
+      ) : (
+        <></>
+      )}
+    </>
+  );
+};

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceSteps.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/TaxClearanceSteps.tsx
@@ -127,6 +127,7 @@ export const TaxClearanceSteps = (props: Props): ReactElement => {
             setStepIndex={setStepIndex}
             fieldErrors={props.getInvalidFieldIds()}
             responseErrorType={responseErrorType}
+            setResponseErrorType={setResponseErrorType}
           />
           <HorizontalStepper
             steps={stepperSteps}

--- a/web/src/lib/api-client/apiClient.ts
+++ b/web/src/lib/api-client/apiClient.ts
@@ -13,6 +13,7 @@ import {
   NameAvailability,
   PropertyInterestType,
   TaxClearanceCertificateResponse,
+  UnlinkTaxIdResponse,
   UserData,
 } from "@businessnjgovnavigator/shared";
 import axios, { AxiosError, AxiosRequestConfig } from "axios";
@@ -91,6 +92,10 @@ export const postTaxClearanceCertificate = (
   userData: UserData,
 ): Promise<TaxClearanceCertificateResponse> => {
   return post(`/postTaxClearanceCertificate`, userData);
+};
+
+export const unlinkTaxId = (userData: UserData): Promise<UnlinkTaxIdResponse> => {
+  return post(`/unlinkTaxId`, userData);
 };
 
 export const postTaxFilingsOnboarding = (props: {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Dev only functionality to unlink a TaxId from a business that has already confirmed its Tax Clearance. 

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14933](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14933).

### Steps to Test

1. run app locally
2. start a owning business
3. navigate to tax clearance
4. fill out all info and use `777-777-777-771` for TaxID and `3889` for TaxPin
5. Submit, and you should receive a success.
6. Create a new business and repeat steps 3 and 4. 
7. When you submit you should receive an error that this TaxID is already in use and a `Dev Only` button should appear to unlink the taxId.
8. Click the unlink button, and the error/alert should go away. 
9. Now submit again with the new business and you should receive a success screen. 

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden

