### PR TITLE
fix: remove duplicate CMS config field

### DIFF
--- a/web/decap-config/collections/02-environmental-compliance.yml
+++ b/web/decap-config/collections/02-environmental-compliance.yml
@@ -30,7 +30,6 @@ collections:
                   - { label: Button Text, name: buttonText, widget: string }
                   - { label: Back Button Text, name: backButtonText, widget: string }
                   - { label: Error Text, name: errorText, widget: string }
-                  - { label: Footer Text, name: footerText, widget: string }
                   - {
                       label: Aria Context Inline Dialog Inactive,
                       name: ariaContextInlineDialogInactive,


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#0000](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
