### PR TITLE
feat: [AB#14930] lock state input for business address in cigarette license step 2

### DIFF
--- a/web/src/components/data-fields/address/UnitedStatesAddress.tsx
+++ b/web/src/components/data-fields/address/UnitedStatesAddress.tsx
@@ -17,6 +17,7 @@ interface Props {
   isFullWidth?: boolean;
   excludeNJ?: boolean | true;
   dataFormErrorMap?: FormContextType<DataFormErrorMap, unknown>;
+  stateInputLocked?: boolean;
 }
 
 export const UnitedStatesAddress = (props: Props): ReactElement => {
@@ -94,7 +95,7 @@ export const UnitedStatesAddress = (props: Props): ReactElement => {
                             });
                           }}
                           error={doesFieldHaveError("addressState") || isAddressStateInvalid}
-                          disabled={false}
+                          disabled={props.stateInputLocked || false}
                           onValidation={props.onValidation}
                           excludeNJ={props.excludeNJ}
                         />

--- a/web/src/components/tasks/cigarette-license/LicenseeInfo.tsx
+++ b/web/src/components/tasks/cigarette-license/LicenseeInfo.tsx
@@ -132,6 +132,7 @@ export const LicenseeInfo = (props: Props): ReactElement => {
           onValidation={onValidation}
           dataFormErrorMap={dataFormErrorMap}
           isFullWidth
+          stateInputLocked
         />
       </div>
       <HorizontalLine />


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Locks Business Address "State" input field for cigarette license applicants.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14930](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14930).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
