### PR TITLE
[AB#15926] updates to license-tasks CMS collection

### DIFF
--- a/web/decap-config/collections/06-tasks.yml
+++ b/web/decap-config/collections/06-tasks.yml
@@ -392,8 +392,20 @@ collections:
           hint: "This is the name displayed internally in CMS list.",
         }
       - { label: "Url Slug", name: "urlSlug", widget: "no-space", required: true }
-      - { label: "Title (Navigator)", name: "name", widget: "string" }
-      - { label: "Title (Webflow)", name: "webflowName", widget: "string" }
+      - {
+          label: "Title (Navigator)",
+          name: "name",
+          widget: "string",
+          required: true,
+          hint: "This is the task name displayed to users in My Account.",
+        }
+      - {
+          label: "Title (Webflow)",
+          name: "webflowName",
+          widget: "string",
+          required: true,
+          hint: "This is the name displayed to users on the Webflow site.",
+        }
       - {
           label: "Summary Description (Webflow and Navigator)",
           name: "summaryDescriptionMd",
@@ -420,12 +432,14 @@ collections:
           name: "callToActionText",
           widget: "string",
           required: false,
+          hint: "Must be supplied to display a CTA button on the Webflow site.",
         }
       - {
           label: "Call To Action Link (Webflow & Navigator)",
           name: "callToActionLink",
           widget: "string",
           required: false,
+          hint: "Must be supplied to display a CTA button on the Webflow site.",
         }
       - {
           label: "Industry (Webflow - archive)",


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

This work makes updates to the `license-tasks` collection of the CMS. Specifically, it makes the title fields (for both My Account and Webflow) required, and adds hint text to the title fields and the CTA fields.

### Ticket

This pull request resolves [#15926](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15926).

### Approach

I changed the configuration of the `license-tasks` collection per suggestions from the content team.

### Steps to Test

- Open the CMS
- Navigate to the `license-tasks` collection (Display Name: License Tasks (Navigator with Webflow mappings)
- Either open an existing item or create a new one
- The following fields should now be required (trigger validation by attempting to save with no value)
  - Title (Navigator)
  - Title (Webflow)
- The following fields should now have helper text
  - Title (Navigator)
  - Title (Webflow)
  - Call To Action Text (Webflow & Navigator)
  - Call To Action Link (Webflow & Navigator)

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
