### PR TITLE
Add Anytime Actions with Non-Essential questions

### DIFF
--- a/content/src/anytime-action-tasks/demo-only.md
+++ b/content/src/anytime-action-tasks/demo-only.md
@@ -1,0 +1,18 @@
+---
+notesMd: This Anytime Action is for demo purposes only. It is being used by the
+  "demo only" industry to illustrate a non-essential question adding an Anytime
+  Action.
+id: demo-only
+name: Demo Anytime Action
+category:
+  - apply-for-state-funding
+description: Example description information.
+industryIds: []
+sectorIds: []
+urlSlug: demo-only
+summaryDescriptionMd: This Anytime Action is for demo purposes only. It is being
+  used by the "demo only" industry to illustrate a non-essential question adding
+  an Anytime Action.
+---
+
+This Anytime Action is for demo purposes only. It is being used by the "demo only" industry to illustrate a non-essential question adding an Anytime Action.

--- a/content/src/roadmaps/industries/demo-only.json
+++ b/content/src/roadmaps/industries/demo-only.json
@@ -21,7 +21,10 @@
     }
   ],
   "name": "Demo Only",
-  "nonEssentialQuestionsIds": ["weights-measures"],
+  "nonEssentialQuestionsIds": [
+    "weights-measures",
+    "demo-only"
+  ],
   "displayname": "Demo Only",
   "industryOnboardingQuestions": {
     "canBeHomeBased": false,

--- a/content/src/roadmaps/nonEssentialQuestions.json
+++ b/content/src/roadmaps/nonEssentialQuestions.json
@@ -204,6 +204,12 @@
       "addOn": "vehicle-cpcn",
       "questionText": "“Will your business provide intrastate transportation of passengers to and from **casinos in Atlantic city,** or **in exchange for compensation** from passengers or groups?”",
       "id": "mvc-cpcn"
+    },
+    {
+      "id": "demo-only",
+      "questionText": "You are a demo industry user. This is an example non-essential question that is being used to add an Anytime Action. Answering \"yes\" will add the Anytime Action \"Demo Anytime Action\".",
+      "addOn": "",
+      "anytimeActions": ["demo-only"]
     }
   ]
 }

--- a/web/decap-config/collections/05-roadmap.yml
+++ b/web/decap-config/collections/05-roadmap.yml
@@ -308,12 +308,28 @@ collections:
                 widget: markdown
               - label: Add On
                 name: addOn
+                required: false
                 widget: "relation"
+                default: []
                 collection: "addons"
-                search_fields: ["{{displayname}}"]
+                search_fields: [displayname]
                 value_field: "{{fields.id}}"
-                display_fields: ["{{displayname}}"]
-                options_length: 500
+                display_fields: [displayname]
+                options_length: 9999
+              - label: Anytime Actions Tasks
+                name: anytimeActions
+                hint: Anytime Actions related to reinstatements are not included in this dropdown
+                required: false
+                default: []
+                widget: relation
+                collection: anytime-action-tasks
+                multiple: true
+                search_fields:
+                  - name
+                value_field: "{{fields.id}}"
+                display_fields:
+                  - name
+                options_length: 9999
 
   - name: "settings"
     label: "Roadmaps - Settings"

--- a/web/src/components/dashboard/AnytimeActionDropdown.test.tsx
+++ b/web/src/components/dashboard/AnytimeActionDropdown.test.tsx
@@ -41,6 +41,7 @@ const mockAnalytics = analytics as jest.Mocked<typeof analytics>;
 
 describe("<AnytimeActionDropdown />", () => {
   let anytimeActionTasks: AnytimeActionTask[] = [];
+  let anytimeActionTasksFromNonEssentialQuestions: AnytimeActionTask[] = [];
   let anytimeActionLicenseReinstatement: AnytimeActionLicenseReinstatement[] = [];
 
   const taskName = "some-task-name";
@@ -106,6 +107,7 @@ describe("<AnytimeActionDropdown />", () => {
       render(
         <AnytimeActionDropdown
           anytimeActionTasks={anytimeActionTasks}
+          anytimeActionTasksFromNonEssentialQuestions={anytimeActionTasksFromNonEssentialQuestions}
           anytimeActionLicenseReinstatements={anytimeActionLicenseReinstatement}
         />,
       );
@@ -229,6 +231,7 @@ describe("<AnytimeActionDropdown />", () => {
       render(
         <AnytimeActionDropdown
           anytimeActionTasks={anytimeActionTasks}
+          anytimeActionTasksFromNonEssentialQuestions={anytimeActionTasksFromNonEssentialQuestions}
           anytimeActionLicenseReinstatements={anytimeActionLicenseReinstatement}
         />,
       );
@@ -394,180 +397,202 @@ describe("<AnytimeActionDropdown />", () => {
       expect(screen.queryByText("license - hvac-reinstatement")).not.toBeInTheDocument();
     });
 
-    it("adds vacant property anytime action for vacant property owners", () => {
-      anytimeActionTasks = [
-        generateAnytimeActionTask({ filename: "vacant-building-fire-permit" }),
-        ...anytimeActionTasks,
-      ];
-      useMockBusiness({
-        profileData: generateProfileData({
-          vacantPropertyOwner: false,
-        }),
-      });
-      renderAnytimeActionDropdown();
-      fireEvent.click(screen.getByLabelText("Open"));
-      expect(screen.queryByTestId("vacant-building-fire-permit-option")).not.toBeInTheDocument();
+    describe("non essential questions", () => {
+      it("duplicate Anytime Actions added via non-essential questions are removed", () => {
+        const duplicateAnytimeAction = generateAnytimeActionTask({
+          filename: "same-anytime-action",
+          name: "same-anytime-action",
+        });
 
-      useMockBusiness({
-        profileData: generateProfileData({
-          vacantPropertyOwner: true,
-        }),
-      });
-      renderAnytimeActionDropdown();
-      fireEvent.click(screen.getByLabelText("Open"));
-      expect(screen.getByTestId("vacant-building-fire-permit-option")).toBeInTheDocument();
-    });
+        anytimeActionTasks = [duplicateAnytimeAction, ...anytimeActionTasks];
+        anytimeActionTasksFromNonEssentialQuestions = [duplicateAnytimeAction];
 
-    it("adds fire carnival modification for carnival ride owning businesses", () => {
-      anytimeActionTasks = [
-        generateAnytimeActionTask({ filename: "carnival-ride-supplemental-modification" }),
-        ...anytimeActionTasks,
-      ];
-      useMockBusiness({
-        profileData: generateProfileData({
-          carnivalRideOwningBusiness: false,
-        }),
+        renderAnytimeActionDropdown();
+        fireEvent.click(screen.getByLabelText("Open"));
+        expect(screen.getAllByText("same-anytime-action").length).toBe(1);
       });
-      renderAnytimeActionDropdown();
-      fireEvent.click(screen.getByLabelText("Open"));
-      expect(
-        screen.queryByTestId("carnival-ride-supplemental-modification-option"),
-      ).not.toBeInTheDocument();
 
-      useMockBusiness({
-        profileData: generateProfileData({
-          carnivalRideOwningBusiness: true,
-        }),
-      });
-      renderAnytimeActionDropdown();
-      fireEvent.click(screen.getByLabelText("Open"));
-      expect(
-        screen.getByTestId("carnival-ride-supplemental-modification-option"),
-      ).toBeInTheDocument();
-    });
+      it("adds vacant property anytime action for vacant property owners", () => {
+        anytimeActionTasks = [
+          generateAnytimeActionTask({ filename: "vacant-building-fire-permit" }),
+          ...anytimeActionTasks,
+        ];
+        useMockBusiness({
+          profileData: generateProfileData({
+            vacantPropertyOwner: false,
+          }),
+        });
+        renderAnytimeActionDropdown();
+        fireEvent.click(screen.getByLabelText("Open"));
+        expect(screen.queryByTestId("vacant-building-fire-permit-option")).not.toBeInTheDocument();
 
-    it("adds operating carnival fire permit for carnival owning businesses", () => {
-      anytimeActionTasks = [
-        generateAnytimeActionTask({ filename: "operating-carnival-fire-permit" }),
-        ...anytimeActionTasks,
-      ];
-      useMockBusiness({
-        profileData: generateProfileData({
-          carnivalRideOwningBusiness: false,
-          travelingCircusOrCarnivalOwningBusiness: false,
-        }),
+        useMockBusiness({
+          profileData: generateProfileData({
+            vacantPropertyOwner: true,
+          }),
+        });
+        renderAnytimeActionDropdown();
+        fireEvent.click(screen.getByLabelText("Open"));
+        expect(screen.getByTestId("vacant-building-fire-permit-option")).toBeInTheDocument();
       });
-      renderAnytimeActionDropdown();
-      fireEvent.click(screen.getByLabelText("Open"));
-      expect(screen.queryByTestId("operating-carnival-fire-permit-option")).not.toBeInTheDocument();
 
-      useMockBusiness({
-        profileData: generateProfileData({
-          carnivalRideOwningBusiness: true,
-          travelingCircusOrCarnivalOwningBusiness: false,
-        }),
-      });
-      renderAnytimeActionDropdown();
-      fireEvent.click(screen.getByLabelText("Open"));
-      expect(screen.getByTestId("operating-carnival-fire-permit-option")).toBeInTheDocument();
-    });
+      it("adds fire carnival modification for carnival ride owning businesses", () => {
+        anytimeActionTasks = [
+          generateAnytimeActionTask({ filename: "carnival-ride-supplemental-modification" }),
+          ...anytimeActionTasks,
+        ];
+        useMockBusiness({
+          profileData: generateProfileData({
+            carnivalRideOwningBusiness: false,
+          }),
+        });
+        renderAnytimeActionDropdown();
+        fireEvent.click(screen.getByLabelText("Open"));
+        expect(
+          screen.queryByTestId("carnival-ride-supplemental-modification-option"),
+        ).not.toBeInTheDocument();
 
-    it("adds operating carnival fire permit for traveling circus or carnival owning businesses", () => {
-      anytimeActionTasks = [
-        generateAnytimeActionTask({ filename: "operating-carnival-fire-permit" }),
-        ...anytimeActionTasks,
-      ];
-      useMockBusiness({
-        profileData: generateProfileData({
-          carnivalRideOwningBusiness: false,
-          travelingCircusOrCarnivalOwningBusiness: false,
-        }),
+        useMockBusiness({
+          profileData: generateProfileData({
+            carnivalRideOwningBusiness: true,
+          }),
+        });
+        renderAnytimeActionDropdown();
+        fireEvent.click(screen.getByLabelText("Open"));
+        expect(
+          screen.getByTestId("carnival-ride-supplemental-modification-option"),
+        ).toBeInTheDocument();
       });
-      renderAnytimeActionDropdown();
-      fireEvent.click(screen.getByLabelText("Open"));
-      expect(screen.queryByTestId("operating-carnival-fire-permit-option")).not.toBeInTheDocument();
 
-      useMockBusiness({
-        profileData: generateProfileData({
-          carnivalRideOwningBusiness: false,
-          travelingCircusOrCarnivalOwningBusiness: true,
-        }),
-      });
-      renderAnytimeActionDropdown();
-      fireEvent.click(screen.getByLabelText("Open"));
-      expect(screen.getByTestId("operating-carnival-fire-permit-option")).toBeInTheDocument();
-    });
+      it("adds operating carnival fire permit for carnival owning businesses", () => {
+        anytimeActionTasks = [
+          generateAnytimeActionTask({ filename: "operating-carnival-fire-permit" }),
+          ...anytimeActionTasks,
+        ];
+        useMockBusiness({
+          profileData: generateProfileData({
+            carnivalRideOwningBusiness: false,
+            travelingCircusOrCarnivalOwningBusiness: false,
+          }),
+        });
+        renderAnytimeActionDropdown();
+        fireEvent.click(screen.getByLabelText("Open"));
+        expect(
+          screen.queryByTestId("operating-carnival-fire-permit-option"),
+        ).not.toBeInTheDocument();
 
-    it("adds operating carnival fire permit for traveling circus or carnival owning businesses based on non-essential question answers", () => {
-      anytimeActionTasks = [
-        generateAnytimeActionTask({ filename: "operating-carnival-fire-permit" }),
-        ...anytimeActionTasks,
-      ];
-      useMockBusiness({
-        profileData: generateProfileData({
-          nonEssentialRadioAnswers: {
-            "carnival-fire-licenses": false,
-            "carnival-ride-permitting": false,
-          },
-          carnivalRideOwningBusiness: false,
-          travelingCircusOrCarnivalOwningBusiness: false,
-        }),
+        useMockBusiness({
+          profileData: generateProfileData({
+            carnivalRideOwningBusiness: true,
+            travelingCircusOrCarnivalOwningBusiness: false,
+          }),
+        });
+        renderAnytimeActionDropdown();
+        fireEvent.click(screen.getByLabelText("Open"));
+        expect(screen.getByTestId("operating-carnival-fire-permit-option")).toBeInTheDocument();
       });
-      renderAnytimeActionDropdown();
-      fireEvent.click(screen.getByLabelText("Open"));
-      expect(screen.queryByTestId("operating-carnival-fire-permit-option")).not.toBeInTheDocument();
 
-      useMockBusiness({
-        profileData: generateProfileData({
-          nonEssentialRadioAnswers: {
-            "carnival-fire-licenses": true,
-            "carnival-ride-permitting": false,
-          },
-          carnivalRideOwningBusiness: false,
-          travelingCircusOrCarnivalOwningBusiness: false,
-        }),
-      });
-      renderAnytimeActionDropdown();
-      fireEvent.click(screen.getByLabelText("Open"));
-      expect(screen.getByTestId("operating-carnival-fire-permit-option")).toBeInTheDocument();
-    });
+      it("adds operating carnival fire permit for traveling circus or carnival owning businesses", () => {
+        anytimeActionTasks = [
+          generateAnytimeActionTask({ filename: "operating-carnival-fire-permit" }),
+          ...anytimeActionTasks,
+        ];
+        useMockBusiness({
+          profileData: generateProfileData({
+            carnivalRideOwningBusiness: false,
+            travelingCircusOrCarnivalOwningBusiness: false,
+          }),
+        });
+        renderAnytimeActionDropdown();
+        fireEvent.click(screen.getByLabelText("Open"));
+        expect(
+          screen.queryByTestId("operating-carnival-fire-permit-option"),
+        ).not.toBeInTheDocument();
 
-    it("adds carnival ride supplemental modification for traveling circus or carnival owning businesses based on non-essential question answers", () => {
-      anytimeActionTasks = [
-        generateAnytimeActionTask({ filename: "carnival-ride-supplemental-modification" }),
-        ...anytimeActionTasks,
-      ];
-      useMockBusiness({
-        profileData: generateProfileData({
-          nonEssentialRadioAnswers: {
-            "carnival-ride-permitting": false,
-            "carnival-fire-licenses": false,
-          },
-          carnivalRideOwningBusiness: false,
-          travelingCircusOrCarnivalOwningBusiness: false,
-        }),
+        useMockBusiness({
+          profileData: generateProfileData({
+            carnivalRideOwningBusiness: false,
+            travelingCircusOrCarnivalOwningBusiness: true,
+          }),
+        });
+        renderAnytimeActionDropdown();
+        fireEvent.click(screen.getByLabelText("Open"));
+        expect(screen.getByTestId("operating-carnival-fire-permit-option")).toBeInTheDocument();
       });
-      renderAnytimeActionDropdown();
-      fireEvent.click(screen.getByLabelText("Open"));
-      expect(
-        screen.queryByTestId("carnival-ride-supplemental-modification-option"),
-      ).not.toBeInTheDocument();
 
-      useMockBusiness({
-        profileData: generateProfileData({
-          nonEssentialRadioAnswers: {
-            "carnival-ride-permitting": true,
-            "carnival-fire-licenses": false,
-          },
-          carnivalRideOwningBusiness: false,
-          travelingCircusOrCarnivalOwningBusiness: false,
-        }),
+      it("adds operating carnival fire permit for traveling circus or carnival owning businesses based on non-essential question answers", () => {
+        anytimeActionTasks = [
+          generateAnytimeActionTask({ filename: "operating-carnival-fire-permit" }),
+          ...anytimeActionTasks,
+        ];
+        useMockBusiness({
+          profileData: generateProfileData({
+            nonEssentialRadioAnswers: {
+              "carnival-fire-licenses": false,
+              "carnival-ride-permitting": false,
+            },
+            carnivalRideOwningBusiness: false,
+            travelingCircusOrCarnivalOwningBusiness: false,
+          }),
+        });
+        renderAnytimeActionDropdown();
+        fireEvent.click(screen.getByLabelText("Open"));
+        expect(
+          screen.queryByTestId("operating-carnival-fire-permit-option"),
+        ).not.toBeInTheDocument();
+
+        useMockBusiness({
+          profileData: generateProfileData({
+            nonEssentialRadioAnswers: {
+              "carnival-fire-licenses": true,
+              "carnival-ride-permitting": false,
+            },
+            carnivalRideOwningBusiness: false,
+            travelingCircusOrCarnivalOwningBusiness: false,
+          }),
+        });
+        renderAnytimeActionDropdown();
+        fireEvent.click(screen.getByLabelText("Open"));
+        expect(screen.getByTestId("operating-carnival-fire-permit-option")).toBeInTheDocument();
       });
-      renderAnytimeActionDropdown();
-      fireEvent.click(screen.getByLabelText("Open"));
-      expect(
-        screen.getByTestId("carnival-ride-supplemental-modification-option"),
-      ).toBeInTheDocument();
+
+      it("adds carnival ride supplemental modification for traveling circus or carnival owning businesses based on non-essential question answers", () => {
+        anytimeActionTasks = [
+          generateAnytimeActionTask({ filename: "carnival-ride-supplemental-modification" }),
+          ...anytimeActionTasks,
+        ];
+        useMockBusiness({
+          profileData: generateProfileData({
+            nonEssentialRadioAnswers: {
+              "carnival-ride-permitting": false,
+              "carnival-fire-licenses": false,
+            },
+            carnivalRideOwningBusiness: false,
+            travelingCircusOrCarnivalOwningBusiness: false,
+          }),
+        });
+        renderAnytimeActionDropdown();
+        fireEvent.click(screen.getByLabelText("Open"));
+        expect(
+          screen.queryByTestId("carnival-ride-supplemental-modification-option"),
+        ).not.toBeInTheDocument();
+
+        useMockBusiness({
+          profileData: generateProfileData({
+            nonEssentialRadioAnswers: {
+              "carnival-ride-permitting": true,
+              "carnival-fire-licenses": false,
+            },
+            carnivalRideOwningBusiness: false,
+            travelingCircusOrCarnivalOwningBusiness: false,
+          }),
+        });
+        renderAnytimeActionDropdown();
+        fireEvent.click(screen.getByLabelText("Open"));
+        expect(
+          screen.getByTestId("carnival-ride-supplemental-modification-option"),
+        ).toBeInTheDocument();
+      });
     });
 
     it("renders an anytime action with a description", () => {

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -8,6 +8,7 @@ import { HideableTasks } from "@/components/dashboard/HideableTasks";
 import { Roadmap } from "@/components/dashboard/Roadmap";
 import { SidebarCardsContainer } from "@/components/dashboard/SidebarCardsContainer";
 import TwoTabDashboardLayout from "@/components/dashboard/TwoTabDashboardLayout";
+import { getAnytimeActionsFromNonEssentialQuestions } from "@/components/dashboard/anytimeActionsBuilder";
 import {
   getPersonalizeTaskButtonTabValue,
   getRoadmapHeadingText,
@@ -71,6 +72,10 @@ export const Dashboard = (props: Props): ReactElement => {
     business?.profileData.homeBasedBusiness === undefined &&
     operatingPhase.displayHomeBasedPrompt;
 
+  const anytimeActionTasksFromNonEssentialQuestions = getAnytimeActionsFromNonEssentialQuestions(
+    business?.profileData,
+    props.anytimeActionTasks,
+  );
   return (
     <>
       {isDesktop ? (
@@ -99,6 +104,9 @@ export const Dashboard = (props: Props): ReactElement => {
                     {operatingPhase.displayAnytimeActions && (
                       <AnytimeActionDropdown
                         anytimeActionTasks={props.anytimeActionTasks}
+                        anytimeActionTasksFromNonEssentialQuestions={
+                          anytimeActionTasksFromNonEssentialQuestions
+                        }
                         anytimeActionLicenseReinstatements={
                           props.anytimeActionLicenseReinstatements
                         }
@@ -162,6 +170,9 @@ export const Dashboard = (props: Props): ReactElement => {
                   {operatingPhase.displayAnytimeActions && (
                     <AnytimeActionDropdown
                       anytimeActionTasks={props.anytimeActionTasks}
+                      anytimeActionTasksFromNonEssentialQuestions={
+                        anytimeActionTasksFromNonEssentialQuestions
+                      }
                       anytimeActionLicenseReinstatements={props.anytimeActionLicenseReinstatements}
                     />
                   )}

--- a/web/src/components/dashboard/anytimeActionsBuilder.test.ts
+++ b/web/src/components/dashboard/anytimeActionsBuilder.test.ts
@@ -1,0 +1,61 @@
+import { getAnytimeActionsFromNonEssentialQuestions } from "@/components/dashboard/anytimeActionsBuilder";
+import { generateAnytimeActionTask } from "@/test/factories";
+import { generateProfileData } from "@businessnjgovnavigator/shared/test";
+
+const anytimeActionsTasks = [
+  generateAnytimeActionTask({ filename: "anytime-action-1" }),
+  generateAnytimeActionTask({ filename: "anytime-action-2" }),
+  generateAnytimeActionTask({ filename: "anytime-action-3" }),
+];
+
+jest.mock("../../../../content/src/roadmaps/nonEssentialQuestions.json", () => ({
+  nonEssentialQuestionsArray: [
+    {
+      id: "test-non-essential-question-1",
+      questionText: "Test Question?",
+      anytimeActions: ["anytime-action-2"],
+    },
+    {
+      id: "test-non-essential-questio-2",
+      questionText: "Test Question?",
+      anytimeActions: ["anytime-action-3"],
+    },
+  ],
+}));
+
+describe("anytimeActionsBuilder", () => {
+  describe("getAnytimeActionsFromNonEssentialQuestions", () => {
+    it("should not return Anytime Actions if profileData is undefined", () => {
+      const returnValue = getAnytimeActionsFromNonEssentialQuestions(
+        undefined,
+        anytimeActionsTasks,
+      );
+      expect(returnValue).toEqual([]);
+    });
+
+    it("should not return Anytime Actions if the user has not answered Non-Essential questions", () => {
+      const profileData = generateProfileData({ nonEssentialRadioAnswers: {} });
+
+      const returnValue = getAnytimeActionsFromNonEssentialQuestions(
+        profileData,
+        anytimeActionsTasks,
+      );
+      expect(returnValue).toEqual([]);
+    });
+
+    it("should return Anytime Actions corresponding to the answered Non-Essential questions", () => {
+      const profileData = generateProfileData({
+        nonEssentialRadioAnswers: {
+          "test-non-essential-question-1": true,
+          "test-non-essential-question-2": false,
+        },
+      });
+
+      const returnValue = getAnytimeActionsFromNonEssentialQuestions(
+        profileData,
+        anytimeActionsTasks,
+      );
+      expect(returnValue).toEqual([anytimeActionsTasks[1]]);
+    });
+  });
+});

--- a/web/src/components/dashboard/anytimeActionsBuilder.ts
+++ b/web/src/components/dashboard/anytimeActionsBuilder.ts
@@ -1,0 +1,30 @@
+import { getNonEssentialQuestionAnytimeActions } from "@/lib/domain-logic/getNonEssentialQuestionAnytimeActions";
+import { AnytimeActionTask } from "@/lib/types/types";
+import { ProfileData } from "@businessnjgovnavigator/shared/profileData";
+
+export const getAnytimeActionsFromNonEssentialQuestions = (
+  profileData: ProfileData | undefined,
+  allAnytimeActionTasks: AnytimeActionTask[],
+): AnytimeActionTask[] => {
+  if (!profileData) return [];
+  if (Object.keys(profileData.nonEssentialRadioAnswers).length === 0) return [];
+
+  const anytimeActionIds = anytimeActionsToAdd(profileData.nonEssentialRadioAnswers);
+  const anytimeActionsFromNonEssentialQuestions = allAnytimeActionTasks.filter((anytimeAction) =>
+    anytimeActionIds.includes(anytimeAction.filename),
+  );
+
+  return anytimeActionsFromNonEssentialQuestions;
+};
+
+const anytimeActionsToAdd = (
+  nonEssentialRadioAnswers: Record<string, boolean | undefined>,
+): string[] => {
+  let anytimeActionIds: string[] = [];
+
+  for (const questionId in nonEssentialRadioAnswers) {
+    const anytimeActionId = getNonEssentialQuestionAnytimeActions(questionId);
+    anytimeActionIds = [...anytimeActionIds, ...anytimeActionId];
+  }
+  return anytimeActionIds;
+};

--- a/web/src/lib/domain-logic/getNonEssentialQuestionAnytimeActions.test.ts
+++ b/web/src/lib/domain-logic/getNonEssentialQuestionAnytimeActions.test.ts
@@ -1,0 +1,43 @@
+import { getNonEssentialQuestionAnytimeActions } from "@/lib/domain-logic/getNonEssentialQuestionAnytimeActions";
+
+jest.mock("../../../../content/src/roadmaps/nonEssentialQuestions.json", () => ({
+  nonEssentialQuestionsArray: [
+    {
+      id: "test-non-essential",
+      questionText: "Test Question?",
+      anytimeActions: ["Action 1", "Action 2"],
+    },
+    {
+      id: "test-non-essential-1",
+      questionText: "Test Question?",
+    },
+    {
+      id: "test-non-essential-2",
+      questionText: "Test Question?",
+      anytimeActions: [],
+    },
+  ],
+}));
+
+describe("getNonEssentialQuestionAnytimeActions", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("returns the associated Anytime Actions if essential question exists", () => {
+    expect(getNonEssentialQuestionAnytimeActions("test-non-essential")).toEqual([
+      "Action 1",
+      "Action 2",
+    ]);
+  });
+
+  it("returns an empty array if question does not contain Anytime Actions", () => {
+    expect(getNonEssentialQuestionAnytimeActions("test-non-essential-1")).toEqual([]);
+
+    expect(getNonEssentialQuestionAnytimeActions("test-non-essential-2")).toEqual([]);
+  });
+
+  it("returns an empty array if question doesn't exist", () => {
+    expect(getNonEssentialQuestionAnytimeActions("does-not-exist")).toEqual([]);
+  });
+});

--- a/web/src/lib/domain-logic/getNonEssentialQuestionAnytimeActions.ts
+++ b/web/src/lib/domain-logic/getNonEssentialQuestionAnytimeActions.ts
@@ -1,0 +1,9 @@
+import NonEssentialQuestions from "@businessnjgovnavigator/content/roadmaps/nonEssentialQuestions.json";
+
+export const getNonEssentialQuestionAnytimeActions = (nonEssentialQuestionId: string): string[] => {
+  return (
+    NonEssentialQuestions.nonEssentialQuestionsArray.find((questionObj) => {
+      return questionObj.id === nonEssentialQuestionId;
+    })?.anytimeActions ?? []
+  );
+};

--- a/web/src/lib/static/loadAnytimeActionTasks.test.ts
+++ b/web/src/lib/static/loadAnytimeActionTasks.test.ts
@@ -82,6 +82,7 @@ describe("loadAnytimeActionTasks", () => {
             callToActionLink: "CallToActionLink1",
             callToActionText: "CallToActionText1",
             form: "Form1",
+            type: "task",
             category: [
               {
                 categoryId: "test-cat",
@@ -98,6 +99,7 @@ describe("loadAnytimeActionTasks", () => {
             callToActionLink: "CallToActionLink2",
             callToActionText: "CallToActionText2",
             form: "Form2",
+            type: "task",
             category: [
               {
                 categoryId: "test-cat",
@@ -166,6 +168,7 @@ describe("loadAnytimeActionTasks", () => {
         callToActionLink: "CallToActionLink2",
         callToActionText: "CallToActionText2",
         form: "Form2",
+        type: "task",
         category: [
           {
             categoryId: "test-cat",

--- a/web/src/lib/static/loadAnytimeActionTasks.ts
+++ b/web/src/lib/static/loadAnytimeActionTasks.ts
@@ -59,7 +59,7 @@ export const loadAnytimeActionTaskByUrlSlug = (
   return loadAnytimeActionTasksByFileName(matchingFileName, isTest);
 };
 
-const loadAnytimeActionTasksByFileName = (
+export const loadAnytimeActionTasksByFileName = (
   fileName: string,
   isTest: boolean = false,
 ): AnytimeActionTask => {

--- a/web/src/lib/types/types.ts
+++ b/web/src/lib/types/types.ts
@@ -176,6 +176,7 @@ export interface AnytimeActionTask extends AnytimeAction {
   contentMd: string;
   description?: string;
   searchMetaDataMatch?: string;
+  type: string;
 }
 
 export interface AnytimeActionCategory {

--- a/web/src/lib/utils/tasksMarkdownReader.ts
+++ b/web/src/lib/utils/tasksMarkdownReader.ts
@@ -29,6 +29,7 @@ export const convertAnytimeActionTaskMd = (
     filename,
     ...anytimeActionGrayMatter,
     category: newAnytimeActionCategoriesData,
+    type: "task",
   };
 };
 

--- a/web/test/demoOnly.test.ts
+++ b/web/test/demoOnly.test.ts
@@ -1,0 +1,39 @@
+import { loadAnytimeActionTasksByFileName } from "@/lib/static/loadAnytimeActionTasks";
+import { nonEssentialQuestionsArray } from "../../content/src/roadmaps/nonEssentialQuestions.json";
+import { LookupIndustryById } from "../../shared/lib/shared/src";
+
+/*
+ * Special test cases to ensure that demo-only content is not used in production
+ */
+describe("demo-only", () => {
+  describe("industry", () => {
+    it("demo-only industry should always be disabled", () => {
+      expect(LookupIndustryById("demo-only").isEnabled).toBe(false);
+    });
+  });
+
+  describe("Non-Essential Question", () => {
+    it("should be the only non-essential question to contain the demo-only Anytime Action", () => {
+      const nonDemoOnlyQuestions = nonEssentialQuestionsArray.filter(
+        (question) => question.id !== "demo-only",
+      );
+      for (const question of nonDemoOnlyQuestions) {
+        expect(question?.anytimeActions ?? []).not.toContain("demo-only");
+      }
+
+      const demoOnlyQuestion = nonEssentialQuestionsArray.find(
+        (question) => question.id === "demo-only",
+      );
+      expect(demoOnlyQuestion?.anytimeActions).toContain("demo-only");
+    });
+  });
+
+  describe("Anytime Action", () => {
+    it("should not appear for any industry or sector", () => {
+      const demoAnytimeAction = loadAnytimeActionTasksByFileName("demo-only.md", true);
+
+      expect(demoAnytimeAction.industryIds.length).toBe(0);
+      expect(demoAnytimeAction.sectorIds.length).toBe(0);
+    });
+  });
+});

--- a/web/test/factories.ts
+++ b/web/test/factories.ts
@@ -321,6 +321,7 @@ export const generateAnytimeActionTask = (
   return {
     filename: `some-filename-${randomInt()}`,
     name: `some-name-${randomInt()}`,
+    type: "task",
     category: [
       { categoryName: `Category ${randomInt()}`, categoryId: `something-${randomInt()}-something` },
     ],


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Users of particular industries are presented with Non-Essential Questions in their Business Profile. Answers to these questions may modify their experience most commonly by adding tasks to their roadmap. This work allows content team members to also add Anytime Actions the same way they may include a roadmap `addOn` to appear to a user.

### Ticket

This pull request resolves [#15159](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15159).

### Approach

**CMS Changes**
A content team member can add a series of Anytime Actions to a Non-Essential Question.

- Updated the CMS config to include Anytime Action Tasks as a multi-select in the Non-Essential Questions collection
- Added `Anytime Actions[]` to the Non-Essential Question type definition

**End User Changes**
When a user answers "yes" to a Non-Essential Question in their profile with associated Anytime Actions, these Anytime Actions will appear on their dashboard in the Anytime Action dropdown.

- I created something I'm calling `anytimeActionsBuilder` which, longer term, I envision being similar to the `roadmapBuilder`. This is responsible for checking if the user has responded "yes" to any Non-Essential questions, checks if the question has Anytime Actions, and returns them as a list.
  - I purposefully did not include this logic in the `AnytimeActionDropdown` to try and keep that component ignorant to `userData`.
- The `AnytimeActionDropdown` accepts the list of Anytime Actions as a 3rd set of Anytime Actions (in addition to the complete list of AA Tasks and AA Reinstatements). It then de-duplicates in the case an Anytime Action would have otherwise been in one of the other lists already.

I also added some demo-only resources. We already have a "Demo Only" industry. This adds a demo-only Non-Essential Question and Anytime Action. I created some tests to hopefully ensure that no user ever actually sees this fake content.

### Steps to Test

- CMS users should be able to modify a Non-Essential Question to include a list of Anytime Actions
- My Account users who see that Non-Essential Question (in the same industry) should be able to answer "yes" and see the associated question
- Answering "no" should remove the Anytime Action

If you use the "Demo Only" industry there is already a demo Non-Essential Question with a demo Anytime Action which will allow you to test this behavior.

### Notes

As we move towards a place where content is "written once, available everywhere" I'm hoping that the `anytimeActionBuilder` might help us rethink the way we approach our Anytime Actions. I could see this and the `roadmapBuilder` getting consolidated into shared resources.

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
