### PR TITLE
refactor: [AB#14614] Remove close button from Tax Calendar Added! Pop…

### DIFF
--- a/web/src/components/filings-calendar/FilingsCalendarTaxAccess.test.tsx
+++ b/web/src/components/filings-calendar/FilingsCalendarTaxAccess.test.tsx
@@ -216,31 +216,6 @@ describe("<FilingsCalendarTaxAccess />", () => {
     expect(screen.getByText(Config.taxCalendar.snackbarSuccessHeader)).toBeInTheDocument();
   });
 
-  it("closes the success alert when the close button is clicked", async () => {
-    mockApi.postTaxFilingsOnboarding.mockResolvedValue(
-      modifyUserData(userDataWithPrefilledFields, {
-        taxFilingData: generateTaxFilingData({
-          state: "SUCCESS",
-          registeredISO: getCurrentDateISOString(),
-        }),
-      }),
-    );
-
-    renderFilingsCalendarTaxAccess(userDataWithPrefilledFields);
-
-    clickSave();
-    await waitFor(() => {
-      return expect(currentBusiness().taxFilingData.state).toEqual("SUCCESS");
-    });
-    await screen.findByTestId("tax-success");
-    expect(screen.getByText(Config.taxCalendar.snackbarSuccessHeader)).toBeInTheDocument();
-    expect(screen.getByTestId("close-icon-button")).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("close-icon-button"));
-    await waitFor(() => {
-      expect(screen.queryByText(Config.taxCalendar.snackbarSuccessHeader)).not.toBeInTheDocument();
-    });
-  });
-
   describe("different taxFiling states and update behavior", () => {
     it("does not do taxFiling lookup on page load if not registered", async () => {
       renderFilingsCalendarTaxAccess(

--- a/web/src/components/filings-calendar/FilingsCalendarTaxAccess.tsx
+++ b/web/src/components/filings-calendar/FilingsCalendarTaxAccess.tsx
@@ -110,9 +110,9 @@ export const FilingsCalendarTaxAccess = (): ReactElement => {
       <SnackbarAlert
         variant={"success"}
         isOpen={showAlert}
-        autoHideDuration={null}
+        autoHideDuration={7000}
         close={(): void => setShowAlert(false)}
-        closeIcon={true}
+        closeIcon={false}
         heading={Config.taxCalendar.snackbarSuccessHeader}
         dataTestid={"tax-success"}
       >


### PR DESCRIPTION
…-up after 7 seconds

<!-- Please complete the following sections as necessary. -->

## Description

To better align with USWDS Accessibility Guidelines, the "Tax Calendar Added" pop-up was refactored to remove close button from "Tax Calendar Added!" pop-up and auto-close after 7 seconds.


### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14614](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14614).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
