### PR TITLE
chore: [AB#15796] add health check for Power Automate email client

### DIFF
--- a/api/src/client/ApiCigaretteLicenseHelpers.test.ts
+++ b/api/src/client/ApiCigaretteLicenseHelpers.test.ts
@@ -1,9 +1,8 @@
 import {
-  makePostBody,
-  makeEmailConfirmationBody,
   CigaretteLicenseApiConfig,
+  makeEmailConfirmationBody,
+  makePostBody,
 } from "@client/ApiCigaretteLicenseHelpers";
-import { randomUUID } from "node:crypto";
 import { CigaretteLicenseData, CigaretteLicensePaymentInfo } from "@shared/cigaretteLicense";
 import {
   generateBusiness,
@@ -11,6 +10,7 @@ import {
   generateUser,
   generateUserData,
 } from "@shared/test";
+import { randomUUID } from "node:crypto";
 
 jest.mock("node:crypto", () => ({
   randomUUID: jest.fn(),
@@ -32,8 +32,6 @@ describe("ApiCigaretteLicenseHelpers", () => {
       merchantCode: "TEST_MERCHANT",
       merchantKey: "TEST_KEY",
       serviceCode: "TEST_SERVICE",
-      emailConfirmationUrl: "TEST_EMAIL_URL",
-      emailConfirmationKey: "TEST_EMAIL_KEY",
     };
 
     const returnUrl = "https://example.com/return";

--- a/api/src/client/ApiCigaretteLicenseHelpers.ts
+++ b/api/src/client/ApiCigaretteLicenseHelpers.ts
@@ -1,5 +1,3 @@
-import { UserData } from "@shared/userData";
-import { getCurrentBusiness } from "@shared/domain-logic/getCurrentBusiness";
 import {
   CigaretteLicenseData,
   EmailConfirmationResponse,
@@ -8,6 +6,8 @@ import {
   PreparePaymentApiSubmission,
   PreparePaymentResponse,
 } from "@shared/cigaretteLicense";
+import { getCurrentBusiness } from "@shared/domain-logic/getCurrentBusiness";
+import { UserData } from "@shared/userData";
 import { randomUUID } from "node:crypto";
 
 export type CigaretteLicenseApiConfig = {
@@ -16,8 +16,6 @@ export type CigaretteLicenseApiConfig = {
   merchantCode: string;
   merchantKey: string;
   serviceCode: string;
-  emailConfirmationUrl: string;
-  emailConfirmationKey: string;
 };
 
 export const makePostBody = (

--- a/api/src/client/ApiPowerAutomateClientFactory.test.ts
+++ b/api/src/client/ApiPowerAutomateClientFactory.test.ts
@@ -1,0 +1,112 @@
+import { ApiPowerAutomateClientFactory } from "@client/ApiPowerAutomateClientFactory";
+import { PowerAutomateClient } from "@domain/types";
+import { DummyLogWriter } from "@libs/logWriter";
+import axios from "axios";
+import { ReasonPhrases } from "http-status-codes";
+
+jest.mock("axios");
+const mockAxios = axios as jest.Mocked<typeof axios>;
+
+describe("ApiPowerAutomateClient", () => {
+  let client: PowerAutomateClient;
+
+  beforeEach(() => {
+    const logger = DummyLogWriter;
+    client = ApiPowerAutomateClientFactory({
+      baseUrl: "some-base-url",
+      apiKey: "some-api-key",
+      logger,
+    });
+  });
+
+  describe("startWorkflow", () => {
+    it("makes a post request to initiate the Power Automate workflow", async () => {
+      mockAxios.post.mockResolvedValue({ data: {} });
+
+      await client.startWorkflow({ body: { some: "data" } });
+
+      expect(mockAxios.post).toHaveBeenCalledWith(
+        "some-base-url",
+        { some: "data" },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            "x-api-key": "some-api-key",
+          },
+        },
+      );
+    });
+
+    it("making a post request with headers does not override the API key or Content-Type", async () => {
+      mockAxios.post.mockResolvedValue({ data: {} });
+
+      await client.startWorkflow({
+        body: { some: "data" },
+        headers: {
+          "some-header": "some-value",
+          "x-api-key": "wrong-api-key",
+          "Content-Type": "something/else",
+        },
+      });
+
+      expect(mockAxios.post).toHaveBeenCalledWith(
+        "some-base-url",
+        { some: "data" },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            "x-api-key": "some-api-key",
+            "some-header": "some-value",
+          },
+        },
+      );
+    });
+
+    it("returns the response from the Power Automate workflow", async () => {
+      const axiosResponse = { data: { some: "response" } };
+      mockAxios.post.mockResolvedValue(axiosResponse);
+
+      const response = await client.startWorkflow({ body: { some: "data" } });
+
+      expect(response).toBe(axiosResponse);
+    });
+
+    it("throws an error if the Power Automate workflow fails", async () => {
+      const axiosError = new Error("Some error");
+      mockAxios.post.mockRejectedValue(axiosError);
+
+      await expect(client.startWorkflow({ body: { some: "data" } })).rejects.toThrow("Some error");
+    });
+  });
+
+  describe("health", () => {
+    it("returns a passing health check if the service is available", async () => {
+      mockAxios.post.mockResolvedValue({});
+
+      expect(await client.health()).toEqual({ success: true, data: { message: ReasonPhrases.OK } });
+    });
+
+    it("returns a failing health check if the service is unavailable", async () => {
+      mockAxios.post.mockRejectedValue({});
+
+      expect(await client.health()).toEqual({
+        success: false,
+        data: { message: ReasonPhrases.INTERNAL_SERVER_ERROR },
+      });
+    });
+
+    it("requests to start the workflow include the health-check header", async () => {
+      mockAxios.post.mockResolvedValue({});
+
+      await client.health();
+
+      expect(mockAxios.post).toHaveBeenCalledWith("some-base-url", undefined, {
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": "some-api-key",
+          "health-check": "active",
+        },
+      });
+    });
+  });
+});

--- a/api/src/client/ApiPowerAutomateClientFactory.ts
+++ b/api/src/client/ApiPowerAutomateClientFactory.ts
@@ -1,0 +1,73 @@
+import { HealthCheckMetadata, PowerAutomateClient } from "@domain/types";
+import { LogWriterType } from "@libs/logWriter";
+import axios, { AxiosResponse } from "axios";
+import { ReasonPhrases } from "http-status-codes";
+
+interface Config {
+  baseUrl: string;
+  apiKey: string;
+  logger: LogWriterType;
+}
+
+export const ApiPowerAutomateClientFactory = (config: Config): PowerAutomateClient => {
+  const logId = config.logger.GetId();
+
+  const startWorkflow = async (props: {
+    body?: object;
+    headers?: object;
+  }): Promise<AxiosResponse> => {
+    return axios
+      .post(config.baseUrl, props.body, {
+        headers: {
+          ...props.headers,
+          "Content-Type": "application/json",
+          "x-api-key": config.apiKey,
+        },
+      })
+      .then((response: AxiosResponse) => {
+        config.logger.LogInfo(
+          `Power Automate Client - Id:${logId} - Response received: ${JSON.stringify(response.data)}`,
+        );
+        return response;
+      })
+      .catch((error) => {
+        config.logger.LogError(
+          `Power Automate Client - Id:${logId} - Error received: ${JSON.stringify(error)}`,
+        );
+        throw error;
+      });
+  };
+
+  const health = async (): Promise<HealthCheckMetadata> => {
+    return startWorkflow({ headers: { "health-check": "active" } })
+      .then((response) => {
+        config.logger.LogInfo(
+          `Power Automate Health Check - Id:${logId} - Response received: ${JSON.stringify(
+            response.data,
+          )}`,
+        );
+        return {
+          success: true,
+          data: {
+            message: ReasonPhrases.OK,
+          },
+        };
+      })
+      .catch((error) => {
+        config.logger.LogError(
+          `Power Automate Health Check - Id:${logId} - Error received: ${JSON.stringify(error)}`,
+        );
+        return {
+          success: false,
+          data: {
+            message: ReasonPhrases.INTERNAL_SERVER_ERROR,
+          },
+        };
+      });
+  };
+
+  return {
+    startWorkflow,
+    health,
+  };
+};

--- a/api/src/client/CigaretteLicenseEmailClient.test.ts
+++ b/api/src/client/CigaretteLicenseEmailClient.test.ts
@@ -1,0 +1,73 @@
+import {
+  mockErrorEmailResponse,
+  mockSuccessEmailResponse,
+} from "@client/ApiCigaretteLicenseHelpers";
+import { ApiPowerAutomateClientFactory } from "@client/ApiPowerAutomateClientFactory";
+import { CigaretteLicenseEmailClient } from "@client/CigaretteLicenseEmailClient";
+import { PowerAutomateClient } from "@domain/types";
+import { DummyLogWriter } from "@libs/logWriter";
+import { getConfigValue } from "@libs/ssmUtils";
+import { generateEmailConfirmationSubmission } from "@shared/test";
+import { StatusCodes } from "http-status-codes";
+
+jest.mock("@libs/ssmUtils", () => ({
+  getConfigValue: jest.fn(),
+}));
+
+jest.mock("@client/ApiPowerAutomateClientFactory", () => ({
+  ApiPowerAutomateClientFactory: jest.fn(),
+}));
+
+const mockPowerAutomateClient = ApiPowerAutomateClientFactory as jest.MockedFunction<
+  typeof ApiPowerAutomateClientFactory
+>;
+const getConfigValueMock = getConfigValue as jest.MockedFunction<typeof getConfigValue>;
+const startWorkflow = jest.fn();
+
+describe("Cigarette License Email Client", () => {
+  const emailClient = CigaretteLicenseEmailClient(DummyLogWriter);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    getConfigValueMock.mockImplementation(async (key: string) => {
+      if (key === "cigarette_license_email_confirmation_url") return "https://example.com/flow";
+      if (key === "cigarette_license_email_confirmation_key") return "api-key-xyz";
+      throw new Error("unexpected key");
+    });
+
+    mockPowerAutomateClient.mockReturnValue({
+      startWorkflow,
+      health: jest.fn(),
+    } as PowerAutomateClient);
+  });
+
+  describe("sendEmail", () => {
+    it("returns a successful response when email is sent successfully", async () => {
+      startWorkflow.mockResolvedValue({
+        status: StatusCodes.OK,
+        data: { message: mockSuccessEmailResponse.message },
+      });
+      const postBody = generateEmailConfirmationSubmission({});
+      const response = await emailClient.sendEmail(postBody);
+
+      expect(response).toEqual({
+        statusCode: StatusCodes.OK,
+        message: "Email confirmation successfully sent",
+      });
+    });
+
+    it("returns an error response when email cannot be sent", async () => {
+      startWorkflow.mockRejectedValue({
+        message: mockErrorEmailResponse.message,
+      });
+      const postBody = generateEmailConfirmationSubmission({});
+      const response = await emailClient.sendEmail(postBody);
+
+      expect(response).toEqual({
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        message: "Failed to send email confirmation",
+      });
+    });
+  });
+});

--- a/api/src/client/CigaretteLicenseEmailClient.ts
+++ b/api/src/client/CigaretteLicenseEmailClient.ts
@@ -1,0 +1,104 @@
+import {
+  EmailConfirmationResponse,
+  EmailConfirmationSubmission,
+} from "@businessnjgovnavigator/shared";
+import { ApiPowerAutomateClientFactory } from "@client/ApiPowerAutomateClientFactory";
+import { EmailClient, HealthCheckMetadata } from "@domain/types";
+import { LogWriterType } from "@libs/logWriter";
+import { getConfigValue } from "@libs/ssmUtils";
+import { ReasonPhrases, StatusCodes } from "http-status-codes";
+
+const getConfig = async (): Promise<{
+  emailConfirmationUrl: string;
+  emailConfirmationKey: string;
+}> => {
+  return {
+    emailConfirmationUrl: await getConfigValue("cigarette_license_email_confirmation_url"),
+    emailConfirmationKey: await getConfigValue("cigarette_license_email_confirmation_key"),
+  };
+};
+
+export const CigaretteLicenseEmailClient = (logger: LogWriterType): EmailClient => {
+  const logId = logger.GetId();
+
+  const sendEmail = async (
+    postBody: EmailConfirmationSubmission,
+  ): Promise<EmailConfirmationResponse> => {
+    const config = await getConfig();
+
+    const cigarettePowerAutomateClient = ApiPowerAutomateClientFactory({
+      baseUrl: config.emailConfirmationUrl,
+      apiKey: config.emailConfirmationKey,
+      logger,
+    });
+
+    logger.LogInfo(
+      `Cigarette License Email Client - Id:${logId} - Sending request to ${
+        config.emailConfirmationUrl
+      } data: ${JSON.stringify(postBody)}`,
+    );
+    return cigarettePowerAutomateClient
+      .startWorkflow({ body: postBody })
+      .then((response) => {
+        logger.LogInfo(
+          `Cigarette License Client - Id:${logId} - Response received: ${JSON.stringify(
+            response.data,
+          )}`,
+        );
+
+        const successResponse: EmailConfirmationResponse = {
+          statusCode: response.status,
+          message: response.data.message,
+        };
+        return successResponse;
+      })
+      .catch((error) => {
+        logger.LogError(
+          `Cigarette License Email Client - Id:${logId} - Error received: ${JSON.stringify(error)}`,
+        );
+        const errorResponse: EmailConfirmationResponse = {
+          statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+          message: error.message,
+        };
+
+        return errorResponse;
+      });
+  };
+
+  const health = async (): Promise<HealthCheckMetadata> => {
+    const config = await getConfig();
+    const cigarettePowerAutomateClient = ApiPowerAutomateClientFactory({
+      baseUrl: config.emailConfirmationUrl,
+      apiKey: config.emailConfirmationKey,
+      logger,
+    });
+
+    return cigarettePowerAutomateClient
+      .health()
+      .then(() => {
+        logger.LogInfo(
+          `Cigarette License Email Health Check - Id:${logId} - Successful response received.`,
+        );
+        return {
+          success: true,
+          data: {
+            message: ReasonPhrases.OK,
+          },
+        };
+      })
+      .catch(() => {
+        logger.LogError(`Cigarette License Email Health Check - Id:${logId} - Error received.`);
+        return {
+          success: false,
+          data: {
+            message: ReasonPhrases.INTERNAL_SERVER_ERROR,
+          },
+        };
+      });
+  };
+
+  return {
+    sendEmail,
+    health,
+  };
+};

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
+  EmailConfirmationSubmission,
   FacilityDetails,
   TaxClearanceCertificateResponse,
   UnlinkTaxIdResponse,
@@ -38,6 +39,7 @@ import {
 import { ProfileData } from "@shared/profileData";
 import { TaxFilingLookupState, TaxFilingOnboardingState } from "@shared/taxFiling";
 import { Business, UserData } from "@shared/userData";
+import { AxiosResponse } from "axios";
 import { ReasonPhrases } from "http-status-codes";
 import * as https from "node:https";
 import { EmployerRatesRequest, EmployerRatesResponse } from "@shared/employerRates";
@@ -264,6 +266,16 @@ export interface TaxClearanceCertificateClient {
   ) => Promise<TaxClearanceCertificateResponse>;
   health: () => Promise<HealthCheckMetadata>;
   unlinkTaxId: (userData: UserData, databaseClient: DatabaseClient) => Promise<UnlinkTaxIdResponse>;
+}
+
+export interface PowerAutomateClient {
+  startWorkflow: (props: { body?: object; headers?: object }) => Promise<AxiosResponse>;
+  health: () => Promise<HealthCheckMetadata>;
+}
+
+export interface EmailClient {
+  sendEmail: (postBody: EmailConfirmationSubmission) => Promise<EmailConfirmationResponse>;
+  health: () => Promise<HealthCheckMetadata>;
 }
 
 export interface CigaretteLicenseClient {

--- a/api/src/functions/express/app.ts
+++ b/api/src/functions/express/app.ts
@@ -18,6 +18,7 @@ import { ApiCigaretteLicenseClient } from "@client/ApiCigaretteLicenseClient";
 import { ApiFormationClient } from "@client/ApiFormationClient";
 import { ApiTaxClearanceCertificateClient } from "@client/ApiTaxClearanceCertificateClient";
 import { AWSCryptoFactory } from "@client/AwsCryptoFactory";
+import { CigaretteLicenseEmailClient } from "@client/CigaretteLicenseEmailClient";
 import { XrayRegistrationHealthCheckClient } from "@client/dep/healthcheck/XrayRegistrationHealthCheckClient";
 import { XrayRegistrationLookupClient } from "@client/dep/XrayRegistrationLookupClient";
 import { XrayRegistrationSearchClient } from "@client/dep/XrayRegistrationSearchClient";
@@ -259,7 +260,8 @@ const taxClearanceCertificateClient = ApiTaxClearanceCertificateClient(logger, {
 });
 const taxClearanceHealthCheckClient = taxClearanceCertificateClient.health;
 
-const cigaretteLicenseClient = ApiCigaretteLicenseClient(logger);
+const cigaretteLicenseEmailClient = CigaretteLicenseEmailClient(logger);
+const cigaretteLicenseClient = ApiCigaretteLicenseClient(cigaretteLicenseEmailClient, logger);
 const cigaretteLicenseHealthCheckClient = cigaretteLicenseClient.health;
 
 const BUSINESS_NAME_BASE_URL =
@@ -500,6 +502,7 @@ app.use(
       ["tax-clearance", taxClearanceHealthCheckClient],
       ["xray-registration", xrayRegistrationHealthCheckClient],
       ["cigarette-license", cigaretteLicenseHealthCheckClient],
+      ["cigarette-email-client", cigaretteLicenseEmailClient.health],
     ]),
     logger,
   ),

--- a/api/src/libs/healthCheck.test.ts
+++ b/api/src/libs/healthCheck.test.ts
@@ -1,12 +1,12 @@
 import { runHealthChecks } from "@libs/healthCheck";
-import { LogWriter } from "@libs/logWriter";
+import { DummyLogWriter } from "@libs/logWriter";
 import axios from "axios";
 
 jest.mock("axios");
 const mockAxios = axios as jest.Mocked<typeof axios>;
 
 describe("healthCheck", () => {
-  const logger = LogWriter(`HealthCheckService`, "ApiLogs");
+  const logger = DummyLogWriter;
 
   it("returns an object with pass statuses if success is true", async () => {
     mockAxios.get.mockResolvedValue({ data: { success: true } });
@@ -20,6 +20,8 @@ describe("healthCheck", () => {
       webserviceFormation: "PASS",
       taxClearance: "PASS",
       xrayRegistration: "PASS",
+      cigaretteLicense: "PASS",
+      cigaretteEmailClient: "PASS",
     });
   });
 
@@ -35,6 +37,8 @@ describe("healthCheck", () => {
       webserviceFormation: "FAIL",
       taxClearance: "FAIL",
       xrayRegistration: "FAIL",
+      cigaretteLicense: "FAIL",
+      cigaretteEmailClient: "FAIL",
     });
   });
 
@@ -50,6 +54,8 @@ describe("healthCheck", () => {
       webserviceFormation: "ERROR",
       taxClearance: "ERROR",
       xrayRegistration: "ERROR",
+      cigaretteLicense: "ERROR",
+      cigaretteEmailClient: "ERROR",
     });
   });
 });

--- a/api/src/libs/ssmUtils.ts
+++ b/api/src/libs/ssmUtils.ts
@@ -5,15 +5,18 @@ const parameterName = `/${process.env.STAGE}/feature-flag/users-migration/kill-s
 
 export type CONFIG_VARS =
   | "cms_alerts_sns_topic_arn"
-  | CIGARETTE_CONFIG_VARS
-  | "employer_rates_base_url";
+  | "employer_rates_base_url"
+  | CIGARETTE_PAYMENT_CONFIG_VARS
+  | CIGARETTE_EMAIL_CONFIG_VARS;
 
-export type CIGARETTE_CONFIG_VARS =
+export type CIGARETTE_PAYMENT_CONFIG_VARS =
   | "cigarette_license_base_url"
   | "cigarette_license_api_key"
   | "cigarette_license_merchant_code"
   | "cigarette_license_merchant_key"
-  | "cigarette_license_service_code"
+  | "cigarette_license_service_code";
+
+export type CIGARETTE_EMAIL_CONFIG_VARS =
   | "cigarette_license_email_confirmation_url"
   | "cigarette_license_email_confirmation_key";
 

--- a/shared/src/test/factories.ts
+++ b/shared/src/test/factories.ts
@@ -1,7 +1,7 @@
 import { randomElementFromArray } from "../arrayHelpers";
 import { BusinessUser } from "../businessUser";
 import { TaxFilingCalendarEvent } from "../calendarEvent";
-import { CigaretteLicenseData } from "../cigaretteLicense";
+import { CigaretteLicenseData, EmailConfirmationSubmission } from "../cigaretteLicense";
 import { getCurrentDate, getCurrentDateFormatted, getCurrentDateISOString } from "../dateHelpers";
 import { defaultDateFormat } from "../defaultConstants";
 import { createBusinessId } from "../domain-logic/createBusinessId";
@@ -48,7 +48,7 @@ import {
 } from "../profileData";
 import { RoadmapTaskData } from "../roadmapTaskData";
 import { arrayOfSectors, SectorType } from "../sector";
-import { arrayOfStateObjects as states, StateObject } from "../states";
+import { StateObject, arrayOfStateObjects as states } from "../states";
 import {
   taxClearanceCertificateAgencies,
   TaxClearanceCertificateData,
@@ -466,6 +466,43 @@ export const generateCigaretteLicenseData = (
     signerRelationship: `some-signer-relationship-${randomInt()}`,
     signature: false,
     lastUpdatedISO: getCurrentDateISOString(),
+    ...overrides,
+  };
+};
+
+export const generateEmailConfirmationSubmission = (
+  overrides: Partial<EmailConfirmationSubmission>,
+): EmailConfirmationSubmission => {
+  return {
+    businessName: `some-business-name-${randomInt()}`,
+    businessType: randomLegalStructure().name,
+    responsibleOwnerName: `some-owner-name-${randomInt()}`,
+    tradeName: `some-trade-name-${randomInt()}`,
+    taxId: maskingCharacter.repeat(7) + randomInt(12).toString().slice(-5),
+    addressLine1: `some-address-1-${randomInt()}`,
+    addressLine2: `some-address-2-${randomInt()}`,
+    addressCity: `some-city-${randomInt()}`,
+    addressState: generateUnitedStatesStateDropdownOption({}).name,
+    addressZipCode: randomInt(5).toString(),
+    mailingAddressIsTheSame: false,
+    mailingAddressLine1: `some-mailing-address-1-${randomInt()}`,
+    mailingAddressLine2: `some-mailing-address-2-${randomInt()}`,
+    mailingAddressCity: `some-mailing-city-${randomInt()}`,
+    mailingAddressState: generateUnitedStatesStateDropdownOption({}).name,
+    mailingAddressZipCode: randomInt(5).toString(),
+    contactName: `some-contact-name-${randomInt()}`,
+    contactPhoneNumber: `some-phone-number-${randomInt()}`,
+    contactEmail: `some-email-${randomInt()}@example.com`,
+    salesInfoStartDate: "08/31/2025",
+    salesInfoSupplier: `some-sales-info-supplier-${randomInt()}`,
+    signerName: `some-signer-name-${randomInt()}`,
+    signerRelationship: `some-signer-relationship-${randomInt()}`,
+    signature: true,
+    paymentInfo: {
+      orderId: randomInt(),
+      orderStatus: "COMPLETED",
+      orderTimestamp: getCurrentDateISOString(),
+    },
     ...overrides,
   };
 };


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

This work includes a refactor to make a standalone Power Automate client factory, pass a cigarette-specific power automate client to our Cigarette License client, and creates a health check for the cigarette-specific power automate client.

### Ticket

This pull request resolves [#15796](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15796).

### Approach

- Refactored existing integration with Power Automate for the Cigarette License Application logic
  - We now have a Power Automate client with a `health` function that can be configured for future Power Automate integrations
- Added a health check for the Power Automate workflow used by the Cigarette License Application
- Refactored the `runHealthChecks` behavior. It appears as though some log messages were not getting properly handled. Specifically, the last endpoint checked was not appearing in our logs. This function now uses `Promise.all` over the existing `for` loop. Preliminary testing indicates that this fixes the issue.

### Steps to Test

**Validate Cigarette License Application Workflow**
- Because this touches fundamental logic for the cigarette license application, we should confirm that this is still in-tact. I am not providing explicit steps for that flow. Please see another relevant ticket/pull request.

**Cigarette Power Automate Health Check**
- Deploy this work to a cloud environment
- Break the configuration details for the Power Automate workflow
or
- Modify the Power Automate workflow to provide an error response
- Run the health check
- Confirm that an error response is visible in our logs

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
