### PR TITLE
fix: [AB#15809] force login for cigarette license

### DIFF
--- a/web/src/components/tasks/cigarette-license/GeneralInfo.test.tsx
+++ b/web/src/components/tasks/cigarette-license/GeneralInfo.test.tsx
@@ -1,0 +1,63 @@
+import { NeedsAccountContext } from "@/contexts/needsAccountContext";
+import { IsAuthenticated } from "@/lib/auth/AuthContext";
+import { useMockProfileData } from "@/test/mock/mockUseUserData";
+import { ConfigContext, getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { GeneralInfo } from "@/components/tasks/cigarette-license/GeneralInfo";
+
+jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
+
+describe("General Info", () => {
+  const mockSetStepIndex = jest.fn();
+  const mockSetShowNeedsAccountModal = jest.fn();
+  const Config = getMergedConfig();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useMockProfileData({});
+  });
+
+  const renderWithContext = (isAuthenticated: IsAuthenticated): void => {
+    render(
+      <ConfigContext.Provider value={{ config: Config, setOverrides: jest.fn() }}>
+        <NeedsAccountContext.Provider
+          value={{
+            isAuthenticated,
+            setShowNeedsAccountModal: mockSetShowNeedsAccountModal,
+            showNeedsAccountModal: false,
+            showNeedsAccountSnackbar: false,
+            setShowNeedsAccountSnackbar: jest.fn(),
+            registrationStatus: undefined,
+            setRegistrationStatus: jest.fn(),
+            showContinueWithoutSaving: false,
+            setShowContinueWithoutSaving: jest.fn(),
+            userWantsToContinueWithoutSaving: false,
+            setUserWantsToContinueWithoutSaving: jest.fn(),
+          }}
+        >
+          <GeneralInfo setStepIndex={mockSetStepIndex} />
+        </NeedsAccountContext.Provider>
+      </ConfigContext.Provider>,
+    );
+  };
+
+  it("shows modal when clicking continue and user is not authenticated", () => {
+    renderWithContext(IsAuthenticated.FALSE);
+
+    const continueButton = screen.getByText(Config.cigaretteLicenseStep1.continueButtonText);
+    fireEvent.click(continueButton);
+
+    expect(mockSetShowNeedsAccountModal).toHaveBeenCalledWith(true);
+    expect(mockSetStepIndex).not.toHaveBeenCalled();
+  });
+
+  it("advances to next step when clicking continue and user is authenticated", () => {
+    renderWithContext(IsAuthenticated.TRUE);
+
+    const continueButton = screen.getByText(Config.cigaretteLicenseStep1.continueButtonText);
+    fireEvent.click(continueButton);
+
+    expect(mockSetShowNeedsAccountModal).not.toHaveBeenCalled();
+    expect(mockSetStepIndex).toHaveBeenCalledWith(1);
+  });
+});

--- a/web/src/components/tasks/cigarette-license/GeneralInfo.tsx
+++ b/web/src/components/tasks/cigarette-license/GeneralInfo.tsx
@@ -3,9 +3,13 @@ import { HorizontalLine } from "@/components/HorizontalLine";
 import { CtaContainer } from "@/components/njwds-extended/cta/CtaContainer";
 import { LiveChatHelpButton } from "@/components/njwds-extended/LiveChatHelpButton";
 import { PrimaryButton } from "@/components/njwds-extended/PrimaryButton";
+import { NeedsAccountContext } from "@/contexts/needsAccountContext";
+import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { ActionBarLayout } from "@/components/njwds-layout/ActionBarLayout";
 import { useConfig } from "@/lib/data-hooks/useConfig";
-import { ReactElement } from "react";
+import { useUserData } from "@/lib/data-hooks/useUserData";
+import { ROUTES } from "@/lib/domain-logic/routes";
+import { ReactElement, useContext } from "react";
 
 interface Props {
   setStepIndex: (step: number) => void;
@@ -13,6 +17,17 @@ interface Props {
 
 export const GeneralInfo = (props: Props): ReactElement => {
   const { Config } = useConfig();
+  const { isAuthenticated, setShowNeedsAccountModal } = useContext(NeedsAccountContext);
+  const { updateQueue } = useUserData();
+
+  const onContinueClick = (): void => {
+    if (isAuthenticated === IsAuthenticated.FALSE) {
+      updateQueue?.queuePreferences({ returnToLink: ROUTES.cigaretteLicense }).update();
+      setShowNeedsAccountModal(true);
+    } else {
+      props.setStepIndex(1);
+    }
+  };
 
   return (
     <>
@@ -25,7 +40,7 @@ export const GeneralInfo = (props: Props): ReactElement => {
           <LiveChatHelpButton />
           <PrimaryButton
             isColor="primary"
-            onClick={() => props.setStepIndex(1)}
+            onClick={onContinueClick}
             dataTestId="cta-primary-1"
             isRightMarginRemoved={true}
           >

--- a/web/src/lib/domain-logic/routes.ts
+++ b/web/src/lib/domain-logic/routes.ts
@@ -14,6 +14,7 @@ export const ROUTES = {
   starterKits: "/starter-kits",
   login: "/login",
   njeda: "/njeda",
+  cigaretteLicense: "/tasks/cigarette-license",
   taxClearanceCertificate: "/actions/tax-clearance-certificate-apply",
   envPermit: "tasks/env-permitting",
 };


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

This PR ensures that a non logged in user can apply for a Cigarette License

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#15809](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15809).

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
