### PR TITLE
fix: [AB#14009] update cigLicense submission errors

### DIFF
--- a/content/src/fieldConfig/cigarette-license-shared.json
+++ b/content/src/fieldConfig/cigarette-license-shared.json
@@ -6,7 +6,8 @@
     "stepperFourLabel": "Review & Pay",
     "issuingAgencyText": "NJ Division of Revenue and Enterprise Services",
     "issuingAgencyLabelText": "Issuing Agency",
-    "alertPaymentError": "**This service is temporarily unavailable.** Try again later.",
+    "alertPaymentError": "**Something went wrong**. Review your information and try again later.",
+    "alertServiceUnavailable": "**This service is temporarily unavailable**. Try again later.",
     "alertInvalidFields": "**Missing or invalid information.** Review the following fields:",
     "alertFieldNames": {
       "businessName": "Business Name",

--- a/shared/src/cigaretteLicense.ts
+++ b/shared/src/cigaretteLicense.ts
@@ -73,6 +73,8 @@ export const emptyCigaretteLicensePaymentInfo = {
   confirmationEmailsent: false,
 };
 
+export type SubmissionError = "PAYMENT" | "UNAVAILABLE" | undefined;
+
 export interface PreparePaymentApiSubmission {
   MerchantCode: string;
   MerchantKey: string;

--- a/web/decap-config/collections/06-tasks.yml
+++ b/web/decap-config/collections/06-tasks.yml
@@ -1224,8 +1224,14 @@ collections:
                   required: true,
                 }
               - {
-                  label: "Alert Submission Error",
+                  label: "Alert Payment Error",
                   name: "alertPaymentError",
+                  widget: "markdown",
+                  required: true,
+                }
+              - {
+                  label: "Alert Service Unavailable Error",
+                  name: "alertServiceUnavailable",
                   widget: "markdown",
                   required: true,
                 }

--- a/web/src/components/tasks/cigarette-license/CigaretteLicenseAlert.test.tsx
+++ b/web/src/components/tasks/cigarette-license/CigaretteLicenseAlert.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { CigaretteLicenseAlert } from "@/components/tasks/cigarette-license/CigaretteLicenseAlert";
 import { getMergedConfig } from "@/contexts/configContext";
 import userEvent from "@testing-library/user-event";
+import { SubmissionError } from "@businessnjgovnavigator/shared/cigaretteLicense";
 
 describe("CigaretteLicenseAlert", () => {
   const Config = getMergedConfig();
@@ -9,7 +10,7 @@ describe("CigaretteLicenseAlert", () => {
 
   const defaultProps = {
     fieldErrors: [],
-    hasResponseError: false,
+    submissionError: undefined,
     setStepIndex: mockSetStepIndex,
   };
 
@@ -36,24 +37,40 @@ describe("CigaretteLicenseAlert", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders alert with response error only", () => {
+  it("renders alert with payment error only", () => {
+    const submissionError: SubmissionError = "PAYMENT";
     const props = {
       ...defaultProps,
-      hasResponseError: true,
+      submissionError,
     };
 
     render(<CigaretteLicenseAlert {...props} />);
 
     expect(screen.getByRole("alert")).toBeInTheDocument();
     // getByTestId needed - markdown content renders across multiple lines
-    expect(screen.getByTestId("cigarette-license-response-error")).toBeInTheDocument();
+    expect(screen.getByTestId("cigarette-license-payment-error")).toBeInTheDocument();
+  });
+
+  it("renders alert with unavailable error only", () => {
+    const submissionError: SubmissionError = "UNAVAILABLE";
+    const props = {
+      ...defaultProps,
+      submissionError,
+    };
+
+    render(<CigaretteLicenseAlert {...props} />);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    // getByTestId needed - markdown content renders across multiple lines
+    expect(screen.getByTestId("cigarette-license-unavailable-error")).toBeInTheDocument();
   });
 
   it("renders alert with both field errors and response error", () => {
+    const submissionError: SubmissionError = "PAYMENT";
     const props = {
       ...defaultProps,
       fieldErrors: ["businessName"],
-      hasResponseError: true,
+      submissionError,
     };
 
     render(<CigaretteLicenseAlert {...props} />);
@@ -61,7 +78,7 @@ describe("CigaretteLicenseAlert", () => {
     expect(screen.getByRole("alert")).toBeInTheDocument();
     // getByTestId needed - markdown content renders across multiple lines
     expect(screen.getByTestId("cigarette-license-error-alert")).toBeInTheDocument();
-    expect(screen.getByTestId("cigarette-license-response-error")).toBeInTheDocument();
+    expect(screen.getByTestId("cigarette-license-payment-error")).toBeInTheDocument();
     expect(
       screen.getByText(Config.cigaretteLicenseShared.alertFieldNames.businessName),
     ).toBeInTheDocument();

--- a/web/src/components/tasks/cigarette-license/CigaretteLicenseAlert.tsx
+++ b/web/src/components/tasks/cigarette-license/CigaretteLicenseAlert.tsx
@@ -1,12 +1,15 @@
 import { Content } from "@/components/Content";
 import { Alert } from "@/components/njwds-extended/Alert";
 import { useConfig } from "@/lib/data-hooks/useConfig";
-import { CigaretteLicenseData } from "@businessnjgovnavigator/shared/cigaretteLicense";
+import {
+  CigaretteLicenseData,
+  SubmissionError,
+} from "@businessnjgovnavigator/shared/cigaretteLicense";
 import { ReactElement } from "react";
 
 interface Props {
   fieldErrors: string[];
-  hasResponseError?: boolean;
+  submissionError?: SubmissionError;
   setStepIndex: (step: number) => void;
 }
 
@@ -38,7 +41,7 @@ export const CigaretteLicenseAlert = (props: Props): ReactElement | null => {
     }
   };
 
-  const hasErrors = props.fieldErrors.length > 0 || props.hasResponseError;
+  const hasErrors = props.fieldErrors.length > 0 || props.submissionError;
 
   return hasErrors ? (
     <Alert className="margin-top-4" variant="error" dataTestid={"cigarette-license-error-alert"}>
@@ -65,9 +68,14 @@ export const CigaretteLicenseAlert = (props: Props): ReactElement | null => {
           </ul>
         </>
       )}
-      {props.hasResponseError && (
-        <div data-testid="cigarette-license-response-error">
+      {props.submissionError === "PAYMENT" && (
+        <div data-testid="cigarette-license-payment-error">
           <Content>{Config.cigaretteLicenseShared.alertPaymentError}</Content>
+        </div>
+      )}
+      {props.submissionError === "UNAVAILABLE" && (
+        <div data-testid="cigarette-license-unavailable-error">
+          <Content>{Config.cigaretteLicenseShared.alertServiceUnavailable}</Content>
         </div>
       )}
     </Alert>

--- a/web/src/lib/cms/previews/CigaretteLicensePreview.tsx
+++ b/web/src/lib/cms/previews/CigaretteLicensePreview.tsx
@@ -66,9 +66,21 @@ const CigaretteLicensePreview = (props: PreviewProps): ReactElement => {
                 setStepIndex={() => null}
               />
               <p>
-                <strong>Example Alert with submission error</strong>
+                <strong>Example Alert with payment error</strong>
               </p>
-              <CigaretteLicenseAlert fieldErrors={[]} setStepIndex={() => null} hasResponseError />
+              <CigaretteLicenseAlert
+                fieldErrors={[]}
+                setStepIndex={() => null}
+                submissionError="PAYMENT"
+              />
+              <p>
+                <strong>Example Alert with unavailable error</strong>
+              </p>
+              <CigaretteLicenseAlert
+                fieldErrors={[]}
+                setStepIndex={() => null}
+                submissionError="UNAVAILABLE"
+              />
             </div>
           </>
         )}


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

The cig license alert box needed a secondary submission error message. The message was added to cms. The prop for submission error was made more dynamic and the type was added to `cigaretteLicense.ts`. Tests were updated. 

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
