### PR TITLE
fix: replace existing dashes with hyphen-minus

### DIFF
--- a/content/src/anytime-action-tasks/transportation-cpcn-aa.md
+++ b/content/src/anytime-action-tasks/transportation-cpcn-aa.md
@@ -47,7 +47,7 @@ summaryDescriptionMd: >-
 
   * Charter buses
 issuingAgency: NJ Motor Vehicle Commission | Business Licensing Services Bureau
-  – Passenger Carrier Unit
+  - Passenger Carrier Unit
 ---
 
 &nbsp;

--- a/content/src/fundings/clean-energy-program-combined-heat-and-power-fuel-cells.md
+++ b/content/src/fundings/clean-energy-program-combined-heat-and-power-fuel-cells.md
@@ -1,5 +1,5 @@
 ---
-name: New Jersey’s Clean Energy Program – Combined Heat & Power - Fuel Cells
+name: New Jersey’s Clean Energy Program - Combined Heat & Power - Fuel Cells
 displayName: chp-clean-energy
 urlSlug: njcep-chpfc
 id: clean-energy-program-combined-heat-and-power-fuel-cells

--- a/content/src/fundings/clean-energy-program-commercial-and-industrial-new-construction.md
+++ b/content/src/fundings/clean-energy-program-commercial-and-industrial-new-construction.md
@@ -1,5 +1,5 @@
 ---
-name: New Jersey’s Clean Energy Program – Commercial & Industrial New Construction
+name: New Jersey’s Clean Energy Program - Commercial & Industrial New Construction
 displayName: cinc-clean-energy
 urlSlug: njcep-cinc
 id: clean-energy-program-commercial-and-industrial-new-construction

--- a/content/src/roadmaps/license-tasks/selfgenerator-waste-transporters-reg.md
+++ b/content/src/roadmaps/license-tasks/selfgenerator-waste-transporters-reg.md
@@ -1,8 +1,8 @@
 ---
 licenseName: ""
-id: selfgenerator-waste–transporters-reg
-displayname: selfgenerator-waste–transporters-reg
-urlSlug: selfgenerator-waste–transporters-reg
+id: selfgenerator-waste-transporters-reg
+displayname: selfgenerator-waste-transporters-reg
+urlSlug: selfgenerator-waste-transporters-reg
 name: Apply for Your Self-Generator Waste Transporter Registration
 webflowName: "  "
 summaryDescriptionMd: >-

--- a/content/src/roadmaps/tasks/transportation-cpcn.md
+++ b/content/src/roadmaps/tasks/transportation-cpcn.md
@@ -41,7 +41,7 @@ id: transportation-cpcn
 callToActionLink: ""
 callToActionText: ""
 agencyId: nj-motor-vehicle
-agencyAdditionalContext: Business Licensing Services Bureau – Passenger Carrier Unit
+agencyAdditionalContext: Business Licensing Services Bureau - Passenger Carrier Unit
 issuingAgency: New Jersey Motor Vehicle Commission
 ---
 


### PR DESCRIPTION
## Description

While we work on a longer-term solution, let's swap out usage of em dashes and en dashes in Markdown frontmatter with the ASCII hyphen-minus dash.