### PR TITLE
fix: [AB#14388] User can bypass checkboxes on Out-of-State business O…

### DIFF
--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -362,7 +362,6 @@ const OnboardingPage = (props: Props): ReactElement => {
 
       const hasBusinessPersonaChanged =
         profileData.businessPersona !== updateQueue.currentBusiness().profileData.businessPersona;
-
       if (page.current === 1 && hasBusinessPersonaChanged) {
         newProfileData = {
           ...emptyProfileData,
@@ -389,9 +388,18 @@ const OnboardingPage = (props: Props): ReactElement => {
         setCurrentFlow(getFlow(profileData));
       }
 
+      if (
+        newProfileData.businessPersona === "FOREIGN" &&
+        newProfileData.foreignBusinessTypeIds.length === 0 &&
+        page.current === 2
+      )
+        return;
+
       const currentPage = onboardingFlows[currentFlow].pages[page.current - 1];
       sendOnboardingOnSubmitEvents(newProfileData, currentPage?.name);
       setAnalyticsDimensions(newProfileData);
+
+      console.log(page.current);
 
       if (determineForeignBusinessType(profileData.foreignBusinessTypeIds) === "NONE") {
         router &&

--- a/web/test/pages/onboarding/onboarding-foreign.test.tsx
+++ b/web/test/pages/onboarding/onboarding-foreign.test.tsx
@@ -180,6 +180,22 @@ describe("onboarding - foreign business", () => {
       ).toBeInTheDocument();
     });
 
+    it("prevents user from moving past Step 2 if you check a foreign business type and uncheck it leaving no foreign business type checked", async () => {
+      useMockRouter({ isReady: true, query: { page: "2" } });
+      const { page } = renderPage({ userData });
+      page.checkByLabelText(transactionsInNJ);
+      page.checkByLabelText(transactionsInNJ);
+      page.clickNext();
+      await waitFor(() => {
+        expect(screen.getByTestId("step-2")).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText(
+          Config.profileDefaults.fields.foreignBusinessTypeIds.default.errorTextRequired,
+        ),
+      ).toBeInTheDocument();
+    });
+
     it("allows user to move past Step 2 if you have made a selection", async () => {
       useMockRouter({ isReady: true, query: { page: "2" } });
       const { page } = renderPage({ userData });


### PR DESCRIPTION

<!-- Please complete the following sections as necessary. -->

## Description
Background
It was recently identified that it is possible to bypass the checkboxes when completing onboarding as an Out-of-State business

Steps to Reproduce
Navigated to https://account.business.nj.gov/ 
Click the "Get Started" button
Select "An out-of-state business" as the option on onboarding step 1
Click the "Next" button
Select at least one of the checkboxes on onboarding step 2; however, do not click the "Show My Guide" button
Deselect all checkboxes (i.e. make the screen appear as though no selection has been made)
Click the "Show My Guide" button
Actual Result
No error message is received, and the user is routed to a dashboard which includes no steps

Note: In some instances the error message has been seen initially, but then the user is subsequently routed to the dashboard. In that instance, the error state is still not preventing the user from arriving at a blank dashboard.
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14388](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14388).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Navigated to https://account.business.nj.gov/
Click the "Get Started" button
Select "An out-of-state business" as the option on onboarding step 1
Click the "Next" button
Select at least one of the checkboxes on onboarding step 2; however, do not click the "Show My Guide" button
Deselect all checkboxes (i.e. make the screen appear as though no selection has been made)
Click the "Show My Guide" button
Actual Result
Error message is received and not routed to the dashboard

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
