### PR TITLE
refactor: [AB#14447] Remove close button and enable auto-close for po…

### DIFF
--- a/web/src/components/auth/RegistrationStatusSnackbar.tsx
+++ b/web/src/components/auth/RegistrationStatusSnackbar.tsx
@@ -2,14 +2,12 @@ import { Content } from "@/components/Content";
 import { AlertVariant } from "@/components/njwds-extended/Alert";
 import { Heading } from "@/components/njwds-extended/Heading";
 import { SnackbarAlert } from "@/components/njwds-extended/SnackbarAlert";
-import { Icon } from "@/components/njwds/Icon";
 import { AuthContext } from "@/contexts/authContext";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import analytics from "@/lib/utils/analytics";
 import { RegistrationStatus } from "@businessnjgovnavigator/shared/";
-import { IconButton } from "@mui/material";
 import { ReactElement, useContext, useEffect } from "react";
 
 export const RegistrationStatusSnackbar = (): ReactElement => {
@@ -55,7 +53,7 @@ export const RegistrationStatusSnackbar = (): ReactElement => {
         close={(): void => setRegistrationStatus(undefined)}
         variant={alertMap[registrationStatus]}
         noIcon={true}
-        autoHideDuration={null}
+        autoHideDuration={7000}
         snackBarProps={{ sx: { paddingX: 0 } }}
         dataTestid="reg-snackbar"
       >
@@ -70,18 +68,6 @@ export const RegistrationStatusSnackbar = (): ReactElement => {
             <Heading level={3} className="padding-right-2">
               {getSuccessTitle()}
             </Heading>
-            <IconButton
-              aria-label="close"
-              onClick={(): void => setRegistrationStatus(undefined)}
-              sx={{
-                position: "absolute",
-                right: 0,
-                top: 0,
-                color: "#757575",
-              }}
-            >
-              <Icon className="usa-icon--size-4" iconName="close" />
-            </IconButton>
             <Content>{contentMap[registrationStatus]}</Content>
           </div>
         </div>


### PR DESCRIPTION
…p-up after 7 seconds

<!-- Please complete the following sections as necessary. -->

## Description

To better align with USWDS accessibility guidelines, the "Welcome to your Business.NJ.gov account!" pop-up was refactored to remove the close button and auto-close after 7 seconds.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14447](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14447).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
