### PR TITLE
fix: resolve webservice/formation bug

### DIFF
--- a/api/src/client/ApiFormationHealth.ts
+++ b/api/src/client/ApiFormationHealth.ts
@@ -110,6 +110,7 @@ const formationData: FormationData = {
     contactFirstName: "some-contact-first-name-15248752",
     contactLastName: "some-contact-last-name-97216646",
     contactPhoneNumber: "6092926748",
+    contactEmail: "some-contact-email@email.com",
     withdrawals: "some-withdrawals-text-62080960",
     dissolution: "some-dissolution-text-69760616",
     combinedInvestment: "some-combinedInvestment-text-57158048",

--- a/shared/src/formationData.ts
+++ b/shared/src/formationData.ts
@@ -177,6 +177,7 @@ export interface FormationFormData extends FormationAddress {
   readonly contactFirstName: string;
   readonly contactLastName: string;
   readonly contactPhoneNumber: string;
+  readonly contactEmail: string;
   readonly foreignStateOfFormation: StateNames | undefined;
   readonly foreignDateOfFormation: string | undefined; // YYYY-MM-DD
   readonly willPracticeLaw: boolean | undefined;
@@ -313,6 +314,7 @@ export const createEmptyFormationFormData = (): FormationFormData => {
     contactFirstName: "",
     contactLastName: "",
     contactPhoneNumber: "",
+    contactEmail: "",
     foreignDateOfFormation: undefined,
     foreignStateOfFormation: undefined,
     willPracticeLaw: false,

--- a/shared/src/test/formationFactories.ts
+++ b/shared/src/test/formationFactories.ts
@@ -247,6 +247,7 @@ export const generateFormationFormData = (
     contactFirstName: `some-contact-first-name-${randomInt()}`,
     contactLastName: `some-contact-last-name-${randomInt()}`,
     contactPhoneNumber: `some-contact-phone-number-${randomInt()}`,
+    contactEmail: `some-contact-email-${randomInt()}@gmail.com`,
     withdrawals: `some-withdrawals-text-${randomInt()}`,
     dissolution: `some-dissolution-text-${randomInt()}`,
     combinedInvestment: `some-combinedInvestment-text-${randomInt()}`,


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

This change addresses the health check error from the Formation service. The Formation endpoint expects a contactEmail to be included in the request body, but our healthCheck function was not providing it.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#0000](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000).

### Approach

Updated the health check logic to include a placeholder contactEmail in the request body when checking the Formation service. Without the contactEmail, the Formation service responds with an error, causing the health check to fail. This update ensures the expected field is passed, allowing the health check to complete successfully.

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
