### PR TITLE
feat: [AB#15155] convert alert on business profile page to callout

### DIFF
--- a/content/src/fieldConfig/profile.json
+++ b/content/src/fieldConfig/profile.json
@@ -497,7 +497,7 @@
       "escapeModalHeader": "Are you sure you want to continue?",
       "profileTabNumbersTitle": "Reference Numbers",
       "profileTabNoteTitle": "Notes",
-      "noteForBusinessesFormedOutsideNavigator": "Your profile helps us make recommendations for your business. We do not submit information for registration.",
+      "noteForBusinessesFormedOutsideNavigator": ":::miniCallout{ headerText=\"Your profile helps us make recommendations for your business. We do not submit information for registration.\" calloutType=\"informational\"  }\n\n:::",
       "locationBasedRequirementsHeader": "Identify Location-Based Requirements",
       "saveButtonText": "Save",
       "permitsAndLicensesSubText": "Answer a few questions to find out what licenses and permits you may need and discover funding programs to help your business grow. New items will appear on your Starter Kit or your For You section.",

--- a/web/decap-config/collections/12-misc.yml
+++ b/web/decap-config/collections/12-misc.yml
@@ -2839,7 +2839,7 @@ collections:
                   - {
                       label: Note for Businesses Formed Outside Navigator,
                       name: noteForBusinessesFormedOutsideNavigator,
-                      widget: string,
+                      widget: markdown,
                     }
                   - {
                       label: Annual Report Deadline Header Text,

--- a/web/src/components/profile/ProfileNoteForBusinessesFormedOutsideNavigator.tsx
+++ b/web/src/components/profile/ProfileNoteForBusinessesFormedOutsideNavigator.tsx
@@ -1,4 +1,4 @@
-import { Alert } from "@/components/njwds-extended/Alert";
+import { Content } from "@/components/Content";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { shouldShowDisclaimerForProfileNotSubmittingData } from "@/lib/domain-logic/shouldShowDisclaimerForProfileNotSubmittingData";
@@ -18,8 +18,6 @@ export const ProfileNoteDisclaimerForSubmittingData = (props: Props): ReactEleme
   }
 
   return (
-    <Alert variant="warning">
-      {Config.profileDefaults.default.noteForBusinessesFormedOutsideNavigator}
-    </Alert>
+    <Content>{Config.profileDefaults.default.noteForBusinessesFormedOutsideNavigator}</Content>
   );
 };

--- a/web/test/pages/profile/profile-shared.test.tsx
+++ b/web/test/pages/profile/profile-shared.test.tsx
@@ -439,13 +439,16 @@ describe("profile - shared", () => {
           }),
         });
         renderPage({ business, isAuthenticated: IsAuthenticated.FALSE });
-        expect(
-          screen.getByText(Config.profileDefaults.default.noteForBusinessesFormedOutsideNavigator),
-        ).toBeInTheDocument();
+        const calloutText =
+          Config.profileDefaults.default.noteForBusinessesFormedOutsideNavigator.match(
+            /headerText="([^"]*)"/,
+          )?.[1];
+        expect(calloutText).toBeDefined();
+        expect(screen.getByText(calloutText!)).toBeInTheDocument();
       },
     );
 
-    it("shows the Note Alert for OWNING businesses and authenticated", () => {
+    it("shows the callout for OWNING businesses and authenticated", () => {
       const business = generateBusinessForProfile({
         formationData: generateFormationData({
           completedFilingPayment: true,
@@ -455,13 +458,16 @@ describe("profile - shared", () => {
         }),
       });
       renderPage({ business, isAuthenticated: IsAuthenticated.TRUE });
-      expect(
-        screen.getByText(Config.profileDefaults.default.noteForBusinessesFormedOutsideNavigator),
-      ).toBeInTheDocument();
+      const calloutText =
+        Config.profileDefaults.default.noteForBusinessesFormedOutsideNavigator.match(
+          /headerText="([^"]*)"/,
+        )?.[1];
+      expect(calloutText).toBeDefined();
+      expect(screen.getByText(calloutText!)).toBeInTheDocument();
     });
 
     it.each(nonOwningPersonas)(
-      "does NOT show Note Alert for %s business that paid via the Navigator and are authenticated",
+      "does NOT show Note Callout for %s business that paid via the Navigator and are authenticated",
       (persona) => {
         const business = generateBusinessForProfile({
           formationData: generateFormationData({
@@ -473,11 +479,12 @@ describe("profile - shared", () => {
           }),
         });
         renderPage({ business, isAuthenticated: IsAuthenticated.TRUE });
-        expect(
-          screen.queryByText(
-            Config.profileDefaults.default.noteForBusinessesFormedOutsideNavigator,
-          ),
-        ).not.toBeInTheDocument();
+        const calloutText =
+          Config.profileDefaults.default.noteForBusinessesFormedOutsideNavigator.match(
+            /headerText="([^"]*)"/,
+          )?.[1];
+        expect(calloutText).toBeDefined();
+        expect(screen.queryByText(calloutText!)).not.toBeInTheDocument();
       },
     );
 
@@ -494,11 +501,12 @@ describe("profile - shared", () => {
           }),
         });
         renderPage({ business, isAuthenticated: IsAuthenticated.TRUE });
-        expect(
-          screen.queryByText(
-            Config.profileDefaults.default.noteForBusinessesFormedOutsideNavigator,
-          ),
-        ).not.toBeInTheDocument();
+        const calloutText =
+          Config.profileDefaults.default.noteForBusinessesFormedOutsideNavigator.match(
+            /headerText="([^"]*)"/,
+          )?.[1];
+        expect(calloutText).toBeDefined();
+        expect(screen.queryByText(calloutText!)).not.toBeInTheDocument();
       },
     );
 
@@ -515,9 +523,12 @@ describe("profile - shared", () => {
           }),
         });
         renderPage({ business, isAuthenticated: IsAuthenticated.TRUE });
-        expect(
-          screen.getByText(Config.profileDefaults.default.noteForBusinessesFormedOutsideNavigator),
-        ).toBeInTheDocument();
+        const calloutText =
+          Config.profileDefaults.default.noteForBusinessesFormedOutsideNavigator.match(
+            /headerText="([^"]*)"/,
+          )?.[1];
+        expect(calloutText).toBeDefined();
+        expect(screen.getByText(calloutText!)).toBeInTheDocument();
       },
     );
   });


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#15155](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15155).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

Used the newer `miniCallout` CMS component per design's requests for easy configurability without needing devs

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->
1. Go through onboarding
2. Navigate to the profile page.
3. New callout should visible at the top of the profile container

### Notes

This uses the same `Note for Businesses Formed Outside Navigator` field as before in the CMS, but updates it to using a CMS content component

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
