### PR TITLE
chore: [AB#14787] disable CMS integrity tests

### DIFF
--- a/api/src/functions/express/app.ts
+++ b/api/src/functions/express/app.ts
@@ -11,7 +11,6 @@ import { selfRegRouterFactory } from "@api/selfRegRouter";
 import { taxClearanceCertificateRouterFactory } from "@api/taxClearanceCertificateRouter";
 import { userRouterFactory } from "@api/userRouter";
 import { xrayRegistrationRouterFactory } from "@api/xrayRegistrationRouter";
-import { runCmsIntegrityTests } from "@businessnjgovnavigator/api/src/cms-integrity-tests/runCmsIntegrityTests";
 import { AbcEmergencyTripPermitClient } from "@client/AbcEmergencyTripPermitClient";
 import { AirtableUserTestingClient } from "@client/AirtableUserTestingClient";
 import { ApiBusinessNameClient } from "@client/ApiBusinessNameClient";
@@ -92,7 +91,7 @@ const app = setupExpress();
 const logger = LogWriter(`NavigatorWebService/${STAGE}`, "ApiLogs");
 const dataLogger = LogWriter(`NavigatorDBClient/${STAGE}`, "DataMigrationLogs");
 
-runCmsIntegrityTests(STAGE);
+// runCmsIntegrityTests(STAGE);
 
 const XRAY_REGISTRATION_STATUS_BASE_URL =
   process.env.XRAY_REGISTRATION_STATUS_BASE_URL || "http://localhost:9000";


### PR DESCRIPTION
## Description

Disable the CMS integrity tests.

### Ticket

This work disables functionality related to [#14787](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14787).

### Approach

Commenting out the function call that invokes this check.

### Notes

This functionality is attempting to load content and then perform a check. Because content is not available on the backend of the application, our backend is erroring out when this function is invoked. I noticed this earlier today when I was using the `testing` environment. This is currently impacting both `testing` and `content` environments. This will work locally because of the mono-repo nature of our application, but in a cloud deployment, the backend will not have access to the content directory, and we get the following error.

<img width="1446" height="610" alt="Screenshot 2025-09-08 at 11 35 49 AM" src="https://github.com/user-attachments/assets/574c9981-1fd2-4f83-bead-9145d9af2998" />

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
