### PR TITLE
feat: [AB#13453] cig license payment redirect

### DIFF
--- a/api/src/api/cigaretteLicenseRouter.test.ts
+++ b/api/src/api/cigaretteLicenseRouter.test.ts
@@ -268,14 +268,14 @@ describe("cigaretteLicenseRouter", () => {
       expect(stubDynamoDataClient.put).toHaveBeenCalledWith(expectedModifiedUserData);
     });
 
-    it("returns errorResult info if no matching orders are found", async () => {
+    it("returns previous userData if no matching orders are found", async () => {
       stubCigaretteLicenseClient.getOrderByToken.mockResolvedValue(mockErrorGetResponse);
 
       const response = await request(app).get("/cigarette-license/get-order-by-token");
 
       expect(response.status).toEqual(StatusCodes.OK);
       expect(stubDynamoDataClient.put).not.toHaveBeenCalled();
-      expect(response.body).toEqual(mockErrorPostResponse.errorResult);
+      expect(response.body).toEqual(signedInUser);
     });
 
     it("returns 500 reponse if unknown error occurs", async () => {

--- a/api/src/client/ApiCigaretteLicenseClient.test.ts
+++ b/api/src/client/ApiCigaretteLicenseClient.test.ts
@@ -140,7 +140,7 @@ describe("CigaretteLicenseClient", () => {
       const result = await client.preparePayment(userData, returnUrl);
 
       expect(result.errorResult).toBeDefined();
-      expect(result.errorResult?.errorCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(result.errorResult?.errorCode).toBe(mockErrorPostResponse.errorResult?.errorCode);
 
       expect(spyOnLogError.mock.calls[0]).toEqual([
         `Cigarette License Client - Id:test - Unknown error received: ${JSON.stringify(mockErrorPostResponse)}`,
@@ -221,7 +221,7 @@ describe("CigaretteLicenseClient", () => {
       const result = await client.getOrderByToken(token);
 
       expect(result.errorResult).toBeDefined();
-      expect(result.errorResult?.errorCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(result.errorResult?.errorCode).toBe(mockErrorGetResponse.errorResult?.errorCode);
 
       expect(spyOnLogError.mock.calls[0]).toEqual([
         `Cigarette License Client - Id:test - Unknown error received: ${JSON.stringify(mockErrorGetResponse)}`,

--- a/api/src/client/ApiCigaretteLicenseClient.ts
+++ b/api/src/client/ApiCigaretteLicenseClient.ts
@@ -70,7 +70,7 @@ export const ApiCigaretteLicenseClient = (logger: LogWriterType): CigaretteLicen
         );
         const errorResponse: PaymentApiError = {
           statusCode: 500,
-          errorCode: 500,
+          errorCode: "500",
           userMessage: "An unknown error occured",
           developerMessage: JSON.stringify(error),
         };
@@ -116,7 +116,7 @@ export const ApiCigaretteLicenseClient = (logger: LogWriterType): CigaretteLicen
         );
         const errorResponse: PaymentApiError = {
           statusCode: 500,
-          errorCode: 500,
+          errorCode: "500",
           userMessage: "An unknown error occured",
           developerMessage: JSON.stringify(error),
         };

--- a/api/src/client/ApiCigaretteLicenseHelpers.ts
+++ b/api/src/client/ApiCigaretteLicenseHelpers.ts
@@ -104,7 +104,7 @@ export const mockErrorPostResponse: PreparePaymentResponse = {
   token: "",
   errorResult: {
     statusCode: 500,
-    errorCode: 500,
+    errorCode: "500",
     userMessage: "An unknown error occured",
     developerMessage: "An unknown error occured",
   },
@@ -119,7 +119,7 @@ export const mockErrorGetResponse: GetOrderByTokenResponse = {
   matchingOrders: 0,
   errorResult: {
     statusCode: 500,
-    errorCode: 500,
+    errorCode: "500",
     userMessage: "An unknown error occured",
     developerMessage: "An unknown error occured",
   },

--- a/api/src/db/migrations/migrations.ts
+++ b/api/src/db/migrations/migrations.ts
@@ -175,6 +175,7 @@ import { migrate_v170_to_v171 } from "@db/migrations/v171_flatten_cigarette_lice
 import { migrate_v171_to_v172 } from "@db/migrations/v172_add_cig_license_payment_info";
 import { migrate_v172_to_v173 } from "@db/migrations/v173_add_school_bus_passenger_transport";
 import { migrate_v173_to_v174 } from "@db/migrations/v174_add_public_works_contractor";
+import { migrate_v174_to_v175 } from "@db/migrations/v175_add_payment_complete_to_cig_license";
 
 // Effectively (data: v_UserData, clients: MigrationClients) => v_UserData | Promise<v_UserData>
 export type MigrationFunction = (data: any, clients: MigrationClients) => any;
@@ -354,6 +355,7 @@ export const Migrations: MigrationFunction[] = [
   migrate_v171_to_v172,
   migrate_v172_to_v173,
   migrate_v173_to_v174,
+  migrate_v174_to_v175,
 ];
 
-export { generatev174UserData as CURRENT_GENERATOR } from "@db/migrations/v174_add_public_works_contractor";
+export { generatev175UserData as CURRENT_GENERATOR } from "@db/migrations/v175_add_payment_complete_to_cig_license";

--- a/api/src/db/migrations/v175_add_payment_complete_to_cig_license.test.ts
+++ b/api/src/db/migrations/v175_add_payment_complete_to_cig_license.test.ts
@@ -1,0 +1,22 @@
+import {
+  generatev174Business,
+  generatev174UserData,
+} from "@db/migrations/v174_add_public_works_contractor";
+import { migrate_v174_to_v175 } from "@db/migrations/v175_add_payment_complete_to_cig_license";
+
+describe("migrate_v174_to_v175", () => {
+  it("adds new field", async () => {
+    const id = "biz-1";
+    const v174UserData = generatev174UserData({
+      businesses: {
+        id: generatev174Business({ id }),
+      },
+    });
+
+    const v175UserData = migrate_v174_to_v175(v174UserData);
+    expect(v175UserData.version).toBe(175);
+    expect(
+      v175UserData.businesses[id].cigaretteLicenseData?.paymentInfo?.paymentComplete,
+    ).not.toBeNull();
+  });
+});

--- a/api/src/db/migrations/v175_add_payment_complete_to_cig_license.ts
+++ b/api/src/db/migrations/v175_add_payment_complete_to_cig_license.ts
@@ -1,0 +1,1184 @@
+import { randomInt } from "@shared/intHelpers";
+import { v174Business, v174UserData } from "@db/migrations/v174_add_public_works_contractor";
+
+export const migrate_v174_to_v175 = (userData: v174UserData): v175UserData => {
+  return {
+    ...userData,
+    businesses: Object.fromEntries(
+      Object.values(userData.businesses)
+        .map((business: v174Business) => migrate_v174Business_to_v175Business(business))
+        .map((currBusiness: v175Business) => [currBusiness.id, currBusiness]),
+    ),
+    version: 175,
+  };
+};
+
+const migrate_v174Business_to_v175Business = (business: v174Business): v175Business => {
+  return {
+    ...business,
+    version: 175,
+    cigaretteLicenseData: {
+      ...business.cigaretteLicenseData,
+      paymentInfo: {
+        ...business.cigaretteLicenseData?.paymentInfo,
+        paymentComplete: false,
+      },
+    },
+  };
+};
+
+export interface v175IndustrySpecificData {
+  liquorLicense: boolean;
+  requiresCpa: boolean;
+  homeBasedBusiness: boolean | undefined;
+  providesStaffingService: boolean;
+  certifiedInteriorDesigner: boolean;
+  realEstateAppraisalManagement: boolean;
+  cannabisLicenseType: v175CannabisLicenseType;
+  cannabisMicrobusiness: boolean | undefined;
+  constructionRenovationPlan: boolean | undefined;
+  carService: v175CarServiceType | undefined;
+  interstateTransport: boolean;
+  interstateLogistics: boolean | undefined;
+  interstateMoving: boolean | undefined;
+  isChildcareForSixOrMore: boolean | undefined;
+  petCareHousing: boolean | undefined;
+  willSellPetCareItems: boolean | undefined;
+  constructionType: v175ConstructionType;
+  residentialConstructionType: v175ResidentialConstructionType;
+  employmentPersonnelServiceType: v175EmploymentAndPersonnelServicesType;
+  employmentPlacementType: v175EmploymentPlacementType;
+  carnivalRideOwningBusiness: boolean | undefined;
+  propertyLeaseType: v175PropertyLeaseType;
+  hasThreeOrMoreRentalUnits: boolean | undefined;
+  travelingCircusOrCarnivalOwningBusiness: boolean | undefined;
+  vacantPropertyOwner: boolean | undefined;
+  publicWorksContractor: boolean | undefined;
+}
+
+export type v175PropertyLeaseType = "SHORT_TERM_RENTAL" | "LONG_TERM_RENTAL" | "BOTH" | undefined;
+
+// ---------------- v175 types ----------------
+type v175TaskProgress = "TO_DO" | "COMPLETED";
+type v175OnboardingFormProgress = "UNSTARTED" | "COMPLETED";
+type v175ABExperience = "ExperienceA" | "ExperienceB";
+
+export interface v175UserData {
+  user: v175BusinessUser;
+  version: number;
+  lastUpdatedISO: string;
+  dateCreatedISO: string;
+  versionWhenCreated: number;
+  businesses: Record<string, v175Business>;
+  currentBusinessId: string;
+}
+
+export interface v175Business {
+  id: string;
+  dateCreatedISO: string;
+  lastUpdatedISO: string;
+  profileData: v175ProfileData;
+  onboardingFormProgress: v175OnboardingFormProgress;
+  taskProgress: Record<string, v175TaskProgress>;
+  taskItemChecklist: Record<string, boolean>;
+  licenseData: v175LicenseData | undefined;
+  preferences: v175Preferences;
+  taxFilingData: v175TaxFilingData;
+  formationData: v175FormationData;
+  environmentData: v175EnvironmentData | undefined;
+  xrayRegistrationData: v175XrayData | undefined;
+  roadmapTaskData: v175RoadmapTaskData;
+  taxClearanceCertificateData: v175TaxClearanceCertificateData | undefined;
+  cigaretteLicenseData: v175CigaretteLicenseData | undefined;
+  version: number;
+  versionWhenCreated: number;
+  userId: string;
+}
+
+export interface v175RoadmapTaskData {
+  manageBusinessVehicles?: boolean;
+  passengerTransportSchoolBus?: boolean;
+  passengerTransportSixteenOrMorePassengers?: boolean;
+}
+
+export interface v175ProfileData extends v175IndustrySpecificData {
+  businessPersona: v175BusinessPersona;
+  businessName: string;
+  responsibleOwnerName: string;
+  tradeName: string;
+  industryId: string | undefined;
+  legalStructureId: string | undefined;
+  municipality: v175Municipality | undefined;
+  dateOfFormation: string | undefined;
+  entityId: string | undefined;
+  employerId: string | undefined;
+  taxId: string | undefined;
+  hashedTaxId: string | undefined;
+  encryptedTaxId: string | undefined;
+  notes: string;
+  documents: v175ProfileDocuments;
+  ownershipTypeIds: string[];
+  existingEmployees: string | undefined;
+  taxPin: string | undefined;
+  encryptedTaxPin: string | undefined;
+  sectorId: string | undefined;
+  naicsCode: string;
+  foreignBusinessTypeIds: v175ForeignBusinessTypeId[];
+  nexusDbaName: string;
+  operatingPhase: v175OperatingPhase;
+  nonEssentialRadioAnswers: Record<string, boolean | undefined>;
+  elevatorOwningBusiness: boolean | undefined;
+  communityAffairsAddress?: v175CommunityAffairsAddress;
+  plannedRenovationQuestion: boolean | undefined;
+  raffleBingoGames: boolean | undefined;
+  businessOpenMoreThanTwoYears: boolean | undefined;
+}
+
+export type v175CommunityAffairsAddress = {
+  streetAddress1: string;
+  streetAddress2?: string;
+  municipality: v175Municipality;
+};
+
+type v175BusinessUser = {
+  name?: string;
+  email: string;
+  id: string;
+  receiveNewsletter: boolean;
+  userTesting: boolean;
+  externalStatus: v175ExternalStatus;
+  myNJUserKey?: string;
+  intercomHash?: string;
+  abExperience: v175ABExperience;
+  accountCreationSource: string;
+  contactSharingWithAccountCreationPartner: boolean;
+};
+
+interface v175ProfileDocuments {
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+}
+
+type v175BusinessPersona = "STARTING" | "OWNING" | "FOREIGN" | undefined;
+type v175OperatingPhase =
+  | "GUEST_MODE"
+  | "NEEDS_TO_FORM"
+  | "NEEDS_BUSINESS_STRUCTURE"
+  | "FORMED"
+  | "UP_AND_RUNNING"
+  | "UP_AND_RUNNING_OWNING"
+  | "REMOTE_SELLER_WORKER"
+  | undefined;
+
+export type v175CannabisLicenseType = "CONDITIONAL" | "ANNUAL" | undefined;
+export type v175CarServiceType = "STANDARD" | "HIGH_CAPACITY" | "BOTH" | undefined;
+export type v175ConstructionType = "RESIDENTIAL" | "COMMERCIAL_OR_INDUSTRIAL" | "BOTH" | undefined;
+export type v175ResidentialConstructionType =
+  | "NEW_HOME_CONSTRUCTION"
+  | "HOME_RENOVATIONS"
+  | "BOTH"
+  | undefined;
+export type v175EmploymentAndPersonnelServicesType = "JOB_SEEKERS" | "EMPLOYERS" | undefined;
+export type v175EmploymentPlacementType = "TEMPORARY" | "PERMANENT" | "BOTH" | undefined;
+
+type v175ForeignBusinessTypeId =
+  | "employeeOrContractorInNJ"
+  | "officeInNJ"
+  | "propertyInNJ"
+  | "companyOperatedVehiclesInNJ"
+  | "employeesInNJ"
+  | "revenueInNJ"
+  | "transactionsInNJ"
+  | "none";
+
+type v175Municipality = {
+  name: string;
+  displayName: string;
+  county: string;
+  id: string;
+};
+
+type v175TaxFilingState = "SUCCESS" | "FAILED" | "UNREGISTERED" | "PENDING" | "API_ERROR";
+type v175TaxFilingErrorFields = "businessName" | "formFailure";
+
+type v175TaxFilingData = {
+  state?: v175TaxFilingState;
+  lastUpdatedISO?: string;
+  registeredISO?: string;
+  errorField?: v175TaxFilingErrorFields;
+  businessName?: string;
+  filings: v175TaxFilingCalendarEvent[];
+};
+
+export type v175CalendarEvent = {
+  readonly dueDate: string; // YYYY-MM-DD
+  readonly calendarEventType: "TAX-FILING" | "LICENSE";
+};
+
+export interface v175TaxFilingCalendarEvent extends v175CalendarEvent {
+  readonly identifier: string;
+  readonly calendarEventType: "TAX-FILING";
+}
+
+export type v175LicenseSearchAddress = {
+  addressLine1: string;
+  addressLine2: string;
+  zipCode: string;
+};
+
+export interface v175LicenseSearchNameAndAddress extends v175LicenseSearchAddress {
+  name: string;
+}
+
+type v175LicenseDetails = {
+  nameAndAddress: v175LicenseSearchNameAndAddress;
+  licenseStatus: v175LicenseStatus;
+  expirationDateISO: string | undefined;
+  lastUpdatedISO: string;
+  checklistItems: v175LicenseStatusItem[];
+};
+
+const v175taskIdLicenseNameMapping = {
+  "apply-for-shop-license": "Cosmetology and Hairstyling-Shop",
+  "appraiser-license": "Real Estate Appraisers-Appraisal Management Company",
+  "architect-license": "Architecture-Certificate of Authorization",
+  "health-club-registration": "Health Club Services",
+  "home-health-aide-license": "Health Care Services",
+  "hvac-license": "HVACR-HVACR CE Sponsor",
+  "landscape-architect-license": "Landscape Architecture-Certificate of Authorization",
+  "license-massage-therapy": "Massage and Bodywork Therapy-Massage and Bodywork Employer",
+  "moving-company-license": "Public Movers and Warehousemen-Public Mover and Warehouseman",
+  "pharmacy-license": "Pharmacy-Pharmacy",
+  "public-accountant-license": "Accountancy-Firm Registration",
+  "register-accounting-firm": "Accountancy-Firm Registration",
+  "register-consumer-affairs": "Home Improvement Contractors-Home Improvement Contractor",
+  "ticket-broker-reseller-registration": "Ticket Brokers",
+  "telemarketing-license": "Telemarketers",
+} as const;
+
+type v175LicenseTaskID = keyof typeof v175taskIdLicenseNameMapping;
+
+export type v175LicenseName = (typeof v175taskIdLicenseNameMapping)[v175LicenseTaskID];
+
+type v175Licenses = Partial<Record<v175LicenseName, v175LicenseDetails>>;
+
+type v175LicenseData = {
+  lastUpdatedISO: string;
+  licenses?: v175Licenses;
+};
+
+type v175Preferences = {
+  roadmapOpenSections: v175SectionType[];
+  roadmapOpenSteps: number[];
+  hiddenFundingIds: string[];
+  hiddenCertificationIds: string[];
+  visibleSidebarCards: string[];
+  isCalendarFullView: boolean;
+  returnToLink: string;
+  isHideableRoadmapOpen: boolean;
+  phaseNewlyChanged: boolean;
+  isNonProfitFromFunding?: boolean;
+};
+
+type v175LicenseStatusItem = {
+  title: string;
+  status: v175CheckoffStatus;
+};
+
+type v175CheckoffStatus = "ACTIVE" | "PENDING" | "UNKNOWN";
+
+type v175LicenseStatus =
+  | "ACTIVE"
+  | "PENDING"
+  | "UNKNOWN"
+  | "EXPIRED"
+  | "BARRED"
+  | "OUT_OF_BUSINESS"
+  | "REINSTATEMENT_PENDING"
+  | "CLOSED"
+  | "DELETED"
+  | "DENIED"
+  | "VOLUNTARY_SURRENDER"
+  | "WITHDRAWN";
+
+const v175LicenseStatuses: v175LicenseStatus[] = [
+  "ACTIVE",
+  "PENDING",
+  "UNKNOWN",
+  "EXPIRED",
+  "BARRED",
+  "OUT_OF_BUSINESS",
+  "REINSTATEMENT_PENDING",
+  "CLOSED",
+  "DELETED",
+  "DENIED",
+  "VOLUNTARY_SURRENDER",
+  "WITHDRAWN",
+];
+
+const v175SectionNames = ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"] as const;
+type v175SectionType = (typeof v175SectionNames)[number];
+
+type v175ExternalStatus = {
+  newsletter?: v175NewsletterResponse;
+  userTesting?: v175UserTestingResponse;
+};
+
+interface v175NewsletterResponse {
+  success?: boolean;
+  status: v175NewsletterStatus;
+}
+
+interface v175UserTestingResponse {
+  success?: boolean;
+  status: v175UserTestingStatus;
+}
+
+type v175NewsletterStatus = (typeof newsletterStatusList)[number];
+
+const externalStatusList = ["SUCCESS", "IN_PROGRESS", "CONNECTION_ERROR"] as const;
+
+const userTestingStatusList = [...externalStatusList] as const;
+
+type v175UserTestingStatus = (typeof userTestingStatusList)[number];
+
+const newsletterStatusList = [
+  ...externalStatusList,
+  "EMAIL_ERROR",
+  "TOPIC_ERROR",
+  "RESPONSE_WARNING",
+  "RESPONSE_ERROR",
+  "RESPONSE_FAIL",
+  "QUESTION_WARNING",
+] as const;
+
+type v175NameAvailabilityStatus =
+  | "AVAILABLE"
+  | "DESIGNATOR_ERROR"
+  | "SPECIAL_CHARACTER_ERROR"
+  | "UNAVAILABLE"
+  | "RESTRICTED_ERROR"
+  | undefined;
+
+interface v175NameAvailabilityResponse {
+  status: v175NameAvailabilityStatus;
+  similarNames: string[];
+  invalidWord?: string;
+}
+
+interface v175NameAvailability extends v175NameAvailabilityResponse {
+  lastUpdatedTimeStamp: string;
+}
+
+export interface v175FormationData {
+  formationFormData: v175FormationFormData;
+  businessNameAvailability: v175NameAvailability | undefined;
+  dbaBusinessNameAvailability: v175NameAvailability | undefined;
+  formationResponse: v175FormationSubmitResponse | undefined;
+  getFilingResponse: v175GetFilingResponse | undefined;
+  completedFilingPayment: boolean;
+  lastVisitedPageIndex: number;
+}
+
+type v175InFormInBylaws = "IN_BYLAWS" | "IN_FORM" | undefined;
+
+export interface v175FormationFormData extends v175FormationAddress {
+  readonly businessName: string;
+  readonly businessSuffix: v175BusinessSuffix | undefined;
+  readonly businessTotalStock: string;
+  readonly businessStartDate: string; // YYYY-MM-DD
+  readonly businessPurpose: string;
+  readonly withdrawals: string;
+  readonly combinedInvestment: string;
+  readonly dissolution: string;
+  readonly canCreateLimitedPartner: boolean | undefined;
+  readonly createLimitedPartnerTerms: string;
+  readonly canGetDistribution: boolean | undefined;
+  readonly getDistributionTerms: string;
+  readonly canMakeDistribution: boolean | undefined;
+  readonly makeDistributionTerms: string;
+  readonly hasNonprofitBoardMembers: boolean | undefined;
+  readonly nonprofitBoardMemberQualificationsSpecified: v175InFormInBylaws;
+  readonly nonprofitBoardMemberQualificationsTerms: string;
+  readonly nonprofitBoardMemberRightsSpecified: v175InFormInBylaws;
+  readonly nonprofitBoardMemberRightsTerms: string;
+  readonly nonprofitTrusteesMethodSpecified: v175InFormInBylaws;
+  readonly nonprofitTrusteesMethodTerms: string;
+  readonly nonprofitAssetDistributionSpecified: v175InFormInBylaws;
+  readonly nonprofitAssetDistributionTerms: string;
+  readonly additionalProvisions: string[] | undefined;
+  readonly agentType: "MYSELF" | "AUTHORIZED_REP" | "PROFESSIONAL_SERVICE";
+  readonly agentNumber: string;
+  readonly agentName: string;
+  readonly agentEmail: string;
+  readonly agentOfficeAddressLine1: string;
+  readonly agentOfficeAddressLine2: string;
+  readonly agentOfficeAddressCity: string;
+  readonly agentOfficeAddressZipCode: string;
+  readonly agentUseAccountInfo: boolean;
+  readonly agentUseBusinessAddress: boolean;
+  readonly members: v175FormationMember[] | undefined;
+  readonly incorporators: v175FormationIncorporator[] | undefined;
+  readonly signers: v175FormationSigner[] | undefined;
+  readonly paymentType: v175PaymentType;
+  readonly annualReportNotification: boolean;
+  readonly corpWatchNotification: boolean;
+  readonly officialFormationDocument: boolean;
+  readonly certificateOfStanding: boolean;
+  readonly certifiedCopyOfFormationDocument: boolean;
+  readonly contactFirstName: string;
+  readonly contactLastName: string;
+  readonly contactPhoneNumber: string;
+  readonly foreignStateOfFormation: v175StateObject | undefined;
+  readonly foreignDateOfFormation: string | undefined; // YYYY-MM-DD
+  readonly foreignGoodStandingFile: v175ForeignGoodStandingFileObject | undefined;
+  readonly legalType: string;
+  readonly willPracticeLaw: boolean | undefined;
+  readonly isVeteranNonprofit: boolean | undefined;
+}
+
+type v175ForeignGoodStandingFileObject = {
+  Extension: "PDF" | "PNG";
+  Content: string;
+};
+
+type v175StateObject = {
+  shortCode: string;
+  name: string;
+};
+
+interface v175FormationAddress {
+  readonly addressLine1: string;
+  readonly addressLine2: string;
+  readonly addressCity?: string;
+  readonly addressState?: v175StateObject;
+  readonly addressMunicipality?: v175Municipality;
+  readonly addressProvince?: string;
+  readonly addressZipCode: string;
+  readonly addressCountry: string;
+  readonly businessLocationType: v175FormationBusinessLocationType | undefined;
+}
+
+type v175FormationBusinessLocationType = "US" | "INTL" | "NJ";
+
+type v175SignerTitle =
+  | "Authorized Representative"
+  | "Authorized Partner"
+  | "Incorporator"
+  | "General Partner"
+  | "President"
+  | "Vice-President"
+  | "Chairman of the Board"
+  | "CEO";
+
+interface v175FormationSigner {
+  readonly name: string;
+  readonly signature: boolean;
+  readonly title: v175SignerTitle;
+}
+
+interface v175FormationIncorporator extends v175FormationSigner, v175FormationAddress {}
+
+interface v175FormationMember extends v175FormationAddress {
+  readonly name: string;
+}
+
+type v175PaymentType = "CC" | "ACH" | undefined;
+
+const llcBusinessSuffix = [
+  "LLC",
+  "L.L.C.",
+  "LTD LIABILITY CO",
+  "LTD LIABILITY CO.",
+  "LTD LIABILITY COMPANY",
+  "LIMITED LIABILITY CO",
+  "LIMITED LIABILITY CO.",
+  "LIMITED LIABILITY COMPANY",
+] as const;
+
+const llpBusinessSuffix = [
+  "Limited Liability Partnership",
+  "LLP",
+  "L.L.P.",
+  "Registered Limited Liability Partnership",
+  "RLLP",
+  "R.L.L.P.",
+] as const;
+
+export const lpBusinessSuffix = ["LIMITED PARTNERSHIP", "LP", "L.P."] as const;
+
+const corpBusinessSuffix = [
+  "Corporation",
+  "Incorporated",
+  "Company",
+  "LTD",
+  "CO",
+  "CO.",
+  "CORP",
+  "CORP.",
+  "INC",
+  "INC.",
+] as const;
+
+export const nonprofitBusinessSuffix = [
+  "A NJ NONPROFIT CORPORATION",
+  "CORPORATION",
+  "INCORPORATED",
+  "CORP",
+  "CORP.",
+  "INC",
+  "INC.",
+] as const;
+
+const foreignCorpBusinessSuffix = [...corpBusinessSuffix, "P.C.", "P.A."] as const;
+
+export const AllBusinessSuffixes = [
+  ...llcBusinessSuffix,
+  ...llpBusinessSuffix,
+  ...lpBusinessSuffix,
+  ...corpBusinessSuffix,
+  ...foreignCorpBusinessSuffix,
+  ...nonprofitBusinessSuffix,
+] as const;
+
+type v175BusinessSuffix = (typeof AllBusinessSuffixes)[number];
+
+type v175FormationSubmitResponse = {
+  success: boolean;
+  token: string | undefined;
+  formationId: string | undefined;
+  redirect: string | undefined;
+  errors: v175FormationSubmitError[];
+  lastUpdatedISO: string | undefined;
+};
+
+type v175FormationSubmitError = {
+  field: string;
+  type: "FIELD" | "UNKNOWN" | "RESPONSE";
+  message: string;
+};
+
+type v175GetFilingResponse = {
+  success: boolean;
+  entityId: string;
+  transactionDate: string;
+  confirmationNumber: string;
+  formationDoc: string;
+  standingDoc: string;
+  certifiedDoc: string;
+};
+
+export interface v175EnvironmentData {
+  questionnaireData?: v175QuestionnaireData;
+  submitted?: boolean;
+}
+
+export type v175QuestionnaireData = {
+  air: v175AirData;
+  land: v175LandData;
+  waste: v175WasteData;
+  drinkingWater: v175DrinkingWaterData;
+  wasteWater: v175WasteWaterData;
+};
+
+export type v175AirFieldIds =
+  | "emitPollutants"
+  | "emitEmissions"
+  | "constructionActivities"
+  | "noAir";
+
+export type v175AirData = Record<v175AirFieldIds, boolean>;
+
+export type v175LandFieldIds =
+  | "takeOverExistingBiz"
+  | "propertyAssessment"
+  | "constructionActivities"
+  | "siteImprovementWasteLands"
+  | "noLand";
+
+export type v175LandData = Record<v175LandFieldIds, boolean>;
+
+export type v175WasteFieldIds =
+  | "transportWaste"
+  | "hazardousMedicalWaste"
+  | "compostWaste"
+  | "treatProcessWaste"
+  | "constructionDebris"
+  | "noWaste";
+
+export type v175WasteData = Record<v175WasteFieldIds, boolean>;
+
+export type v175DrinkingWaterFieldIds =
+  | "ownWell"
+  | "combinedWellCapacity"
+  | "wellDrilled"
+  | "potableWater"
+  | "noDrinkingWater";
+
+export type v175DrinkingWaterData = Record<v175DrinkingWaterFieldIds, boolean>;
+
+export type v175WasteWaterFieldIds =
+  | "sanitaryWaste"
+  | "industrialWaste"
+  | "localSewage"
+  | "septicSystem"
+  | "streamsRiversOrLakes"
+  | "needsTreatment"
+  | "planningConstruction"
+  | "stormWaterDischarge"
+  | "takeoverIndustrialStormWaterPermit"
+  | "noWasteWater";
+
+export type v175WasteWaterData = Record<v175WasteWaterFieldIds, boolean>;
+
+export type v175TaxClearanceCertificateData = {
+  requestingAgencyId: string | undefined;
+  businessName: string | undefined;
+  addressLine1: string | undefined;
+  addressLine2: string | undefined;
+  addressCity: string | undefined;
+  addressState?: v175StateObject | undefined;
+  addressZipCode: string | undefined;
+  taxId: string | undefined;
+  taxPin: string | undefined;
+  hasPreviouslyReceivedCertificate: boolean | undefined;
+  lastUpdatedISO: string | undefined;
+};
+
+export type v175CigaretteLicenseData = {
+  businessName?: string;
+  responsibleOwnerName?: string;
+  tradeName?: string;
+  taxId?: string;
+  encryptedTaxId?: string;
+  addressLine1?: string;
+  addressLine2?: string;
+  addressCity?: string;
+  addressState?: v175StateObject;
+  addressZipCode?: string;
+  mailingAddressIsTheSame?: boolean;
+  mailingAddressLine1?: string;
+  mailingAddressLine2?: string;
+  mailingAddressCity?: string;
+  mailingAddressState?: v175StateObject;
+  mailingAddressZipCode?: string;
+  contactName?: string;
+  contactPhoneNumber?: string;
+  contactEmail?: string;
+  salesInfoStartDate?: string;
+  salesInfoSupplier?: string[];
+  signerName?: string;
+  signerRelationship?: string;
+  signature?: boolean;
+  lastUpdatedISO?: string;
+  paymentInfo?: v175CigaretteLicensePaymentInfo;
+};
+
+export type v175CigaretteLicensePaymentInfo = {
+  token?: string;
+  paymentComplete?: boolean;
+  orderId?: number;
+  orderStatus?: string;
+  orderTimestamp?: string;
+  confirmationEmailsent?: boolean;
+};
+
+export type v175XrayData = {
+  facilityDetails?: v175FacilityDetails;
+  machines?: v175MachineDetails[];
+  status?: v175XrayRegistrationStatus;
+  expirationDate?: string;
+  deactivationDate?: string;
+  lastUpdatedISO?: string;
+};
+
+export type v175FacilityDetails = {
+  businessName: string;
+  addressLine1: string;
+  addressLine2?: string;
+  addressZipCode: string;
+};
+
+export type v175MachineDetails = {
+  name?: string;
+  registrationNumber?: string;
+  roomId?: string;
+  registrationCategory?: string;
+  manufacturer?: string;
+  modelNumber?: string;
+  serialNumber?: string;
+  annualFee?: number;
+};
+
+export type v175XrayRegistrationStatusResponse = {
+  machines: v175MachineDetails[];
+  status: v175XrayRegistrationStatus;
+  expirationDate?: string;
+  deactivationDate?: string;
+};
+
+export type v175XrayRegistrationStatus = "ACTIVE" | "EXPIRED" | "INACTIVE";
+
+// ---------------- v175 generators ----------------
+
+export const generatev175UserData = (overrides: Partial<v175UserData>): v175UserData => {
+  return {
+    user: generatev175BusinessUser({}),
+    version: 175,
+    lastUpdatedISO: "",
+    dateCreatedISO: "",
+    versionWhenCreated: 141,
+    businesses: {
+      "123": generatev175Business({ id: "123" }),
+    },
+    currentBusinessId: "",
+    ...overrides,
+  };
+};
+
+export const generatev175BusinessUser = (
+  overrides: Partial<v175BusinessUser>,
+): v175BusinessUser => {
+  return {
+    name: `some-name-${randomInt()}`,
+    email: `some-email-${randomInt()}@example.com`,
+    id: `some-id-${randomInt()}`,
+    receiveNewsletter: false,
+    userTesting: false,
+    externalStatus: {
+      userTesting: {
+        success: true,
+        status: "SUCCESS",
+      },
+    },
+    myNJUserKey: undefined,
+    intercomHash: undefined,
+    abExperience: "ExperienceA",
+    accountCreationSource: `some-source-${randomInt()}`,
+    contactSharingWithAccountCreationPartner: false,
+    ...overrides,
+  };
+};
+
+export const generatev175RoadmapTaskData = (
+  overrides: Partial<v175RoadmapTaskData>,
+): v175RoadmapTaskData => {
+  return {
+    manageBusinessVehicles: undefined,
+    passengerTransportSchoolBus: undefined,
+    passengerTransportSixteenOrMorePassengers: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev175Business = (overrides: Partial<v175Business>): v175Business => {
+  const profileData = generatev175ProfileData({});
+
+  return {
+    id: `some-id-${randomInt()}`,
+    dateCreatedISO: "",
+    lastUpdatedISO: "",
+    profileData: profileData,
+    preferences: generatev175Preferences({}),
+    formationData: generatev175FormationData({}, profileData.legalStructureId ?? ""),
+    onboardingFormProgress: "UNSTARTED",
+    taxClearanceCertificateData: generatev175TaxClearanceCertificateData({}),
+    cigaretteLicenseData: generatev175CigaretteLicenseData({}),
+    taskProgress: {
+      "business-structure": "TO_DO",
+    },
+    taskItemChecklist: {
+      "general-dvob": false,
+    },
+    roadmapTaskData: generatev175RoadmapTaskData({}),
+    licenseData: undefined,
+    taxFilingData: generatev175TaxFilingData({}),
+    environmentData: undefined,
+    xrayRegistrationData: undefined,
+    userId: `some-id-${randomInt()}`,
+    version: 175,
+    versionWhenCreated: -1,
+    ...overrides,
+  };
+};
+
+export const generatev175ProfileData = (overrides: Partial<v175ProfileData>): v175ProfileData => {
+  const id = `some-id-${randomInt()}`;
+  const persona = randomInt() % 2 ? "STARTING" : "OWNING";
+  return {
+    ...generatev175IndustrySpecificData({}),
+    businessPersona: persona,
+    businessName: `some-business-name-${randomInt()}`,
+    industryId: "restaurant",
+    legalStructureId: "limited-liability-partnership",
+    dateOfFormation: undefined,
+    entityId: randomInt(10).toString(),
+    employerId: randomInt(9).toString(),
+    taxId: randomInt() % 2 ? randomInt(9).toString() : randomInt(12).toString(),
+    hashedTaxId: `some-hashed-tax-id`,
+    encryptedTaxId: `some-encrypted-tax-id`,
+    notes: `some-notes-${randomInt()}`,
+    existingEmployees: randomInt(7).toString(),
+    naicsCode: randomInt(6).toString(),
+    nexusDbaName: "undefined",
+    operatingPhase: "NEEDS_TO_FORM",
+    ownershipTypeIds: [],
+    documents: {
+      certifiedDoc: `${id}/certifiedDoc-${randomInt()}.pdf`,
+      formationDoc: `${id}/formationDoc-${randomInt()}.pdf`,
+      standingDoc: `${id}/standingDoc-${randomInt()}.pdf`,
+    },
+    taxPin: randomInt(4).toString(),
+    encryptedTaxPin: `some-encrypted-tax-pin`,
+    sectorId: undefined,
+    foreignBusinessTypeIds: [],
+    municipality: undefined,
+    responsibleOwnerName: `some-owner-name-${randomInt()}`,
+    tradeName: `some-trade-name-${randomInt()}`,
+    elevatorOwningBusiness: undefined,
+    nonEssentialRadioAnswers: {},
+    plannedRenovationQuestion: undefined,
+    communityAffairsAddress: undefined,
+    raffleBingoGames: undefined,
+    businessOpenMoreThanTwoYears: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev175IndustrySpecificData = (
+  overrides: Partial<v175IndustrySpecificData>,
+): v175IndustrySpecificData => {
+  return {
+    liquorLicense: false,
+    requiresCpa: false,
+    homeBasedBusiness: false,
+    cannabisLicenseType: undefined,
+    cannabisMicrobusiness: undefined,
+    constructionRenovationPlan: undefined,
+    providesStaffingService: false,
+    certifiedInteriorDesigner: false,
+    realEstateAppraisalManagement: false,
+    carService: undefined,
+    interstateTransport: false,
+    isChildcareForSixOrMore: undefined,
+    willSellPetCareItems: undefined,
+    petCareHousing: undefined,
+    interstateLogistics: undefined,
+    interstateMoving: undefined,
+    constructionType: undefined,
+    residentialConstructionType: undefined,
+    employmentPersonnelServiceType: undefined,
+    employmentPlacementType: undefined,
+    carnivalRideOwningBusiness: undefined,
+    propertyLeaseType: undefined,
+    hasThreeOrMoreRentalUnits: undefined,
+    travelingCircusOrCarnivalOwningBusiness: undefined,
+    vacantPropertyOwner: undefined,
+    publicWorksContractor: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev175Preferences = (overrides: Partial<v175Preferences>): v175Preferences => {
+  return {
+    roadmapOpenSections: ["PLAN", "START"],
+    roadmapOpenSteps: [],
+    hiddenCertificationIds: [],
+    hiddenFundingIds: [],
+    visibleSidebarCards: [],
+    returnToLink: "",
+    isCalendarFullView: true,
+    isHideableRoadmapOpen: false,
+    phaseNewlyChanged: false,
+    isNonProfitFromFunding: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev175FormationData = (
+  overrides: Partial<v175FormationData>,
+  legalStructureId: string,
+): v175FormationData => {
+  return {
+    formationFormData: generatev175FormationFormData({}, legalStructureId),
+    formationResponse: undefined,
+    getFilingResponse: undefined,
+    completedFilingPayment: false,
+    businessNameAvailability: undefined,
+    lastVisitedPageIndex: 0,
+    dbaBusinessNameAvailability: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev175FormationFormData = (
+  overrides: Partial<v175FormationFormData>,
+  legalStructureId: string,
+): v175FormationFormData => {
+  const isCorp = legalStructureId
+    ? ["s-corporation", "c-corporation"].includes(legalStructureId)
+    : false;
+
+  return <v175FormationFormData>{
+    businessName: `some-business-name-${randomInt()}`,
+    businessSuffix: "LLC",
+    businessTotalStock: isCorp ? randomInt().toString() : "",
+    businessStartDate: new Date(Date.now()).toISOString().split("T")[0],
+    businessPurpose: `some-purpose-${randomInt()}`,
+    addressLine1: `some-members-address-1-${randomInt()}`,
+    addressLine2: `some-members-address-2-${randomInt()}`,
+    addressCity: `some-members-address-city-${randomInt()}`,
+    addressState: { shortCode: "123", name: "new-jersey" },
+    addressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    addressCountry: `some-county`,
+    addressMunicipality: generatev175Municipality({}),
+    addressProvince: "",
+    withdrawals: `some-withdrawals-text-${randomInt()}`,
+    combinedInvestment: `some-combinedInvestment-text-${randomInt()}`,
+    dissolution: `some-dissolution-text-${randomInt()}`,
+    canCreateLimitedPartner: !!(randomInt() % 2),
+    createLimitedPartnerTerms: `some-createLimitedPartnerTerms-text-${randomInt()}`,
+    canGetDistribution: !!(randomInt() % 2),
+    getDistributionTerms: `some-getDistributionTerms-text-${randomInt()}`,
+    canMakeDistribution: !!(randomInt() % 2),
+    makeDistributionTerms: `make-getDistributionTerms-text-${randomInt()}`,
+    hasNonprofitBoardMembers: true,
+    nonprofitBoardMemberQualificationsSpecified: "IN_BYLAWS",
+    nonprofitBoardMemberQualificationsTerms: "",
+    nonprofitBoardMemberRightsSpecified: "IN_BYLAWS",
+    nonprofitBoardMemberRightsTerms: "",
+    nonprofitTrusteesMethodSpecified: "IN_BYLAWS",
+    nonprofitTrusteesMethodTerms: "",
+    nonprofitAssetDistributionSpecified: "IN_BYLAWS",
+    nonprofitAssetDistributionTerms: "",
+    provisions: [],
+    agentNumberOrManual: randomInt() % 2 ? "NUMBER" : "MANUAL_ENTRY",
+    agentNumber: `some-agent-number-${randomInt()}`,
+    agentName: `some-agent-name-${randomInt()}`,
+    agentEmail: `some-agent-email-${randomInt()}`,
+    agentOfficeAddressLine1: `some-agent-office-address-1-${randomInt()}`,
+    agentOfficeAddressLine2: `some-agent-office-address-2-${randomInt()}`,
+    agentOfficeAddressCity: `some-agent-office-address-city-${randomInt()}`,
+    agentOfficeAddressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    agentUseAccountInfo: !!(randomInt() % 2),
+    agentUseBusinessAddress: !!(randomInt() % 2),
+    signers: [],
+    members:
+      legalStructureId === "limited-liability-partnership" ? [] : [generatev175FormationMember({})],
+    incorporators: undefined,
+    paymentType: randomInt() % 2 ? "ACH" : "CC",
+    annualReportNotification: !!(randomInt() % 2),
+    corpWatchNotification: !!(randomInt() % 2),
+    officialFormationDocument: !!(randomInt() % 2),
+    certificateOfStanding: !!(randomInt() % 2),
+    certifiedCopyOfFormationDocument: !!(randomInt() % 2),
+    contactFirstName: `some-contact-first-name-${randomInt()}`,
+    contactLastName: `some-contact-last-name-${randomInt()}`,
+    contactPhoneNumber: `some-contact-phone-number-${randomInt()}`,
+    foreignStateOfFormation: undefined,
+    foreignDateOfFormation: undefined,
+    foreignGoodStandingFile: undefined,
+    willPracticeLaw: false,
+    isVeteranNonprofit: false,
+    legalType: "",
+    additionalProvisions: undefined,
+    businessLocationType: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev175Municipality = (
+  overrides: Partial<v175Municipality>,
+): v175Municipality => {
+  return {
+    displayName: `some-display-name-${randomInt()}`,
+    name: `some-name-${randomInt()}`,
+    county: `some-county-${randomInt()}`,
+    id: `some-id-${randomInt()}`,
+    ...overrides,
+  };
+};
+
+export const generatev175FormationMember = (
+  overrides: Partial<v175FormationMember>,
+): v175FormationMember => {
+  return {
+    name: `some-name`,
+    addressLine1: `some-members-address-1-${randomInt()}`,
+    addressLine2: `some-members-address-2-${randomInt()}`,
+    addressCity: `some-members-address-city-${randomInt()}`,
+    addressState: { shortCode: "123", name: "new-jersey" },
+    addressZipCode: `some-agent-office-zipcode-${randomInt()}`,
+    addressCountry: `some-county`,
+    businessLocationType: undefined,
+    ...overrides,
+  };
+};
+
+export const generatev175TaxFilingData = (
+  overrides: Partial<v175TaxFilingData>,
+): v175TaxFilingData => {
+  return {
+    state: undefined,
+    businessName: undefined,
+    errorField: undefined,
+    lastUpdatedISO: undefined,
+    registeredISO: undefined,
+    filings: [],
+    ...overrides,
+  };
+};
+
+export const generatev175LicenseDetails = (
+  overrides: Partial<v175LicenseDetails>,
+): v175LicenseDetails => {
+  return {
+    nameAndAddress: generatev175LicenseSearchNameAndAddress({}),
+    licenseStatus: getRandomv175LicenseStatus(),
+    expirationDateISO: "some-expiration-iso",
+    lastUpdatedISO: "some-last-updated",
+    checklistItems: [generatev175LicenseStatusItem()],
+    ...overrides,
+  };
+};
+
+const generatev175LicenseSearchNameAndAddress = (
+  overrides: Partial<v175LicenseSearchNameAndAddress>,
+): v175LicenseSearchNameAndAddress => {
+  return {
+    name: `some-name`,
+    addressLine1: `some-members-address-1-${randomInt()}`,
+    addressLine2: `some-members-address-2-${randomInt()}`,
+    zipCode: `some-agent-office-zipcode-${randomInt()}`,
+    ...overrides,
+  };
+};
+
+const generatev175LicenseStatusItem = (): v175LicenseStatusItem => {
+  return {
+    title: `some-title-${randomInt()}`,
+    status: "ACTIVE",
+  };
+};
+
+export const getRandomv175LicenseStatus = (): v175LicenseStatus => {
+  const randomIndex = Math.floor(Math.random() * v175LicenseStatuses.length);
+  return v175LicenseStatuses[randomIndex];
+};
+
+export const generatev175TaxClearanceCertificateData = (
+  overrides: Partial<v175TaxClearanceCertificateData>,
+): v175TaxClearanceCertificateData => {
+  return {
+    requestingAgencyId: "",
+    businessName: `some-business-name-${randomInt()}`,
+    addressLine1: `some-address-1-${randomInt()}`,
+    addressLine2: `some-address-2-${randomInt()}`,
+    addressCity: `some-city-${randomInt()}`,
+    addressState: undefined,
+    addressZipCode: randomInt(5).toString(),
+    taxId: `${randomInt(12)}`,
+    taxPin: randomInt(4).toString(),
+    hasPreviouslyReceivedCertificate: undefined,
+    lastUpdatedISO: "",
+    ...overrides,
+  };
+};
+
+export const generatev175CigaretteLicenseData = (
+  overrides: Partial<v175CigaretteLicenseData>,
+): v175CigaretteLicenseData => {
+  const taxId = randomInt(12).toString();
+  const maskingCharacter = "*";
+  return {
+    businessName: `some-business-name-${randomInt()}`,
+    responsibleOwnerName: `some-owner-name-${randomInt()}`,
+    tradeName: `some-trade-name-${randomInt()}`,
+    taxId: maskingCharacter.repeat(7) + taxId.slice(-5),
+    encryptedTaxId: `encrypted-${taxId}`,
+    addressLine1: `some-address-1-${randomInt()}`,
+    addressLine2: `some-address-2-${randomInt()}`,
+    addressCity: `some-city-${randomInt()}`,
+    addressState: undefined,
+    addressZipCode: randomInt(5).toString(),
+    mailingAddressIsTheSame: false,
+    mailingAddressLine1: "",
+    mailingAddressLine2: "",
+    mailingAddressCity: "",
+    mailingAddressState: undefined,
+    mailingAddressZipCode: "",
+    contactName: `some-contact-name-${randomInt()}`,
+    contactPhoneNumber: `some-phone-number-${randomInt()}`,
+    contactEmail: `some-email-${randomInt()}`,
+    salesInfoStartDate: "08/31/2025",
+    salesInfoSupplier: [],
+    signerName: `some-signer-name-${randomInt()}`,
+    signerRelationship: `some-signer-relationship-${randomInt()}`,
+    signature: false,
+    lastUpdatedISO: "",
+    ...overrides,
+  };
+};
+
+export const generatev175EnvironmentQuestionnaireData = ({
+  airOverrides,
+  landOverrides,
+  wasteOverrides,
+  drinkingWaterOverrides,
+  wasteWaterOverrides,
+}: {
+  airOverrides?: Partial<v175AirData>;
+  landOverrides?: Partial<v175LandData>;
+  wasteOverrides?: Partial<v175WasteData>;
+  drinkingWaterOverrides?: Partial<v175DrinkingWaterData>;
+  wasteWaterOverrides?: Partial<v175WasteWaterData>;
+}): v175QuestionnaireData => {
+  return {
+    air: {
+      emitPollutants: false,
+      emitEmissions: false,
+      constructionActivities: false,
+      noAir: false,
+      ...airOverrides,
+    },
+    land: {
+      takeOverExistingBiz: false,
+      propertyAssessment: false,
+      constructionActivities: false,
+      siteImprovementWasteLands: false,
+      noLand: false,
+      ...landOverrides,
+    },
+    waste: {
+      transportWaste: false,
+      hazardousMedicalWaste: false,
+      compostWaste: false,
+      treatProcessWaste: false,
+      constructionDebris: false,
+      noWaste: false,
+      ...wasteOverrides,
+    },
+    drinkingWater: {
+      ownWell: false,
+      combinedWellCapacity: false,
+      wellDrilled: false,
+      potableWater: false,
+      noDrinkingWater: false,
+      ...drinkingWaterOverrides,
+    },
+    wasteWater: {
+      sanitaryWaste: false,
+      industrialWaste: false,
+      localSewage: false,
+      septicSystem: false,
+      streamsRiversOrLakes: false,
+      needsTreatment: false,
+      planningConstruction: false,
+      stormWaterDischarge: false,
+      takeoverIndustrialStormWaterPermit: false,
+      noWasteWater: false,
+      ...wasteWaterOverrides,
+    },
+  };
+};

--- a/api/wiremock/mappings/cigarette-license-send-email-fail.json
+++ b/api/wiremock/mappings/cigarette-license-send-email-fail.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/cigarette-license/send-email-confirmation",
+    "bodyPatterns": [
+      {
+        "matchesJsonPath": "$[?(@.businessName !== 'Mock Success Company')]"
+      }
+    ]
+  },
+  "response": {
+    "status": 400,
+    "body": "There was an issue sending the email confirmation.",
+    "headers": {
+      "Content-Type": "text/json"
+    }
+  }
+}

--- a/content/src/fieldConfig/cigarette-license-confirmation.json
+++ b/content/src/fieldConfig/cigarette-license-confirmation.json
@@ -18,6 +18,11 @@
     "licenseeInformationHeader": "Licensee Information",
     "submissionDetails": "Submission Details",
     "issuingAgency": "**Issuing Agency:** NJ Division of Revenue and Enterprise Services",
-    "confirmationNumber": "Confirmation number"
+    "confirmationNumber": "Confirmation number",
+    "cantCompleteFilingAlert": "We received your payment, but we couldn’t complete your filing.",
+    "cantCompleteFilingMessage1": "Select “Try Again” and we’ll resend your filing details. **Do not** submit payment again.",
+    "cantCompleteFilingMessage2": "If you are still having trouble after trying again, select “Start a Live Chat” to get help.",
+    "tryAgainButton": "Try Again",
+    "startLiveChatButton": "Start a Live Chat"
   }
 }

--- a/shared/src/cigaretteLicense.ts
+++ b/shared/src/cigaretteLicense.ts
@@ -31,6 +31,7 @@ export interface CigaretteLicenseData {
 
 export type CigaretteLicensePaymentInfo = {
   token?: string;
+  paymentComplete?: boolean;
   orderId?: number;
   orderStatus?: string;
   orderTimestamp?: string;
@@ -65,8 +66,9 @@ export const emptyCigaretteLicenseData: CigaretteLicenseData = {
   signature: false,
 };
 
-export const emptyCigaretteLicensePaymentInfo = {
+export const emptyCigaretteLicensePaymentInfo: CigaretteLicensePaymentInfo = {
   token: "",
+  paymentComplete: false,
   orderId: undefined,
   orderStatus: "",
   orderTimestamp: "",
@@ -134,7 +136,7 @@ export interface EmailConfirmationSubmission {
 
 export type PaymentApiError = {
   statusCode: number;
-  errorCode: number;
+  errorCode: string;
   userMessage: string;
   developerMessage: string;
 };

--- a/shared/src/userData.ts
+++ b/shared/src/userData.ts
@@ -42,7 +42,7 @@ export interface Business {
   readonly userId: string;
 }
 
-export const CURRENT_VERSION = 174;
+export const CURRENT_VERSION = 175;
 
 export const createEmptyBusiness = ({
   userId,

--- a/web/decap-config/collections/06-tasks.yml
+++ b/web/decap-config/collections/06-tasks.yml
@@ -1483,6 +1483,36 @@ collections:
                   widget: "string",
                   required: true,
                 }
+              - {
+                  label: "Cant Complete Filing Alert",
+                  name: "cantCompleteFilingAlert",
+                  widget: "string",
+                  required: true,
+                }
+              - {
+                  label: "Cant Complete Filing Message Line 1",
+                  name: "cantCompleteFilingMessage1",
+                  widget: "markdown",
+                  required: true,
+                }
+              - {
+                  label: "Cant Complete Filing Message Line 2",
+                  name: "cantCompleteFilingMessage2",
+                  widget: "markdown",
+                  required: true,
+                }
+              - {
+                  label: "Try Again Button",
+                  name: "tryAgainButton",
+                  widget: "string",
+                  required: true,
+                }
+              - {
+                  label: "Start a Live Chat Button",
+                  name: "startLiveChatButton",
+                  widget: "string",
+                  required: true,
+                }
   - name: "ein-task"
     label: "Tasks - EIN"
     delete: false

--- a/web/src/components/tasks/cigarette-license/CigaretteLicense.test.tsx
+++ b/web/src/components/tasks/cigarette-license/CigaretteLicense.test.tsx
@@ -1,22 +1,27 @@
 import { CigaretteLicense } from "@/components/tasks/cigarette-license/CigaretteLicense";
 import { generateTask } from "@/test/factories";
 import { useMockRoadmap } from "@/test/mock/mockUseRoadmap";
-import { WithStatefulUserData } from "@/test/mock/withStatefulUserData";
+import { WithStatefulUserData, currentBusiness } from "@/test/mock/withStatefulUserData";
 import { getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
+
 import { createEmptyFormationFormData } from "@businessnjgovnavigator/shared/formationData";
+import { useMockRouter } from "@/test/mock/mockRouter";
+import { QUERIES } from "@/lib/domain-logic/routes";
 import {
   generateBusiness,
+  generateCigaretteLicenseData,
   generateFormationData,
   generateProfileData,
   generateUserDataForBusiness,
 } from "@businessnjgovnavigator/shared/test";
 import { Business } from "@businessnjgovnavigator/shared/userData";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const Config = getMergedConfig();
 
 jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
+jest.mock("next/compat/router", () => ({ useRouter: jest.fn() }));
 
 describe("<CigaretteLicense />", () => {
   beforeEach(() => {
@@ -112,6 +117,69 @@ describe("<CigaretteLicense />", () => {
           }
         },
       );
+    });
+  });
+
+  describe("query param completePayment", () => {
+    it("completePayment=failure show alert on review step", async () => {
+      useMockRouter({ isReady: true, query: { [QUERIES.completePayment]: "failure" } });
+      await renderComponent();
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("completePayment=duplicate show alert on review step", async () => {
+      useMockRouter({ isReady: true, query: { [QUERIES.completePayment]: "duplicate" } });
+      await renderComponent();
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("completePayment=cancel show review step with no alert", async () => {
+      useMockRouter({ isReady: true, query: { [QUERIES.completePayment]: "cancel" } });
+      await renderComponent();
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("completePayment=success should update task and cigarette paymentInfo", async () => {
+      useMockRouter({ isReady: true, query: { [QUERIES.completePayment]: "success" } });
+      const business = generateBusiness({
+        profileData: generateProfileData({}),
+        cigaretteLicenseData: generateCigaretteLicenseData({}),
+      });
+      await renderComponent(business);
+
+      await waitFor(() => {
+        expect(currentBusiness().cigaretteLicenseData?.paymentInfo?.paymentComplete).toEqual(true);
+      });
+      await waitFor(() => {
+        expect(currentBusiness().taskProgress["cigarette-license"]).toEqual("COMPLETED");
+      });
+    });
+  });
+
+  describe("payment complete", () => {
+    it("if cigarette-license paymentInfo.paymentComplete is true stepper should not show", async () => {
+      const business = generateBusiness({
+        profileData: generateProfileData({}),
+        cigaretteLicenseData: generateCigaretteLicenseData({
+          paymentInfo: {
+            paymentComplete: true,
+            orderId: 12345,
+            confirmationEmailsent: true,
+          },
+        }),
+      });
+
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        await renderComponent(business);
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole("tablist")).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/web/src/components/tasks/cigarette-license/Confirmation.test.tsx
+++ b/web/src/components/tasks/cigarette-license/Confirmation.test.tsx
@@ -1,21 +1,31 @@
 import { ConfirmationPage } from "@/components/tasks/cigarette-license/Confirmation";
+import * as api from "@/lib/api-client/apiClient";
 import { CigaretteLicenseData } from "@businessnjgovnavigator/shared/cigaretteLicense";
 import { getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
 import { formatUTCDate } from "@businessnjgovnavigator/shared/dateHelpers";
 import { emptyProfileData } from "@businessnjgovnavigator/shared/profileData";
-import { generateBusiness } from "@businessnjgovnavigator/shared/test";
-import { Business } from "@businessnjgovnavigator/shared/userData";
-import { render, screen } from "@testing-library/react";
+import { generateBusiness, generateUserDataForBusiness } from "@businessnjgovnavigator/shared/test";
+import { Business, UserData } from "@businessnjgovnavigator/shared/userData";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 const Config = getMergedConfig();
+
+jest.mock("@/lib/api-client/apiClient", () => ({
+  cigaretteLicenseConfirmPayment: jest.fn(),
+}));
+
+const mockApi = api as jest.Mocked<typeof api>;
 
 describe("<ConfirmationPage />", () => {
   const mockCigaretteLicenseData: CigaretteLicenseData = {
     paymentInfo: {
+      token: "12345",
       orderId: 12345,
       orderTimestamp: "2024-01-15T10:30:00Z",
+      confirmationEmailsent: true,
     },
-    businessName: "Test Business LLC",
+    businessName: "Mock Success Business",
     responsibleOwnerName: "John Doe",
     tradeName: "Test Trade Name",
     addressLine1: "123 Main St",
@@ -30,10 +40,44 @@ describe("<ConfirmationPage />", () => {
     mailingAddressZipCode: "21210",
     contactName: "Jane Smith",
     contactPhoneNumber: "555-123-4567",
-    contactEmail: "contact@testbusiness.com",
+    contactEmail: "mock-success@test.com",
     salesInfoStartDate: "2024-02-01T00:00:00Z",
     salesInfoSupplier: ["Supplier A", "Supplier B", "Supplier C"],
   };
+
+  const mockFailCigaretteLicenseData: CigaretteLicenseData = {
+    paymentInfo: {
+      token: "12345",
+      confirmationEmailsent: false,
+    },
+    businessName: "Mock Fail Business",
+    responsibleOwnerName: "John Doe",
+    tradeName: "Test Trade Name",
+    addressLine1: "123 Main St",
+    addressLine2: "Suite 100",
+    addressCity: "Newark",
+    addressState: { name: "New Jersey", shortCode: "NJ" },
+    addressZipCode: "07102",
+    mailingAddressLine1: "456 Oak Ave",
+    mailingAddressLine2: "Apt 2B",
+    mailingAddressCity: "Baltimore",
+    mailingAddressState: { name: "Maryland", shortCode: "MD" },
+    mailingAddressZipCode: "21210",
+    contactName: "Jane Smith",
+    contactPhoneNumber: "555-123-4567",
+    contactEmail: "mock-fail@test.com",
+    salesInfoStartDate: "2024-02-01T00:00:00Z",
+    salesInfoSupplier: ["Supplier A", "Supplier B", "Supplier C"],
+  };
+
+  const mockBusiness: Business = generateBusiness({
+    cigaretteLicenseData: mockCigaretteLicenseData,
+  });
+
+  beforeEach(() => {
+    const userData: UserData = generateUserDataForBusiness(mockBusiness);
+    mockApi.cigaretteLicenseConfirmPayment.mockResolvedValue(userData);
+  });
 
   const renderComponent = (business?: Business): void => {
     render(
@@ -44,72 +88,98 @@ describe("<ConfirmationPage />", () => {
   };
 
   describe("Basic rendering", () => {
-    it("renders the confirmation page", () => {
+    it("renders the confirmation page", async () => {
       renderComponent();
-      expect(screen.getByTestId("cig-license-confirmation-page")).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByTestId("cig-license-confirmation-page")).toBeInTheDocument();
+      });
     });
 
-    it("displays the success header and info", () => {
+    it("displays the success header and info", async () => {
       renderComponent();
-      expect(
-        screen.getByText(Config.cigaretteLicenseConfirmation.paymentSuccessfulHeader),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(Config.cigaretteLicenseConfirmation.paymentSuccessfulInfo),
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseConfirmation.paymentSuccessfulHeader),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseConfirmation.paymentSuccessfulInfo),
+        ).toBeInTheDocument();
+      });
     });
 
-    it("displays what happens next header and content", () => {
+    it("displays what happens next header and content", async () => {
       renderComponent();
-      expect(
-        screen.getByText(Config.cigaretteLicenseConfirmation.whatHappensNextHeader),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(Config.cigaretteLicenseConfirmation.whatHappensNextInfo),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(Config.cigaretteLicenseConfirmation.whatHappensNextBullet1),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(Config.cigaretteLicenseConfirmation.whatHappensNextBullet2),
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseConfirmation.whatHappensNextHeader),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseConfirmation.whatHappensNextInfo),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseConfirmation.whatHappensNextBullet1),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseConfirmation.whatHappensNextBullet2),
+        ).toBeInTheDocument();
+      });
     });
   });
 
   describe("Payment information section", () => {
-    it("displays confirmation number", () => {
+    it("displays confirmation number", async () => {
       renderComponent();
-      expect(
-        screen.getByText(Config.cigaretteLicenseConfirmation.confirmationNumber),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(mockCigaretteLicenseData!.paymentInfo!.orderId!.toString()),
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseConfirmation.confirmationNumber),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(mockCigaretteLicenseData!.paymentInfo!.orderId!.toString()),
+        ).toBeInTheDocument();
+      });
     });
 
-    it("displays date submitted", () => {
+    it("displays date submitted", async () => {
       renderComponent();
-      expect(
-        screen.getByText(Config.cigaretteLicenseConfirmation.dateSubmitted),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(formatUTCDate(mockCigaretteLicenseData!.paymentInfo!.orderTimestamp!)),
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseConfirmation.dateSubmitted),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(formatUTCDate(mockCigaretteLicenseData!.paymentInfo!.orderTimestamp!)),
+        ).toBeInTheDocument();
+      });
     });
   });
 
   describe("Licensee information section", () => {
-    it("displays submission details header", () => {
+    it("displays submission details header", async () => {
       renderComponent();
-      expect(
-        screen.getByText(Config.cigaretteLicenseConfirmation.submissionDetails),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(Config.cigaretteLicenseConfirmation.licenseeInformationHeader),
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseConfirmation.submissionDetails),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseConfirmation.licenseeInformationHeader),
+        ).toBeInTheDocument();
+      });
     });
 
-    it("displays business name for applicable legal structures", () => {
+    it("displays business name for applicable legal structures", async () => {
       const business: Business = generateBusiness({
         profileData: {
           ...emptyProfileData,
@@ -119,13 +189,17 @@ describe("<ConfirmationPage />", () => {
       });
       render(<ConfirmationPage business={business} />);
 
-      expect(
-        screen.getByText(Config.profileDefaults.fields.businessName.default.header),
-      ).toBeInTheDocument();
-      expect(screen.getByText(mockCigaretteLicenseData!.businessName!)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.profileDefaults.fields.businessName.default.header),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByText(mockCigaretteLicenseData!.businessName!)).toBeInTheDocument();
+      });
     });
 
-    it("displays responsible owner name and trade name for non-applicable legal structures", () => {
+    it("displays responsible owner name and trade name for non-applicable legal structures", async () => {
       const business: Business = generateBusiness({
         profileData: {
           ...emptyProfileData,
@@ -135,104 +209,229 @@ describe("<ConfirmationPage />", () => {
       });
       render(<ConfirmationPage business={business} />);
 
-      expect(
-        screen.getByText(Config.profileDefaults.fields.responsibleOwnerName.default.header),
-      ).toBeInTheDocument();
-      expect(screen.getByText(mockCigaretteLicenseData!.responsibleOwnerName!)).toBeInTheDocument();
-      expect(
-        screen.getByText(Config.profileDefaults.fields.tradeName.default.header),
-      ).toBeInTheDocument();
-      expect(screen.getByText(mockCigaretteLicenseData!.tradeName!)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.profileDefaults.fields.responsibleOwnerName.default.header),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(mockCigaretteLicenseData!.responsibleOwnerName!),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.profileDefaults.fields.tradeName.default.header),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByText(mockCigaretteLicenseData!.tradeName!)).toBeInTheDocument();
+      });
     });
   });
 
   describe("Business address section", () => {
-    it("displays business address header and all address fields", () => {
+    it("displays business address header and all address fields", async () => {
       renderComponent();
 
-      expect(
-        screen.getByText(Config.cigaretteLicenseStep2.businessAddressHeader),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(Config.cigaretteLicenseConfirmation.businessAddressLine1),
-      ).toBeInTheDocument();
-      expect(screen.getByText(mockCigaretteLicenseData!.addressLine1!)).toBeInTheDocument();
-      expect(
-        screen.getByText(Config.cigaretteLicenseConfirmation.businessAddressLine2),
-      ).toBeInTheDocument();
-      expect(screen.getByText(mockCigaretteLicenseData!.addressLine2!)).toBeInTheDocument();
-      expect(screen.getByText(mockCigaretteLicenseData!.addressCity!)).toBeInTheDocument();
-      expect(
-        screen.getByText(mockCigaretteLicenseData!.addressState!.shortCode!),
-      ).toBeInTheDocument();
-      expect(screen.getByText(mockCigaretteLicenseData!.addressZipCode!)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseStep2.businessAddressHeader),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseConfirmation.businessAddressLine1),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByText(mockCigaretteLicenseData!.addressLine1!)).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseConfirmation.businessAddressLine2),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByText(mockCigaretteLicenseData!.addressLine2!)).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByText(mockCigaretteLicenseData!.addressCity!)).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(mockCigaretteLicenseData!.addressState!.shortCode!),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByText(mockCigaretteLicenseData!.addressZipCode!)).toBeInTheDocument();
+      });
     });
   });
 
   describe("Mailing address section", () => {
-    it("displays mailing address header and all address fields", () => {
+    it("displays mailing address header and all address fields", async () => {
       renderComponent();
 
-      expect(
-        screen.getByText(Config.cigaretteLicenseStep2.mailingAddressHeader),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(Config.cigaretteLicenseConfirmation.mailingAddressLine1),
-      ).toBeInTheDocument();
-      expect(screen.getByText(mockCigaretteLicenseData!.mailingAddressLine1!)).toBeInTheDocument();
-      expect(
-        screen.getByText(Config.cigaretteLicenseConfirmation.mailingAddressLine2),
-      ).toBeInTheDocument();
-      expect(screen.getByText(mockCigaretteLicenseData!.mailingAddressLine2!)).toBeInTheDocument();
-      expect(screen.getByText(mockCigaretteLicenseData!.mailingAddressCity!)).toBeInTheDocument();
-      expect(
-        screen.getByText(mockCigaretteLicenseData!.addressState!.shortCode!),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(mockCigaretteLicenseData!.mailingAddressZipCode!),
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseStep2.mailingAddressHeader),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseConfirmation.mailingAddressLine1),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(mockCigaretteLicenseData!.mailingAddressLine1!),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseConfirmation.mailingAddressLine2),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(mockCigaretteLicenseData!.mailingAddressLine2!),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByText(mockCigaretteLicenseData!.mailingAddressCity!)).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(mockCigaretteLicenseData!.addressState!.shortCode!),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(mockCigaretteLicenseData!.mailingAddressZipCode!),
+        ).toBeInTheDocument();
+      });
     });
   });
 
   describe("Contact information section", () => {
-    it("displays contact information header and all contact fields", () => {
+    it("displays contact information header and all contact fields", async () => {
       renderComponent();
 
-      expect(
-        screen.getByText(Config.cigaretteLicenseStep2.contactInformationHeader),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(Config.cigaretteLicenseStep2.fields.contactName.label),
-      ).toBeInTheDocument();
-      expect(screen.getByText(mockCigaretteLicenseData!.contactName!)).toBeInTheDocument();
-      expect(
-        screen.getByText(Config.cigaretteLicenseStep2.fields.contactPhoneNumber.label),
-      ).toBeInTheDocument();
-      expect(screen.getByText(mockCigaretteLicenseData!.contactPhoneNumber!)).toBeInTheDocument();
-      expect(
-        screen.getByText(Config.cigaretteLicenseStep2.fields.contactEmail.label),
-      ).toBeInTheDocument();
-      expect(screen.getByText(mockCigaretteLicenseData!.contactEmail!)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseStep2.contactInformationHeader),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseStep2.fields.contactName.label),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByText(mockCigaretteLicenseData!.contactName!)).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseStep2.fields.contactPhoneNumber.label),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByText(mockCigaretteLicenseData!.contactPhoneNumber!)).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseStep2.fields.contactEmail.label),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByText(mockCigaretteLicenseData!.contactEmail!)).toBeInTheDocument();
+      });
     });
   });
 
   describe("Sales information section", () => {
-    it("displays sales information header and fields", () => {
+    it("displays sales information header and fields", async () => {
       renderComponent();
 
-      expect(
-        screen.getByText(Config.cigaretteLicenseStep3.salesInformationHeader),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(Config.cigaretteLicenseStep3.fields.startDateOfSales.label),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(formatUTCDate(mockCigaretteLicenseData!.salesInfoStartDate!)),
-      ).toBeInTheDocument();
-      expect(screen.getByText(Config.cigaretteLicenseConfirmation.suppliers)).toBeInTheDocument();
-      expect(
-        screen.getByText(mockCigaretteLicenseData!.salesInfoSupplier!.join(", ")),
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseStep3.salesInformationHeader),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseStep3.fields.startDateOfSales.label),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(formatUTCDate(mockCigaretteLicenseData!.salesInfoStartDate!)),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByText(Config.cigaretteLicenseConfirmation.suppliers)).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText(mockCigaretteLicenseData!.salesInfoSupplier!.join(", ")),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Try again page", () => {
+    const mockFailBusiness: Business = generateBusiness({
+      cigaretteLicenseData: mockFailCigaretteLicenseData,
+    });
+    const userData: UserData = generateUserDataForBusiness(mockFailBusiness);
+
+    beforeEach(() => {
+      mockApi.cigaretteLicenseConfirmPayment.mockResolvedValue(userData);
+    });
+
+    it("displays try again page when email confirmatin is not sent", async () => {
+      renderComponent(mockFailBusiness);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(Config.cigaretteLicenseConfirmation.cantCompleteFilingAlert),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("get order details api call is made when Try Again Button is clicked", async () => {
+      renderComponent(mockFailBusiness);
+
+      await waitFor(() => {
+        expect(mockApi.cigaretteLicenseConfirmPayment).toHaveBeenCalledTimes(2);
+      });
+
+      const button = await screen.findByRole("button", { name: /try again/i });
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        expect(mockApi.cigaretteLicenseConfirmPayment).toHaveBeenCalledTimes(3);
+      });
+    });
+  });
+
+  describe("Loading spinner", () => {
+    const mockFailBusiness: Business = generateBusiness({
+      cigaretteLicenseData: mockFailCigaretteLicenseData,
+    });
+    const userData: UserData = generateUserDataForBusiness(mockFailBusiness);
+
+    beforeEach(() => {
+      mockApi.cigaretteLicenseConfirmPayment.mockResolvedValue(userData);
+    });
+
+    it("is displayed on initial load of confirmation page", async () => {
+      renderComponent(mockFailBusiness);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("loading indicator")).toBeInTheDocument();
+      });
     });
   });
 });

--- a/web/src/components/tasks/cigarette-license/Confirmation.tsx
+++ b/web/src/components/tasks/cigarette-license/Confirmation.tsx
@@ -2,236 +2,374 @@ import { Content } from "@/components/Content";
 import { Heading } from "@/components/njwds-extended/Heading";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { Business } from "@businessnjgovnavigator/shared/userData";
-import { ReactElement } from "react";
+import { Alert } from "@/components/njwds-extended/Alert";
 import { ReviewLineItem } from "@/components/tasks/review-screen-components/ReviewLineItem";
+import analytics from "@/lib/utils/analytics";
+import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
+import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
 import { isTradeNameLegalStructureApplicable } from "@/lib/domain-logic/isTradeNameLegalStructureApplicable";
 import { formatUTCDate } from "@businessnjgovnavigator/shared/dateHelpers";
+import { useEffect, useRef, useState, ReactElement } from "react";
+import {
+  CigaretteLicenseData,
+  emptyCigaretteLicenseData,
+} from "@businessnjgovnavigator/shared/cigaretteLicense";
+import { PageCircularIndicator } from "@/components/PageCircularIndicator";
+import * as api from "@/lib/api-client/apiClient";
 
 interface Props {
   business: Business;
 }
 
+type Status = "LOADING" | "CONFIRMED" | "RETRY";
+
+interface CheckPaymentResponse {
+  success: boolean;
+  data: CigaretteLicenseData;
+}
+
 export const ConfirmationPage = (props: Props): ReactElement => {
   const { Config } = useConfig();
-  const cigLicenseData = props.business.cigaretteLicenseData;
+  const [cigLicenseData, setCigLicenseData] = useState<CigaretteLicenseData>(
+    props.business?.cigaretteLicenseData || emptyCigaretteLicenseData,
+  );
+  const [status, setStatus] = useState<Status>("LOADING");
+  const [shouldCheckOrder, setShouldCheckOrder] = useState(true);
+  const cigLicenseDataRef = useRef(cigLicenseData);
 
-  return (
-    <>
-      <div className="maxw-tablet margin-x-auto">
-        <div className="fdc fac" data-testid="cig-license-confirmation-page">
-          <img className="margin-y-4 width-card-lg" src={`/img/email-sent.svg`} alt="" />
-          <Heading level={2} className="margin-bottom-0">
-            {Config.cigaretteLicenseConfirmation.paymentSuccessfulHeader}
-          </Heading>
-          <p className="text-center">{Config.cigaretteLicenseConfirmation.paymentSuccessfulInfo}</p>
-        </div>
+  useEffect(() => {
+    cigLicenseDataRef.current = cigLicenseData;
+  }, [cigLicenseData]);
 
-        <div>
-          <hr className="width-full margin-top-4 margin-bottom-3" />
+  const checkPaymentConfirmation = async (
+    cigLicenseData: CigaretteLicenseData,
+  ): Promise<CheckPaymentResponse> => {
+    if (cigLicenseData?.paymentInfo?.orderId && cigLicenseData.paymentInfo.confirmationEmailsent) {
+      return {
+        success: true,
+        data: cigLicenseData,
+      };
+    }
 
-          <div className="grid-row">
-            <ReviewLineItem
-              label={Config.cigaretteLicenseConfirmation.confirmationNumber}
-              value={cigLicenseData?.paymentInfo?.orderId?.toString()}
-              marginOverride="width-full margin-top-1"
-              noColonAfterLabel
-            />
-            <ReviewLineItem
-              label={Config.cigaretteLicenseConfirmation.dateSubmitted}
-              value={formatUTCDate(cigLicenseData?.paymentInfo?.orderTimestamp || "")}
-              marginOverride="width-full margin-top-2"
-              noColonAfterLabel
-            />
-            <ReviewLineItem
-              label={Config.cigaretteLicenseConfirmation.amountPaid}
-              value="$50"
-              marginOverride="width-full margin-top-2 "
-              noColonAfterLabel
-            />
+    try {
+      const response = await api.cigaretteLicenseConfirmPayment();
+      const currentBusiness = response.businesses[response.currentBusinessId];
+
+      if (
+        currentBusiness?.cigaretteLicenseData?.paymentInfo?.orderId &&
+        currentBusiness?.cigaretteLicenseData?.paymentInfo?.confirmationEmailsent
+      ) {
+        return {
+          success: true,
+          data: currentBusiness.cigaretteLicenseData,
+        };
+      }
+
+      return {
+        success: false,
+        data: currentBusiness?.cigaretteLicenseData || cigLicenseData,
+      };
+    } catch (error) {
+      console.log("API call failed:", error);
+      return {
+        success: false,
+        data: cigLicenseData,
+      };
+    }
+  };
+
+  useEffect(() => {
+    const handlePaymentConfirmation = async (): Promise<void> => {
+      try {
+        setStatus("LOADING");
+
+        const result = await checkPaymentConfirmation(cigLicenseDataRef.current);
+
+        setCigLicenseData(result.data);
+
+        if (result.success) {
+          setStatus("CONFIRMED");
+        } else {
+          setStatus("RETRY");
+        }
+      } catch (error) {
+        console.log("Payment confirmation check failed:", error);
+        setStatus("RETRY");
+      }
+    };
+
+    handlePaymentConfirmation();
+  }, [shouldCheckOrder]);
+
+  const handleRetry = (): void => {
+    setShouldCheckOrder((prev) => !prev);
+  };
+
+  if (status === "LOADING") {
+    return (
+      <div className="height-mobile">
+        <PageCircularIndicator />
+      </div>
+    );
+  }
+
+  if (status === "CONFIRMED") {
+    return (
+      <>
+        <div className="maxw-tablet margin-x-auto">
+          <div className="fdc fac" data-testid="cig-license-confirmation-page">
+            <img className="margin-y-4 width-card-lg" src={`/img/email-sent.svg`} alt="" />
+            <Heading level={2} className="margin-bottom-0">
+              {Config.cigaretteLicenseConfirmation.paymentSuccessfulHeader}
+            </Heading>
+            <p className="text-center">
+              {Config.cigaretteLicenseConfirmation.paymentSuccessfulInfo}
+            </p>
           </div>
 
-          <hr className="width-full margin-top-4 margin-bottom-3" />
+          <div>
+            <hr className="width-full margin-top-4 margin-bottom-3" />
 
-          <Heading level={3} className="margin-bottom-0">
-            {Config.cigaretteLicenseConfirmation.whatHappensNextHeader}
-          </Heading>
-          <p>{Config.cigaretteLicenseConfirmation.whatHappensNextInfo}</p>
-          <ul>
-            <li>{Config.cigaretteLicenseConfirmation.whatHappensNextBullet1}</li>
-            <li>{Config.cigaretteLicenseConfirmation.whatHappensNextBullet2}</li>
-          </ul>
-
-          <hr className="width-full margin-top-4 margin-bottom-3" />
-
-          <Heading level={3}>{Config.cigaretteLicenseConfirmation.submissionDetails}</Heading>
-          <Heading level={4} className="padding-top-05">
-            {Config.cigaretteLicenseConfirmation.licenseeInformationHeader}
-          </Heading>
-          <div className="grid-row">
-            {isTradeNameLegalStructureApplicable(props.business.profileData.legalStructureId) ? (
-              <>
-                <ReviewLineItem
-                  label={Config.profileDefaults.fields.responsibleOwnerName.default.header}
-                  value={cigLicenseData?.responsibleOwnerName}
-                  marginOverride="width-full margin-top-1"
-                  noColonAfterLabel
-                />
-                <ReviewLineItem
-                  label={Config.profileDefaults.fields.tradeName.default.header}
-                  value={cigLicenseData?.tradeName}
-                  marginOverride="width-full margin-top-2"
-                  noColonAfterLabel
-                />
-              </>
-            ) : (
+            <div className="grid-row">
               <ReviewLineItem
-                label={Config.profileDefaults.fields.businessName.default.header}
-                value={cigLicenseData?.businessName}
+                label={Config.cigaretteLicenseConfirmation.confirmationNumber}
+                value={cigLicenseData?.paymentInfo?.orderId?.toString()}
                 marginOverride="width-full margin-top-1"
                 noColonAfterLabel
               />
-            )}
+              <ReviewLineItem
+                label={Config.cigaretteLicenseConfirmation.dateSubmitted}
+                value={formatUTCDate(cigLicenseData?.paymentInfo?.orderTimestamp || "")}
+                marginOverride="width-full margin-top-2"
+                noColonAfterLabel
+              />
+              <ReviewLineItem
+                label={Config.cigaretteLicenseConfirmation.amountPaid}
+                value="$50"
+                marginOverride="width-full margin-top-2 "
+                noColonAfterLabel
+              />
+            </div>
+
+            <hr className="width-full margin-top-4 margin-bottom-3" />
+
+            <Heading level={3} className="margin-bottom-0">
+              {Config.cigaretteLicenseConfirmation.whatHappensNextHeader}
+            </Heading>
+            <p>{Config.cigaretteLicenseConfirmation.whatHappensNextInfo}</p>
+            <ul>
+              <li>{Config.cigaretteLicenseConfirmation.whatHappensNextBullet1}</li>
+              <li>{Config.cigaretteLicenseConfirmation.whatHappensNextBullet2}</li>
+            </ul>
+
+            <hr className="width-full margin-top-4 margin-bottom-3" />
+
+            <Heading level={3}>{Config.cigaretteLicenseConfirmation.submissionDetails}</Heading>
+            <Heading level={4} className="padding-top-05">
+              {Config.cigaretteLicenseConfirmation.licenseeInformationHeader}
+            </Heading>
+            <div className="grid-row">
+              {isTradeNameLegalStructureApplicable(props.business.profileData.legalStructureId) ? (
+                <>
+                  <ReviewLineItem
+                    label={Config.profileDefaults.fields.responsibleOwnerName.default.header}
+                    value={cigLicenseData?.responsibleOwnerName}
+                    marginOverride="width-full margin-top-1"
+                    noColonAfterLabel
+                  />
+                  <ReviewLineItem
+                    label={Config.profileDefaults.fields.tradeName.default.header}
+                    value={cigLicenseData?.tradeName}
+                    marginOverride="width-full margin-top-2"
+                    noColonAfterLabel
+                  />
+                </>
+              ) : (
+                <ReviewLineItem
+                  label={Config.profileDefaults.fields.businessName.default.header}
+                  value={cigLicenseData?.businessName}
+                  marginOverride="width-full margin-top-1"
+                  noColonAfterLabel
+                />
+              )}
+            </div>
+
+            <hr className="width-full margin-top-4 margin-bottom-3" />
+
+            <Heading level={4} className="padding-top-05">
+              {Config.cigaretteLicenseStep2.businessAddressHeader}
+            </Heading>
+            <div className="grid-row">
+              <ReviewLineItem
+                label={Config.cigaretteLicenseConfirmation.businessAddressLine1}
+                value={cigLicenseData?.addressLine1}
+                marginOverride="width-full margin-top-1"
+                noColonAfterLabel
+              />
+              <ReviewLineItem
+                label={Config.cigaretteLicenseConfirmation.businessAddressLine2}
+                value={cigLicenseData?.addressLine2}
+                marginOverride="width-full margin-top-1"
+                noColonAfterLabel
+              />
+              <ReviewLineItem
+                label={Config.formation.fields.addressCity.label}
+                value={cigLicenseData?.addressCity}
+                marginOverride="width-full margin-top-2"
+                noColonAfterLabel
+              />
+              <ReviewLineItem
+                label={Config.formation.fields.addressState.label}
+                value={cigLicenseData?.addressState?.shortCode}
+                marginOverride="width-full margin-top-2"
+                noColonAfterLabel
+              />
+              <ReviewLineItem
+                label={Config.formation.fields.addressZipCode.label}
+                value={cigLicenseData?.addressZipCode}
+                marginOverride="width-full margin-top-2"
+                noColonAfterLabel
+              />
+            </div>
+
+            <hr className="width-full margin-top-4 margin-bottom-3" />
+
+            <Heading level={4} className="padding-top-05">
+              {Config.cigaretteLicenseStep2.mailingAddressHeader}
+            </Heading>
+            <div className="grid-row">
+              <ReviewLineItem
+                label={Config.cigaretteLicenseConfirmation.mailingAddressLine1}
+                value={cigLicenseData?.mailingAddressLine1}
+                marginOverride="width-full margin-top-1"
+                noColonAfterLabel
+              />
+              <ReviewLineItem
+                label={Config.cigaretteLicenseConfirmation.mailingAddressLine2}
+                value={cigLicenseData?.mailingAddressLine2}
+                marginOverride="width-full margin-top-1"
+                noColonAfterLabel
+              />
+              <ReviewLineItem
+                label={Config.formation.fields.addressCity.label}
+                value={cigLicenseData?.mailingAddressCity}
+                marginOverride="width-full margin-top-2"
+                noColonAfterLabel
+              />
+              <ReviewLineItem
+                label={Config.formation.fields.addressState.label}
+                value={cigLicenseData?.mailingAddressState?.shortCode}
+                marginOverride="width-full margin-top-2"
+                noColonAfterLabel
+              />
+              <ReviewLineItem
+                label={Config.formation.fields.addressZipCode.label}
+                value={cigLicenseData?.mailingAddressZipCode}
+                marginOverride="width-full margin-top-2"
+                noColonAfterLabel
+              />
+            </div>
+
+            <hr className="width-full margin-top-4 margin-bottom-3" />
+
+            <Heading level={4} className="padding-top-05">
+              {Config.cigaretteLicenseStep2.contactInformationHeader}
+            </Heading>
+            <div className="grid-row">
+              <ReviewLineItem
+                label={Config.cigaretteLicenseStep2.fields.contactName.label}
+                value={cigLicenseData?.contactName}
+                marginOverride="width-full margin-top-1"
+                noColonAfterLabel
+              />
+              <ReviewLineItem
+                label={Config.cigaretteLicenseStep2.fields.contactPhoneNumber.label}
+                value={cigLicenseData?.contactPhoneNumber}
+                marginOverride="width-full margin-top-1"
+                noColonAfterLabel
+              />
+              <ReviewLineItem
+                label={Config.cigaretteLicenseStep2.fields.contactEmail.label}
+                value={cigLicenseData?.contactEmail}
+                marginOverride="width-full margin-top-1"
+                ignoreContent
+                noColonAfterLabel
+              />
+            </div>
+
+            <hr className="width-full margin-top-4 margin-bottom-3" />
+
+            <Heading level={4} className="padding-top-05">
+              {Config.cigaretteLicenseStep3.salesInformationHeader}
+            </Heading>
+            <div className="grid-row">
+              <ReviewLineItem
+                label={Config.cigaretteLicenseStep3.fields.startDateOfSales.label}
+                value={formatUTCDate(cigLicenseData?.salesInfoStartDate || "")}
+                marginOverride="width-full margin-top-1"
+                noColonAfterLabel
+              />
+              <ReviewLineItem
+                label={Config.cigaretteLicenseConfirmation.suppliers}
+                value={cigLicenseData?.salesInfoSupplier?.join(", ")}
+                marginOverride="width-full margin-top-1"
+                noColonAfterLabel
+              />
+            </div>
+
+            <hr className="width-full margin-top-4 margin-bottom-3" />
+
+            <Heading level={3} className="margin-bottom-0 padding-top-1">
+              {Config.cigaretteLicenseConfirmation.needHelpHeader}
+            </Heading>
+            <div className="padding-bottom-1">
+              <Content>{Config.cigaretteLicenseConfirmation.needHelpInfo}</Content>
+            </div>
+
+            <hr className="width-full margin-y-4" />
           </div>
+        </div>
+        <hr className="width-full margin-bottom-1" />
+        <Content className="margin-bottom-neg-2 font-sans-2xs">
+          {Config.cigaretteLicenseConfirmation.issuingAgency}
+        </Content>
+      </>
+    );
+  }
 
-          <hr className="width-full margin-top-4 margin-bottom-3" />
-
-          <Heading level={4} className="padding-top-05">
-            {Config.cigaretteLicenseStep2.businessAddressHeader}
-          </Heading>
-          <div className="grid-row">
-            <ReviewLineItem
-              label={Config.cigaretteLicenseConfirmation.businessAddressLine1}
-              value={cigLicenseData?.addressLine1}
-              marginOverride="width-full margin-top-1"
-              noColonAfterLabel
-            />
-            <ReviewLineItem
-              label={Config.cigaretteLicenseConfirmation.businessAddressLine2}
-              value={cigLicenseData?.addressLine2}
-              marginOverride="width-full margin-top-1"
-              noColonAfterLabel
-            />
-            <ReviewLineItem
-              label={Config.formation.fields.addressCity.label}
-              value={cigLicenseData?.addressCity}
-              marginOverride="width-full margin-top-2"
-              noColonAfterLabel
-            />
-            <ReviewLineItem
-              label={Config.formation.fields.addressState.label}
-              value={cigLicenseData?.addressState?.shortCode}
-              marginOverride="width-full margin-top-2"
-              noColonAfterLabel
-            />
-            <ReviewLineItem
-              label={Config.formation.fields.addressZipCode.label}
-              value={cigLicenseData?.addressZipCode}
-              marginOverride="width-full margin-top-2"
-              noColonAfterLabel
-            />
-          </div>
-
-          <hr className="width-full margin-top-4 margin-bottom-3" />
-
-          <Heading level={4} className="padding-top-05">
-            {Config.cigaretteLicenseStep2.mailingAddressHeader}
-          </Heading>
-          <div className="grid-row">
-            <ReviewLineItem
-              label={Config.cigaretteLicenseConfirmation.mailingAddressLine1}
-              value={cigLicenseData?.mailingAddressLine1}
-              marginOverride="width-full margin-top-1"
-              noColonAfterLabel
-            />
-            <ReviewLineItem
-              label={Config.cigaretteLicenseConfirmation.mailingAddressLine2}
-              value={cigLicenseData?.mailingAddressLine2}
-              marginOverride="width-full margin-top-1"
-              noColonAfterLabel
-            />
-            <ReviewLineItem
-              label={Config.formation.fields.addressCity.label}
-              value={cigLicenseData?.mailingAddressCity}
-              marginOverride="width-full margin-top-2"
-              noColonAfterLabel
-            />
-            <ReviewLineItem
-              label={Config.formation.fields.addressState.label}
-              value={cigLicenseData?.mailingAddressState?.shortCode}
-              marginOverride="width-full margin-top-2"
-              noColonAfterLabel
-            />
-            <ReviewLineItem
-              label={Config.formation.fields.addressZipCode.label}
-              value={cigLicenseData?.mailingAddressZipCode}
-              marginOverride="width-full margin-top-2"
-              noColonAfterLabel
-            />
-          </div>
-
-          <hr className="width-full margin-top-4 margin-bottom-3" />
-
-          <Heading level={4} className="padding-top-05">
-            {Config.cigaretteLicenseStep2.contactInformationHeader}
-          </Heading>
-          <div className="grid-row">
-            <ReviewLineItem
-              label={Config.cigaretteLicenseStep2.fields.contactName.label}
-              value={cigLicenseData?.contactName}
-              marginOverride="width-full margin-top-1"
-              noColonAfterLabel
-            />
-            <ReviewLineItem
-              label={Config.cigaretteLicenseStep2.fields.contactPhoneNumber.label}
-              value={cigLicenseData?.contactPhoneNumber}
-              marginOverride="width-full margin-top-1"
-              noColonAfterLabel
-            />
-            <ReviewLineItem
-              label={Config.cigaretteLicenseStep2.fields.contactEmail.label}
-              value={cigLicenseData?.contactEmail}
-              marginOverride="width-full margin-top-1"
-              ignoreContent
-              noColonAfterLabel
-            />
-          </div>
-
-          <hr className="width-full margin-top-4 margin-bottom-3" />
-
-          <Heading level={4} className="padding-top-05">
-            {Config.cigaretteLicenseStep3.salesInformationHeader}
-          </Heading>
-          <div className="grid-row">
-            <ReviewLineItem
-              label={Config.cigaretteLicenseStep3.fields.startDateOfSales.label}
-              value={formatUTCDate(cigLicenseData?.salesInfoStartDate || "")}
-              marginOverride="width-full margin-top-1"
-              noColonAfterLabel
-            />
-            <ReviewLineItem
-              label={Config.cigaretteLicenseConfirmation.suppliers}
-              value={cigLicenseData?.salesInfoSupplier?.join(", ")}
-              marginOverride="width-full margin-top-1"
-              noColonAfterLabel
-            />
-          </div>
-
-          <hr className="width-full margin-top-4 margin-bottom-3" />
-
-          <Heading level={3} className="margin-bottom-0 padding-top-1">
-            {Config.cigaretteLicenseConfirmation.needHelpHeader}
-          </Heading>
-          <div className="padding-bottom-1">
-            <Content>{Config.cigaretteLicenseConfirmation.needHelpInfo}</Content>
-          </div>
-
-          <hr className="width-full margin-y-4" />
+  return (
+    <div className="maxw-full">
+      <div className="fdc fal" data-testid="cig-license-confirmation-page">
+        <img className="margin-y-4 width-card-lg margin-x-auto" src={`/img/signpost.svg`} alt="" />
+        <Alert variant="warning" className="width-full">
+          {Config.cigaretteLicenseConfirmation.cantCompleteFilingAlert}
+        </Alert>
+        <Content className="margin-y-1">
+          {Config.cigaretteLicenseConfirmation.cantCompleteFilingMessage1}
+        </Content>
+        <Content className="margin-y-1">
+          {Config.cigaretteLicenseConfirmation.cantCompleteFilingMessage2}
+        </Content>
+        <div className="margin-y-3 margin-x-auto">
+          <PrimaryButton isColor="primary" onClick={handleRetry}>
+            {Config.cigaretteLicenseConfirmation.tryAgainButton}
+          </PrimaryButton>
+          <SecondaryButton
+            isColor="primary"
+            isIntercomEnabled
+            onClick={() => {
+              analytics.event.business_formation_help_button.click.open_live_chat();
+            }}
+            isRightMarginRemoved
+          >
+            {Config.cigaretteLicenseConfirmation.startLiveChatButton}
+          </SecondaryButton>
         </div>
       </div>
       <hr className="width-full margin-bottom-1" />
       <Content className="margin-bottom-neg-2 font-sans-2xs">
         {Config.cigaretteLicenseConfirmation.issuingAgency}
       </Content>
-    </>
+    </div>
   );
 };

--- a/web/src/lib/api-client/apiClient.ts
+++ b/web/src/lib/api-client/apiClient.ts
@@ -20,7 +20,7 @@ import axios, { AxiosError, AxiosRequestConfig } from "axios";
 
 const apiBaseUrl = process.env.API_BASE_URL || "";
 
-export const getUserData = (id: string): Promise<UserData> => {
+export const getUserData = async (id: string): Promise<UserData> => {
   return get<UserData>(`/users/${id}`).then((userData) => {
     setPhaseDimension(getCurrentBusiness(userData).profileData.operatingPhase);
     return userData;
@@ -92,6 +92,10 @@ export const postTaxClearanceCertificate = (
   userData: UserData,
 ): Promise<TaxClearanceCertificateResponse> => {
   return post(`/postTaxClearanceCertificate`, userData);
+};
+
+export const cigaretteLicenseConfirmPayment = (): Promise<UserData> => {
+  return get(`/cigarette-license/get-order-by-token`);
 };
 
 export const unlinkTaxId = (userData: UserData): Promise<UnlinkTaxIdResponse> => {

--- a/web/src/lib/domain-logic/routes.ts
+++ b/web/src/lib/domain-logic/routes.ts
@@ -27,6 +27,7 @@ export interface QUERY_PARAMS_VALUES {
   fromFunding: "true";
   fromOnboarding: "true";
   completeFiling: "true" | "false";
+  completePayment: "success" | "failure" | "duplicate" | "cancel";
   success: "true";
   additionalBusiness: "true";
   path: "businessFormation";
@@ -42,6 +43,7 @@ export enum QUERIES {
   businessMunicipality = "businessMunicipality",
   code = "code",
   completeFiling = "completeFiling",
+  completePayment = "completePayment",
   deferredQuestionAnswered = "deferredQuestionAnswered",
   flow = "flow",
   fromAdditionalBusiness = "fromAdditionalBusiness",


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

This PR handles two pieces of logic: 
1. After payment for Cigarette License is redirected back to MyAccount from Tyler Tech, the application needs to handle the 4 different redirect options. 
2. Once it has been redirectted back successfully, it loads the Confirmation Page and retrieves the order details via TylerTechs api. Depending on how this api call proceeds, the confirmation screen will either show a Loading Spinner, the Confirmation Screen with all order details, or a Try Again screen.

A small migration was also added this PR to add a `paymentComplete` boolean to the `paymentInfo` of the `cigaretteLicenseData`. This boolean is used to keep track of the state when a user has paid for their cigaretteLicense, but has not received their order details yet. 
 

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#13453](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13453).

### Approach

A `useEffect` in `CigaretteLicense.tsx` handles the `queryParam` `completePayment`. There are 4 options that Tyler Tech can send back, `success`, `cancel`, `duplicate`, and `failure`. If Either `failure` or `duplicate` are sent, then the stepper should be loaded, showing step 4 of Cigarette License, along with an Error Alert box showing at the top. If `cancel` is sent, then step 4 is shown, but with no error. If `success` is sent, then the userData is updated to have `cigaretteLicenseData.payment.paymentComplete` set to true, and the `task-progress["cigarette-license"]` set to `completed`. This will trigger the Confirmation page to load. 
 
On the confirmation page if the `cigaretteLicenseData.payment.orderId` is set and `cigaretteLicenseData.payment.emailConfirmationSent` is true, then the confirmation page is loaded. If not, then an api call is made to get the order details and send email confirmation. If that call fails, it will load the `Try Again` page. This page has two buttons. One allows the user to attempt to make the above api call again, and the other allows them to start a help chat session. 

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
