### PR TITLE
feat: [AB#14009] cig license alert box

### DIFF
--- a/content/src/fieldConfig/cigarette-license-shared.json
+++ b/content/src/fieldConfig/cigarette-license-shared.json
@@ -5,6 +5,32 @@
     "stepperThreeLabel": "Sales Info",
     "stepperFourLabel": "Review & Pay",
     "issuingAgencyText": "NJ Division of Revenue and Enterprise Services",
-    "issuingAgencyLabelText": "Issuing Agency"
+    "issuingAgencyLabelText": "Issuing Agency",
+    "alertPaymentError": "**This service is temporarily unavailable.** Try again later.",
+    "alertInvalidFields": "**Missing or invalid information.** Review the following fields:",
+    "alertFieldNames": {
+      "businessName": "Business Name",
+      "responsibleOwnerName": "Responsible Owner Name",
+      "tradeName": "Trade Name",
+      "taxId": "Tax ID",
+      "addressLine1": "Address Line 1",
+      "addressLine2": "Address Line 2",
+      "addressCity": "City",
+      "addressState": "State",
+      "addressZipCode": "ZIP Code",
+      "mailingAddressLine1": "Mailing Address Line 1",
+      "mailingAddressLine2": "Mailing Address Line 2",
+      "mailingAddressCity": "Mailing City",
+      "mailingAddressState": "Mailing State",
+      "mailingAddressZipCode": "Mailing ZIP Code",
+      "contactName": "Contact Name",
+      "contactPhoneNumber": "Contact Phone Number",
+      "contactEmail": "Contact Email",
+      "salesInfoStartDate": "Sales Start Date",
+      "salesInfoSupplier": "Suppliers",
+      "signerName": "Signer Name",
+      "signerRelationship": "Signer Relationship",
+      "signature": "Signature"
+    }
   }
 }

--- a/web/decap-config/collections/06-tasks.yml
+++ b/web/decap-config/collections/06-tasks.yml
@@ -1223,6 +1223,150 @@ collections:
                   widget: "string",
                   required: true,
                 }
+              - {
+                  label: "Alert Submission Error",
+                  name: "alertPaymentError",
+                  widget: "markdown",
+                  required: true,
+                }
+              - {
+                  label: "Alert Invalid Fields Error",
+                  name: "alertInvalidFields",
+                  widget: "markdown",
+                  required: true,
+                }
+              - label: "Alert Field Names"
+                name: "alertFieldNames"
+                collapsed: true
+                widget: object
+                fields:
+                  - {
+                      label: "Business Name Field Label",
+                      name: "businessName",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Responsible Owner Name Field Label",
+                      name: "responsibleOwnerName",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Trade Name Field Label",
+                      name: "tradeName",
+                      widget: "string",
+                      required: true,
+                    }
+                  - { label: "Tax ID Field Label", name: "taxId", widget: "string", required: true }
+                  - {
+                      label: "Address Line 1 Field Label",
+                      name: "addressLine1",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Address Line 2 Field Label",
+                      name: "addressLine2",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Address City Field Label",
+                      name: "addressCity",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Address State Field Label",
+                      name: "addressState",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Address ZIP Code Field Label",
+                      name: "addressZipCode",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Mailing Address Line 1 Field Label",
+                      name: "mailingAddressLine1",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Mailing Address Line 2 Field Label",
+                      name: "mailingAddressLine2",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Mailing Address City Field Label",
+                      name: "mailingAddressCity",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Mailing Address State Field Label",
+                      name: "mailingAddressState",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Mailing Address ZIP Code Field Label",
+                      name: "mailingAddressZipCode",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Contact Name Field Label",
+                      name: "contactName",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Contact Phone Number Field Label",
+                      name: "contactPhoneNumber",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Contact Email Field Label",
+                      name: "contactEmail",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Sales Start Date Field Label",
+                      name: "salesInfoStartDate",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Suppliers Field Label",
+                      name: "salesInfoSupplier",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Signer Name Field Label",
+                      name: "signerName",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Signer Relationship Field Label",
+                      name: "signerRelationship",
+                      widget: "string",
+                      required: true,
+                    }
+                  - {
+                      label: "Signature Field Label",
+                      name: "signature",
+                      widget: "string",
+                      required: true,
+                    }
       - label: "Cigarette License Confirmation"
         name: "cigaretteLicense-confirmation"
         file: "content/src/fieldConfig/cigarette-license-confirmation.json"

--- a/web/src/components/tasks/cigarette-license/CigaretteLicense.tsx
+++ b/web/src/components/tasks/cigarette-license/CigaretteLicense.tsx
@@ -16,6 +16,7 @@ import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { StepperStep, Task } from "@/lib/types/types";
 import { getFlow, useMountEffectWhenDefined } from "@/lib/utils/helpers";
+import { CigaretteLicenseAlert } from "@/components/tasks/cigarette-license/CigaretteLicenseAlert";
 import {
   CigaretteLicenseData,
   emptyCigaretteLicenseData,
@@ -37,7 +38,8 @@ type Props = {
 export const CigaretteLicense = (props: Props): ReactElement => {
   const { Config } = useConfig();
   const [stepIndex, setStepIndex] = useState(props.CMS_ONLY_stepIndex ?? 0);
-  const { state: formContextState } = useFormContextHelper(createDataFormErrorMap());
+  const { getInvalidFieldIds, state: formContextState } =
+    useFormContextHelper(createDataFormErrorMap());
 
   const [profileData, setProfileData] = useState<ProfileData>(emptyProfileData);
   const [formationAddressData, setAddressData] =
@@ -199,6 +201,7 @@ export const CigaretteLicense = (props: Props): ReactElement => {
   return (
     <>
       <TaskHeader task={props.task} />
+      <CigaretteLicenseAlert fieldErrors={getInvalidFieldIds()} setStepIndex={setStepIndex} />
       <HorizontalStepper
         steps={stepperSteps}
         currentStep={stepIndex}

--- a/web/src/components/tasks/cigarette-license/CigaretteLicenseAlert.test.tsx
+++ b/web/src/components/tasks/cigarette-license/CigaretteLicenseAlert.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from "@testing-library/react";
+import { CigaretteLicenseAlert } from "@/components/tasks/cigarette-license/CigaretteLicenseAlert";
+import { getMergedConfig } from "@/contexts/configContext";
+import userEvent from "@testing-library/user-event";
+
+describe("CigaretteLicenseAlert", () => {
+  const Config = getMergedConfig();
+  const mockSetStepIndex = jest.fn();
+
+  const defaultProps = {
+    fieldErrors: [],
+    hasResponseError: false,
+    setStepIndex: mockSetStepIndex,
+  };
+
+  it("renders null when no errors", () => {
+    render(<CigaretteLicenseAlert {...defaultProps} />);
+    const alertBox = screen.queryByRole("alert");
+    expect(alertBox).not.toBeInTheDocument();
+  });
+
+  it("renders alert with field errors", () => {
+    const props = {
+      ...defaultProps,
+      fieldErrors: ["businessName", "contactEmail"],
+    };
+
+    render(<CigaretteLicenseAlert {...props} />);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(
+      screen.getByText(Config.cigaretteLicenseShared.alertFieldNames.businessName),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(Config.cigaretteLicenseShared.alertFieldNames.contactEmail),
+    ).toBeInTheDocument();
+  });
+
+  it("renders alert with response error only", () => {
+    const props = {
+      ...defaultProps,
+      hasResponseError: true,
+    };
+
+    render(<CigaretteLicenseAlert {...props} />);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    // getByTestId needed - markdown content renders across multiple lines
+    expect(screen.getByTestId("cigarette-license-response-error")).toBeInTheDocument();
+  });
+
+  it("renders alert with both field errors and response error", () => {
+    const props = {
+      ...defaultProps,
+      fieldErrors: ["businessName"],
+      hasResponseError: true,
+    };
+
+    render(<CigaretteLicenseAlert {...props} />);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    // getByTestId needed - markdown content renders across multiple lines
+    expect(screen.getByTestId("cigarette-license-error-alert")).toBeInTheDocument();
+    expect(screen.getByTestId("cigarette-license-response-error")).toBeInTheDocument();
+    expect(
+      screen.getByText(Config.cigaretteLicenseShared.alertFieldNames.businessName),
+    ).toBeInTheDocument();
+  });
+
+  it("calls setStepIndex with correct step when clicking step 2 field error links", async () => {
+    const props = {
+      ...defaultProps,
+      fieldErrors: ["businessName"],
+    };
+
+    render(<CigaretteLicenseAlert {...props} />);
+
+    await userEvent.click(
+      screen.getByText(Config.cigaretteLicenseShared.alertFieldNames.businessName),
+    );
+    expect(mockSetStepIndex).toHaveBeenCalledWith(1);
+  });
+
+  it("calls setStepIndex with correct step when clicking step 3 field error links", async () => {
+    const props = {
+      ...defaultProps,
+      fieldErrors: ["salesInfoSupplier"],
+    };
+
+    render(<CigaretteLicenseAlert {...props} />);
+
+    await userEvent.click(
+      screen.getByText(Config.cigaretteLicenseShared.alertFieldNames.salesInfoSupplier),
+    );
+    expect(mockSetStepIndex).toHaveBeenCalledWith(2);
+  });
+
+  it("calls setStepIndex with correct step when clicking step 4 field error links", async () => {
+    const props = {
+      ...defaultProps,
+      fieldErrors: ["signature"],
+    };
+
+    render(<CigaretteLicenseAlert {...props} />);
+
+    await userEvent.click(
+      screen.getByText(Config.cigaretteLicenseShared.alertFieldNames.signature),
+    );
+    expect(mockSetStepIndex).toHaveBeenCalledWith(3);
+  });
+
+  it("renders field error links with correct href attributes", () => {
+    const props = {
+      ...defaultProps,
+      fieldErrors: ["businessName", "contactEmail"],
+    };
+
+    render(<CigaretteLicenseAlert {...props} />);
+
+    const businessNameLink = screen.getByRole("link", {
+      name: Config.cigaretteLicenseShared.alertFieldNames.businessName,
+    });
+    const contactEmailLink = screen.getByRole("link", {
+      name: Config.cigaretteLicenseShared.alertFieldNames.contactEmail,
+    });
+
+    expect(businessNameLink).toHaveAttribute("href", "#question-businessName");
+    expect(contactEmailLink).toHaveAttribute("href", "#question-contactEmail");
+  });
+});

--- a/web/src/components/tasks/cigarette-license/CigaretteLicenseAlert.tsx
+++ b/web/src/components/tasks/cigarette-license/CigaretteLicenseAlert.tsx
@@ -1,0 +1,77 @@
+import { Content } from "@/components/Content";
+import { Alert } from "@/components/njwds-extended/Alert";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { CigaretteLicenseData } from "@businessnjgovnavigator/shared/cigaretteLicense";
+import { ReactElement } from "react";
+
+interface Props {
+  fieldErrors: string[];
+  hasResponseError?: boolean;
+  setStepIndex: (step: number) => void;
+}
+
+type CigaretteLicenseKey = Exclude<
+  keyof CigaretteLicenseData,
+  "encryptedTaxId" | "lastUpdatedISO" | "mailingAddressIsTheSame" | "paymentInfo"
+>;
+
+export const CigaretteLicenseAlert = (props: Props): ReactElement | null => {
+  const { Config } = useConfig();
+
+  const getLabel = (key: CigaretteLicenseKey): string =>
+    Config.cigaretteLicenseShared.alertFieldNames[key] ?? key;
+
+  const getStepIndex = (key: CigaretteLicenseKey): number => {
+    switch (key) {
+      case "signerName":
+        return 3;
+      case "signerRelationship":
+        return 3;
+      case "signature":
+        return 3;
+      case "salesInfoStartDate":
+        return 2;
+      case "salesInfoSupplier":
+        return 2;
+      default:
+        return 1;
+    }
+  };
+
+  const hasErrors = props.fieldErrors.length > 0 || props.hasResponseError;
+
+  return hasErrors ? (
+    <Alert className="margin-top-4" variant="error" dataTestid={"cigarette-license-error-alert"}>
+      {props.fieldErrors.length > 0 && (
+        <>
+          <div>
+            {props.fieldErrors.length > 0 && (
+              <Content>{Config.cigaretteLicenseShared.alertInvalidFields}</Content>
+            )}
+          </div>
+          <ul>
+            {props.fieldErrors.map((id) => (
+              <li key={`${id}`} id={`label-${id}`}>
+                <a
+                  onClick={() => {
+                    props.setStepIndex(getStepIndex(id as CigaretteLicenseKey));
+                  }}
+                  href={`#question-${id}`}
+                >
+                  {getLabel(id as CigaretteLicenseKey)}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+      {props.hasResponseError && (
+        <div data-testid="cigarette-license-response-error">
+          <Content>{Config.cigaretteLicenseShared.alertPaymentError}</Content>
+        </div>
+      )}
+    </Alert>
+  ) : (
+    <></>
+  );
+};

--- a/web/src/components/tasks/cigarette-license/fields/ContactInformation.tsx
+++ b/web/src/components/tasks/cigarette-license/fields/ContactInformation.tsx
@@ -45,7 +45,7 @@ export const ContactInformation = (props: Props): ReactElement => {
         className="margin-bottom-2"
       >
         <div className="grid-row grid-gap-2 margin-y-2">
-          <span className="grid-col-6">
+          <span id="question-contactName" className="grid-col-6">
             <strong>
               <Content>{Config.cigaretteLicenseStep2.fields.contactName.label}</Content>
             </strong>
@@ -63,7 +63,7 @@ export const ContactInformation = (props: Props): ReactElement => {
               preventRefreshWhenUnmounted
             />
           </span>
-          <span className="grid-col-6">
+          <span id="question-contactPhoneNumber" className="grid-col-6">
             <strong>
               <Content>{Config.cigaretteLicenseStep2.fields.contactPhoneNumber.label}</Content>
             </strong>
@@ -88,30 +88,32 @@ export const ContactInformation = (props: Props): ReactElement => {
         </div>
       </WithErrorBar>
 
-      <WithErrorBar
-        hasError={props.CMS_ONLY_show_error || isContactEmailValid}
-        type="ALWAYS"
-        className="margin-top-2 margin-bottom-2"
-      >
-        <strong>
-          <Content>{Config.cigaretteLicenseStep2.fields.contactEmail.label}</Content>
-        </strong>
-        <GenericTextField
-          fieldName="contactEmail"
-          handleChange={(val) => handleChange(val, "contactEmail")}
-          onValidation={(fieldName, invalid) => setIsContactEmailValid(!invalid)}
-          additionalValidationIsValid={validateEmail}
-          error={props.CMS_ONLY_show_error || isContactEmailValid}
-          validationText={Config.cigaretteLicenseStep2.fields.contactEmail.errorRequiredText}
-          required={true}
-          autoComplete="email"
-          type="email"
-          inputWidth="full"
-          formContext={DataFormErrorMapContext}
-          value={state.contactEmail}
-          preventRefreshWhenUnmounted
-        />
-      </WithErrorBar>
+      <div id="question-contactEmail">
+        <WithErrorBar
+          hasError={props.CMS_ONLY_show_error || isContactEmailValid}
+          type="ALWAYS"
+          className="margin-top-2 margin-bottom-2"
+        >
+          <strong>
+            <Content>{Config.cigaretteLicenseStep2.fields.contactEmail.label}</Content>
+          </strong>
+          <GenericTextField
+            fieldName="contactEmail"
+            handleChange={(val) => handleChange(val, "contactEmail")}
+            onValidation={(fieldName, invalid) => setIsContactEmailValid(!invalid)}
+            additionalValidationIsValid={validateEmail}
+            error={props.CMS_ONLY_show_error || isContactEmailValid}
+            validationText={Config.cigaretteLicenseStep2.fields.contactEmail.errorRequiredText}
+            required={true}
+            autoComplete="email"
+            type="email"
+            inputWidth="full"
+            formContext={DataFormErrorMapContext}
+            value={state.contactEmail}
+            preventRefreshWhenUnmounted
+          />
+        </WithErrorBar>
+      </div>
     </>
   );
 };

--- a/web/src/components/tasks/cigarette-license/fields/MailingAddress.tsx
+++ b/web/src/components/tasks/cigarette-license/fields/MailingAddress.tsx
@@ -124,7 +124,7 @@ export const MailingAddress = (props: Props): ReactElement => {
       />
       {!state.mailingAddressIsTheSame && (
         <>
-          <div className="margin-y-2">
+          <div id="question-mailingAddressLine1" className="margin-y-2">
             <WithErrorBar
               className={"padding-bottom-1"}
               hasError={props.CMS_ONLY_show_error || isLine1FieldInvalid}
@@ -150,7 +150,7 @@ export const MailingAddress = (props: Props): ReactElement => {
               </label>
             </WithErrorBar>
           </div>
-          <div className="margin-y-2">
+          <div id="question-mailingAddressLine2" className="margin-y-2">
             <WithErrorBar
               className={"padding-bottom-1"}
               hasError={props.CMS_ONLY_show_error || isLine2FieldInvalid}
@@ -191,7 +191,7 @@ export const MailingAddress = (props: Props): ReactElement => {
                   hasError={props.CMS_ONLY_show_error || isCityFieldInvalid}
                   type={"MOBILE-ONLY"}
                 >
-                  <label htmlFor="mailingAddressCity">
+                  <label id="question-mailingAddressCity" htmlFor="mailingAddressCity">
                     <span className={"text-bold"}>
                       <Content>
                         {Config.cigaretteLicenseStep2.fields.mailingAddressCity.label}
@@ -221,7 +221,7 @@ export const MailingAddress = (props: Props): ReactElement => {
                   }
                   type={"MOBILE-ONLY"}
                 >
-                  <label htmlFor="mailingAddressState">
+                  <label id="question-mailingAddressState" htmlFor="mailingAddressState">
                     <span className={"text-bold"}>
                       <Content>
                         {Config.cigaretteLicenseStep2.fields.mailingAddressState.label}
@@ -241,7 +241,7 @@ export const MailingAddress = (props: Props): ReactElement => {
               </span>
 
               <span className={`${isMobile ? "grid-col-6" : "grid-col-3"}`}>
-                <label htmlFor="mailingAddressZipCode">
+                <label id="question-mailingAddressZipCode" htmlFor="mailingAddressZipCode">
                   <span className={"text-bold"}>
                     <Content>
                       {Config.cigaretteLicenseStep2.fields.mailingAddressZipCode.label}

--- a/web/src/lib/cms/previews/CigaretteLicensePreview.tsx
+++ b/web/src/lib/cms/previews/CigaretteLicensePreview.tsx
@@ -1,4 +1,5 @@
 import { CigaretteLicense } from "@/components/tasks/cigarette-license/CigaretteLicense";
+import { CigaretteLicenseAlert } from "@/components/tasks/cigarette-license/CigaretteLicenseAlert";
 import { ConfigContext } from "@/contexts/configContext";
 import { PreviewProps } from "@/lib/cms/helpers/previewHelpers";
 import { usePageData } from "@/lib/cms/helpers/usePageData";
@@ -33,6 +34,42 @@ const CigaretteLicensePreview = (props: PreviewProps): ReactElement => {
         {tab === "shared" && (
           <>
             <CigaretteLicense task={task} />
+            <div className="margin-top-8">
+              <p>
+                <strong>Example Alert with all field errors</strong>
+              </p>
+              <CigaretteLicenseAlert
+                fieldErrors={[
+                  "businessName",
+                  "responsibleOwnerName",
+                  "tradeName",
+                  "taxId",
+                  "addressLine1",
+                  "addressLine2",
+                  "addressCity",
+                  "addressState",
+                  "addressZipCode",
+                  "mailingAddressLine1",
+                  "mailingAddressLine2",
+                  "mailingAddressCity",
+                  "mailingAddressState",
+                  "mailingAddressZipCode",
+                  "contactName",
+                  "contactPhoneNumber",
+                  "contactEmail",
+                  "salesInfoStartDate",
+                  "salesInfoSupplier",
+                  "signerName",
+                  "signerRelationship",
+                  "signature",
+                ]}
+                setStepIndex={() => null}
+              />
+              <p>
+                <strong>Example Alert with submission error</strong>
+              </p>
+              <CigaretteLicenseAlert fieldErrors={[]} setStepIndex={() => null} hasResponseError />
+            </div>
           </>
         )}
       </div>


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Adds a persistent error alert box on the Cigarette License stepper. 

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14009](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14009).

### Approach

Created `CigaretteLicenseAlert.tsx` and corresponding tests. The component has props for `fieldErrors` that are mapped to config display names. If any field in the CigaretteLicense dataformerror map is invalid, it will show a line item for that field. There is also a separate prop for a submission error that would be shown if the `prepare-payment` api call fails. The line items are also anchor tags that point directly to the field in question. 

### Steps to Test

1. pull down this branch and start the app locally
2. create a new new jersey business
3. navigate to `http://localhost:3000/tasks/cigarette-license`
4. select a field and then tab out of it. 
5. the field should show in the alert box
6. if you click on the line item in the alert box, it should jump to the field

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
