### PR TITLE
feat: [AB#14270] fixing broken analytics

### DIFF
--- a/web/src/components/tasks/ElevatorRegistrationTask.test.tsx
+++ b/web/src/components/tasks/ElevatorRegistrationTask.test.tsx
@@ -57,7 +57,8 @@ describe("<ElevatorRegistrationTask />", () => {
 
       expect(mockAnalyticsBase.sendEvent).toHaveBeenCalledWith(
         expect.objectContaining({
-          event: "outbound_link_clicks",
+          event: "analytics_event",
+          event_category: "outbound_link_clicks",
           legacy_event_category: "elevator_registration_button_click_register",
           legacy_event_action: "click",
         }),
@@ -76,7 +77,8 @@ describe("<ElevatorRegistrationTask />", () => {
       fireEvent.click(screen.getByTestId("check-status-tab"));
       expect(mockAnalyticsBase.sendEvent).toHaveBeenCalledWith(
         expect.objectContaining({
-          event: "task_tab_clicked",
+          event: "analytics_event",
+          event_category: "task_tab_clicked",
           legacy_event_category: "check_my_elevator_application_status_tab_click",
           legacy_event_action: "click",
         }),
@@ -92,7 +94,8 @@ describe("<ElevatorRegistrationTask />", () => {
       fireEvent.click(screen.getByTestId("cta-secondary"));
       expect(mockAnalyticsBase.sendEvent).toHaveBeenCalledWith(
         expect.objectContaining({
-          event: "task_tab_continue_button_clicks",
+          event: "analytics_event",
+          event_category: "task_tab_continue_button_clicks",
           legacy_event_category: "elevator_registration_button_click_update",
           legacy_event_action: "click",
         }),
@@ -111,14 +114,16 @@ describe("<ElevatorRegistrationTask />", () => {
 
       expect(mockAnalyticsBase.sendEvent).toHaveBeenCalledWith(
         expect.objectContaining({
-          event: "form_submits",
+          event: "analytics_event",
+          event_category: "form_submits",
           legacy_event_category: "elevator_registration_form_submission",
           legacy_event_action: "submit",
         }),
       );
       expect(mockAnalyticsBase.sendEvent).toHaveBeenCalledWith(
         expect.objectContaining({
-          event: "form_submits",
+          event: "analytics_event",
+          event_category: "form_submits",
           legacy_event_category: "elevator_registration_form_submission_failed",
           legacy_event_action: "submit",
         }),
@@ -145,7 +150,8 @@ describe("<ElevatorRegistrationTask />", () => {
 
       expect(mockAnalyticsBase.sendEvent).toHaveBeenCalledWith(
         expect.objectContaining({
-          event: "form_submits",
+          event: "analytics_event",
+          event_category: "form_submits",
           legacy_event_category: "elevator_registration_form_submission",
           legacy_event_action: "submit",
         }),

--- a/web/src/lib/utils/analytics-base.js
+++ b/web/src/lib/utils/analytics-base.js
@@ -5,7 +5,7 @@ const sendEvent = (event) => {
 
 const userUpdate = (user_update) => {
   window.userData = { ...window.userData, ...user_update };
-  sendEvent({ event: "user_update", ...window.userData });
+  sendEvent({ event: "user_update_revised", ...window.userData });
 };
 
 let analyticsContext = { calendar_view: undefined };

--- a/web/src/lib/utils/analytics.test.ts
+++ b/web/src/lib/utils/analytics.test.ts
@@ -39,7 +39,8 @@ describe("analytics", () => {
         });
 
         expect(mockAnalyticsBase.sendEvent).toHaveBeenNthCalledWith(1, {
-          event: "form_submits",
+          event_category: "form_submits",
+          event: "analytics_event",
           form_name: "industry_essential_questions",
           hostname: "localhost",
           on_site_section: "landing_page",
@@ -48,7 +49,8 @@ describe("analytics", () => {
         });
 
         expect(mockAnalyticsBase.sendEvent).toHaveBeenNthCalledWith(2, {
-          event: "form_submits",
+          event_category: "form_submits",
+          event: "analytics_event",
           form_name: "industry_essential_questions",
           hostname: "localhost",
           on_site_section: "landing_page",
@@ -63,7 +65,8 @@ describe("analytics", () => {
         window.location.href = "https://localhost";
         analytics.eventRunner.track({ event: "account_clicks" });
         expect(mockAnalyticsBase.sendEvent).toHaveBeenCalledWith({
-          event: "account_clicks",
+          event_category: "account_clicks",
+          event: "analytics_event",
           hostname: "localhost",
           on_site_section: "landing_page",
         });
@@ -73,7 +76,8 @@ describe("analytics", () => {
         window.location.href = "https://localhost/onboarding";
         analytics.eventRunner.track({ event: "account_clicks" });
         expect(mockAnalyticsBase.sendEvent).toHaveBeenCalledWith({
-          event: "account_clicks",
+          event_category: "account_clicks",
+          event: "analytics_event",
           hostname: "localhost",
           on_site_section: "onboarding_screen",
         });
@@ -83,7 +87,8 @@ describe("analytics", () => {
         window.location.href = "https://localhost/dashboard";
         analytics.eventRunner.track({ event: "account_clicks" });
         expect(mockAnalyticsBase.sendEvent).toHaveBeenCalledWith({
-          event: "account_clicks",
+          event_category: "account_clicks",
+          event: "analytics_event",
           hostname: "localhost",
           on_site_section: "dashboard_screen",
         });
@@ -93,7 +98,8 @@ describe("analytics", () => {
         window.location.href = "https://localhost/profile";
         analytics.eventRunner.track({ event: "account_clicks" });
         expect(mockAnalyticsBase.sendEvent).toHaveBeenCalledWith({
-          event: "account_clicks",
+          event_category: "account_clicks",
+          event: "analytics_event",
           hostname: "localhost",
           on_site_section: "profile_screen",
         });
@@ -103,7 +109,8 @@ describe("analytics", () => {
         window.location.href = "https://localhost/tasks/evaluate-your-location";
         analytics.eventRunner.track({ event: "account_clicks" });
         expect(mockAnalyticsBase.sendEvent).toHaveBeenCalledWith({
-          event: "account_clicks",
+          event_category: "account_clicks",
+          event: "analytics_event",
           hostname: "localhost",
           on_site_section: "generic_task_screen",
           on_task_id: "evaluate-your-location",
@@ -114,7 +121,8 @@ describe("analytics", () => {
         window.location.href = "https://localhost/tasks/form-business-entity";
         analytics.eventRunner.track({ event: "account_clicks" });
         expect(mockAnalyticsBase.sendEvent).toHaveBeenCalledWith({
-          event: "account_clicks",
+          event_category: "account_clicks",
+          event: "analytics_event",
           hostname: "localhost",
           on_site_section: "business_formation_task",
           on_task_id: "form-business-entity",
@@ -125,7 +133,8 @@ describe("analytics", () => {
         window.location.href = "https://localhost/tasks/conditional-permit-cannabis";
         analytics.eventRunner.track({ event: "account_clicks" });
         expect(mockAnalyticsBase.sendEvent).toHaveBeenCalledWith({
-          event: "account_clicks",
+          event_category: "account_clicks",
+          event: "analytics_event",
           hostname: "localhost",
           on_site_section: "cannabis_task",
           on_task_id: "conditional-permit-cannabis",
@@ -136,7 +145,8 @@ describe("analytics", () => {
         window.location.href = "https://localhost/filings/annual-report";
         analytics.eventRunner.track({ event: "account_clicks" });
         expect(mockAnalyticsBase.sendEvent).toHaveBeenCalledWith({
-          event: "account_clicks",
+          event_category: "account_clicks",
+          event: "analytics_event",
           hostname: "localhost",
           on_site_section: "generic_filing_screen",
         });
@@ -146,7 +156,8 @@ describe("analytics", () => {
         window.location.href = "https://localhost/tasks/conditional-permit-cannabis?foo=bar";
         analytics.eventRunner.track({ event: "account_clicks" });
         expect(mockAnalyticsBase.sendEvent).toHaveBeenCalledWith({
-          event: "account_clicks",
+          event_category: "account_clicks",
+          event: "analytics_event",
           hostname: "localhost",
           on_site_section: "cannabis_task",
           on_task_id: "conditional-permit-cannabis",

--- a/web/src/lib/utils/analytics.ts
+++ b/web/src/lib/utils/analytics.ts
@@ -354,7 +354,8 @@ class GTMTracker {
           return acc;
         },
         {
-          event: eventName,
+          event: "analytics_event",
+          event_category: eventName,
           hostname: location.hostname,
           on_site_section,
           on_task_id,


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

The analytics were generally broken (in that data wasn't being passed from code to GTM to GA4). 

This ticket is the code changes involved in solving this.

changes have already been made in GTM to support this and GA4 did not require any changes

NOTE: we will also have to update an environment variable in all environments when this is deployed to get the desired effect as well. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14270](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14270).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

I would say probably don't bother. 

What you would need to do involves running this locally, 
Opening google tag manager,
opening the preview and putting in local host as the address,
then watching events come through and being collected / processed
Then open the GA4 debugger and see that events and values are coming through as well

But this is kinda messy and most people don't have permission for it. 

Plus I already did testing and verified results with Aleks

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
