### PR TITLE
chore: [AB#15504] adding wiremocks for cig license

### DIFF
--- a/api/src/functions/express/app.ts
+++ b/api/src/functions/express/app.ts
@@ -258,12 +258,14 @@ const taxClearanceCertificateClient = ApiTaxClearanceCertificateClient(logger, {
 const taxClearanceHealthCheckClient = taxClearanceCertificateClient.health;
 
 const cigaretteLicenseClient = ApiCigaretteLicenseClient(logger, {
-  baseUrl: process.env.CIGARETTE_LICENSE_BASE_URL || "",
+  baseUrl: process.env.CIGARETTE_LICENSE_BASE_URL || "http://localhost:9000/cigarette-license",
   apiKey: process.env.CIGARETTE_LICENSE_API_KEY || "",
   merchantCode: process.env.CIGARETTE_LICENSE_MERCHANT_CODE || "",
   merchantKey: process.env.CIGARETTE_LICENSE_MERCHANT_KEY || "",
   serviceCode: process.env.CIGARETTE_LICENSE_SERVICE_CODE || "",
-  emailConfirmationUrl: process.env.CIGARETTE_LICENSE_EMAIL_CONFIRMATION_URL || "",
+  emailConfirmationUrl:
+    process.env.CIGARETTE_LICENSE_EMAIL_CONFIRMATION_URL ||
+    "http://localhost:9000/cigarette-license/send-email-confirmation",
   emailConfirmationKey: process.env.CIGARETTE_LICENSE_EMAIL_CONFIRMATION_KEY || "",
 });
 const cigaretteLicenseHealthCheckClient = cigaretteLicenseClient.health;

--- a/api/wiremock/__files/cigarette-license-get-order-success.json
+++ b/api/wiremock/__files/cigarette-license-get-order-success.json
@@ -1,0 +1,10 @@
+{
+  "matchingOrders": 1,
+  "orders": [
+    {
+      "orderId": 123456,
+      "orderStatus": "COMPLETE",
+      "timestamp": "2025-07-31T19:09:10Z"
+    }
+  ]
+}

--- a/api/wiremock/__files/cigarette-license-prepare-payment-fail.json
+++ b/api/wiremock/__files/cigarette-license-prepare-payment-fail.json
@@ -1,0 +1,10 @@
+{
+  "token": "",
+  "errorResult": {
+    "statusCode": 500,
+    "errorCode": "140",
+    "userMessage": "There was an issue with this prepare payment request",
+    "developerMessage": "There was an issue with this prepare payment request",
+    "validationErrors": []
+  }
+}

--- a/api/wiremock/__files/cigarette-license-prepare-payment-success.json
+++ b/api/wiremock/__files/cigarette-license-prepare-payment-success.json
@@ -1,0 +1,6 @@
+{
+  "token": "00000000-1111-2222-3333-444444444444",
+  "legacyRedirectUrl": "https://success.com?token=00000000-1111-2222-3333-444444444444",
+  "htmL5RedirectUrl": "https://success.com?token=00000000-1111-2222-3333-444444444444",
+  "inContextRedirectUrl": "https://success.com?token=00000000-1111-2222-3333-444444444444"
+}

--- a/api/wiremock/mappings/cigarette-license-get-order-success.json
+++ b/api/wiremock/mappings/cigarette-license-get-order-success.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/cigarette-license/tokens/[^/]+"
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "cigarette-license-get-order-success.json",
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/api/wiremock/mappings/cigarette-license-prepare-payment-fail.json
+++ b/api/wiremock/mappings/cigarette-license-prepare-payment-fail.json
@@ -1,0 +1,21 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/cigarette-license/tokens",
+    "bodyPatterns": [
+      {
+        "matchesJsonPath": "$[?(@.CompanyName !== 'Mock Success Company')]"
+      },
+      {
+        "matchesJsonPath": "$[?(@.Email !== 'mock-success@test.com')]"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "cigarette-license-prepare-payment-fail.json",
+    "headers": {
+      "Content-Type": "text/json"
+    }
+  }
+}

--- a/api/wiremock/mappings/cigarette-license-prepare-payment-success.json
+++ b/api/wiremock/mappings/cigarette-license-prepare-payment-success.json
@@ -1,0 +1,21 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/cigarette-license/tokens",
+    "bodyPatterns": [
+      {
+        "matchesJsonPath": "$[?(@.CompanyName === 'Mock Success Company')]"
+      },
+      {
+        "matchesJsonPath": "$[?(@.Email === 'mock-success@test.com')]"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "cigarette-license-prepare-payment-success.json",
+    "headers": {
+      "Content-Type": "text/json"
+    }
+  }
+}

--- a/api/wiremock/mappings/cigarette-license-send-email-success.json
+++ b/api/wiremock/mappings/cigarette-license-send-email-success.json
@@ -1,0 +1,21 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/cigarette-license/send-email-confirmation",
+    "bodyPatterns": [
+      {
+        "matchesJsonPath": "$[?(@.businessName === 'Mock Success Company')]"
+      },
+      {
+        "matchesJsonPath": "$[?(@.contactEmail === 'mock-success@test.com')]"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "body": "Successfully sent email confirmation.",
+    "headers": {
+      "Content-Type": "text/json"
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Adding a few wiremocks for the three api calls in Cigarette License Client

### Ticket

This pull request resolves [#15504](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15504).

### Approach

Added a success and fail for the main `prepare-payment` call, with related response json files. For `get-order-by-token` and `send-email` a simple success response was mocked to make front end work easier to work on. 

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
