### PR TITLE
Remove anytime actions when users answer 'no' to non-essential questions

### DIFF
--- a/web/src/components/dashboard/anytimeActionsBuilder.test.ts
+++ b/web/src/components/dashboard/anytimeActionsBuilder.test.ts
@@ -16,7 +16,7 @@ jest.mock("../../../../content/src/roadmaps/nonEssentialQuestions.json", () => (
       anytimeActions: ["anytime-action-2"],
     },
     {
-      id: "test-non-essential-questio-2",
+      id: "test-non-essential-question-2",
       questionText: "Test Question?",
       anytimeActions: ["anytime-action-3"],
     },
@@ -43,10 +43,25 @@ describe("anytimeActionsBuilder", () => {
       expect(returnValue).toEqual([]);
     });
 
-    it("should return Anytime Actions corresponding to the answered Non-Essential questions", () => {
+    it("should return Anytime Actions corresponding to the Non-Essential questions answered 'yes'", () => {
       const profileData = generateProfileData({
         nonEssentialRadioAnswers: {
           "test-non-essential-question-1": true,
+          "test-non-essential-question-2": true,
+        },
+      });
+
+      const returnValue = getAnytimeActionsFromNonEssentialQuestions(
+        profileData,
+        anytimeActionsTasks,
+      );
+      expect(returnValue).toEqual([anytimeActionsTasks[1], anytimeActionsTasks[2]]);
+    });
+
+    it("should not return Anytime Actions corresponding to the Non-Essential questions answered 'no'", () => {
+      const profileData = generateProfileData({
+        nonEssentialRadioAnswers: {
+          "test-non-essential-question-1": false,
           "test-non-essential-question-2": false,
         },
       });
@@ -55,7 +70,7 @@ describe("anytimeActionsBuilder", () => {
         profileData,
         anytimeActionsTasks,
       );
-      expect(returnValue).toEqual([anytimeActionsTasks[1]]);
+      expect(returnValue).toEqual([]);
     });
   });
 });

--- a/web/src/components/dashboard/anytimeActionsBuilder.ts
+++ b/web/src/components/dashboard/anytimeActionsBuilder.ts
@@ -22,9 +22,11 @@ const anytimeActionsToAdd = (
 ): string[] => {
   let anytimeActionIds: string[] = [];
 
-  for (const questionId in nonEssentialRadioAnswers) {
-    const anytimeActionId = getNonEssentialQuestionAnytimeActions(questionId);
-    anytimeActionIds = [...anytimeActionIds, ...anytimeActionId];
+  for (const [questionId, response] of Object.entries(nonEssentialRadioAnswers)) {
+    if (response) {
+      const anytimeActionId = getNonEssentialQuestionAnytimeActions(questionId);
+      anytimeActionIds = [...anytimeActionIds, ...anytimeActionId];
+    }
   }
   return anytimeActionIds;
 };


### PR DESCRIPTION
## Description

The previous PR #10766 incorrectly added anytime actions if the user had provided any answer to a non-essential question. This work properly removes the anytime action if the user responds "no".

### Ticket

This pull request resolves [#15159](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15159).

### Steps to Test

See "Steps to Test" in #10766. 

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
