### PR TITLE
chore: fixed flaky onboarding profile test

### DIFF
--- a/web/cypress/support/helpers/helpers-profile.ts
+++ b/web/cypress/support/helpers/helpers-profile.ts
@@ -241,6 +241,7 @@ export const updateExistingBusinessProfilePage = ({
   taxPin,
 }: Partial<ExistingProfileData>): void => {
   cy.url().should("contain", "/dashboard");
+  cy.wait(1500);
   onDashboardPage.clickEditProfileInDropdown();
   cy.url().should("contain", "/profile");
   cy.wait(1000);


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

We were experiencing some flakyness on the onboarding / profile fill out tests. 

I think this is due to a race condition 

What is suppose to happen is we save new profile data, and are automatically redirected to the dashboard onSave. Then we want to go back to the profile page via the dropdown menu to verify our changes. 

Whats actually happening is that we save our profile data and then before we can be redirected to dashboard we hit the dropdown menu and profile buttons basically instantly so it redirects us to profile then the save for profile finished and our onSave redirects us to dashboard. So we end up being on dashboard when we wanted to be on profile. 

This didn't happen before because the link we were using to get to profile only existed on dashboard as opposed to our dropdown menu which exists on both the profile and dashboard pages. 

I added a short wait to allow the re-direct to dashboard to succeed. 

I really wanted to add something that makes sure we are on the dashboard however this is hard most of the dashboard is dynamic and there isn't a super reliable value to check here, I tried waiting on the URL but this didn't work for whatever reason. I suspect that the URL loads before the rest of the DOM in cypress



<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#0000](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
