### PR TITLE
fix: [AB#15336] prevent duplicate myNJ self-registration calls

### DIFF
--- a/web/src/components/njwds-extended/GenericButton.tsx
+++ b/web/src/components/njwds-extended/GenericButton.tsx
@@ -74,10 +74,13 @@ export const GenericButton = forwardRef(function GenericButton(
     })
     .join(" ");
 
+  const isLoading = Boolean(props.isLoading);
   return (
     <button
+      disabled={isLoading}
+      aria-disabled={isLoading}
       className={className}
-      onClick={props.onClick}
+      onClick={isLoading ? undefined : props.onClick}
       ref={ref}
       {...(props.isSubmitButton ? { type: "submit" } : { type: "button" })}
       {...(props.dataTestId ? { "data-testid": props.dataTestId } : {})}


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#0000](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
