### PR TITLE
chore: add log statement to determine if  accessToken is defined

### DIFF
--- a/api/src/client/dynamics/license-status/RegulatedBusinessDynamicsLicenseHealthCheckClient.ts
+++ b/api/src/client/dynamics/license-status/RegulatedBusinessDynamicsLicenseHealthCheckClient.ts
@@ -16,13 +16,10 @@ export const RegulatedBusinessDynamicsLicenseHealthCheckClient = (
   return async (): Promise<HealthCheckMetadata> => {
     const logId = logWriter.GetId();
     try {
-      logWriter.LogInfo(
-        `RGB Dynamics License Status Health Check - Id:${logId} - Request Sent to ${config.orgUrl}/api/data/v9.2/accounts?$top=1`,
-      );
       const accessToken = await config.accessTokenClient.getAccessToken();
 
-      if (!accessToken) {
-        logWriter.LogError(`RGB Dynamics - Access token is undefined. Skipping request.`);
+      if (!accessToken || accessToken === "undefined") {
+        logWriter.LogError(`Access token is undefined or invalid. Skipping Dynamics request.`);
         return {
           success: false,
           error: {
@@ -31,6 +28,13 @@ export const RegulatedBusinessDynamicsLicenseHealthCheckClient = (
           },
         };
       }
+      logWriter.LogInfo(
+        `RGB Dynamics License Status Health Check - Id:${logId} - Access Token retrieved successfully.`,
+      );
+
+      logWriter.LogInfo(
+        `RGB Dynamics License Status Health Check - Id:${logId} - Request Sent to ${config.orgUrl}/api/data/v9.2/accounts?$top=1`,
+      );
       const response = await axios.get(`${config.orgUrl}/api/data/v9.2/accounts?$top=1`, {
         headers: {
           Authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description


Added a log to continue with the debugging efforts on this issue with RGBDynamicsLicense.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#0000](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
