### PR TITLE
14931 cigarette license step 3

### DIFF
--- a/content/src/fieldConfig/cigarette-license-step3.json
+++ b/content/src/fieldConfig/cigarette-license-step3.json
@@ -4,7 +4,7 @@
     "fields": {
       "startDateOfSales": {
         "label": "Start Date of Cigarette Sales",
-        "errorRequiredText": "A valid date is required",
+        "errorRequiredText": "A valid date is required.",
         "errorValidationText": ""
       },
       "selectASupplier": {

--- a/web/decap-config/collections/06-tasks.yml
+++ b/web/decap-config/collections/06-tasks.yml
@@ -1149,7 +1149,7 @@ collections:
                         widget: "string"
                         required: true
                   - label: "Select A Supplier"
-                    name: "selectSupplierLabel"
+                    name: "selectASupplier"
                     widget: "object"
                     fields:
                       - label: "Label"

--- a/web/src/components/tasks/cigarette-license/CigaretteLicense.tsx
+++ b/web/src/components/tasks/cigarette-license/CigaretteLicense.tsx
@@ -5,6 +5,7 @@ import { ConfirmationPage } from "@/components/tasks/cigarette-license/Confirmat
 import { GeneralInfo } from "@/components/tasks/cigarette-license/GeneralInfo";
 import { getInitialData } from "@/components/tasks/cigarette-license/helpers";
 import { LicenseeInfo } from "@/components/tasks/cigarette-license/LicenseeInfo";
+import { SalesInfo } from "@/components/tasks/cigarette-license/SalesInfo";
 import { AddressContext } from "@/contexts/addressContext";
 import { checkQueryValue, QUERIES } from "@/lib/domain-logic/routes";
 import { useUpdateTaskProgress } from "@/lib/data-hooks/useUpdateTaskProgress";
@@ -288,7 +289,12 @@ export const CigaretteLicense = (props: Props): ReactElement => {
                   CMS_ONLY_show_error={props.CMS_ONLY_show_error}
                 />
               )}
-              {stepIndex === 2 && <></>}
+              {stepIndex === 2 && (
+                <SalesInfo
+                  setStepIndex={setStepIndex}
+                  CMS_ONLY_show_error={props.CMS_ONLY_show_error}
+                />
+              )}
             </AddressContext.Provider>
           </ProfileDataContext.Provider>
         </CigaretteLicenseContext.Provider>

--- a/web/src/components/tasks/cigarette-license/LicenseeInfo.test.tsx
+++ b/web/src/components/tasks/cigarette-license/LicenseeInfo.test.tsx
@@ -8,7 +8,6 @@ import {
 import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { fillTextUserEvent } from "@/test/helpers/helpers-testing-library-selectors";
-import { useMockRoadmap } from "@/test/mock/mockUseRoadmap";
 
 import { WithStatefulUserData } from "@/test/mock/withStatefulUserData";
 import { emptyCigaretteLicenseData } from "@businessnjgovnavigator/shared/cigaretteLicense";
@@ -29,14 +28,7 @@ import { useState } from "react";
 
 const Config = getMergedConfig();
 
-jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
-
 describe("<LicenseeInfo />", () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-    useMockRoadmap({});
-  });
-
   const renderComponent = ({
     business,
     userData,

--- a/web/src/components/tasks/cigarette-license/SalesInfo.test.tsx
+++ b/web/src/components/tasks/cigarette-license/SalesInfo.test.tsx
@@ -1,0 +1,172 @@
+import { SalesInfo } from "@/components/tasks/cigarette-license/SalesInfo";
+import { AddressContext } from "@/contexts/addressContext";
+import { CigaretteLicenseContext } from "@/contexts/cigaretteLicenseContext";
+import {
+  createDataFormErrorMap,
+  DataFormErrorMapContext,
+} from "@/contexts/dataFormErrorMapContext";
+import { ProfileDataContext } from "@/contexts/profileDataContext";
+import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
+import { getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
+
+import { WithStatefulUserData } from "@/test/mock/withStatefulUserData";
+import { emptyCigaretteLicenseData } from "@businessnjgovnavigator/shared/cigaretteLicense";
+import { emptyFormationAddressData } from "@businessnjgovnavigator/shared/formationData";
+import { generateBusiness, generateUserDataForBusiness } from "@businessnjgovnavigator/shared/test";
+import { Business, UserData } from "@businessnjgovnavigator/shared/userData";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { SUPPLIER_NAMES } from "@/components/tasks/cigarette-license/fields/CigaretteSupplierDropdown";
+import { useState } from "react";
+
+const Config = getMergedConfig();
+
+describe("<SalesInfo />", () => {
+  const renderComponent = ({
+    business,
+    userData,
+  }: {
+    business?: Business;
+    userData?: UserData;
+    runValidations?: boolean;
+  } = {}): void => {
+    const testBusiness =
+      business ?? generateBusiness({ cigaretteLicenseData: emptyCigaretteLicenseData });
+    const testUserData = userData ?? generateUserDataForBusiness(testBusiness);
+
+    const TestComponent = (): JSX.Element => {
+      const [cigaretteLicenseData, setCigaretteLicenseData] = useState(emptyCigaretteLicenseData);
+      const [profileData, setProfileData] = useState(testBusiness.profileData);
+
+      const { state: formContextState } = useFormContextHelper(createDataFormErrorMap());
+      return (
+        <WithStatefulUserData initialUserData={testUserData}>
+          <DataFormErrorMapContext.Provider value={formContextState}>
+            <AddressContext.Provider
+              value={{
+                state: {
+                  formationAddressData: emptyFormationAddressData,
+                },
+                setAddressData: jest.fn(),
+              }}
+            >
+              <CigaretteLicenseContext.Provider
+                value={{
+                  state: cigaretteLicenseData,
+                  setCigaretteLicenseData,
+                }}
+              >
+                <ProfileDataContext.Provider
+                  value={{
+                    state: {
+                      profileData,
+                      flow: "STARTING",
+                    },
+                    setProfileData,
+                    onBack: (): void => {},
+                  }}
+                >
+                  <SalesInfo setStepIndex={() => {}} />
+                </ProfileDataContext.Provider>
+              </CigaretteLicenseContext.Provider>
+            </AddressContext.Provider>
+          </DataFormErrorMapContext.Provider>
+        </WithStatefulUserData>
+      );
+    };
+
+    render(<TestComponent />);
+  };
+
+  describe("Form Fields", () => {
+    it("renders section header", () => {
+      renderComponent();
+
+      expect(
+        screen.getByText(Config.cigaretteLicenseStep3.salesInformationHeader),
+      ).toBeInTheDocument();
+    });
+
+    it("renders start date of cigarette sales field", () => {
+      renderComponent();
+
+      expect(
+        screen.getByRole("textbox", {
+          name: Config.cigaretteLicenseStep3.fields.startDateOfSales.label,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders cigarette suppliers dropdown", () => {
+      renderComponent();
+
+      expect(
+        screen.getByRole("combobox", {
+          name: Config.cigaretteLicenseStep3.fields.selectASupplier.label,
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Field Validation", () => {
+    it("renders error for Start Date of Cigarette Sales when empty on blur", async () => {
+      renderComponent({});
+
+      await userEvent.click(
+        screen.getByLabelText(Config.cigaretteLicenseStep3.fields.startDateOfSales.label),
+      );
+      await userEvent.tab();
+
+      expect(
+        screen.getByText(Config.cigaretteLicenseStep3.fields.startDateOfSales.errorRequiredText),
+      ).toBeInTheDocument();
+    });
+
+    it("renders error for Start Date of Cigarette Sales when invalid date on blur", async () => {
+      renderComponent({});
+
+      await userEvent.type(
+        screen.getByLabelText(Config.cigaretteLicenseStep3.fields.startDateOfSales.label),
+        "000000",
+      );
+      await userEvent.tab();
+
+      expect(
+        screen.getByText(Config.cigaretteLicenseStep3.fields.startDateOfSales.errorRequiredText),
+      ).toBeInTheDocument();
+    });
+
+    it("renders error for Select Supplier dropdown when no options are selected on blur", async () => {
+      renderComponent({});
+
+      const openSupplierDropdownButton = screen.getByRole("button", { name: "Open" });
+      await userEvent.click(openSupplierDropdownButton);
+      await userEvent.tab();
+
+      expect(
+        screen.getByText(Config.cigaretteLicenseStep3.fields.selectASupplier.errorRequiredText),
+      ).toBeInTheDocument();
+    });
+
+    it("removes error for Select Supplier dropdown when an option is selected", async () => {
+      renderComponent({});
+
+      const openSupplierDropdownButton = screen.getByRole("button", { name: "Open" });
+      await userEvent.click(openSupplierDropdownButton);
+      await userEvent.tab();
+
+      expect(
+        screen.getByText(Config.cigaretteLicenseStep3.fields.selectASupplier.errorRequiredText),
+      ).toBeInTheDocument();
+
+      await userEvent.click(openSupplierDropdownButton);
+      await userEvent.click(screen.getByRole("option", { name: SUPPLIER_NAMES[0] }));
+      await userEvent.tab();
+
+      expect(
+        screen.queryByText(Config.cigaretteLicenseStep3.fields.selectASupplier.errorRequiredText),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/components/tasks/cigarette-license/SalesInfo.tsx
+++ b/web/src/components/tasks/cigarette-license/SalesInfo.tsx
@@ -1,0 +1,47 @@
+import { HorizontalLine } from "@/components/HorizontalLine";
+import { CtaContainer } from "@/components/njwds-extended/cta/CtaContainer";
+import { LiveChatHelpButton } from "@/components/njwds-extended/LiveChatHelpButton";
+import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
+import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
+import { ActionBarLayout } from "@/components/njwds-layout/ActionBarLayout";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { ReactElement } from "react";
+
+import { CigaretteSalesStartDate } from "@/components/tasks/cigarette-license/fields/CigaretteSalesStartDate";
+import { CigaretteSupplierDropdown } from "@/components/tasks/cigarette-license/fields/CigaretteSupplierDropdown";
+
+interface Props {
+  setStepIndex: (step: number) => void;
+  CMS_ONLY_show_error?: boolean;
+}
+
+export const SalesInfo = (props: Props): ReactElement => {
+  const { Config } = useConfig();
+  return (
+    <>
+      <h2>{Config.cigaretteLicenseStep3.salesInformationHeader}</h2>
+      <CigaretteSalesStartDate CMS_ONLY_show_error={props.CMS_ONLY_show_error} />
+      <div className="margin-top-3">
+        <CigaretteSupplierDropdown CMS_ONLY_show_error={props.CMS_ONLY_show_error} />
+      </div>
+      <HorizontalLine />
+      <span className="h5-styling">{Config.cigaretteLicenseShared.issuingAgencyLabelText}: </span>
+      <span className="h6-styling">{Config.cigaretteLicenseShared.issuingAgencyText}</span>
+      <CtaContainer>
+        <ActionBarLayout>
+          <LiveChatHelpButton />
+          <SecondaryButton isColor="primary" onClick={() => props.setStepIndex(1)}>
+            {Config.cigaretteLicenseStep3.backButtonText}
+          </SecondaryButton>
+          <PrimaryButton
+            isColor="primary"
+            onClick={() => props.setStepIndex(3)}
+            isRightMarginRemoved={true}
+          >
+            {Config.cigaretteLicenseStep3.nextButtonText}
+          </PrimaryButton>
+        </ActionBarLayout>
+      </CtaContainer>
+    </>
+  );
+};

--- a/web/src/components/tasks/cigarette-license/fields/CigaretteSalesStartDate.tsx
+++ b/web/src/components/tasks/cigarette-license/fields/CigaretteSalesStartDate.tsx
@@ -1,0 +1,83 @@
+import { WithErrorBar } from "@/components/WithErrorBar";
+import { CigaretteLicenseContext } from "@/contexts/cigaretteLicenseContext";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
+import { DateObject } from "@businessnjgovnavigator/shared/dateHelpers";
+import { TextField, TextFieldProps } from "@mui/material";
+import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { ReactElement, useContext } from "react";
+interface Props {
+  CMS_ONLY_show_error?: boolean;
+}
+
+export const CigaretteSalesStartDate = (props: Props): ReactElement => {
+  const { Config } = useConfig();
+  const { state: cigaretteLicenseData, setCigaretteLicenseData } =
+    useContext(CigaretteLicenseContext);
+
+  const { isFormFieldInvalid, setIsValid } = useFormContextFieldHelpers(
+    "salesInfoStartDate",
+    DataFormErrorMapContext,
+  );
+
+  const performValidation = (salesInfoStartDate?: string): void => {
+    setIsValid(!!salesInfoStartDate && salesInfoStartDate !== "Invalid Date");
+  };
+
+  const onChange = (newValue: DateObject | null): void => {
+    setCigaretteLicenseData((cigaretteLicenseData) => {
+      return {
+        ...cigaretteLicenseData,
+        salesInfoStartDate: newValue ? newValue.format() : "",
+      };
+    });
+
+    performValidation(newValue?.format());
+  };
+
+  const renderInput = (params: TextFieldProps): JSX.Element => (
+    <div className="width-100">
+      <TextField
+        id="sales-start-date-picker"
+        {...params}
+        variant="outlined"
+        error={props.CMS_ONLY_show_error || isFormFieldInvalid}
+        sx={{
+          svg: { fill: "#4b7600" },
+        }}
+        inputProps={{
+          ...params.inputProps,
+          "aria-label": Config.cigaretteLicenseStep3.fields.startDateOfSales.label,
+        }}
+        style={{ maxWidth: 450 }}
+        value={cigaretteLicenseData.salesInfoStartDate}
+        onBlur={() => {
+          performValidation(cigaretteLicenseData.salesInfoStartDate);
+        }}
+        helperText={
+          (props.CMS_ONLY_show_error || isFormFieldInvalid) &&
+          Config.cigaretteLicenseStep3.fields.startDateOfSales.errorRequiredText
+        }
+      />
+    </div>
+  );
+
+  return (
+    <div id="question-salesInfoStartDate">
+      <WithErrorBar hasError={props.CMS_ONLY_show_error || isFormFieldInvalid} type={"ALWAYS"}>
+        <label htmlFor="sales-start-date-picker" className="text-bold">
+          {Config.cigaretteLicenseStep3.fields.startDateOfSales.label}
+        </label>
+        <LocalizationProvider dateAdapter={AdapterDayjs}>
+          <DatePicker
+            onChange={onChange}
+            value={cigaretteLicenseData.salesInfoStartDate}
+            renderInput={renderInput}
+          ></DatePicker>
+        </LocalizationProvider>
+      </WithErrorBar>
+    </div>
+  );
+};

--- a/web/src/components/tasks/cigarette-license/fields/CigaretteSupplierDropdown.tsx
+++ b/web/src/components/tasks/cigarette-license/fields/CigaretteSupplierDropdown.tsx
@@ -1,0 +1,220 @@
+import { WithErrorBar } from "@/components/WithErrorBar";
+import { CigaretteLicenseContext } from "@/contexts/cigaretteLicenseContext";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
+import CheckBoxIcon from "@mui/icons-material/CheckBox";
+import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank";
+import {
+  Autocomplete,
+  AutocompleteRenderInputParams,
+  AutocompleteRenderOptionState,
+  Checkbox,
+  TextField,
+} from "@mui/material";
+import { HTMLAttributes, ReactElement, SyntheticEvent, useContext } from "react";
+
+const SUPPLIERS = [
+  { licenseNumber: 501, name: "A TRENK, INC" },
+  { licenseNumber: 539, name: "A WHOLESALERS COMPANY" },
+  { licenseNumber: 540, name: "AJJA DISTRIBUTORS, LLC" },
+  { licenseNumber: 541, name: "ALL COUNTY WHOLESALE INC" },
+  { licenseNumber: 502, name: "ALLEN BROTHERS WHSLE DIST INC" },
+  { licenseNumber: 542, name: "ANTHONY'S PHARMACY, LLC" },
+  { licenseNumber: 543, name: "ANYA ENTERPRISES INC" },
+  { licenseNumber: 544, name: "ARTHUR R. MUSTARDO & SONS, INC." },
+  { licenseNumber: 545, name: "BEE GEE CANDY CO., INC." },
+  { licenseNumber: 546, name: "BEST MANAGEMENT INC" },
+  { licenseNumber: 547, name: "BEST MARK SUPERMARKETS, INC." },
+  { licenseNumber: 548, name: "BJ'S WHOLESALE CLUB, INC." },
+  { licenseNumber: 503, name: "BOZZUTOS, INC" },
+  { licenseNumber: 549, name: "BROAD BEVERAGES, INC." },
+  { licenseNumber: 504, name: "BROWNY FOOD PRODUCTS" },
+  { licenseNumber: 550, name: "C & J BROTHERS DISTRIBUTORS INC." },
+  { licenseNumber: 505, name: "C & S WHOLESALE GROCERS INC." },
+  { licenseNumber: 619, name: "CHEERS & COMPANY LLC" },
+  { licenseNumber: 506, name: "CONSUMER PRODUCTS DISTRIBUTOR INC" },
+  { licenseNumber: 614, name: "CONTINENTAL WHOLESALE DISTRIBUTOR LLC" },
+  { licenseNumber: 507, name: "COOPER-BOOTH WHOLESALE CO L L P" },
+  { licenseNumber: 508, name: "CORE-MARK MIDCONTINENT INC" },
+  { licenseNumber: 509, name: "COSTCO WHOLESALE CORPORATION" },
+  { licenseNumber: 551, name: "CREATIVE MANAGEMENT, INCORPORATED" },
+  { licenseNumber: 552, name: "D & B BUSSINESS INC." },
+  { licenseNumber: 611, name: "D & V WHOLESALE INC" },
+  { licenseNumber: 553, name: "EASY WHOLESALE INCORPORATED" },
+  { licenseNumber: 554, name: "ESE DISTRIBUTION COMPANY INC." },
+  { licenseNumber: 510, name: "FRANCHISE WHOLESALE CO LLC" },
+  { licenseNumber: 511, name: "GARBER BROS.INC." },
+  { licenseNumber: 555, name: "GARCIA CANDY & TOBACCO, LLC" },
+  { licenseNumber: 556, name: "GARCIA,PEDRO" },
+  { licenseNumber: 512, name: "GENERAL EQUITIES, INC" },
+  { licenseNumber: 557, name: "GLOBE VENDING, INC." },
+  { licenseNumber: 558, name: "GROVER WHOLESALE INC" },
+  { licenseNumber: 559, name: "GUGLIELMI, RAYMOND J" },
+  { licenseNumber: 612, name: "HACA USA CORP" },
+  { licenseNumber: 513, name: "HAROLD LEVINSON ASSOC., INC." },
+  { licenseNumber: 560, name: "HENRY & LARRY, INC." },
+  { licenseNumber: 561, name: "HERITAGE'S DAIRY STORES, INC." },
+  { licenseNumber: 514, name: "HERITAGES WHOLESALE,INC" },
+  { licenseNumber: 562, name: "HH CHOICE, L.L.C." },
+  { licenseNumber: 515, name: "IRVINGTON TABACCO COMPANY" },
+  { licenseNumber: 563, name: "J. N. DISTRIBUTOR INCORPORATED" },
+  { licenseNumber: 516, name: "JOHN BRICKS, INCORPORATED" },
+  { licenseNumber: 517, name: "JOSEPH FRIEDMAN & SONS INC" },
+  { licenseNumber: 564, name: "KANDI METRO DISTRIBUTORS LLC" },
+  { licenseNumber: 518, name: "KEYSTONE STATE DIST INC" },
+  { licenseNumber: 565, name: "KHAN, SHAMIM" },
+  { licenseNumber: 519, name: "KING DISTRIBUTORS CORP" },
+  { licenseNumber: 520, name: "KRETEK DISTRIBUTORS,INC." },
+  { licenseNumber: 566, name: "KRICHIAN,SARKIS" },
+  { licenseNumber: 521, name: "L.J.ZUCCA,INCORPORATED" },
+  { licenseNumber: 567, name: "LAWS,DONALD A" },
+  { licenseNumber: 568, name: "M & J WHOLESALE, INC." },
+  { licenseNumber: 522, name: "M.BERNSTEIN & SONS" },
+  { licenseNumber: 569, name: "MAHANNA WHOLESALE LLC" },
+  { licenseNumber: 617, name: "MAHI MAHI INC." },
+  { licenseNumber: 613, name: "MALLIKARJUN WHOLESALE" },
+  { licenseNumber: 570, name: "MANCINELLI,LOUIS F" },
+  { licenseNumber: 523, name: "MANDEL TOBACCO CO OF NEW JERSEY INC" },
+  { licenseNumber: 524, name: "MC LANE PA" },
+  { licenseNumber: 525, name: "MC LANE/MID-ATLANTIC,INC" },
+  { licenseNumber: 526, name: "MC LANE/NORTHEAST" },
+  { licenseNumber: 571, name: "MCLANE NEW JERSEY, INC." },
+  { licenseNumber: 572, name: "MCLANE/EASTERN, INC." },
+  { licenseNumber: 573, name: "MECCA DISTRIBUTION, INC." },
+  { licenseNumber: 574, name: "MINA TOBACCO LIMITED LIABILITY COMPANY" },
+  { licenseNumber: 575, name: "MORRIS COUNTY TOBACCO & CANDY CO. INC." },
+  { licenseNumber: 527, name: "MOUNTAIN CANDY & CIGAR CO INC" },
+  { licenseNumber: 576, name: "N.B.R. CIGARETTE VENDORS" },
+  { licenseNumber: 577, name: "NASH DISTRIBUTORS, INC., A NEW JERSEY CORPORATION" },
+  { licenseNumber: 528, name: "NAT SHERMAN INCORPORATED" },
+  { licenseNumber: 578, name: "NORTH JERSEY DISTRIBUTORS LLC" },
+  { licenseNumber: 579, name: "PATRY CONFECTIONARY MARKET, INC." },
+  { licenseNumber: 580, name: "PENA,ABILET" },
+  { licenseNumber: 581, name: "PHILLY CANDY & TOBACCO WHOLESALER LLC" },
+  { licenseNumber: 529, name: "PINE LESSER & SONS" },
+  { licenseNumber: 582, name: "PK WHOLESALER LLC" },
+  { licenseNumber: 583, name: "PLAINFIELD TOBACCO AND CANDY CO., INC." },
+  { licenseNumber: 584, name: "QUALITY PACKING SUPPLIES CORP." },
+  { licenseNumber: 585, name: "QUIK PIK, INC." },
+  { licenseNumber: 586, name: "R. C. MANNING, INC." },
+  { licenseNumber: 587, name: "RAB CORPORATION" },
+  { licenseNumber: 588, name: "RAINBOW HEAVEN DISTRIBUTION, L.L.C." },
+  { licenseNumber: 589, name: "READ,FRANCIS W JR" },
+  { licenseNumber: 590, name: "RED BANK MART INC." },
+  { licenseNumber: 591, name: "REEM WHOLESALE INC" },
+  { licenseNumber: 530, name: "RESNICK DIST.,DIV.OF PLAINFIELD" },
+  { licenseNumber: 592, name: "RESTAURANT DEPOT, LLC" },
+  { licenseNumber: 593, name: "RINTEL DISTRIBUTOR'S INC." },
+  { licenseNumber: 616, name: "ROYAL WHOLESALE LLC" },
+  { licenseNumber: 531, name: "S & K IMPORTS" },
+  { licenseNumber: 594, name: "S. C. J. VENDING, INC." },
+  { licenseNumber: 595, name: "SAINT MINA WHOLESALE, INC." },
+  { licenseNumber: 596, name: "SALDANA,MARTIN & ESTEVEZ,VICTOR" },
+  { licenseNumber: 597, name: "SAMS'S WHOLESALE LLC" },
+  { licenseNumber: 532, name: "SENECA DISTRBUTIONS" },
+  { licenseNumber: 598, name: "SHAKER DISTRIBUTIONS, INC." },
+  { licenseNumber: 599, name: "SHRI HARI DISTRIBUTION LIMITED LIABILITY COMPANY" },
+  { licenseNumber: 600, name: "SIDNEY & ROBERT ROSENKRANTZ, INC." },
+  { licenseNumber: 601, name: "SMOKER CASTLE INC" },
+  { licenseNumber: 533, name: "STAR TOBACCO COMPANY" },
+  { licenseNumber: 534, name: "STARKMAN GENERAL PRODUCTS" },
+  { licenseNumber: 602, name: "SUN WHOLESALE, INC." },
+  { licenseNumber: 618, name: "SUNRISE DISTRIBUTORS INC" },
+  { licenseNumber: 535, name: "SUPER FOOD SERVICE INC" },
+  { licenseNumber: 536, name: "SUPERVALU TTSJ, INC" },
+  { licenseNumber: 603, name: "TAVERAS BROTHERS, LLC" },
+  { licenseNumber: 604, name: "THE NEW PROVEEDORA LATINA LLC" },
+  { licenseNumber: 615, name: "TOBACCO AND CANDY OF NORTH NEW JERSEY LLC" },
+  { licenseNumber: 605, name: "TOWN MART, INC." },
+  { licenseNumber: 537, name: "UNITED CANDY & TOBACCO COMPANY" },
+  { licenseNumber: 606, name: "V & P GARWOOD HESS, INC." },
+  { licenseNumber: 607, name: "VALUE KING WHOLESALE LLC" },
+  { licenseNumber: 608, name: "VIKISHA CORP" },
+  { licenseNumber: 609, name: "WAKEFERN FOOD CORP." },
+  { licenseNumber: 538, name: "WAWA PROCUREMENT INC" },
+  { licenseNumber: 610, name: "YOUNES,NASHWA" },
+];
+export const SUPPLIER_NAMES = SUPPLIERS.map(
+  (supplier) => `${supplier.name} (${supplier.licenseNumber})`,
+);
+
+interface Props {
+  CMS_ONLY_show_error?: boolean;
+}
+
+export const CigaretteSupplierDropdown = (props: Props): ReactElement => {
+  const { Config } = useConfig();
+  const { state: cigaretteLicenseData, setCigaretteLicenseData } =
+    useContext(CigaretteLicenseContext);
+
+  const { isFormFieldInvalid, setIsValid } = useFormContextFieldHelpers(
+    "salesInfoSupplier",
+    DataFormErrorMapContext,
+  );
+
+  const onChange = (_: SyntheticEvent<Element, Event>, newValue: string[]): void => {
+    setCigaretteLicenseData((data) => {
+      return { ...data, salesInfoSupplier: newValue };
+    });
+    if (newValue.length > 0) setIsValid(true);
+  };
+
+  const renderOption = (
+    props: HTMLAttributes<HTMLLIElement> & {
+      key: string;
+    },
+    option: string,
+    { selected }: AutocompleteRenderOptionState,
+  ): JSX.Element => {
+    const { key, ...optionProps } = props;
+    return (
+      <li key={key} {...optionProps}>
+        <Checkbox
+          icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
+          checkedIcon={<CheckBoxIcon fontSize="small" />}
+          style={{ marginRight: 8 }}
+          checked={selected}
+        />
+        {option}
+      </li>
+    );
+  };
+
+  const renderInput = (params: AutocompleteRenderInputParams): JSX.Element => (
+    <TextField
+      {...params}
+      error={props.CMS_ONLY_show_error || isFormFieldInvalid}
+      onBlur={() => {
+        if (cigaretteLicenseData.salesInfoSupplier?.length === 0) setIsValid(false);
+      }}
+      helperText={
+        (props.CMS_ONLY_show_error || isFormFieldInvalid) &&
+        Config.cigaretteLicenseStep3.fields.selectASupplier.errorRequiredText
+      }
+    />
+  );
+
+  return (
+    <div id="question-salesInfoSupplier">
+      <WithErrorBar hasError={props.CMS_ONLY_show_error || isFormFieldInvalid} type={"ALWAYS"}>
+        <label htmlFor="supplier-select" className="text-bold">
+          {Config.cigaretteLicenseStep3.fields.selectASupplier.label}
+        </label>
+
+        <Autocomplete
+          multiple
+          id="supplier-select"
+          options={SUPPLIER_NAMES}
+          onChange={onChange}
+          value={cigaretteLicenseData.salesInfoSupplier}
+          disableCloseOnSelect
+          getOptionLabel={(option) => option}
+          renderOption={renderOption}
+          renderInput={renderInput}
+          style={{ maxWidth: 450 }}
+        />
+      </WithErrorBar>
+    </div>
+  );
+};

--- a/web/src/lib/cms/previews/CigaretteLicensePreview.tsx
+++ b/web/src/lib/cms/previews/CigaretteLicensePreview.tsx
@@ -31,6 +31,11 @@ const CigaretteLicensePreview = (props: PreviewProps): ReactElement => {
             <CigaretteLicense CMS_ONLY_stepIndex={1} task={task} CMS_ONLY_show_error />
           </>
         )}
+        {tab === "step3" && (
+          <>
+            <CigaretteLicense CMS_ONLY_stepIndex={2} task={task} CMS_ONLY_show_error />
+          </>
+        )}
         {tab === "shared" && (
           <>
             <CigaretteLicense task={task} />

--- a/web/src/pages/mgmt/cms.tsx
+++ b/web/src/pages/mgmt/cms.tsx
@@ -28,8 +28,8 @@ import AnytimeActionLicenseReinstatementPreview from "@/lib/cms/previews/Anytime
 import AnytimeActionTaskPreview from "@/lib/cms/previews/AnytimeActionTaskPreview";
 import AnytimeActionTaxClearancePreview from "@/lib/cms/previews/AnytimeActionTaxClearancePreview";
 import BusinessStructurePreview from "@/lib/cms/previews/BusinessStructurePreview";
-import CigaretteLicensePreview from "@/lib/cms/previews/CigaretteLicensePreview";
 import CigaretteLicenseConfirmationPreview from "@/lib/cms/previews/CigaretteLicenseConfirmationPreview";
+import CigaretteLicensePreview from "@/lib/cms/previews/CigaretteLicensePreview";
 import LoginEmailCheckPreview from "@/lib/cms/previews/EmailLoginCheckPreview";
 import EmergencyTripPermitPreview from "@/lib/cms/previews/EmergencyTripPermitPreview";
 import FormationDateDeletionModalPreview from "@/lib/cms/previews/FormationDateDeletionModalPreview";
@@ -46,6 +46,7 @@ import NexusDbaFormationPreview from "@/lib/cms/previews/NexusDbaFormationPrevie
 import NexusNameSearchPreview from "@/lib/cms/previews/NexusNameSearchPreview";
 import NjedaPreview from "@/lib/cms/previews/NjedaPreview";
 import PageNotFoundPreview from "@/lib/cms/previews/PageNotFoundPreview";
+import PassengerTransportCdlPreview from "@/lib/cms/previews/PassengerTransportCdlPreview";
 import ProfileFieldsPreview from "@/lib/cms/previews/ProfileFieldsPreview";
 import ProfilePreviewMisc from "@/lib/cms/previews/ProfileMiscPreview";
 import RaffleBingoPreview from "@/lib/cms/previews/RaffleBingoPreview";
@@ -61,7 +62,6 @@ import { useMountEffect } from "@/lib/utils/helpers";
 import { GetStaticPropsResult } from "next";
 import dynamic from "next/dynamic";
 import { ReactElement } from "react";
-import PassengerTransportCdlPreview from "@/lib/cms/previews/PassengerTransportCdlPreview";
 
 const CMS_CONFIG = {};
 const Loading = (): ReactElement => {
@@ -124,6 +124,7 @@ const CMS = dynamic(
 
       registerPreview(CMS, "cigaretteLicense-step1", CigaretteLicensePreview);
       registerPreview(CMS, "cigaretteLicense-step2", CigaretteLicensePreview);
+      registerPreview(CMS, "cigaretteLicense-step3", CigaretteLicensePreview);
 
       registerPreview(CMS, "cigaretteLicense-shared", CigaretteLicensePreview);
       registerPreview(CMS, "cigaretteLicense-confirmation", CigaretteLicenseConfirmationPreview);


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

This PR adds step 3 of the cigarette license task, which includes a date input and a multi-select dropdown. These have been added as components and integrated to the CigaretteLicenseData context.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14931](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14931).

### Approach
Pulled the list of suppliers from [this list](https://docs.google.com/spreadsheets/d/1Xa5R8BPzKm-_XzcV8Cqc-WD6y4B_ZgyG0mSM8rL7uDM/edit?gid=0#gid=0), unclear whether the license numbers might eventually be used for anything or not. I asked and it seems like this list hasn't changed in a very long time so it doesn't need to be dynamic, and since it isn't used in any other part of the app, I just left it in the CigaretteSupplierDropdown component.

### Steps to Test

1. Onboard as a new business.
2. Go to localhost:3000/tasks/cigarette-license
3. Click on step 3: Sales Info on the horizontal stepper
4. Test out entering a date via the textbox & opening the date picker via the calendar button. Leave it blank or enter an invalid date to trigger the validation error.
5. Test out selecting suppliers. Leave it without any suppliers selected to trigger the validation error.

CMS testing:
1. Run `yarn cms:proxy`
2. Go to http://localhost:3000/mgmt/cms#/collections/cigarette-license
3. Edit fields and see that they change what is in the preview. NOTE: `errorValidationText` is blank for both fields, since this implementation doesn't differentiate between empty vs. nonempty but invalid fields for its errors. The structure is needed for the wider cigarette license task, so these fields are left in there. 

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
