### PR TITLE
feat: [#AB15063] manage business vehicle cta updated to use primary b…

### DIFF
--- a/web/src/components/tasks/manage-business-vehicles/ManageBusinessVehicleQuestion.tsx
+++ b/web/src/components/tasks/manage-business-vehicles/ManageBusinessVehicleQuestion.tsx
@@ -1,6 +1,6 @@
 import { Content } from "@/components/Content";
 import { Heading } from "@/components/njwds-extended/Heading";
-import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
+import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -95,9 +95,9 @@ export const ManageBusinessVehicleQuestion: React.FC<Props> = (props: Props) => 
         </WithErrorBar>
         <Content>{Config.manageBusinessVehicles.learnMoreText}</Content>
         <div className="margin-top-3 flex flex-justify-end">
-          <SecondaryButton isColor="accent-cooler" isSubmitButton>
+          <PrimaryButton isColor="accent-cooler" isSubmitButton>
             {Config.manageBusinessVehicles.saveButtonText}
-          </SecondaryButton>
+          </PrimaryButton>
         </div>
       </form>
     </div>


### PR DESCRIPTION
…utton

<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#15063](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15063).

### Approach
Switch secondary button with primary button in cta.

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
