### PR TITLE
fix: [AB#15397] env permit none of the above option and test refactors

### DIFF
--- a/web/src/components/tasks/environment-questionnaire/EnvQuestionnaireStepper.tsx
+++ b/web/src/components/tasks/environment-questionnaire/EnvQuestionnaireStepper.tsx
@@ -105,6 +105,15 @@ export const EnvQuestionnaireStepper = (): ReactElement => {
     </div>
   );
 
+  const allOptionsAsFalse = (mediaArea: MediaArea): Record<QuestionnaireFieldIds, boolean> => {
+    const mediaAreaOptions = Object.keys(Config.envQuestionPage[mediaArea].questionnaireOptions);
+    const allOptionsAsFalse = {} as Record<QuestionnaireFieldIds, boolean>;
+    for (const option of mediaAreaOptions) {
+      allOptionsAsFalse[option as QuestionnaireFieldIds] = false;
+    }
+    return allOptionsAsFalse;
+  };
+
   const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
     if (mediaArea === undefined) return;
     const value: QuestionnaireFieldIds = event.target.id as QuestionnaireFieldIds;
@@ -115,7 +124,8 @@ export const EnvQuestionnaireStepper = (): ReactElement => {
         envContext.setQuestionnaireData((prevData) => ({
           ...prevData,
           [mediaArea]: {
-            [value]: event.target.checked,
+            ...allOptionsAsFalse(mediaArea),
+            [noSelectionOption]: event.target.checked,
           },
         }));
       }


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
Fix to clear other selected options when `None of the above apply` is selected. Additionally, I also refactored the tests to be more concise by pulling out the render into function.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#15397](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15397).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
