### PR TITLE
Add Non Essential Questions to industry sectors

### DIFF
--- a/content/src/mappings/sectors.json
+++ b/content/src/mappings/sectors.json
@@ -2,103 +2,128 @@
   "arrayOfSectors": [
     {
       "id": "accommodation-and-food-services",
-      "name": "Accommodation and Food Services"
+      "name": "Accommodation and Food Services",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "administrative-and-employment-services",
-      "name": "Administrative and Employment Services"
+      "name": "Administrative and Employment Services",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "agriculture-forestry-fishing-and-hunting",
-      "name": "Agriculture, Forestry, Fishing and Hunting"
+      "name": "Agriculture, Forestry, Fishing and Hunting",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "arts-entertainment-and-recreation",
-      "name": "Arts, Entertainment, and Recreation"
+      "name": "Arts, Entertainment, and Recreation",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "cannabis",
-      "name": "Cannabis"
+      "name": "Cannabis",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "clean-energy",
-      "name": "Clean Energy"
+      "name": "Clean Energy",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "construction",
-      "name": "Construction"
+      "name": "Construction",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "digital-and-print-media",
-      "name": "Digital and Print Media"
+      "name": "Digital and Print Media",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "educational-services",
-      "name": "Educational Services"
+      "name": "Educational Services",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "finance-and-insurance",
-      "name": "Finance and Insurance"
+      "name": "Finance and Insurance",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "health-care-and-social-assistance",
-      "name": "Health Care and Social Assistance"
+      "name": "Health Care and Social Assistance",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "life-sciences",
-      "name": "Life Sciences"
+      "name": "Life Sciences",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "manufacturing",
-      "name": "Manufacturing"
+      "name": "Manufacturing",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "mining-quarrying-and-oil-and-gas-extraction",
-      "name": "Mining, Quarrying, and Oil and Gas Extraction"
+      "name": "Mining, Quarrying, and Oil and Gas Extraction",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "offshore-wind",
-      "name": "Offshore Wind"
+      "name": "Offshore Wind",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "organizational-or-financial-management",
-      "name": "Organizational or Financial Management Companies"
+      "name": "Organizational or Financial Management Companies",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "other-services",
-      "name": "Other Services"
+      "name": "Other Services",
+      "nonEssentialQuestionsIds": ["resale-tax-cert"]
     },
     {
       "id": "professional-scientific-and-technical-services",
-      "name": "Professional, Scientific, and Technical Services"
+      "name": "Professional, Scientific, and Technical Services",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "real-estate",
-      "name": "Real Estate and Leasing"
+      "name": "Real Estate and Leasing",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "retail-trade-and-ecommerce",
-      "name": "Retail Trade and E-Commerce"
+      "name": "Retail Trade and E-Commerce",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "technology",
-      "name": "Technology"
+      "name": "Technology",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "transportation-and-warehousing",
-      "name": "Transportation and Warehousing"
+      "name": "Transportation and Warehousing",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "utilities",
-      "name": "Utilities"
+      "name": "Utilities",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "waste-management-and-Remediation",
-      "name": "Waste Management and Remediation"
+      "name": "Waste Management and Remediation",
+      "nonEssentialQuestionsIds": []
     },
     {
       "id": "wholesale-trade",
-      "name": "Wholesale Trade"
+      "name": "Wholesale Trade",
+      "nonEssentialQuestionsIds": []
     }
   ]
 }

--- a/content/src/roadmaps/nonEssentialQuestions.json
+++ b/content/src/roadmaps/nonEssentialQuestions.json
@@ -198,7 +198,8 @@
     {
       "id": "resale-tax-cert",
       "questionText": "Will you buy products for resale, or will you sell products to resellers?",
-      "addOn": "resale-certificate"
+      "addOn": "resale-certificate",
+      "anytimeActions": ["resale-tax-certificate"]
     },
     {
       "addOn": "vehicle-cpcn",
@@ -209,9 +210,7 @@
       "id": "demo-only",
       "questionText": "You are a demo industry user. This is an example non-essential question that is being used to add an Anytime Action. Answering \"yes\" will add the Anytime Action \"Demo Anytime Action\".",
       "addOn": "",
-      "anytimeActions": [
-        "demo-only"
-      ]
+      "anytimeActions": ["demo-only"]
     },
     {
       "id": "well-driller",

--- a/shared/src/sector.ts
+++ b/shared/src/sector.ts
@@ -3,15 +3,17 @@ import SectorsJSON from "../../content/src/mappings/sectors.json";
 export interface SectorType {
   readonly id: string;
   readonly name: string;
+  readonly nonEssentialQuestionsIds: string[];
 }
 
-export const LookupSectorTypeById = (id: string): SectorType => {
+export const LookupSectorTypeById = (id: string | undefined): SectorType => {
   return (
     arrayOfSectors.find((x) => {
       return x.id === id;
     }) ?? {
       id: "",
       name: "",
+      nonEssentialQuestionsIds: [],
     }
   );
 };

--- a/web/decap-config/collections/12-misc.yml
+++ b/web/decap-config/collections/12-misc.yml
@@ -254,6 +254,18 @@ collections:
               - label: Id
                 name: id
                 widget: hidden
+              - label: Non Essential Questions
+                name: nonEssentialQuestionsIds
+                widget: relation
+                multiple: true
+                required: false
+                default: []
+                collection: nonEssentialQuestionsCollection
+                search_fields:
+                  - nonEssentialQuestionsArray.*.id
+                value_field: nonEssentialQuestionsArray.*.id
+                display_fields:
+                  - nonEssentialQuestionsArray.*.id
       - label: "Tax Clearance Certificate Issuing Agencies"
         name: "arrayOfTaxClearanceCertificateIssuingAgencies"
         file: "content/src/mappings/taxClearanceCertificateIssuingAgencies.json"

--- a/web/src/components/dashboard/AnytimeActionDropdown.tsx
+++ b/web/src/components/dashboard/AnytimeActionDropdown.tsx
@@ -70,7 +70,6 @@ export const AnytimeActionDropdown = (props: Props): ReactElement => {
       props.anytimeActionLicenseReinstatements.filter(licenseReinstatementMatch).map((action) => {
         return {
           ...action,
-          type: "license-reinstatement",
         };
       }),
     ];

--- a/web/src/components/data-fields/non-essential-questions/IndustryBasedNonEssentialQuestionsSection.test.tsx
+++ b/web/src/components/data-fields/non-essential-questions/IndustryBasedNonEssentialQuestionsSection.test.tsx
@@ -20,6 +20,17 @@ jest.mock("../../../../../shared/lib/content/lib/industry.json", () => ({
       industryOnboardingQuestions: {},
     },
     {
+      id: "test-industry-with-duplicate-questions",
+      name: "test-industry-with-duplicate-questions",
+      description: "",
+      canHavePermanentLocation: true,
+      roadmapSteps: [],
+      nonEssentialQuestionsIds: ["test-question-4"],
+      naicsCodes: "",
+      isEnabled: true,
+      industryOnboardingQuestions: {},
+    },
+    {
       id: "test-industry-with-no-non-essential-questions",
       name: "test-industry-with-no-non-essential-questions",
       description: "",
@@ -35,6 +46,39 @@ jest.mock("../../../../../shared/lib/content/lib/industry.json", () => ({
 
 jest.mock("@/lib/domain-logic/getNonEssentialQuestionText", () => ({
   getNonEssentialQuestionText: jest.fn(),
+}));
+
+const mockArrayOfSectors = [
+  {
+    id: "test-sector-with-non-essential-questions",
+    name: "test-sector-with-non-essential-questions",
+    nonEssentialQuestionsIds: ["test-question-3"],
+  },
+  {
+    id: "test-sector-with-duplicate.-questions",
+    name: "test-sector-with-duplicate-questions",
+    nonEssentialQuestionsIds: ["test-question-4"],
+  },
+  {
+    id: "test-sector-with-no-non-essential-questions",
+    name: "test-sector-with-no-non-essential-questions",
+    nonEssentialQuestionsIds: [],
+  },
+];
+
+jest.mock("@businessnjgovnavigator/shared/sector", () => ({
+  ...jest.requireActual("@businessnjgovnavigator/shared/sector"),
+  LookupSectorTypeById: jest.fn((id) => {
+    return (
+      mockArrayOfSectors.find((sector) => {
+        return sector.id === id;
+      }) ?? {
+        id: "",
+        name: "",
+        nonEssentialQuestionsIds: [],
+      }
+    );
+  }),
 }));
 
 const mockGetNonEssentialQuestionText = (
@@ -54,6 +98,10 @@ describe("ProfileNonEssentialQuestionsSection", () => {
     );
   };
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("doesn't display section if industry doesn't have any non essential questions", () => {
     renderComponent({
       industryId: "test-industry-with-no-non-essential-questions",
@@ -62,22 +110,64 @@ describe("ProfileNonEssentialQuestionsSection", () => {
     expect(screen.queryByTestId("non-essential-questions-wrapper")).not.toBeInTheDocument();
   });
 
-  it("displays all the non essential questions if industry has non essential questions", () => {
+  it("displays all the non essential questions if industry has non essential questions and persona is not OWNING", () => {
     mockGetNonEssentialQuestionText
       .mockReturnValueOnce("Non Essential Question 1?")
-      .mockReturnValueOnce("Non Essential Question 2?");
+      .mockReturnValueOnce("Non Essential Question 2?")
+      .mockReturnValueOnce("Non Essential Question 3?");
 
     renderComponent({
       industryId: "test-industry-with-non-essential-questions",
+      sectorId: "test-sector-with-non-essential-questions",
       businessPersona: "STARTING",
     });
 
     expect(screen.getAllByTestId("non-essential-questions-wrapper").length).toBeGreaterThan(0);
     expect(screen.getByText("Non Essential Question 1?")).toBeInTheDocument();
     expect(screen.getByText("Non Essential Question 2?")).toBeInTheDocument();
+    expect(screen.getByText("Non Essential Question 3?")).toBeInTheDocument();
   });
 
-  it("displays different values specifically for Owning businesses", () => {
+  it("displays a non essential question once if it is contained in both the industry and sector and person is not OWNING", () => {
+    mockGetNonEssentialQuestionText.mockReturnValueOnce("Non Essential Question 4?");
+
+    renderComponent({
+      industryId: "test-industry-with-duplicate-questions",
+      sectorId: "test-sector-with-duplicate-questions",
+      businessPersona: "STARTING",
+    });
+
+    expect(screen.getAllByTestId("non-essential-questions-wrapper").length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("Non Essential Question 4?").length).toBe(1);
+    expect(screen.getByText("Non Essential Question 4?")).toBeInTheDocument();
+  });
+
+  it("only displays sector non essential questions if sector has non essential questions and persona is OWNING", () => {
+    mockGetNonEssentialQuestionText.mockReturnValueOnce("Non Essential Question 3?");
+
+    renderComponent({
+      industryId: "test-industry-with-non-essential-questions",
+      sectorId: "test-sector-with-non-essential-questions",
+      businessPersona: "OWNING",
+    });
+
+    expect(screen.getAllByTestId("non-essential-questions-wrapper").length).toBeGreaterThan(0);
+    expect(mockGetNonEssentialQuestionText).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Non Essential Question 3?")).toBeInTheDocument();
+  });
+
+  it("does not display section if sector doesn't have any non essential questions", () => {
+    renderComponent({
+      industryId: "test-industry-with-non-essential-questions",
+      sectorId: "test-sector-with-no-non-essential-questions",
+      businessPersona: "OWNING",
+    });
+
+    expect(screen.queryAllByTestId("non-essential-questions-wrapper").length).toBe(0);
+    expect(mockGetNonEssentialQuestionText).toHaveBeenCalledTimes(0);
+  });
+
+  it("displays custom non essential questions specifically for Owning businesses", () => {
     mockGetNonEssentialQuestionText
       .mockReturnValueOnce("Non Essential Question 1?")
       .mockReturnValueOnce("Non Essential Question 2?");

--- a/web/src/lib/static/loadAnytimeActionLicenseReinstatements.test.ts
+++ b/web/src/lib/static/loadAnytimeActionLicenseReinstatements.test.ts
@@ -87,6 +87,7 @@ describe("loadAnytimeActionLicenseReinstatements", () => {
               },
             ],
             form: "Form1",
+            type: "license-reinstatement",
           },
           {
             name: "anytime action license reinstatement name2",
@@ -103,6 +104,7 @@ describe("loadAnytimeActionLicenseReinstatements", () => {
               },
             ],
             form: "Form2",
+            type: "license-reinstatement",
           },
         ]),
       );
@@ -170,6 +172,7 @@ describe("loadAnytimeActionLicenseReinstatements", () => {
             categoryName: "Reactivate My Expired Permit, License or Registration",
           },
         ],
+        type: "license-reinstatement",
       });
     });
   });

--- a/web/src/lib/types/types.ts
+++ b/web/src/lib/types/types.ts
@@ -158,6 +158,7 @@ export interface Opportunity {
 interface AnytimeAction {
   name: string;
   filename: string;
+  type: string;
   synonyms?: string[];
 }
 
@@ -176,7 +177,6 @@ export interface AnytimeActionTask extends AnytimeAction {
   contentMd: string;
   description?: string;
   searchMetaDataMatch?: string;
-  type: string;
 }
 
 export interface AnytimeActionCategory {

--- a/web/src/lib/utils/non-essential-questions-helpers.ts
+++ b/web/src/lib/utils/non-essential-questions-helpers.ts
@@ -1,10 +1,12 @@
 import { ProfileContentField } from "@/lib/types/types";
 import { LookupIndustryById } from "@businessnjgovnavigator/shared/industry";
 import { ProfileData } from "@businessnjgovnavigator/shared/profileData";
+import { LookupSectorTypeById } from "@businessnjgovnavigator/shared/sector";
 
 export const hasNonEssentialQuestions = (profileData: ProfileData): boolean => {
   if (
     doesIndustryHaveNonEssentialQuestions(profileData) ||
+    doesSectorHaveNonEssentialQuestions(profileData) ||
     getPersonaBasedNonEssentialQuestionsIds(profileData).length > 0
   ) {
     return true;
@@ -15,6 +17,13 @@ export const hasNonEssentialQuestions = (profileData: ProfileData): boolean => {
 export const doesIndustryHaveNonEssentialQuestions = (profileData: ProfileData): boolean => {
   if (profileData.businessPersona !== "OWNING") {
     return LookupIndustryById(profileData.industryId).nonEssentialQuestionsIds.length > 0;
+  }
+  return false;
+};
+
+export const doesSectorHaveNonEssentialQuestions = (profileData: ProfileData): boolean => {
+  if (profileData.sectorId) {
+    return LookupSectorTypeById(profileData.sectorId).nonEssentialQuestionsIds.length > 0;
   }
   return false;
 };

--- a/web/src/lib/utils/tasksMarkdownReader.ts
+++ b/web/src/lib/utils/tasksMarkdownReader.ts
@@ -52,6 +52,7 @@ export const convertAnytimeActionLicenseReinstatementMd = (
     filename,
     ...anytimeActionGrayMatter,
     category: [permermitsAndLicenseReinstatementCategoryInfo],
+    type: "license-reinstatement",
   };
 };
 

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -613,11 +613,7 @@ const ProfilePage = (props: Props): ReactElement => {
           heading={Config.profileDefaults.fields.nonEssentialQuestions.default.sectionHeader}
           subText={Config.profileDefaults.fields.nonEssentialQuestions.default.sectionSubText}
         >
-          {
-            <>
-              <IndustryBasedNonEssentialQuestionsSection />
-            </>
-          }
+          <IndustryBasedNonEssentialQuestionsSection />
         </ProfileSubSection>
       </div>
     ),

--- a/web/test/factories.ts
+++ b/web/test/factories.ts
@@ -358,6 +358,7 @@ export const generateAnytimeActionLicenseReinstatement = (
         categoryId: `something-id-something`,
       },
     ],
+    type: "license-reinstatement",
     ...overrides,
   };
 };


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

In #10766 we added the ability for a user's response to a Non Essential Question (NEQ) to add an Anytime Action. This work allows a NEQ to be added to a sector. This allows users who enter the application as an "Up and Running" business who only self-identify with a sector to have NEQs and are then granted a richer experience.

Additionally, this adds a specific NEQ to the "Other Services" industry.

### Ticket

This pull request resolves [#15159](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15159).

### Approach

- Added NEQs to the Sector type definition and CMS config
- Updated `IndustryBasedNonEssentialQuestionsSection` to display NEQs associated with a sector

### Steps to Test

- Create a new "Up and Running" business in the "Other Services" sector
- Navigate to the business profile
  - You should see a NEQ related to reselling products
- Answer "yes" the resale NEQ
- There should now be an additional Anytime Action related to the resale tax certificate in your Anytime Actions dropdown

- Answering "no" should remove this from the dropdown

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
