### PR TITLE
feat: [AB#8391] Add analytics events to CMS generated non-essential q…

### DIFF
--- a/web/src/components/data-fields/non-essential-questions/IndustryBasedNonEssentialQuestionsSection.test.tsx
+++ b/web/src/components/data-fields/non-essential-questions/IndustryBasedNonEssentialQuestionsSection.test.tsx
@@ -4,6 +4,7 @@ import { WithStatefulProfileData } from "@/test/mock/withStatefulProfileData";
 import { ProfileData } from "@businessnjgovnavigator/shared";
 import { generateProfileData } from "@businessnjgovnavigator/shared/test";
 import { render, screen } from "@testing-library/react";
+import { useMockIntersectionObserver } from "@/test/mock/MockIntersectionObserver";
 
 jest.mock("../../../../../shared/lib/content/lib/industry.json", () => ({
   industries: [
@@ -86,6 +87,7 @@ const mockGetNonEssentialQuestionText = (
 ).getNonEssentialQuestionText;
 
 describe("ProfileNonEssentialQuestionsSection", () => {
+  useMockIntersectionObserver();
   const renderComponent = (profileData: Partial<ProfileData>): void => {
     render(
       <WithStatefulProfileData

--- a/web/src/components/data-fields/non-essential-questions/LocationBasedNonEssentialQuestions.test.tsx
+++ b/web/src/components/data-fields/non-essential-questions/LocationBasedNonEssentialQuestions.test.tsx
@@ -8,6 +8,7 @@ import { getFlow } from "@/lib/utils/helpers";
 import { randomHomeBasedIndustry, randomNonHomeBasedIndustry } from "@/test/factories";
 import { randomElementFromArray } from "@/test/helpers/helpers-utilities";
 import { useMockBusiness } from "@/test/mock/mockUseUserData";
+import { useMockIntersectionObserver } from "@/test/mock/MockIntersectionObserver";
 import { generateBusinessForProfile } from "@/test/pages/profile/profile-helpers";
 import { getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
 import { OperatingPhase, OperatingPhases } from "@businessnjgovnavigator/shared/operatingPhase";
@@ -17,9 +18,14 @@ import { render, screen } from "@testing-library/react";
 
 jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
 
+jest.mock("@/lib/utils/useIntersectionOnElement", () => ({
+  useIntersectionOnElement: jest.fn(),
+}));
+
 describe("LocationBasedNonEssentialQuestions", () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    useMockIntersectionObserver();
   });
 
   const renderComponent = (profileData: ProfileData): void => {

--- a/web/src/components/data-fields/non-essential-questions/NonEssentialQuestion.test.tsx
+++ b/web/src/components/data-fields/non-essential-questions/NonEssentialQuestion.test.tsx
@@ -8,9 +8,29 @@ import {
 } from "@businessnjgovnavigator/shared";
 import { getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
 import { fireEvent, render, screen, within } from "@testing-library/react";
+import { useIntersectionOnElement } from "@/lib/utils/useIntersectionOnElement";
+import analytics from "@/lib/utils/analytics";
 
 jest.mock("@/lib/domain-logic/getNonEssentialQuestionText", () => ({
   getNonEssentialQuestionText: jest.fn(),
+}));
+
+jest.mock("@/lib/utils/analytics-helpers", () => ({
+  setNonEssentialQuestionViewedDimension: jest.fn(),
+}));
+
+jest.mock("@/lib/utils/useIntersectionOnElement", () => ({
+  useIntersectionOnElement: jest.fn(),
+}));
+
+jest.mock("@/lib/utils/analytics", () => ({
+  event: {
+    non_essential_question_view: {
+      view: {
+        non_essential_question_view: jest.fn(),
+      },
+    },
+  },
 }));
 
 const mockGetNonEssentialQuestionText = (
@@ -76,5 +96,31 @@ describe("ProfileNonEssentialQuestion", () => {
     });
     fireEvent.click(screen.getByTestId("cool-test-id-radio-no"));
     expect(currentProfileData().nonEssentialRadioAnswers).toEqual({ "cool-test-id": false });
+  });
+
+  describe("NonEssentialQuestion Analytics", () => {
+    it("should set the nonEssentialQuestionViewedDimenension and call the analytics", () => {
+      (useIntersectionOnElement as jest.Mock).mockReturnValue(true);
+      renderEssentialQuestion({
+        essentialQuestionId: "cool-test-id",
+        profileData: { nonEssentialRadioAnswers: { "cool-test-id": false } },
+      });
+
+      expect(
+        analytics.event.non_essential_question_view.view.non_essential_question_view,
+      ).toHaveBeenCalledWith("cool-test-id");
+    });
+
+    it("should set HasBeenSeen to false when not in view and not call analytics", () => {
+      (useIntersectionOnElement as jest.Mock).mockReturnValue(false);
+      renderEssentialQuestion({
+        essentialQuestionId: "cool-test-id",
+        profileData: { nonEssentialRadioAnswers: { "cool-test-id": false } },
+      });
+
+      expect(
+        analytics.event.non_essential_question_view.view.non_essential_question_view,
+      ).not.toHaveBeenCalledWith("cool-test-id");
+    });
   });
 });

--- a/web/src/components/data-fields/non-essential-questions/NonEssentialQuestion.tsx
+++ b/web/src/components/data-fields/non-essential-questions/NonEssentialQuestion.tsx
@@ -2,9 +2,11 @@ import { Content } from "@/components/Content";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { getNonEssentialQuestionText } from "@/lib/domain-logic/getNonEssentialQuestionText";
+import analytics from "@/lib/utils/analytics";
 import { convertTextToMarkdownBold } from "@/lib/utils/content-helpers";
+import { useIntersectionOnElement } from "@/lib/utils/useIntersectionOnElement";
 import { FormControl, FormControlLabel, Radio, RadioGroup } from "@mui/material";
-import React, { ReactElement, useContext } from "react";
+import React, { ReactElement, useContext, useEffect, useRef, useState } from "react";
 
 interface Props {
   essentialQuestionId: string;
@@ -14,6 +16,9 @@ export const NonEssentialQuestion = (props: Props): ReactElement => {
   const nonEssentialQuestionText = getNonEssentialQuestionText(props.essentialQuestionId);
   const { state, setProfileData } = useContext(ProfileDataContext);
   const { Config } = useConfig();
+  const nonEssentialQuestion = useRef(null);
+  const [hasBeenSeen, setHasBeenSeen] = useState(false);
+  const nonEssentialQuestionInViewPort = useIntersectionOnElement(nonEssentialQuestion, "-20px");
 
   const handleChange = (event: React.ChangeEvent<{ name?: string; value: string }>): void => {
     setProfileData({
@@ -25,46 +30,66 @@ export const NonEssentialQuestion = (props: Props): ReactElement => {
     });
   };
 
+  useEffect(() => {
+    if (!(nonEssentialQuestionInViewPort && !hasBeenSeen)) {
+      return;
+    }
+
+    if (props.essentialQuestionId) {
+      analytics.event.non_essential_question_view.view.non_essential_question_view(
+        props.essentialQuestionId,
+      );
+    }
+    setHasBeenSeen(true);
+  }, [
+    nonEssentialQuestionInViewPort,
+    hasBeenSeen,
+    nonEssentialQuestionText,
+    props.essentialQuestionId,
+  ]);
+
   return (
     <>
       {nonEssentialQuestionText && (
         <>
-          <Content className={"margin-top-2"}>
-            {`${convertTextToMarkdownBold(nonEssentialQuestionText)} ${
-              Config.profileDefaults.fields.nonEssentialQuestions.default.optionalText
-            }`}
-          </Content>
-          <FormControl fullWidth>
-            <RadioGroup
-              aria-label={nonEssentialQuestionText}
-              name={props.essentialQuestionId}
-              value={state.profileData.nonEssentialRadioAnswers?.[props.essentialQuestionId]}
-              onChange={handleChange}
-              row
-              data-testid={`${props.essentialQuestionId}-essential-question`}
-            >
-              <FormControlLabel
-                style={{ alignItems: "center" }}
-                labelPlacement="end"
-                data-testid={`${props.essentialQuestionId}-radio-yes`}
-                value={true}
-                control={<Radio color="primary" />}
-                label={
-                  Config.profileDefaults.fields.nonEssentialQuestions.default.radioButtonTrueText
-                }
-              />
-              <FormControlLabel
-                style={{ alignItems: "center" }}
-                labelPlacement="end"
-                data-testid={`${props.essentialQuestionId}-radio-no`}
-                value={false}
-                control={<Radio color="primary" />}
-                label={
-                  Config.profileDefaults.fields.nonEssentialQuestions.default.radioButtonFalseText
-                }
-              />
-            </RadioGroup>
-          </FormControl>
+          <section ref={nonEssentialQuestion}>
+            <Content className={"margin-top-2"}>
+              {`${convertTextToMarkdownBold(nonEssentialQuestionText)} ${
+                Config.profileDefaults.fields.nonEssentialQuestions.default.optionalText
+              }`}
+            </Content>
+            <FormControl fullWidth>
+              <RadioGroup
+                aria-label={nonEssentialQuestionText}
+                name={props.essentialQuestionId}
+                value={state.profileData.nonEssentialRadioAnswers?.[props.essentialQuestionId]}
+                onChange={handleChange}
+                row
+                data-testid={`${props.essentialQuestionId}-essential-question`}
+              >
+                <FormControlLabel
+                  style={{ alignItems: "center" }}
+                  labelPlacement="end"
+                  data-testid={`${props.essentialQuestionId}-radio-yes`}
+                  value={true}
+                  control={<Radio color="primary" />}
+                  label={
+                    Config.profileDefaults.fields.nonEssentialQuestions.default.radioButtonTrueText
+                  }
+                />
+                <FormControlLabel
+                  style={{ alignItems: "center" }}
+                  labelPlacement="end"
+                  data-testid={`${props.essentialQuestionId}-radio-no`}
+                  value={false}
+                  control={<Radio color="primary" />}
+                  label={
+                    Config.profileDefaults.fields.nonEssentialQuestions.default.radioButtonFalseText
+                  }
+                />
+              </RadioGroup>
+            </FormControl>
+          </section>
         </>
       )}
     </>

--- a/web/src/components/data-fields/non-essential-questions/nonEssentialQuestionsHelpers.test.tsx
+++ b/web/src/components/data-fields/non-essential-questions/nonEssentialQuestionsHelpers.test.tsx
@@ -1,0 +1,55 @@
+import { NonEssentialQuestionForPersonas } from "@/components/data-fields/non-essential-questions/nonEssentialQuestionsHelpers";
+import { render } from "@testing-library/react";
+import { generateProfileData } from "@businessnjgovnavigator/shared/test";
+import { WithStatefulProfileData } from "@/test/mock/withStatefulProfileData";
+import { ProfileContentField } from "@businessnjgovnavigator/shared/types";
+import { useIntersectionOnElement } from "@/lib/utils/useIntersectionOnElement";
+import analytics from "@/lib/utils/analytics";
+
+const renderNonEssentialQuestionsHelpers = (questionId: ProfileContentField): void => {
+  const initialProfileData = generateProfileData({});
+  render(
+    <WithStatefulProfileData initialData={initialProfileData}>
+      <NonEssentialQuestionForPersonas questionId={questionId} />
+    </WithStatefulProfileData>,
+  );
+};
+
+jest.mock("@/lib/utils/useIntersectionOnElement", () => ({
+  useIntersectionOnElement: jest.fn(),
+}));
+
+jest.mock("@/lib/utils/analytics", () => ({
+  event: {
+    non_essential_question_view: {
+      view: {
+        non_essential_question_view: jest.fn(),
+      },
+    },
+  },
+}));
+
+describe("NonEssentialQuestionForPersonas", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  describe("Analytics Tracking", () => {
+    it("triggers analytics when element enters viewport for the first time", () => {
+      (useIntersectionOnElement as jest.Mock).mockReturnValue(true);
+      renderNonEssentialQuestionsHelpers("homeBasedBusiness");
+      expect(
+        analytics.event.non_essential_question_view.view.non_essential_question_view,
+      ).toHaveBeenCalledWith("homeBasedBusiness");
+    });
+
+    it("does not trigger analytics when element does not enter viewport", () => {
+      (useIntersectionOnElement as jest.Mock).mockReturnValue(false);
+      renderNonEssentialQuestionsHelpers("homeBasedBusiness");
+      expect(
+        analytics.event.non_essential_question_view.view.non_essential_question_view,
+      ).not.toHaveBeenCalledWith("homeBasedBusiness");
+    });
+  });
+});

--- a/web/src/components/data-fields/non-essential-questions/nonEssentialQuestionsHelpers.tsx
+++ b/web/src/components/data-fields/non-essential-questions/nonEssentialQuestionsHelpers.tsx
@@ -1,27 +1,56 @@
 import { RadioQuestion } from "@/components/data-fields/RadioQuestion";
 import { ProfileField } from "@/components/profile/ProfileField";
 import { ProfileContentField } from "@businessnjgovnavigator/shared/types";
-import { ReactElement } from "react";
+import { ReactElement, useEffect, useRef, useState } from "react";
+import { useIntersectionOnElement } from "@/lib/utils/useIntersectionOnElement";
+import { getProfileConfig } from "@/lib/domain-logic/getProfileConfig";
+import { getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
+import analytics from "@/lib/utils/analytics";
 
 export const NonEssentialQuestionForPersonas = (props: {
   questionId: ProfileContentField;
   displayAltDescription?: boolean;
 }): ReactElement => {
+  const nonEssentialQuestion = useRef(null);
+  const [hasBeenSeen, setHasBeenSeen] = useState(false);
+  const nonEssentialQuestionInViewPort = useIntersectionOnElement(nonEssentialQuestion, "-20px");
+  const Config = getMergedConfig();
+  const contentFromConfig = getProfileConfig({
+    config: Config,
+    fieldName: props.questionId,
+  });
+  const nonEssentialQuestionText = contentFromConfig.description;
+
+  useEffect(() => {
+    if (!(nonEssentialQuestionInViewPort && !hasBeenSeen)) {
+      return;
+    }
+
+    if (nonEssentialQuestionText) {
+      analytics.event.non_essential_question_view.view.non_essential_question_view(
+        props.questionId,
+      );
+    }
+    setHasBeenSeen(true);
+  }, [nonEssentialQuestionInViewPort, hasBeenSeen, nonEssentialQuestionText, props.questionId]);
+
   return (
-    <div data-testid="non-essential-questions-wrapper">
-      <ProfileField
-        fieldName={props.questionId}
-        isVisible
-        hideHeader
-        hideLine
-        fullWidth
-        boldAltDescription
-        boldDescription
-        optionalText
-        displayAltDescription={props.displayAltDescription}
-      >
-        <RadioQuestion<boolean> fieldName={props.questionId} choices={[true, false]} />
-      </ProfileField>
-    </div>
+    <section ref={nonEssentialQuestion}>
+      <div data-testid="non-essential-questions-wrapper">
+        <ProfileField
+          fieldName={props.questionId}
+          isVisible
+          hideHeader
+          hideLine
+          fullWidth
+          boldAltDescription
+          boldDescription
+          optionalText
+          displayAltDescription={props.displayAltDescription}
+        >
+          <RadioQuestion<boolean> fieldName={props.questionId} choices={[true, false]} />
+        </ProfileField>
+      </div>
+    </section>
   );
 };

--- a/web/src/components/profile/PersonalizeYourTasksTab.test.tsx
+++ b/web/src/components/profile/PersonalizeYourTasksTab.test.tsx
@@ -26,6 +26,10 @@ jest.mock("@/components/Content", () => ({
   Content: (({ children }) => <div>{children}</div>) as React.FC<{ children: React.ReactNode }>,
 }));
 
+jest.mock("@/lib/utils/useIntersectionOnElement", () => ({
+  useIntersectionOnElement: jest.fn(),
+}));
+
 const Config = getMergedConfig();
 
 const renderPersonalizeYourTasksTab = ({

--- a/web/src/lib/domain-logic/sendChangedNonEssentialQuestionAnalytics.test.ts
+++ b/web/src/lib/domain-logic/sendChangedNonEssentialQuestionAnalytics.test.ts
@@ -1,0 +1,300 @@
+import { getNonEssentialQuestionText } from "@/lib/domain-logic/getNonEssentialQuestionText";
+import { sendChangedNonEssentialQuestionAnalytics } from "@/lib/domain-logic/sendChangedNonEssentialQuestionAnalytics";
+import { ProfileData } from "@businessnjgovnavigator/shared/profileData";
+import { generateProfileData } from "@businessnjgovnavigator/shared/test/factories";
+import analytics from "@/lib/utils/analytics";
+
+jest.mock("@/lib/domain-logic/getNonEssentialQuestionText", () => ({
+  getNonEssentialQuestionText: jest.fn(),
+}));
+
+jest.mock("@/lib/utils/analytics", () => ({
+  event: {
+    non_essential_question_set: {
+      view: {
+        non_essential_question_set: jest.fn(),
+      },
+    },
+  },
+}));
+
+describe("sendChangedNonEssentialQuestionAnalytics", () => {
+  let prevProfile: ProfileData | null;
+  let newProfile: ProfileData | null;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    prevProfile = null;
+    newProfile = null;
+  });
+
+  it("send analytics when a nonEssentialRadioAnswers field changes", () => {
+    (getNonEssentialQuestionText as jest.Mock).mockReturnValue("Question Text");
+
+    prevProfile = generateProfileData({
+      nonEssentialRadioAnswers: {},
+      carnivalRideOwningBusiness: undefined,
+      raffleBingoGames: undefined,
+      travelingCircusOrCarnivalOwningBusiness: undefined,
+      vacantPropertyOwner: undefined,
+      elevatorOwningBusiness: undefined,
+      homeBasedBusiness: undefined,
+      plannedRenovationQuestion: undefined,
+    });
+
+    newProfile = generateProfileData({
+      nonEssentialRadioAnswers: { q1: true },
+      carnivalRideOwningBusiness: undefined,
+      raffleBingoGames: undefined,
+      travelingCircusOrCarnivalOwningBusiness: undefined,
+      vacantPropertyOwner: undefined,
+      elevatorOwningBusiness: undefined,
+      homeBasedBusiness: undefined,
+      plannedRenovationQuestion: undefined,
+    });
+
+    sendChangedNonEssentialQuestionAnalytics(prevProfile, newProfile);
+
+    expect(
+      analytics.event.non_essential_question_set.view.non_essential_question_set,
+    ).toHaveBeenCalledWith("q1", "Yes");
+  });
+
+  it("does not send analytics when nonEssentialRadioAnswers  does not change", () => {
+    (getNonEssentialQuestionText as jest.Mock).mockReturnValue("Question Text");
+
+    prevProfile = generateProfileData({
+      nonEssentialRadioAnswers: { q1: true },
+    });
+
+    newProfile = prevProfile;
+    sendChangedNonEssentialQuestionAnalytics(prevProfile, newProfile);
+    expect(
+      analytics.event.non_essential_question_set.view.non_essential_question_set,
+    ).not.toHaveBeenCalledWith("q1", "Yes");
+  });
+
+  it("send analytics when a carnival ride business radio answer field changes", () => {
+    (getNonEssentialQuestionText as jest.Mock).mockReturnValue("Question Text");
+
+    prevProfile = generateProfileData({
+      nonEssentialRadioAnswers: {},
+      carnivalRideOwningBusiness: undefined,
+      raffleBingoGames: undefined,
+      travelingCircusOrCarnivalOwningBusiness: undefined,
+      vacantPropertyOwner: undefined,
+      elevatorOwningBusiness: undefined,
+      homeBasedBusiness: undefined,
+      plannedRenovationQuestion: undefined,
+    });
+
+    newProfile = generateProfileData({
+      nonEssentialRadioAnswers: {},
+      carnivalRideOwningBusiness: false,
+      raffleBingoGames: undefined,
+      travelingCircusOrCarnivalOwningBusiness: undefined,
+      vacantPropertyOwner: undefined,
+      elevatorOwningBusiness: undefined,
+      homeBasedBusiness: undefined,
+      plannedRenovationQuestion: undefined,
+    });
+    sendChangedNonEssentialQuestionAnalytics(prevProfile, newProfile);
+
+    expect(
+      analytics.event.non_essential_question_set.view.non_essential_question_set,
+    ).toHaveBeenCalledWith("carnivalRideOwningBusiness", "No");
+  });
+
+  it("send analytics when a non essential raffle bingo radio answer field changes", () => {
+    (getNonEssentialQuestionText as jest.Mock).mockReturnValue("Question Text");
+
+    prevProfile = generateProfileData({
+      nonEssentialRadioAnswers: {},
+      carnivalRideOwningBusiness: undefined,
+      raffleBingoGames: undefined,
+      travelingCircusOrCarnivalOwningBusiness: undefined,
+      vacantPropertyOwner: undefined,
+      elevatorOwningBusiness: undefined,
+      homeBasedBusiness: undefined,
+      plannedRenovationQuestion: undefined,
+    });
+
+    newProfile = generateProfileData({
+      nonEssentialRadioAnswers: {},
+      carnivalRideOwningBusiness: undefined,
+      raffleBingoGames: true,
+      travelingCircusOrCarnivalOwningBusiness: undefined,
+      vacantPropertyOwner: undefined,
+      elevatorOwningBusiness: undefined,
+      homeBasedBusiness: undefined,
+      plannedRenovationQuestion: undefined,
+    });
+
+    sendChangedNonEssentialQuestionAnalytics(prevProfile, newProfile);
+
+    expect(
+      analytics.event.non_essential_question_set.view.non_essential_question_set,
+    ).toHaveBeenCalledWith("raffleBingoGames", "Yes");
+  });
+
+  it("send analytics when a non essential traveling Circus Or Carnival Owning Business radio answer field changes", () => {
+    (getNonEssentialQuestionText as jest.Mock).mockReturnValue("Question Text");
+
+    prevProfile = generateProfileData({
+      nonEssentialRadioAnswers: {},
+      carnivalRideOwningBusiness: undefined,
+      raffleBingoGames: undefined,
+      travelingCircusOrCarnivalOwningBusiness: undefined,
+      vacantPropertyOwner: undefined,
+      elevatorOwningBusiness: undefined,
+      homeBasedBusiness: undefined,
+      plannedRenovationQuestion: undefined,
+    });
+
+    newProfile = generateProfileData({
+      nonEssentialRadioAnswers: {},
+      carnivalRideOwningBusiness: undefined,
+      raffleBingoGames: undefined,
+      travelingCircusOrCarnivalOwningBusiness: true,
+      vacantPropertyOwner: undefined,
+      elevatorOwningBusiness: undefined,
+      homeBasedBusiness: undefined,
+      plannedRenovationQuestion: undefined,
+    });
+
+    sendChangedNonEssentialQuestionAnalytics(prevProfile, newProfile);
+
+    expect(
+      analytics.event.non_essential_question_set.view.non_essential_question_set,
+    ).toHaveBeenCalledWith("travelingCircusOrCarnivalOwningBusiness", "Yes");
+  });
+
+  it("send analytics when a non essential Vacant Property Owner radio answer field changes", () => {
+    (getNonEssentialQuestionText as jest.Mock).mockReturnValue("Question Text");
+
+    prevProfile = generateProfileData({
+      nonEssentialRadioAnswers: {},
+      carnivalRideOwningBusiness: undefined,
+      raffleBingoGames: undefined,
+      travelingCircusOrCarnivalOwningBusiness: undefined,
+      vacantPropertyOwner: undefined,
+      elevatorOwningBusiness: undefined,
+      homeBasedBusiness: undefined,
+      plannedRenovationQuestion: undefined,
+    });
+
+    newProfile = generateProfileData({
+      nonEssentialRadioAnswers: {},
+      carnivalRideOwningBusiness: undefined,
+      raffleBingoGames: undefined,
+      travelingCircusOrCarnivalOwningBusiness: undefined,
+      vacantPropertyOwner: true,
+      elevatorOwningBusiness: undefined,
+      homeBasedBusiness: undefined,
+      plannedRenovationQuestion: undefined,
+    });
+
+    sendChangedNonEssentialQuestionAnalytics(prevProfile, newProfile);
+
+    expect(
+      analytics.event.non_essential_question_set.view.non_essential_question_set,
+    ).toHaveBeenCalledWith("vacantPropertyOwner", "Yes");
+  });
+
+  it("send analytics when a non essential has Elevator Owning Business radio answer field changes", () => {
+    (getNonEssentialQuestionText as jest.Mock).mockReturnValue("Question Text");
+
+    prevProfile = generateProfileData({
+      nonEssentialRadioAnswers: {},
+      carnivalRideOwningBusiness: undefined,
+      raffleBingoGames: undefined,
+      travelingCircusOrCarnivalOwningBusiness: undefined,
+      vacantPropertyOwner: undefined,
+      elevatorOwningBusiness: undefined,
+      homeBasedBusiness: undefined,
+      plannedRenovationQuestion: undefined,
+    });
+
+    newProfile = generateProfileData({
+      nonEssentialRadioAnswers: {},
+      carnivalRideOwningBusiness: undefined,
+      raffleBingoGames: undefined,
+      travelingCircusOrCarnivalOwningBusiness: undefined,
+      vacantPropertyOwner: undefined,
+      elevatorOwningBusiness: true,
+      homeBasedBusiness: undefined,
+      plannedRenovationQuestion: undefined,
+    });
+
+    sendChangedNonEssentialQuestionAnalytics(prevProfile, newProfile);
+
+    expect(
+      analytics.event.non_essential_question_set.view.non_essential_question_set,
+    ).toHaveBeenCalledWith("elevatorOwningBusiness", "Yes");
+  });
+
+  it("send analytics when a non essential has Home Based Business radio answer field changes", () => {
+    (getNonEssentialQuestionText as jest.Mock).mockReturnValue("Question Text");
+
+    prevProfile = generateProfileData({
+      nonEssentialRadioAnswers: {},
+      carnivalRideOwningBusiness: undefined,
+      raffleBingoGames: undefined,
+      travelingCircusOrCarnivalOwningBusiness: undefined,
+      vacantPropertyOwner: undefined,
+      elevatorOwningBusiness: undefined,
+      homeBasedBusiness: undefined,
+      plannedRenovationQuestion: undefined,
+    });
+
+    newProfile = generateProfileData({
+      nonEssentialRadioAnswers: {},
+      carnivalRideOwningBusiness: undefined,
+      raffleBingoGames: undefined,
+      travelingCircusOrCarnivalOwningBusiness: undefined,
+      vacantPropertyOwner: undefined,
+      elevatorOwningBusiness: undefined,
+      homeBasedBusiness: true,
+      plannedRenovationQuestion: undefined,
+    });
+
+    sendChangedNonEssentialQuestionAnalytics(prevProfile, newProfile);
+
+    expect(
+      analytics.event.non_essential_question_set.view.non_essential_question_set,
+    ).toHaveBeenCalledWith("homeBasedBusiness", "Yes");
+  });
+
+  it("send analytics when a non essential Planned Renovation radio answer field changes", () => {
+    (getNonEssentialQuestionText as jest.Mock).mockReturnValue("Question Text");
+
+    prevProfile = generateProfileData({
+      nonEssentialRadioAnswers: {},
+      carnivalRideOwningBusiness: undefined,
+      raffleBingoGames: undefined,
+      travelingCircusOrCarnivalOwningBusiness: undefined,
+      vacantPropertyOwner: undefined,
+      elevatorOwningBusiness: undefined,
+      homeBasedBusiness: undefined,
+      plannedRenovationQuestion: undefined,
+    });
+
+    newProfile = generateProfileData({
+      nonEssentialRadioAnswers: {},
+      carnivalRideOwningBusiness: undefined,
+      raffleBingoGames: undefined,
+      travelingCircusOrCarnivalOwningBusiness: undefined,
+      vacantPropertyOwner: undefined,
+      elevatorOwningBusiness: undefined,
+      homeBasedBusiness: undefined,
+      plannedRenovationQuestion: true,
+    });
+
+    sendChangedNonEssentialQuestionAnalytics(prevProfile, newProfile);
+
+    expect(
+      analytics.event.non_essential_question_set.view.non_essential_question_set,
+    ).toHaveBeenCalledWith("plannedRenovationQuestion", "Yes");
+  });
+});

--- a/web/src/lib/domain-logic/sendChangedNonEssentialQuestionAnalytics.ts
+++ b/web/src/lib/domain-logic/sendChangedNonEssentialQuestionAnalytics.ts
@@ -1,0 +1,127 @@
+import { getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
+import { ProfileData } from "@businessnjgovnavigator/shared/profileData";
+import analytics from "@/lib/utils/analytics";
+
+const Config = getMergedConfig();
+
+export const sendChangedNonEssentialQuestionAnalytics = (
+  prevProfileData: ProfileData,
+  newProfileData: ProfileData,
+): void => {
+  const prevNonEssentialRadioAnswers: Record<string, boolean | undefined> =
+    prevProfileData.nonEssentialRadioAnswers;
+  const newNonEssentialRadioAnswers: Record<string, boolean | undefined> =
+    newProfileData.nonEssentialRadioAnswers;
+
+  for (const key in newNonEssentialRadioAnswers) {
+    const prevValue = prevNonEssentialRadioAnswers[key];
+    const currValue = newNonEssentialRadioAnswers[key];
+
+    if (didNonEssentialQuestionAnswerChange(prevValue, currValue)) {
+      analytics.event.non_essential_question_set.view.non_essential_question_set(
+        key,
+        getNonEssentialQuestionAnswer(currValue),
+      );
+    }
+  }
+
+  if (
+    didNonEssentialQuestionAnswerChange(
+      prevProfileData.carnivalRideOwningBusiness,
+      newProfileData.carnivalRideOwningBusiness,
+    )
+  ) {
+    analytics.event.non_essential_question_set.view.non_essential_question_set(
+      "carnivalRideOwningBusiness",
+      getNonEssentialQuestionAnswer(newProfileData.carnivalRideOwningBusiness),
+    );
+  }
+
+  if (
+    didNonEssentialQuestionAnswerChange(
+      prevProfileData.raffleBingoGames,
+      newProfileData.raffleBingoGames,
+    )
+  ) {
+    analytics.event.non_essential_question_set.view.non_essential_question_set(
+      "raffleBingoGames",
+      getNonEssentialQuestionAnswer(newProfileData.raffleBingoGames),
+    );
+  }
+
+  if (
+    didNonEssentialQuestionAnswerChange(
+      prevProfileData.travelingCircusOrCarnivalOwningBusiness,
+      newProfileData.travelingCircusOrCarnivalOwningBusiness,
+    )
+  ) {
+    analytics.event.non_essential_question_set.view.non_essential_question_set(
+      "travelingCircusOrCarnivalOwningBusiness",
+      getNonEssentialQuestionAnswer(newProfileData.travelingCircusOrCarnivalOwningBusiness),
+    );
+  }
+
+  if (
+    didNonEssentialQuestionAnswerChange(
+      prevProfileData.elevatorOwningBusiness,
+      newProfileData.elevatorOwningBusiness,
+    )
+  ) {
+    analytics.event.non_essential_question_set.view.non_essential_question_set(
+      "elevatorOwningBusiness",
+      getNonEssentialQuestionAnswer(newProfileData.elevatorOwningBusiness),
+    );
+  }
+
+  if (
+    didNonEssentialQuestionAnswerChange(
+      prevProfileData.homeBasedBusiness,
+      newProfileData.homeBasedBusiness,
+    )
+  ) {
+    analytics.event.non_essential_question_set.view.non_essential_question_set(
+      "homeBasedBusiness",
+      getNonEssentialQuestionAnswer(newProfileData.homeBasedBusiness),
+    );
+  }
+
+  if (
+    didNonEssentialQuestionAnswerChange(
+      prevProfileData.plannedRenovationQuestion,
+      newProfileData.plannedRenovationQuestion,
+    )
+  ) {
+    analytics.event.non_essential_question_set.view.non_essential_question_set(
+      "plannedRenovationQuestion",
+      getNonEssentialQuestionAnswer(newProfileData.plannedRenovationQuestion),
+    );
+  }
+
+  if (
+    didNonEssentialQuestionAnswerChange(
+      prevProfileData.vacantPropertyOwner,
+      newProfileData.vacantPropertyOwner,
+    )
+  ) {
+    analytics.event.non_essential_question_set.view.non_essential_question_set(
+      "vacantPropertyOwner",
+      getNonEssentialQuestionAnswer(newProfileData.vacantPropertyOwner),
+    );
+  }
+};
+
+const didNonEssentialQuestionAnswerChange = (
+  prevAnswer: boolean | undefined,
+  newAnswer: boolean | undefined,
+): boolean => {
+  return (
+    (prevAnswer === undefined && newAnswer !== undefined) ||
+    (prevAnswer !== undefined && newAnswer !== undefined && prevAnswer !== newAnswer)
+  );
+};
+
+const getNonEssentialQuestionAnswer = (questionAnswer: boolean | undefined): string => {
+  return questionAnswer
+    ? Config.profileDefaults.fields.nonEssentialQuestions.default.radioButtonTrueText
+    : Config.profileDefaults.fields.nonEssentialQuestions.default.radioButtonFalseText;
+};

--- a/web/src/lib/utils/analytics-legacy.ts
+++ b/web/src/lib/utils/analytics-legacy.ts
@@ -157,7 +157,8 @@ export type LegacyEventCategory =
   | "xray_registration_expired_cta"
   | "xray_registration_check_status_error"
   | "xray_registration_check_status_form"
-  | "xray_registration_check_status_results";
+  | "xray_registration_check_status_results"
+  | string;
 
 export type LegacyEventAction =
   | "appear"
@@ -169,7 +170,8 @@ export type LegacyEventAction =
   | "mouseover"
   | "response"
   | "scroll"
-  | "submit";
+  | "submit"
+  | string;
 
 export type LegacyEventLabel =
   | "active_registration_found"
@@ -297,4 +299,5 @@ export type LegacyEventLabel =
   | "yes_i_offer_public_accounting"
   | "yes_more_than_6_childred"
   | "yes_moving_across_state_lines"
-  | "yes_require_liquor_license";
+  | "yes_require_liquor_license"
+  | string;

--- a/web/src/lib/utils/analytics.ts
+++ b/web/src/lib/utils/analytics.ts
@@ -43,7 +43,9 @@ type EventType =
   | "xray_renewal_started_expired_card"
   | "xray_status_check_started"
   | "xray_status_check_success_active"
-  | "xray_status_check_success_expired";
+  | "xray_status_check_success_expired"
+  | "non_essential_question_view"
+  | string;
 
 const eventMap: Record<EventType, string> = {
   account_clicks: "account_clicks",
@@ -2588,6 +2590,30 @@ export default {
             legacy_event_action: "click",
             legacy_event_category: "xray_registration_expired_status_card",
             legacy_event_label: "renew_ref_link",
+          });
+        },
+      },
+    },
+    non_essential_question_view: {
+      view: {
+        non_essential_question_view: (question: string) => {
+          eventRunner.track({
+            event: "non_essential_question_view",
+            legacy_event_action: "view",
+            legacy_event_category: `non_essential_question_view_${question}`,
+            legacy_event_label: "non_essential_question_radio_button",
+          });
+        },
+      },
+    },
+    non_essential_question_set: {
+      view: {
+        non_essential_question_set: (question: string, value: string) => {
+          eventRunner.track({
+            event: "non_essential_question_view",
+            legacy_event_action: "set",
+            legacy_event_category: `non_essential_question_${question}_${value}`,
+            legacy_event_label: "non_essential_question_radio_button",
           });
         },
       },

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -97,6 +97,7 @@ import { GetStaticPropsResult } from "next";
 import { NextSeo } from "next-seo";
 import { useRouter } from "next/compat/router";
 import { ReactElement, ReactNode, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { sendChangedNonEssentialQuestionAnalytics } from "@/lib/domain-logic/sendChangedNonEssentialQuestionAnalytics";
 
 interface Props {
   municipalities: Municipality[];
@@ -262,6 +263,8 @@ const ProfilePage = (props: Props): ReactElement => {
     if (prevProfileData.dateOfFormation !== newProfileData.dateOfFormation) {
       analytics.event.profile_formation_date.submit.formation_date_changed();
     }
+
+    sendChangedNonEssentialQuestionAnalytics(prevProfileData, newProfileData);
 
     const municipalityEnteredForFirstTime =
       prevProfileData.municipality === undefined && newProfileData.municipality !== undefined;

--- a/web/test/mock/MockIntersectionObserver.ts
+++ b/web/test/mock/MockIntersectionObserver.ts
@@ -1,0 +1,9 @@
+export const useMockIntersectionObserver = (): void => {
+  const mockIntersectionObserver = jest.fn();
+  mockIntersectionObserver.mockReturnValue({
+    observe: () => jest.fn(),
+    unobserve: () => jest.fn(),
+    disconnect: () => jest.fn(),
+  });
+  window.IntersectionObserver = mockIntersectionObserver;
+};

--- a/web/test/pages/profile/profile-owning.test.tsx
+++ b/web/test/pages/profile/profile-owning.test.tsx
@@ -5,6 +5,7 @@ import { templateEval } from "@/lib/utils/helpers";
 import * as mockRouter from "@/test/mock/mockRouter";
 import { useMockRouter } from "@/test/mock/mockRouter";
 import { useMockRoadmap } from "@/test/mock/mockUseRoadmap";
+import { useMockIntersectionObserver } from "@/test/mock/MockIntersectionObserver";
 import {
   currentBusiness,
   currentUserData,
@@ -86,6 +87,7 @@ describe("profile - owning existing business", () => {
     jest.resetAllMocks();
     useMockRouter({});
     useMockRoadmap({});
+    useMockIntersectionObserver();
     setupStatefulUserDataContext();
     mockApi.postGetAnnualFilings.mockImplementation((userData) => {
       return Promise.resolve(userData);

--- a/web/test/pages/profile/profile-shared.test.tsx
+++ b/web/test/pages/profile/profile-shared.test.tsx
@@ -12,6 +12,7 @@ import { markdownToText, randomElementFromArray } from "@/test/helpers/helpers-u
 import { useMockRouter } from "@/test/mock/mockRouter";
 import { useMockDocuments } from "@/test/mock/mockUseDocuments";
 import { useMockRoadmap } from "@/test/mock/mockUseRoadmap";
+import { useMockIntersectionObserver } from "@/test/mock/MockIntersectionObserver";
 import {
   currentBusiness,
   setupStatefulUserDataContext,
@@ -118,6 +119,7 @@ describe("profile - shared", () => {
     useMockRoadmap({});
     setupStatefulUserDataContext();
     useMockDocuments({});
+    useMockIntersectionObserver();
     mockApi.postGetAnnualFilings.mockImplementation((userData) => {
       return Promise.resolve(userData);
     });

--- a/web/test/pages/profile/profile-starting.test.tsx
+++ b/web/test/pages/profile/profile-starting.test.tsx
@@ -13,6 +13,7 @@ import * as mockRouter from "@/test/mock/mockRouter";
 import { useMockRouter } from "@/test/mock/mockRouter";
 import { setMockDocumentsResponse, useMockDocuments } from "@/test/mock/mockUseDocuments";
 import { useMockRoadmap } from "@/test/mock/mockUseRoadmap";
+import { useMockIntersectionObserver } from "@/test/mock/MockIntersectionObserver";
 import {
   currentBusiness,
   setupStatefulUserDataContext,
@@ -116,6 +117,7 @@ describe("profile - starting business", () => {
     useMockRoadmap({});
     setupStatefulUserDataContext();
     useMockDocuments({});
+    useMockIntersectionObserver();
     mockApi.postGetAnnualFilings.mockImplementation((userData) => {
       return Promise.resolve(userData);
     });


### PR DESCRIPTION
Add analytics events to CMS generated non-essential questions.

<!-- Please complete the following sections as necessary. -->

## Description

Scenario: Add a unique analytics event to each existing CMS generated non-essential question
Given I am any user
When I select an answer for any CMS generated non-essential question
Then a unique Google analytics (GA4) event will be used to capture data 
And the data will be made available for use in Looker Studio

Note: The list of CMS generated non-essential questions is as follows:
Do you plan to resell admission tickets to places of entertainment and charge more than the original price?
Do you plan to own a multiple dwelling, such as an apartment or condominium complex?
Do you plan to own a hotel, motel, or guesthouse with 10 rooms or more?
Do you plan to own and/or operate a carnival or amusement ride?
Do you plan to own and/or operate a traveling carnival or circus?
Do you plan to serve food?
Do you plan to serve liquor, including beer or wine?
Will you be using a weighing or measuring device, such as a scale or meter, for your business?
Are you a dentist?
Do you specialize in any area of dentistry, such as orthodontics or oral surgery?
Are you a dental hygienist?
Do you plan to own and/or operate a `free-standing residential health care facility?
Do you plan to own and/or operate a rooming or boarding house?
Will you provide entertainment booking services in New Jersey?
Will you be offering electrologist/electrolysis services?
Will you store sodium pentobarbital for animal euthanasia?
Will you train dogs to detect illegal substances?
Do you plan to test or research Controlled Dangerous Substances (CDS)?
Does your business make, buy, or sell products that contain Controlled Dangerous Substances (CDS)?
Will you sell cigarettes, have a cigarette vending machine, or be a cigarette manufacturer sales representative?
Will you offer professional planning services?
Will you be using x-ray machines?
Are you an optometrist?
Will you deliver packages by air (for example by airplane or helicopter)?
Will your business fall under [one of these industries](https://www.nj.gov/dep/enforcement/opppc/reports/rtknaics.pdf)?
Will you sell lawn and garden supplies, flowers, or florists' supplies?
Will you do management consulting services (not including manufacturing management, physical distribution, and site location consulting)?
Will your business be selling pesticides?
Do you plan to either own or operate business vehicles in NJ?
Will your business be selling pesticides?
Will your business be using pesticides or offering pesticide application services?


Scenario: Add a unique analytics event to each existing individually generated non-essential question
Given I am any user
When I select an answer for any individually generated non-essential question
Then a unique Google analytics (GA4) event will be used to capture data 
And the data will be made available for use in Looker Studio

Note: To identify questions, you can reference display in profile.tsx. The list of individually generated non-essential questions is as follows:
Do you plan to be a home-based business? (displayHomedBaseBusinessQuestion)
Do you plan to do any renovations or construction on your commercial/industrial space (displayPlannedRenovationQuestionQuestion)
Do you plan to own a space now or in the future with a new or existing
elevator device, such as an elevator, escalator, or lift? (displayElevatorQuestion)
Do you own a vacant or unoccupied property in New Jersey with a total floor space of 2,500 square feet or more? (displayVacantBuildingOwnerQuestion)
Will you be holding, operating, or conducting raffles or bingo games (displayRaffleBingoGameQuestion

Note: In addition to adding the events, we should ensure that we update and maintain proper documentation of the events for reference. The ga4-eventslist tab in the linked Google sheet would be an appropriate place to ensure that we have proper documentation:

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#8391](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8391).

and also covers 

This pull request resolves [#13786](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13786).
### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
