### PR TITLE
feat: [AB#14007] lock cig license fields

### DIFF
--- a/web/src/components/tasks/cigarette-license/LicenseeInfo.tsx
+++ b/web/src/components/tasks/cigarette-license/LicenseeInfo.tsx
@@ -15,11 +15,14 @@ import { ActionBarLayout } from "@/components/njwds-layout/ActionBarLayout";
 import { ProfileField } from "@/components/profile/ProfileField";
 import { getInitialTaxId } from "@/components/tasks/anytime-action/tax-clearance-certificate/helpers";
 import { ContactInformation } from "@/components/tasks/cigarette-license/fields/ContactInformation";
+import { ProfileAddressLockedFields } from "@/components/profile/ProfileAddressLockedFields";
 import { MailingAddress } from "@/components/tasks/cigarette-license/fields/MailingAddress";
 import { CigaretteLicenseContext } from "@/contexts/cigaretteLicenseContext";
+import { hasCompletedFormation } from "@businessnjgovnavigator/shared";
 import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { useAddressErrors } from "@/lib/data-hooks/useAddressErrors";
 import { useConfig } from "@/lib/data-hooks/useConfig";
+import { shouldLockBusinessAddress } from "@/components/tasks/cigarette-license/helpers";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { isTradeNameLegalStructureApplicable } from "@/lib/domain-logic/isTradeNameLegalStructureApplicable";
@@ -35,6 +38,7 @@ export const LicenseeInfo = (props: Props): ReactElement => {
   const { business } = useUserData();
   const hasSubmittedTaxData =
     business?.taxFilingData.state === "SUCCESS" || business?.taxFilingData.state === "PENDING";
+  const hasFormedBusiness = hasCompletedFormation(business);
 
   const dataFormErrorMap = useContext(DataFormErrorMapContext);
   const { saveCigaretteLicenseData } = useContext(CigaretteLicenseContext);
@@ -78,6 +82,7 @@ export const LicenseeInfo = (props: Props): ReactElement => {
 
       <div className="margin-y-2">
         <ProfileField
+          locked={hasSubmittedTaxData || hasFormedBusiness}
           fieldName={"businessName"}
           hideLine
           fullWidth
@@ -93,13 +98,14 @@ export const LicenseeInfo = (props: Props): ReactElement => {
         <ProfileField
           fieldName="responsibleOwnerName"
           isVisible={isTradeNameLegalStructureApplicable(business?.profileData.legalStructureId)}
-          locked={hasSubmittedTaxData}
+          locked={hasSubmittedTaxData || hasFormedBusiness}
           hideLine
           fullWidth
         >
           <ResponsibleOwnerName inputWidth="full" required />
         </ProfileField>
         <ProfileField
+          locked={hasSubmittedTaxData || hasFormedBusiness}
           fieldName="tradeName"
           isVisible={isTradeNameLegalStructureApplicable(business?.profileData.legalStructureId)}
           hideLine
@@ -130,12 +136,16 @@ export const LicenseeInfo = (props: Props): ReactElement => {
       <h2 className="padding-top-2">{Config.cigaretteLicenseStep2.businessAddressHeader}</h2>
       <p>{Config.cigaretteLicenseStep2.businessAddressDescription}</p>
       <div data-testid="business-address-section" className="margin-y-4">
-        <UnitedStatesAddress
-          onValidation={onValidation}
-          isFullWidth
-          dataFormErrorMap={dataFormErrorMap}
-          stateInputLocked
-        />
+        {shouldLockBusinessAddress(business) ? (
+          <ProfileAddressLockedFields businessLocation="US" />
+        ) : (
+          <UnitedStatesAddress
+            onValidation={onValidation}
+            isFullWidth
+            dataFormErrorMap={dataFormErrorMap}
+            stateInputLocked
+          />
+        )}
       </div>
       <HorizontalLine />
 

--- a/web/src/components/tasks/cigarette-license/helpers.test.ts
+++ b/web/src/components/tasks/cigarette-license/helpers.test.ts
@@ -1,0 +1,120 @@
+import {
+  getInitialData,
+  shouldLockBusinessAddress,
+} from "@/components/tasks/cigarette-license/helpers";
+import {
+  generateBusiness,
+  generateFormationFormData,
+  generateFormationData,
+  generateUser,
+  generateProfileData,
+  generateCigaretteLicenseData,
+  generateUserDataForBusiness,
+} from "@businessnjgovnavigator/shared/test";
+
+describe("getInitialData", () => {
+  it("should prioritize cigaretteLicenseData over other sources", () => {
+    const business = generateBusiness({
+      cigaretteLicenseData: generateCigaretteLicenseData({
+        businessName: "Cigarette Business",
+        responsibleOwnerName: "Cigarette Owner",
+        tradeName: "Cigarette Trade",
+        taxId: "cigarette-tax-123",
+        addressLine1: "456 Cigarette St",
+        contactName: "Cigarette Contact",
+        contactEmail: "cigarette@email.com",
+        mailingAddressIsTheSame: true,
+        salesInfoSupplier: ["Supplier1", "Supplier2"],
+        lastUpdatedISO: "2023-01-01T00:00:00.000Z",
+      }),
+      profileData: generateProfileData({
+        businessName: "Profile Business",
+        responsibleOwnerName: "Profile Owner",
+      }),
+    });
+
+    const userData = generateUserDataForBusiness(business, {
+      user: generateUser({
+        name: "User Contact",
+        email: "user@email.com",
+      }),
+    });
+
+    const result = getInitialData(userData, business);
+
+    expect(result.businessName).toBe("Cigarette Business");
+    expect(result.responsibleOwnerName).toBe("Cigarette Owner");
+    expect(result.tradeName).toBe("Cigarette Trade");
+    expect(result.taxId).toBe("cigarette-tax-123");
+    expect(result.addressLine1).toBe("456 Cigarette St");
+    expect(result.contactName).toBe("Cigarette Contact");
+    expect(result.contactEmail).toBe("cigarette@email.com");
+    expect(result.mailingAddressIsTheSame).toBe(true);
+    expect(result.salesInfoSupplier).toEqual(["Supplier1", "Supplier2"]);
+    expect(result.lastUpdatedISO).toBe("2023-01-01T00:00:00.000Z");
+  });
+});
+
+describe("shouldLockBusinessAddress", () => {
+  it("should return true when business has formed and has complete address data", () => {
+    const business = generateBusiness({
+      profileData: generateProfileData({
+        businessName: "Profile Business",
+        responsibleOwnerName: "Profile Owner",
+      }),
+      formationData: generateFormationData({
+        completedFilingPayment: true,
+        formationFormData: generateFormationFormData({
+          addressLine1: "Test Address",
+          addressCity: "Test City",
+          addressZipCode: "07111",
+        }),
+      }),
+    });
+
+    expect(shouldLockBusinessAddress(business)).toBe(true);
+  });
+
+  it("should return false when business has not formed", () => {
+    const business = generateBusiness({
+      profileData: generateProfileData({
+        businessName: "Profile Business",
+        responsibleOwnerName: "Profile Owner",
+      }),
+      formationData: generateFormationData({
+        completedFilingPayment: false,
+        formationFormData: generateFormationFormData({
+          addressLine1: "Test Address",
+          addressCity: "Test City",
+          addressZipCode: "07111",
+        }),
+      }),
+    });
+
+    expect(shouldLockBusinessAddress(business)).toBe(false);
+  });
+
+  it("should return false when address data is incomplete", () => {
+    const business = generateBusiness({
+      profileData: generateProfileData({
+        businessName: "Profile Business",
+        responsibleOwnerName: "Profile Owner",
+      }),
+      formationData: generateFormationData({
+        completedFilingPayment: false,
+        formationFormData: generateFormationFormData({
+          addressLine1: "Test Address",
+          addressCity: "",
+          addressMunicipality: undefined,
+          addressZipCode: "07111",
+        }),
+      }),
+    });
+
+    expect(shouldLockBusinessAddress(business)).toBe(false);
+  });
+
+  it("should return false when business is undefined", () => {
+    expect(shouldLockBusinessAddress(undefined)).toBe(false);
+  });
+});

--- a/web/src/components/tasks/cigarette-license/helpers.ts
+++ b/web/src/components/tasks/cigarette-license/helpers.ts
@@ -109,3 +109,19 @@ export const getInitialData = (
     lastUpdatedISO: business.cigaretteLicenseData?.lastUpdatedISO,
   };
 };
+
+export const shouldLockBusinessAddress = (business?: Business): boolean => {
+  if (!business) return false;
+
+  if (!business.formationData.completedFilingPayment) return false;
+
+  const addressLine1 = business.formationData.formationFormData.addressLine1;
+  const addressCity =
+    business.formationData?.formationFormData?.addressMunicipality ||
+    business.formationData.formationFormData.addressCity;
+  const addressZipCode = business.formationData.formationFormData.addressZipCode;
+
+  if (!addressLine1 || !addressCity || !addressZipCode) return false;
+
+  return true;
+};


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Locks pre-populated fields for Cigarette License that come from Formation or Tax Calendar lookup. 

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14007](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14007).

### Approach

If the user has completed their tax calendar lookup, then the TaxID and Business name are pre-populated and locked for Cigarette License. Similarly, if a user has completed formation then the Business Name and Business Address fields are locked. If the address was not filled out during formation then it is not pre-populated and locked. Helper function was added to `web/src/components/tasks/cigarette-license/helpers.ts` that returns a boolean if the Business Address should be locked. 

### Steps to Test

##### Locked via formation
1. Create a new retail business
2. Go through formation filling out the name and address
3. After completing formation navigate to `http://localhost:3000/tasks/cigarette-license` and go to step 2
4. Business Name, and all business address fields should be locked and prepopulated
5. If you go through the same process but do not supply an address during formation, then only the Business name should be pre-populated and locked

##### Locked via tax calendar
1. Create a new retail business
2. Go through tax calendar lookup (entering a tax id)
3. After completing tax calendar lookup navigate to `http://localhost:3000/tasks/cigarette-license` and go to step 2
4. Business Name and TaxID should be locked and prepopulated

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden

