### PR TITLE
fix: [AB#14930] update AddressComponents for CigLicense

### DIFF
--- a/web/src/components/data-fields/address/AddressMunicipalityDropdown.tsx
+++ b/web/src/components/data-fields/address/AddressMunicipalityDropdown.tsx
@@ -7,7 +7,6 @@ import { ReactElement, useContext } from "react";
 
 interface Props {
   onValidation: () => void;
-  error?: boolean;
 }
 
 export const AddressMunicipalityDropdown = (props: Props): ReactElement => {
@@ -26,7 +25,7 @@ export const AddressMunicipalityDropdown = (props: Props): ReactElement => {
       onValidation={props.onValidation}
       municipalities={municipalities}
       fieldName={"addressMunicipality"}
-      error={doesFieldHaveError("addressMunicipality") || props.error}
+      error={doesFieldHaveError("addressMunicipality")}
       value={state.formationAddressData.addressMunicipality}
       onSelect={onSelect}
       helperText={getFieldErrorLabel("addressMunicipality")}

--- a/web/src/components/data-fields/address/NewJerseyAddress.tsx
+++ b/web/src/components/data-fields/address/NewJerseyAddress.tsx
@@ -7,62 +7,38 @@ import { WithErrorBar } from "@/components/WithErrorBar";
 import { useAddressErrors } from "@/lib/data-hooks/useAddressErrors";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { ReactElement } from "react";
-import { FormContextType } from "@/lib/types/types";
-import { DataFormErrorMap } from "@/contexts/dataFormErrorMapContext";
 import { ScrollableFormFieldWrapper } from "@/components/data-fields/ScrollableFormFieldWrapper";
 
 interface Props {
   onValidation: () => void;
-  isFullWidth?: boolean;
-  dataFormErrorMap?: FormContextType<DataFormErrorMap, unknown>;
 }
 
 export const NewJerseyAddress = (props: Props): ReactElement => {
   const { Config } = useConfig();
   const { doSomeFieldsHaveError, doesFieldHaveError, getFieldErrorLabel } = useAddressErrors();
 
-  const isAddressLine1Invalid =
-    props.dataFormErrorMap?.fieldStates?.["addressLine1"]?.invalid ?? false;
-  const isAddressCityInvalid =
-    props.dataFormErrorMap?.fieldStates?.["addressCity"]?.invalid ?? false;
-  const isAddressZipCodeInvalid =
-    props.dataFormErrorMap?.fieldStates?.["addressZipCode"]?.invalid ?? false;
-
   return (
     <>
-      <AddressLines1And2
-        onValidation={props.onValidation}
-        isFullWidth={props.isFullWidth}
-        isAddressLine1Invalid={isAddressLine1Invalid}
-      />
-      <div className={`${props.isFullWidth ? "" : "text-field-width-default"}`}>
+      <AddressLines1And2 onValidation={props.onValidation} />
+      <div className="text-field-width-default">
         <WithErrorBar
-          hasError={
-            doSomeFieldsHaveError(["addressState", "addressZipCode", "addressMunicipality"]) ||
-            isAddressCityInvalid ||
-            isAddressZipCodeInvalid
-          }
+          hasError={doSomeFieldsHaveError([
+            "addressState",
+            "addressZipCode",
+            "addressMunicipality",
+          ])}
           type="DESKTOP-ONLY"
         >
           <div className="grid-row tablet:grid-gap-2">
             <div className="grid-col-12 tablet:grid-col-6">
-              <WithErrorBar
-                hasError={doesFieldHaveError("addressMunicipality") || isAddressCityInvalid}
-                type="MOBILE-ONLY"
-              >
+              <WithErrorBar hasError={doesFieldHaveError("addressMunicipality")} type="MOBILE-ONLY">
                 <span className="text-bold">{Config.formation.fields.addressCity.label}</span>
-                <AddressMunicipalityDropdown
-                  onValidation={props.onValidation}
-                  error={isAddressCityInvalid}
-                />
+                <AddressMunicipalityDropdown onValidation={props.onValidation} />
               </WithErrorBar>
             </div>
             <div className="grid-col-12 tablet:grid-col-6 margin-top-2 tablet:margin-top-0">
               <WithErrorBar
-                hasError={
-                  doSomeFieldsHaveError(["addressState", "addressZipCode"]) ||
-                  isAddressZipCodeInvalid
-                }
+                hasError={doSomeFieldsHaveError(["addressState", "addressZipCode"])}
                 type="MOBILE-ONLY"
               >
                 <div className="grid-row grid-gap tablet:grid-gap-2">
@@ -94,7 +70,6 @@ export const NewJerseyAddress = (props: Props): ReactElement => {
                           validationText={getFieldErrorLabel("addressZipCode")}
                           fieldName={"addressZipCode"}
                           onValidation={props.onValidation}
-                          error={isAddressZipCodeInvalid}
                         />
                       </div>
                     </ScrollableFormFieldWrapper>

--- a/web/src/components/data-fields/address/UnitedStatesAddress.tsx
+++ b/web/src/components/data-fields/address/UnitedStatesAddress.tsx
@@ -17,6 +17,7 @@ interface Props {
   isFullWidth?: boolean;
   excludeNJ?: boolean | true;
   dataFormErrorMap?: FormContextType<DataFormErrorMap, unknown>;
+  stateInputLocked?: boolean;
 }
 
 export const UnitedStatesAddress = (props: Props): ReactElement => {
@@ -94,7 +95,7 @@ export const UnitedStatesAddress = (props: Props): ReactElement => {
                             });
                           }}
                           error={doesFieldHaveError("addressState") || isAddressStateInvalid}
-                          disabled={false}
+                          disabled={props.stateInputLocked}
                           onValidation={props.onValidation}
                           excludeNJ={props.excludeNJ}
                         />

--- a/web/src/components/tasks/cigarette-license/LicenseeInfo.test.tsx
+++ b/web/src/components/tasks/cigarette-license/LicenseeInfo.test.tsx
@@ -151,7 +151,7 @@ describe("<LicenseeInfo />", () => {
         businessAddressContainer.getByRole("textbox", { name: /address line1/i }),
       ).toBeInTheDocument();
       expect(
-        businessAddressContainer.getByRole("combobox", { name: /address municipality/i }),
+        businessAddressContainer.getByRole("textbox", { name: /address city/i }),
       ).toBeInTheDocument();
       expect(
         businessAddressContainer.getByRole("combobox", { name: /address state/i }),

--- a/web/src/components/tasks/cigarette-license/LicenseeInfo.tsx
+++ b/web/src/components/tasks/cigarette-license/LicenseeInfo.tsx
@@ -1,5 +1,5 @@
 import { Content } from "@/components/Content";
-import { NewJerseyAddress } from "@/components/data-fields/address/NewJerseyAddress";
+import { UnitedStatesAddress } from "@/components/data-fields/address/UnitedStatesAddress";
 import { BusinessName } from "@/components/data-fields/BusinessName";
 import { ResponsibleOwnerName } from "@/components/data-fields/ResponsibleOwnerName";
 import { DisabledTaxId } from "@/components/data-fields/tax-id/DisabledTaxId";
@@ -128,10 +128,11 @@ export const LicenseeInfo = (props: Props): ReactElement => {
       <h2 className="padding-top-2">{Config.cigaretteLicenseStep2.businessAddressHeader}</h2>
       <p>{Config.cigaretteLicenseStep2.businessAddressDescription}</p>
       <div data-testid="business-address-section" className="margin-y-4">
-        <NewJerseyAddress
+        <UnitedStatesAddress
           onValidation={onValidation}
           isFullWidth
           dataFormErrorMap={dataFormErrorMap}
+          stateInputLocked
         />
       </div>
       <HorizontalLine />

--- a/web/src/components/tasks/cigarette-license/helpers.ts
+++ b/web/src/components/tasks/cigarette-license/helpers.ts
@@ -58,10 +58,7 @@ export const getInitialData = (
       ?.displayName ||
     business.formationData.formationFormData.addressCity ||
     "";
-  const addressState =
-    business.cigaretteLicenseData?.addressState ||
-    business.formationData?.formationFormData?.addressState ||
-    undefined;
+  const addressState = { name: "New Jersey", shortCode: "NJ" } as StateObject;
   const addressZipCode =
     business.cigaretteLicenseData?.addressZipCode ||
     business.formationData.formationFormData.addressZipCode ||


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Reverting `NewJerseyAddress` back to previous state and updating `UnitedStatesAddress` to have a locked state field option. Updating the `getInitialData` function in `web/src/components/tasks/cigarette-license/helpers.ts` to hard code the `addressState` to `NJ`

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
