### PR TITLE
fix: [#AB15504] adding ssm setup for cigarette_license_email_confirma…

### DIFF
--- a/api/serverless.ts
+++ b/api/serverless.ts
@@ -295,10 +295,6 @@ const serverlessConfiguration: AWS = {
       CIGARETTE_LICENSE_MERCHANT_CODE: cigaretteLicenseMerchantCode,
       CIGARETTE_LICENSE_MERCHANT_KEY: cigaretteLicenseMerchantKey,
       CIGARETTE_LICENSE_SERVICE_CODE: cigaretteLicenseServiceCode,
-      CIGARETTE_LICENSE_EMAIL_CONFIRMATION_URL:
-        stage === "local"
-          ? "${ssm:/dev/cigarette_license_email_confirmation_url}"
-          : `\${ssm:/${stage}/cigarette_license_email_confirmation_url}`,
       CIGARETTE_LICENSE_EMAIL_CONFIRMATION_KEY: cigaretteLicenseEmailConfirmationKey,
     } as AwsLambdaEnvironment,
     logRetentionInDays: 180,

--- a/api/src/client/ApiCigaretteLicenseClient.ts
+++ b/api/src/client/ApiCigaretteLicenseClient.ts
@@ -17,6 +17,7 @@ import { HealthCheckMethod, HealthCheckMetadata } from "@domain/types";
 import { UserData } from "@shared/userData";
 import axios, { AxiosError, AxiosResponse } from "axios";
 import { ReasonPhrases, StatusCodes } from "http-status-codes";
+import { getCigLicenseEmailUrl } from "@libs/ssmUtils";
 
 export const ApiCigaretteLicenseClient = (
   logger: LogWriterType,
@@ -123,6 +124,7 @@ export const ApiCigaretteLicenseClient = (
     const logId = logger.GetId();
     const currentBusiness = getCurrentBusiness(userData);
     const cigaretteLicenseData = currentBusiness.cigaretteLicenseData;
+    const cigLicenseEmailUrl = await getCigLicenseEmailUrl();
 
     if (!cigaretteLicenseData) {
       const errorMessage = `Cigarette License Client - Id:${logId} - cigarette license data is not defined`;
@@ -146,12 +148,12 @@ export const ApiCigaretteLicenseClient = (
 
     logger.LogInfo(
       `Cigarette License Client - Id:${logId} - Sending request to ${
-        config.emailConfirmationUrl
+        cigLicenseEmailUrl
       } data: ${JSON.stringify(postBody)}`,
     );
 
     return axios
-      .post(config.emailConfirmationUrl, postBody, {
+      .post(cigLicenseEmailUrl, postBody, {
         headers: {
           "Content-Type": "application/json",
           "x-api-key": config.emailConfirmationKey,

--- a/api/src/client/ApiCigaretteLicenseHelpers.test.ts
+++ b/api/src/client/ApiCigaretteLicenseHelpers.test.ts
@@ -32,7 +32,6 @@ describe("ApiCigaretteLicenseHelpers", () => {
       merchantCode: "TEST_MERCHANT",
       merchantKey: "TEST_KEY",
       serviceCode: "TEST_SERVICE",
-      emailConfirmationUrl: "TEST_EMAIL_URL",
       emailConfirmationKey: "TEST_EMAIL_KEY",
     };
 

--- a/api/src/client/ApiCigaretteLicenseHelpers.ts
+++ b/api/src/client/ApiCigaretteLicenseHelpers.ts
@@ -16,7 +16,6 @@ export type CigaretteLicenseApiConfig = {
   merchantCode: string;
   merchantKey: string;
   serviceCode: string;
-  emailConfirmationUrl: string;
   emailConfirmationKey: string;
 };
 

--- a/api/src/functions/express/app.ts
+++ b/api/src/functions/express/app.ts
@@ -263,9 +263,6 @@ const cigaretteLicenseClient = ApiCigaretteLicenseClient(logger, {
   merchantCode: process.env.CIGARETTE_LICENSE_MERCHANT_CODE || "",
   merchantKey: process.env.CIGARETTE_LICENSE_MERCHANT_KEY || "",
   serviceCode: process.env.CIGARETTE_LICENSE_SERVICE_CODE || "",
-  emailConfirmationUrl:
-    process.env.CIGARETTE_LICENSE_EMAIL_CONFIRMATION_URL ||
-    "http://localhost:9000/cigarette-license/send-email-confirmation",
   emailConfirmationKey: process.env.CIGARETTE_LICENSE_EMAIL_CONFIRMATION_KEY || "",
 });
 const cigaretteLicenseHealthCheckClient = cigaretteLicenseClient.health;


### PR DESCRIPTION
## Description

Moving the `cigLicenseEmail` env var to the `api/src/libs/ssmUtils.ts` file to load at runtime, rather than in the `serverless.ts` file

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
