### PR TITLE
fix: [AB#15812] fix locked tax clearance address fields

### DIFF
--- a/api/src/client/ApiCigaretteLicenseHelpers.test.ts
+++ b/api/src/client/ApiCigaretteLicenseHelpers.test.ts
@@ -157,10 +157,16 @@ describe("ApiCigaretteLicenseHelpers", () => {
     it("should create email confirmation body with all fields", async () => {
       const decryptedTaxId =
         mockCigaretteLicenseData.encryptedTaxId?.replace("encrypted-", "") || "";
-      const result = await makeEmailConfirmationBody(mockCigaretteLicenseData, decryptedTaxId);
+      const legalStructureId = "limited-liability-corporation";
+      const result = await makeEmailConfirmationBody(
+        mockCigaretteLicenseData,
+        legalStructureId,
+        decryptedTaxId,
+      );
 
       expect(result).toEqual({
         businessName: mockCigaretteLicenseData.businessName,
+        businessType: legalStructureId,
         responsibleOwnerName: mockCigaretteLicenseData.responsibleOwnerName,
         tradeName: mockCigaretteLicenseData.tradeName,
         taxId: mockCigaretteLicenseData.encryptedTaxId?.replace("encrypted-", ""),

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/CheckEligibility.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/CheckEligibility.tsx
@@ -24,6 +24,7 @@ import { useAddressErrors } from "@/lib/data-hooks/useAddressErrors";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { useUserData } from "@/lib/data-hooks/useUserData";
+import { shouldLockBusinessAddress } from "@/lib/utils/taskHelpers";
 import analytics from "@/lib/utils/analytics";
 import { useMountEffectWhenDefined } from "@/lib/utils/helpers";
 import { hasCompletedFormation } from "@businessnjgovnavigator/shared";
@@ -122,7 +123,7 @@ export const CheckEligibility = (props: Props): ReactElement => {
           </ProfileField>
         </div>
         <div className="margin-y-2">
-          {shouldLockFormationFields ? (
+          {shouldLockBusinessAddress(business) ? (
             <ProfileAddressLockedFields businessLocation="US" />
           ) : (
             <UnitedStatesAddress

--- a/web/src/components/tasks/cigarette-license/LicenseeInfo.tsx
+++ b/web/src/components/tasks/cigarette-license/LicenseeInfo.tsx
@@ -22,7 +22,7 @@ import { hasCompletedFormation } from "@businessnjgovnavigator/shared";
 import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { useAddressErrors } from "@/lib/data-hooks/useAddressErrors";
 import { useConfig } from "@/lib/data-hooks/useConfig";
-import { shouldLockBusinessAddress } from "@/components/tasks/cigarette-license/helpers";
+import { shouldLockBusinessAddress } from "@/lib/utils/taskHelpers";
 import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { isTradeNameLegalStructureApplicable } from "@/lib/domain-logic/isTradeNameLegalStructureApplicable";

--- a/web/src/components/tasks/cigarette-license/helpers.test.ts
+++ b/web/src/components/tasks/cigarette-license/helpers.test.ts
@@ -1,13 +1,10 @@
 import {
   getInitialData,
   isAnyRequiredFieldEmpty,
-  shouldLockBusinessAddress,
 } from "@/components/tasks/cigarette-license/helpers";
 import {
   generateBusiness,
   generateCigaretteLicenseData,
-  generateFormationData,
-  generateFormationFormData,
   generateProfileData,
   generateUser,
   generateUserDataForBusiness,
@@ -53,70 +50,6 @@ describe("getInitialData", () => {
     expect(result.mailingAddressIsTheSame).toBe(true);
     expect(result.salesInfoSupplier).toEqual(["Supplier1", "Supplier2"]);
     expect(result.lastUpdatedISO).toBe("2023-01-01T00:00:00.000Z");
-  });
-});
-
-describe("shouldLockBusinessAddress", () => {
-  it("should return true when business has formed and has complete address data", () => {
-    const business = generateBusiness({
-      profileData: generateProfileData({
-        businessName: "Profile Business",
-        responsibleOwnerName: "Profile Owner",
-      }),
-      formationData: generateFormationData({
-        completedFilingPayment: true,
-        formationFormData: generateFormationFormData({
-          addressLine1: "Test Address",
-          addressCity: "Test City",
-          addressZipCode: "07111",
-        }),
-      }),
-    });
-
-    expect(shouldLockBusinessAddress(business)).toBe(true);
-  });
-
-  it("should return false when business has not formed", () => {
-    const business = generateBusiness({
-      profileData: generateProfileData({
-        businessName: "Profile Business",
-        responsibleOwnerName: "Profile Owner",
-      }),
-      formationData: generateFormationData({
-        completedFilingPayment: false,
-        formationFormData: generateFormationFormData({
-          addressLine1: "Test Address",
-          addressCity: "Test City",
-          addressZipCode: "07111",
-        }),
-      }),
-    });
-
-    expect(shouldLockBusinessAddress(business)).toBe(false);
-  });
-
-  it("should return false when address data is incomplete", () => {
-    const business = generateBusiness({
-      profileData: generateProfileData({
-        businessName: "Profile Business",
-        responsibleOwnerName: "Profile Owner",
-      }),
-      formationData: generateFormationData({
-        completedFilingPayment: false,
-        formationFormData: generateFormationFormData({
-          addressLine1: "Test Address",
-          addressCity: "",
-          addressMunicipality: undefined,
-          addressZipCode: "07111",
-        }),
-      }),
-    });
-
-    expect(shouldLockBusinessAddress(business)).toBe(false);
-  });
-
-  it("should return false when business is undefined", () => {
-    expect(shouldLockBusinessAddress(undefined)).toBe(false);
   });
 });
 

--- a/web/src/components/tasks/cigarette-license/helpers.ts
+++ b/web/src/components/tasks/cigarette-license/helpers.ts
@@ -112,22 +112,6 @@ export const getInitialData = (
   };
 };
 
-export const shouldLockBusinessAddress = (business?: Business): boolean => {
-  if (!business) return false;
-
-  if (!business.formationData.completedFilingPayment) return false;
-
-  const addressLine1 = business.formationData.formationFormData.addressLine1;
-  const addressCity =
-    business.formationData?.formationFormData?.addressMunicipality ||
-    business.formationData.formationFormData.addressCity;
-  const addressZipCode = business.formationData.formationFormData.addressZipCode;
-
-  if (!addressLine1 || !addressCity || !addressZipCode) return false;
-
-  return true;
-};
-
 export const isAnyRequiredFieldEmpty = (
   data: CigaretteLicenseData,
   stepIndex: number,

--- a/web/src/lib/utils/taskHelpers.test.ts
+++ b/web/src/lib/utils/taskHelpers.test.ts
@@ -1,0 +1,71 @@
+import {
+  generateBusiness,
+  generateFormationData,
+  generateFormationFormData,
+  generateProfileData,
+} from "@businessnjgovnavigator/shared/test";
+import { shouldLockBusinessAddress } from "@/lib/utils/taskHelpers";
+
+describe("shouldLockBusinessAddress", () => {
+  it("should return true when business has formed and has complete address data", () => {
+    const business = generateBusiness({
+      profileData: generateProfileData({
+        businessName: "Profile Business",
+        responsibleOwnerName: "Profile Owner",
+      }),
+      formationData: generateFormationData({
+        completedFilingPayment: true,
+        formationFormData: generateFormationFormData({
+          addressLine1: "Test Address",
+          addressCity: "Test City",
+          addressZipCode: "07111",
+        }),
+      }),
+    });
+
+    expect(shouldLockBusinessAddress(business)).toBe(true);
+  });
+
+  it("should return false when business has not formed", () => {
+    const business = generateBusiness({
+      profileData: generateProfileData({
+        businessName: "Profile Business",
+        responsibleOwnerName: "Profile Owner",
+      }),
+      formationData: generateFormationData({
+        completedFilingPayment: false,
+        formationFormData: generateFormationFormData({
+          addressLine1: "Test Address",
+          addressCity: "Test City",
+          addressZipCode: "07111",
+        }),
+      }),
+    });
+
+    expect(shouldLockBusinessAddress(business)).toBe(false);
+  });
+
+  it("should return false when address data is incomplete", () => {
+    const business = generateBusiness({
+      profileData: generateProfileData({
+        businessName: "Profile Business",
+        responsibleOwnerName: "Profile Owner",
+      }),
+      formationData: generateFormationData({
+        completedFilingPayment: false,
+        formationFormData: generateFormationFormData({
+          addressLine1: "Test Address",
+          addressCity: "",
+          addressMunicipality: undefined,
+          addressZipCode: "07111",
+        }),
+      }),
+    });
+
+    expect(shouldLockBusinessAddress(business)).toBe(false);
+  });
+
+  it("should return false when business is undefined", () => {
+    expect(shouldLockBusinessAddress(undefined)).toBe(false);
+  });
+});

--- a/web/src/lib/utils/taskHelpers.ts
+++ b/web/src/lib/utils/taskHelpers.ts
@@ -1,0 +1,17 @@
+import { Business } from "@businessnjgovnavigator/shared/userData";
+
+export const shouldLockBusinessAddress = (business?: Business): boolean => {
+  if (!business) return false;
+
+  if (!business.formationData.completedFilingPayment) return false;
+
+  const addressLine1 = business.formationData.formationFormData.addressLine1;
+  const addressCity =
+    business.formationData?.formationFormData?.addressMunicipality ||
+    business.formationData.formationFormData.addressCity;
+  const addressZipCode = business.formationData.formationFormData.addressZipCode;
+
+  if (!addressLine1 || !addressCity || !addressZipCode) return false;
+
+  return true;
+};


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

When a user completes formation without entering an address, the Tax Clearance form becomes unusable. The address field appears locked/disabled, preventing user input, but the form cannot be submitted because the address field is required and blank. User has no way to correct this and complete the Tax Clearance process. This PR address that issue. 

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#15812](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15812).

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
