### PR TITLE
feat: [AB#15109] removed date and profile link from dashbaord

### DIFF
--- a/content/src/fieldConfig/dashboard-defaults.json
+++ b/content/src/fieldConfig/dashboard-defaults.json
@@ -4,9 +4,6 @@
     "defaultHeaderText": "Hello, ${name}",
     "starterKitText": "Your ${industry} Starter Kit",
     "genericStarterKitText": "Your Starter Kit",
-    "newJerseyDateBodyText": "ET",
-    "guestModeToProfileButtonText": "Guest Account",
-    "genericToProfileButtonText": "Business Profile",
     "personalizeMyTasksButtonText": "Personalize My Experience"
   },
   "dashboardRoadmapHeaderDefaults": {

--- a/content/src/fieldConfig/header-defaults.json
+++ b/content/src/fieldConfig/header-defaults.json
@@ -3,9 +3,6 @@
     "noUserNameHeaderText": " ",
     "defaultHeaderText": " ",
     "genericStarterKitText": " ",
-    "starterKitText": " ",
-    "newJerseyDateBodyText": " ",
-    "guestModeToProfileButtonText": " ",
-    "genericToProfileButtonText": " "
+    "starterKitText": " "
   }
 }

--- a/web/cypress/e2e/auto-tax-filing.spec.ts
+++ b/web/cypress/e2e/auto-tax-filing.spec.ts
@@ -27,7 +27,7 @@ describe.skip(
       completeNewBusinessOnboarding({ industry: randomNonHomeBasedNonDomesticEmployerIndustry() });
       completeBusinessStructureTask({ legalStructureId: randomPublicFilingLegalStructure() });
 
-      onDashboardPage.getEditProfileLink().should("exist");
+      onDashboardPage.getDashboardHeader().should("exist");
       cy.visit("/profile");
       cy.get('input[data-testid="businessName"]').type(businessName);
       onProfilePage.getSaveButton().first().click();
@@ -51,7 +51,7 @@ describe.skip(
       completeNewBusinessOnboarding({ industry: randomNonHomeBasedNonDomesticEmployerIndustry() });
       completeBusinessStructureTask({ legalStructureId: randomPublicFilingLegalStructure() });
 
-      onDashboardPage.getEditProfileLink().should("exist");
+      onDashboardPage.getDashboardHeader().should("exist");
       openFormationDateModal();
       selectDate("04/2021");
       selectLocation("Allendale");
@@ -70,7 +70,7 @@ describe.skip(
       completeNewBusinessOnboarding({ industry: randomNonHomeBasedNonDomesticEmployerIndustry() });
       completeBusinessStructureTask({ legalStructureId: randomPublicFilingLegalStructure() });
 
-      onDashboardPage.getEditProfileLink().should("exist");
+      onDashboardPage.getDashboardHeader().should("exist");
       cy.visit("/profile");
       cy.get('input[data-testid="businessName"]').type(businessName);
       onProfilePage.getSaveButton().first().click();

--- a/web/cypress/e2e/dashboard.spec.ts
+++ b/web/cypress/e2e/dashboard.spec.ts
@@ -37,7 +37,7 @@ describe("Dashboard [feature] [all] [group2]", () => {
         completeExistingBusinessOnboarding({});
         cy.url().should("contain", "/dashboard");
         // check dashboard
-        onDashboardPage.getEditProfileLink().should("exist");
+        onDashboardPage.getDashboardHeader().should("exist");
       });
     });
 
@@ -53,7 +53,7 @@ describe("Dashboard [feature] [all] [group2]", () => {
         completeBusinessStructureTask({ legalStructureId });
 
         // check dashboard
-        onDashboardPage.getEditProfileLink().should("exist");
+        onDashboardPage.getDashboardHeader().should("exist");
 
         // step 1
         cy.get('[id="plan-content"]').should("be.visible");
@@ -128,7 +128,7 @@ describe("Dashboard [feature] [all] [group2]", () => {
         completeBusinessStructureTask({ legalStructureId });
 
         // editing data in the Profile page
-        onDashboardPage.clickEditProfileLink();
+        onDashboardPage.clickEditProfileInDropdown();
         cy.url().should("contain", "/profile");
 
         cy.get('[aria-label="Industry"]').first().click({ force: true });
@@ -140,7 +140,6 @@ describe("Dashboard [feature] [all] [group2]", () => {
         cy.url().should("contain", "/dashboard");
 
         // check dashboard
-        onDashboardPage.getEditProfileLink().should("exist");
 
         cy.get('[data-task="check-site-requirements"]').should("exist");
         cy.get('[data-task="food-safety-course"]').should("exist");

--- a/web/cypress/e2e/deferred-onboarding.spec.ts
+++ b/web/cypress/e2e/deferred-onboarding.spec.ts
@@ -209,7 +209,7 @@ describe.skip("Deferred Onboarding [feature] [all] [group5]", () => {
 
   const doesNotShowHomeBasedBusinessQuestionAtAll = (): void => {
     onDashboardPage.getHomeBased().should("not.exist");
-    onDashboardPage.clickEditProfileLink();
+    onDashboardPage.clickEditProfileInDropdown();
     cy.url().should("contain", "/profile");
     cy.wait(1000);
     onProfilePage.getHomeBased().should("not.exist");
@@ -227,7 +227,7 @@ describe.skip("Deferred Onboarding [feature] [all] [group5]", () => {
   const showsAndAnswersHomeBasedBusinessQuestionOnDashboard = (): void => {
     selectHomeBased(true);
 
-    onDashboardPage.clickEditProfileLink();
+    onDashboardPage.clickEditProfileInDropdown();
     cy.url().should("contain", "/profile");
     cy.wait(1000);
 
@@ -237,7 +237,7 @@ describe.skip("Deferred Onboarding [feature] [all] [group5]", () => {
   };
 
   const goToProfile = (): void => {
-    onDashboardPage.clickEditProfileLink();
+    onDashboardPage.clickEditProfileInDropdown();
     cy.url().should("contain", "/profile");
     cy.wait(1000);
   };

--- a/web/cypress/e2e/group_1_onboarding/accessibility.spec.ts
+++ b/web/cypress/e2e/group_1_onboarding/accessibility.spec.ts
@@ -33,7 +33,6 @@ describe("Automated Accessibilty Testing [feature] [all] [group1]", () => {
       onOnboardingPageStartingBusiness.clickNext();
 
       cy.url().should("include", "dashboard");
-      cy.get('[data-testid="header-link-to-profile"]');
       cy.checkA11y(undefined, {
         runOnly: {
           type: "tag",
@@ -74,7 +73,6 @@ describe("Automated Accessibilty Testing [feature] [all] [group1]", () => {
       onOnboardingPageStartingBusiness.clickNext();
 
       cy.url().should("include", "dashboard");
-      cy.get('[data-testid="header-link-to-profile"]');
       cy.checkA11y(undefined, {
         runOnly: {
           type: "tag",

--- a/web/cypress/e2e/group_1_onboarding/onboarding-as-existing-business.spec.ts
+++ b/web/cypress/e2e/group_1_onboarding/onboarding-as-existing-business.spec.ts
@@ -19,7 +19,6 @@ describe("Onboarding for all sectors as an existing business [feature] [all] [gr
 
         onOnboardingPageExistingBusiness.clickShowMyGuide();
         cy.url().should("include", "dashboard");
-        cy.get('[data-testid="header-link-to-profile"]');
       });
     }
   });
@@ -39,7 +38,6 @@ describe("Onboarding for all sectors as an existing business [feature] [all] [gr
 
       onOnboardingPageExistingBusiness.clickShowMyGuide();
       cy.url().should("include", "dashboard");
-      cy.get('[data-testid="header-link-to-profile"]');
     });
   });
 });

--- a/web/cypress/e2e/group_1_onboarding/onboarding-as-foreign-business.spec.ts
+++ b/web/cypress/e2e/group_1_onboarding/onboarding-as-foreign-business.spec.ts
@@ -186,7 +186,6 @@ describe("Onboarding for all industries when out of state nexus business [featur
 
         onOnboardingPageNexusBusiness.clickShowMyGuide();
         cy.url().should("include", "dashboard");
-        cy.get('[data-testid="header-link-to-profile"]');
       });
     }
   });
@@ -213,7 +212,6 @@ describe("Onboarding for all industries when out of state nexus business [featur
 
       onOnboardingPageNexusBusiness.clickNext();
       cy.url().should("include", "dashboard");
-      cy.get('[data-testid="header-link-to-profile"]');
     });
   });
 
@@ -237,7 +235,6 @@ describe("Onboarding for all industries when out of state nexus business [featur
         onOnboardingPageRemoteWorkerBusiness.clickShowMyGuide();
 
         cy.url().should("include", "dashboard");
-        cy.get('[data-testid="header-link-to-profile"]');
       });
     });
 
@@ -261,7 +258,6 @@ describe("Onboarding for all industries when out of state nexus business [featur
         onOnboardingPageRemoteWorkerBusiness.clickShowMyGuide();
 
         cy.url().should("include", "dashboard");
-        cy.get('[data-testid="header-link-to-profile"]');
       });
     });
   });
@@ -286,7 +282,6 @@ describe("Onboarding for all industries when out of state nexus business [featur
         onOnboardingPageRemoteSellerBusiness.clickShowMyGuide();
 
         cy.url().should("include", "dashboard");
-        cy.get('[data-testid="header-link-to-profile"]');
       });
     });
 
@@ -310,7 +305,6 @@ describe("Onboarding for all industries when out of state nexus business [featur
         onOnboardingPageRemoteWorkerBusiness.clickShowMyGuide();
 
         cy.url().should("include", "dashboard");
-        cy.get('[data-testid="header-link-to-profile"]');
       });
     });
   });

--- a/web/cypress/e2e/group_1_onboarding/onboarding-as-starting-business.spec.ts
+++ b/web/cypress/e2e/group_1_onboarding/onboarding-as-starting-business.spec.ts
@@ -187,7 +187,6 @@ describe("Onboarding for all industries when starting a business [feature] [all]
 
         onOnboardingPageStartingBusiness.clickShowMyGuide();
         cy.url().should("include", "dashboard");
-        cy.get('[data-testid="header-link-to-profile"]');
       });
     }
   });
@@ -209,7 +208,6 @@ describe("Onboarding for all industries when starting a business [feature] [all]
 
       onOnboardingPageStartingBusiness.clickNext();
       cy.url().should("include", "dashboard");
-      cy.get('[data-testid="header-link-to-profile"]');
     });
   });
 });

--- a/web/cypress/e2e/guest.spec.ts
+++ b/web/cypress/e2e/guest.spec.ts
@@ -25,7 +25,7 @@ describe("Guest Dashboard [feature] [all] [group2]", () => {
     cy.url().should("contain", "/dashboard");
 
     // check dashboard
-    onDashboardPage.getEditProfileLink().should("exist");
+    onDashboardPage.getDashboardHeader().should("exist");
 
     cy.get('[data-testid="needs-account-alert"]').should("be.visible");
 
@@ -56,7 +56,7 @@ describe("Guest Dashboard [feature] [all] [group2]", () => {
     cy.get('[data-testid="needs-account-alert"]').should("not.exist");
 
     // try editing data in the Profile page
-    onDashboardPage.clickEditProfileLink();
+    onDashboardPage.clickEditProfileInDropdown();
 
     cy.get('input[aria-label="Business name"]').clear();
     cy.get('input[aria-label="Business name"]').type("Applebee's");

--- a/web/cypress/e2e/performance-and-accessability.spec.ts
+++ b/web/cypress/e2e/performance-and-accessability.spec.ts
@@ -94,7 +94,7 @@ describe("Performance and Accessability - Onboarding [all] [group4]", () => {
 //       industry,
 //     });
 //
-//     onDashboardPage.getEditProfileLink().should("exist");
+//     onDashboardPage.getDashboardHeader().should("exist");
 //
 //     cy.lighthouse(undefined, lighthouseDesktopConfig);
 //     cy.pa11y(defaultPa11yThresholds);

--- a/web/cypress/support/helpers/helpers-profile.ts
+++ b/web/cypress/support/helpers/helpers-profile.ts
@@ -6,7 +6,11 @@ import {
   ForeignProfileData,
   StartingProfileData,
 } from "@businessnjgovnavigator/cypress/support/types";
-import { Industry, LookupLegalStructureById, LookupSectorTypeById } from "@businessnjgovnavigator/shared/";
+import {
+  Industry,
+  LookupLegalStructureById,
+  LookupSectorTypeById,
+} from "@businessnjgovnavigator/shared/";
 
 export const checkNewBusinessProfilePage = ({
   businessName,
@@ -21,7 +25,7 @@ export const checkNewBusinessProfilePage = ({
   entityId = "",
 }: Partial<StartingProfileData & { businessName: string }>): void => {
   cy.url().should("contain", "/dashboard");
-  onDashboardPage.clickEditProfileLink();
+  onDashboardPage.clickEditProfileInDropdown();
   cy.url().should("contain", "/profile");
   cy.wait(1000);
 
@@ -80,7 +84,7 @@ export const checkExistingBusinessProfilePage = ({
   taxPin = "",
 }: Partial<ExistingProfileData>): void => {
   cy.url().should("contain", "/dashboard");
-  onDashboardPage.clickEditProfileLink();
+  onDashboardPage.clickEditProfileInDropdown();
   cy.url().should("contain", "/profile");
 
   cy.wait(1000);
@@ -92,7 +96,10 @@ export const checkExistingBusinessProfilePage = ({
       expect(value).to.contain(LookupSectorTypeById(sectorId as string).name);
     });
   if (numberOfEmployees !== undefined) {
-    onProfilePage.getNumberOfEmployees().invoke("prop", "value").should("contain", numberOfEmployees);
+    onProfilePage
+      .getNumberOfEmployees()
+      .invoke("prop", "value")
+      .should("contain", numberOfEmployees);
   }
   if (townDisplayName !== undefined) {
     onProfilePage.getLocationDropdown().invoke("prop", "value").should("contain", townDisplayName);
@@ -137,7 +144,7 @@ export const updateNewBusinessProfilePage = ({
   entityId,
 }: Partial<StartingProfileData & { businessName: string }>): void => {
   cy.url().should("contain", "/dashboard");
-  onDashboardPage.clickEditProfileLink();
+  onDashboardPage.clickEditProfileInDropdown();
   cy.url().should("contain", "/profile");
   cy.wait(1000);
 
@@ -159,7 +166,7 @@ export const updateNewBusinessProfilePage = ({
       .should("contain", legalStructureId);
     onProfilePage.clickSaveButton(); // save because changing legal structure can change fields
     cy.wait(1000);
-    onDashboardPage.clickEditProfileLink();
+    onDashboardPage.clickEditProfileInDropdown();
     cy.url().should("contain", "/profile");
     cy.wait(1000);
 
@@ -234,7 +241,7 @@ export const updateExistingBusinessProfilePage = ({
   taxPin,
 }: Partial<ExistingProfileData>): void => {
   cy.url().should("contain", "/dashboard");
-  onDashboardPage.clickEditProfileLink();
+  onDashboardPage.clickEditProfileInDropdown();
   cy.url().should("contain", "/profile");
   cy.wait(1000);
 
@@ -255,7 +262,10 @@ export const updateExistingBusinessProfilePage = ({
 
   if (numberOfEmployees) {
     onProfilePage.typeNumberOfEmployees(numberOfEmployees);
-    onProfilePage.getNumberOfEmployees().invoke("prop", "value").should("contain", numberOfEmployees);
+    onProfilePage
+      .getNumberOfEmployees()
+      .invoke("prop", "value")
+      .should("contain", numberOfEmployees);
   }
 
   if (townDisplayName) {
@@ -313,7 +323,10 @@ export const updateExistingBusinessProfilePage = ({
   onProfilePage.clickSaveButton();
   cy.url().should("contain", "/dashboard");
 };
-export const updateForeignBusinessProfilePage = ({ taxId, notes }: Partial<ForeignProfileData>): void => {
+export const updateForeignBusinessProfilePage = ({
+  taxId,
+  notes,
+}: Partial<ForeignProfileData>): void => {
   cy.url().should("contain", "/dashboard");
   onDashboardPage.clickEditProfileInDropdown();
   cy.url().should("contain", "/profile");

--- a/web/cypress/support/page_objects/dashboardPage.ts
+++ b/web/cypress/support/page_objects/dashboardPage.ts
@@ -1,6 +1,6 @@
 export class DashboardPage {
-  getEditProfileLink = () => {
-    return cy.get('[data-testid="header-link-to-profile"]');
+  getDashboardHeader = () => {
+    return cy.get('[data-testid="dashboard-header"]');
   };
 
   getDropdown = () => {
@@ -16,7 +16,8 @@ export class DashboardPage {
   };
 
   clickEditProfileLink = () => {
-    this.getEditProfileLink().first().click();
+    cy.get('[data-testid="nav-bar-desktop-dropdown-button"]').first().click();
+    cy.get('[data-testid="profile-link"]').first().click();
   };
 
   clickEditProfileInDropdown = () => {
@@ -39,7 +40,9 @@ export class DashboardPage {
   }
 
   getHomeBased(radio?: boolean) {
-    return cy.get(`input[name="home-based-business"]${radio === undefined ? "" : `[value="${radio}"]`}`);
+    return cy.get(
+      `input[name="home-based-business"]${radio === undefined ? "" : `[value="${radio}"]`}`,
+    );
   }
 
   getTaxFilingCalendar() {

--- a/web/decap-config/collections/09-dashboard.yml
+++ b/web/decap-config/collections/09-dashboard.yml
@@ -33,17 +33,6 @@ collections:
                   name: starterKitText,
                   widget: string,
                 }
-              - { label: NJ Date Text, name: newJerseyDateBodyText, widget: string }
-              - {
-                  label: Guest Mode - To Profile Button Text,
-                  name: guestModeToProfileButtonText,
-                  widget: string,
-                }
-              - {
-                  label: Generic - To Profile Button Text,
-                  name: genericToProfileButtonText,
-                  widget: string,
-                }
               - {
                   label: Personalize My Tasks Button Text,
                   name: personalizeMyTasksButtonText,

--- a/web/decap-config/collections/12-misc.yml
+++ b/web/decap-config/collections/12-misc.yml
@@ -709,17 +709,6 @@ collections:
                   name: starterKitText,
                   widget: string,
                 }
-              - { label: NJ Date Text, name: newJerseyDateBodyText, widget: string }
-              - {
-                  label: Guest Mode - To Profile Button Text,
-                  name: guestModeToProfileButtonText,
-                  widget: string,
-                }
-              - {
-                  label: Generic - To Profile Button Text,
-                  name: genericToProfileButtonText,
-                  widget: string,
-                }
   - label: Task Defaults
     name: taskDefaults
     delete: false

--- a/web/src/components/Header.test.tsx
+++ b/web/src/components/Header.test.tsx
@@ -1,16 +1,10 @@
 import { DashboardHeader } from "@/components/dashboard/DashboardHeader";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
-import { ROUTES } from "@/lib/domain-logic/routes";
 import { templateEval } from "@/lib/utils/helpers";
-import { randomPublicFilingLegalStructure, randomTradeNameLegalStructure } from "@/test/factories";
 import { withAuth } from "@/test/helpers/helpers-renderers";
-import { mockPush, useMockRouter } from "@/test/mock/mockRouter";
+import { useMockRouter } from "@/test/mock/mockRouter";
 import { useMockBusiness, useMockProfileData, useMockUserData } from "@/test/mock/mockUseUserData";
-import {
-  generateUser,
-  getCurrentDateInNewJersey,
-  randomInt,
-} from "@businessnjgovnavigator/shared/";
+import { generateUser } from "@businessnjgovnavigator/shared/";
 import { getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
 import { LookupIndustryById } from "@businessnjgovnavigator/shared/industry";
 import { BusinessPersona } from "@businessnjgovnavigator/shared/profileData";
@@ -20,7 +14,7 @@ import {
   generateUserDataForBusiness,
 } from "@businessnjgovnavigator/shared/test";
 import { createTheme, ThemeProvider } from "@mui/material";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 const Config = getMergedConfig();
 
@@ -33,14 +27,6 @@ describe("<Header />", () => {
     useMockBusiness({});
     useMockRouter({});
   });
-
-  const renderHeader = (): void => {
-    render(
-      <ThemeProvider theme={createTheme()}>
-        <DashboardHeader />
-      </ThemeProvider>,
-    );
-  };
 
   const renderHeaderWithAuth = ({
     isAuthenticated,
@@ -129,82 +115,6 @@ describe("<Header />", () => {
         });
         expect(screen.getByText(expectedHeaderText)).toBeInTheDocument();
       });
-    });
-  });
-
-  describe("date", () => {
-    it("shows date based on New Jersey Local time", () => {
-      const date = getCurrentDateInNewJersey().format("MMMM DD, YYYY");
-      useMockProfileData({});
-      renderHeader();
-
-      expect(screen.getByText(date)).toBeInTheDocument();
-    });
-  });
-
-  describe("go to profile link", () => {
-    it("displays guest mode content when user is not authenticated and routes to profile page on button click", () => {
-      useMockProfileData({
-        businessName: "Business Name",
-        legalStructureId: randomPublicFilingLegalStructure(),
-      });
-      renderHeaderWithAuth({ isAuthenticated: IsAuthenticated.FALSE });
-      fireEvent.click(
-        screen.getByText(Config.dashboardHeaderDefaults.guestModeToProfileButtonText),
-      );
-      expect(mockPush).toHaveBeenCalledWith(ROUTES.profile);
-    });
-
-    it("displays generic content when business name is not an empty string and user is authenticated then routes to profile page on button click", () => {
-      useMockProfileData({
-        businessName: "",
-        legalStructureId: randomPublicFilingLegalStructure(),
-      });
-      renderHeaderWithAuth({ isAuthenticated: IsAuthenticated.TRUE });
-      fireEvent.click(screen.getByText(Config.dashboardHeaderDefaults.genericToProfileButtonText));
-      expect(mockPush).toHaveBeenCalledWith(ROUTES.profile);
-    });
-
-    it("displays generic content when trade name is undefined and user is authenticated then routes to profile page on button click", () => {
-      useMockProfileData({
-        tradeName: undefined,
-        legalStructureId: randomTradeNameLegalStructure(),
-      });
-      renderHeaderWithAuth({ isAuthenticated: IsAuthenticated.TRUE });
-      fireEvent.click(screen.getByText(Config.dashboardHeaderDefaults.genericToProfileButtonText));
-      expect(mockPush).toHaveBeenCalledWith(ROUTES.profile);
-    });
-
-    it("displays generic content when business name is undefined and user is authenticated then routes to profile page on button click", () => {
-      useMockProfileData({
-        businessName: undefined,
-        legalStructureId: randomPublicFilingLegalStructure(),
-      });
-      renderHeaderWithAuth({ isAuthenticated: IsAuthenticated.TRUE });
-      fireEvent.click(screen.getByText(Config.dashboardHeaderDefaults.genericToProfileButtonText));
-      expect(mockPush).toHaveBeenCalledWith(ROUTES.profile);
-    });
-
-    it("displays business name when legal structure is public filing", () => {
-      const businessName = `Test Company ${randomInt(6)}`;
-      useMockProfileData({
-        businessName: businessName,
-        tradeName: "tradeName",
-        legalStructureId: randomPublicFilingLegalStructure(),
-      });
-      renderHeaderWithAuth({ isAuthenticated: IsAuthenticated.TRUE });
-      expect(screen.getByText(businessName)).toBeInTheDocument();
-    });
-
-    it("displays trade name when legal structure is trade name", () => {
-      const tradeName = `Test Company ${randomInt(6)}`;
-      useMockProfileData({
-        businessName: "businessName",
-        tradeName: tradeName,
-        legalStructureId: randomTradeNameLegalStructure(),
-      });
-      renderHeaderWithAuth({ isAuthenticated: IsAuthenticated.TRUE });
-      expect(screen.getByText(tradeName)).toBeInTheDocument();
     });
   });
 });

--- a/web/src/components/dashboard/DashboardHeader.tsx
+++ b/web/src/components/dashboard/DashboardHeader.tsx
@@ -1,29 +1,17 @@
 import { Heading } from "@/components/njwds-extended/Heading";
-import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { AuthContext } from "@/contexts/authContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
-import { ROUTES } from "@/lib/domain-logic/routes";
-import analytics from "@/lib/utils/analytics";
 import { templateEval } from "@/lib/utils/helpers";
 import { isStartingBusiness } from "@businessnjgovnavigator/shared/domain-logic/businessPersonaHelpers";
-import { getCurrentDateInNewJersey } from "@businessnjgovnavigator/shared/index";
 import { LookupIndustryById } from "@businessnjgovnavigator/shared/industry";
-import { LookupLegalStructureById } from "@businessnjgovnavigator/shared/legalStructure";
-import { useRouter } from "next/compat/router";
 import { ReactElement, useContext } from "react";
 
 export const DashboardHeader = (): ReactElement => {
   const { state } = useContext(AuthContext);
   const { Config } = useConfig();
   const { business, userData } = useUserData();
-  const router = useRouter();
-
-  const editOnClick = (): void => {
-    analytics.event.roadmap_profile_edit_button.click.go_to_profile_screen();
-    router && router.push(ROUTES.profile);
-  };
 
   const getHeader = (): string => {
     if (state.isAuthenticated === IsAuthenticated.FALSE && isStartingBusiness(business)) {
@@ -40,45 +28,12 @@ export const DashboardHeader = (): ReactElement => {
         })
       : Config.dashboardHeaderDefaults.noUserNameHeaderText;
   };
-
-  const getButtonText = (): string | undefined => {
-    if (state.isAuthenticated === "FALSE" || state.isAuthenticated === "UNKNOWN") {
-      return Config.dashboardHeaderDefaults.guestModeToProfileButtonText;
-    }
-
-    const businessName = LookupLegalStructureById(business?.profileData.legalStructureId)
-      .requiresPublicFiling
-      ? business?.profileData.businessName
-      : business?.profileData.tradeName;
-
-    if (!businessName && state.isAuthenticated === "TRUE") {
-      return Config.dashboardHeaderDefaults.genericToProfileButtonText;
-    }
-
-    if (businessName && state.isAuthenticated === "TRUE") {
-      return businessName;
-    }
-  };
   return (
     <>
-      <div className="margin-bottom-4">
+      <div className="margin-bottom-4" data-testid="dashboard-header">
         <Heading level={1} className={`margin-top-0 break-word`}>
           {getHeader()}
         </Heading>
-        <UnStyledButton
-          isUnderline
-          isTextBold
-          onClick={editOnClick}
-          dataTestid="header-link-to-profile"
-          ariaLabel="Link To Business Profile"
-        >
-          {getButtonText()}
-        </UnStyledButton>
-        <span className="vertical-line margin-x-105 border-right-base" />
-        <span className="text-base">
-          {getCurrentDateInNewJersey().format("MMMM DD, YYYY")}
-        </span>{" "}
-        <span className="text-base">{Config.dashboardHeaderDefaults.newJerseyDateBodyText}</span>
       </div>
     </>
   );


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

removed date and profile link from dashboard. This has proven unnecessary given the evolution of the dashboard over time

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#15109](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15109).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

go to dashboard,
see that there is no date and profile link above the personalize button

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
