### PR TITLE
fix: [AB#15014] Resolve Untracked Sections in CMS

### DIFF
--- a/content/src/renewal-calendar-events/xray-renewal.md
+++ b/content/src/renewal-calendar-events/xray-renewal.md
@@ -1,6 +1,6 @@
 ---
 id: xray-renewal
-filename: xray-calendar-event
+filename: xray-renewal
 displayname: xray-renewal
 urlSlug: xray-renewal
 name: Renew Your X-Ray Machine Registration

--- a/content/src/renewal-calendar-events/xray-renewal.md
+++ b/content/src/renewal-calendar-events/xray-renewal.md
@@ -1,6 +1,6 @@
 ---
 id: xray-renewal
-filename: xray-renewal
+filename: xray-calendar-event
 displayname: xray-renewal
 urlSlug: xray-renewal
 name: Renew Your X-Ray Machine Registration

--- a/web/decap-config/collections/08-calendar.yml
+++ b/web/decap-config/collections/08-calendar.yml
@@ -227,7 +227,7 @@ collections:
     create: false
     files:
       - label: "Xray Renewal Calendar Event"
-        name: "xray-calendar-event"
+        name: "xray-renewal"
         file: "content/src/renewal-calendar-events/xray-renewal.md"
         editor:
           preview: true

--- a/web/src/lib/search/searchBusinessFormation.ts
+++ b/web/src/lib/search/searchBusinessFormation.ts
@@ -1,0 +1,38 @@
+import { findMatchInLabelledText } from "@/lib/search/helpers";
+import { Match } from "@/lib/search/typesForSearch";
+import { TaskWithoutLinks } from "@/lib/types/types";
+
+export const searchBusinessFormation = (
+  tasks: TaskWithoutLinks[],
+  term: string,
+  cmsCollectionName: string,
+): Match[] => {
+  const matches: Match[] = [];
+
+  for (const task of tasks) {
+    let match: Match = {
+      filename: task.id,
+      snippets: [],
+      cmsCollectionName: cmsCollectionName,
+    };
+
+    const name = task.name.toLowerCase();
+    const description = task.summaryDescriptionMd.toLowerCase();
+    const contentMd = task.contentMd?.toLowerCase() ?? "";
+    const callToActionText = task.callToActionText?.toLowerCase() ?? "";
+    const labelledTexts = [
+      { content: name, label: "Name" },
+      { content: description, label: "Summary" },
+      { content: contentMd, label: "Content" },
+      { content: callToActionText, label: "CTA Text" },
+    ];
+
+    match = findMatchInLabelledText(labelledTexts, term, match);
+
+    if (match.snippets.length > 0) {
+      matches.push(match);
+    }
+  }
+
+  return matches;
+};

--- a/web/src/lib/search/searchRenewalCalendarEvents.ts
+++ b/web/src/lib/search/searchRenewalCalendarEvents.ts
@@ -20,6 +20,7 @@ export const searchXrayRenewalCalendarEvent = (
   const callToActionText = renewalCalendarEvent.callToActionText?.toLowerCase();
   const urlSlug = renewalCalendarEvent.urlSlug.toLowerCase();
   const eventDisplayName = renewalCalendarEvent.eventDisplayName.toLowerCase();
+  const name = renewalCalendarEvent.name.toLowerCase();
 
   const blockTexts = [content];
 
@@ -29,6 +30,7 @@ export const searchXrayRenewalCalendarEvent = (
     { content: callToActionText, label: "CTA Text" },
     { content: urlSlug, label: "Url Slug" },
     { content: eventDisplayName, label: "Event Display Name" },
+    { content: name, label: "Name" },
   ];
 
   match = findMatchInBlock(blockTexts, term, match);


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
Certain collections were not showing up in the search result including "Biz Form - DBA Tasks ", "Xray Renewal Calendar and Event", "Roadmaps - Industries"

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#15014](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15014).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
For "Roadmaps - Industries" I added the to the roadmapsCollection so when passed it would be rendered.
For "Xray Renewal Calendar Event", I corrected the incorrectly name filename so it would directed to page
For Business formation, I implemented search function and rendered the matches

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->
Enter "register your business name"
It will output related pages from business formation

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
