### PR TITLE
feat: [AB#15515] add confirmation checks and callout to business formation review

### DIFF
--- a/content/src/fieldConfig/business-formation.json
+++ b/content/src/fieldConfig/business-formation.json
@@ -80,7 +80,6 @@
       "submitButtonText": "Submit & Pay",
       "radioYesText": "Yes",
       "viewMoreButtonText": "Read more",
-      "amendmentInfo": "#### Review your information before submitting to the New Jersey Division of Revenue and Enterprise Services.\n If you need to make a change after submitting, you must file an [amendment online.](https://www.njportal.com/dor/businessamendments)",
       "viewLessButtonText": "Read less",
       "genericErrorText": "This field requires information.",
       "ariaContextStepperStateComplete": "Complete",
@@ -103,7 +102,15 @@
       "notificationsHeader": "Notifications",
       "review": {
         "nameLabel": "Full Name",
-        "billingContactHeader": "Billing Contact Information"
+        "billingContactHeader": "Billing Contact Information",
+        "warningAlert": "**Review carefully before you submit.** If you need to correct any errors (even a simple typo) after filing, you will need to file a [correction](https://www.njportal.com/dor/businessamendments) and be charged an additional fee. This fee could be **over $100**. Also, your approval could be delayed up to **2 weeks**.",
+        "confirmationBox": {
+          "title": "Ready to Submit?",
+          "namesAddressesDatesCheckbox": "Yes, I have carefully checked all **names, addresses,** and **dates**, and confirm they are correct and complete.",
+          "permanentRecordCheckbox": "Yes, I understand that after I submit, filing becomes a permanent public record, and **filing false information may result in penalties**.",
+          "correctionFeesCheckbox": "Yes, I understand if I need to correct any errors after I submit, I'll have to file a [correction](https://www.njportal.com/dor/businessamendments), could pay **over $100** outside of this website, and my approval may be delayed up to 2 weeks.",
+          "confirmationError": "Select all three checkboxes if you understand and want to continue."
+        }
       },
       "contactInfoHeader": "Billing Contact Information",
       "servicesDescription": "Use the table below to select all the services you’d like to purchase as well as the payment type."

--- a/web/decap-config/collections/01-business-formation.yml
+++ b/web/decap-config/collections/01-business-formation.yml
@@ -1170,6 +1170,33 @@ collections:
                           name: "billingContactHeader",
                           widget: "string",
                         }
+                      - { label: "Warning alert", name: "warningAlert", widget: "markdown" }
+                      - label: "Confirmation box"
+                        name: confirmationBox
+                        widget: object
+                        fields:
+                          - { label: "Title", name: "title", widget: "string" }
+                          - {
+                              label: "Names addresses dates checkbox",
+                              name: "namesAddressesDatesCheckbox",
+                              widget: "markdown",
+                            }
+                          - {
+                              label: "Permanent record checkbox",
+                              name: "permanentRecordCheckbox",
+                              widget: "markdown",
+                            }
+                          - {
+                              label: "Correction fees checkbox",
+                              name: "correctionFeesCheckbox",
+                              widget: "markdown",
+                            }
+                          - {
+                              label: "Confirmation error",
+                              name: "confirmationError",
+                              widget: "string",
+                            }
+
               - label: Error Banner
                 name: errorBanner
                 collapsed: true
@@ -1251,7 +1278,6 @@ collections:
                 collapsed: true
                 widget: object
                 fields:
-                  - { label: "Amendment Info Alert", name: "amendmentInfo", widget: "markdown" }
                   - {
                       label: "Not entered text - review page",
                       name: "notEntered",

--- a/web/src/components/tasks/business-formation/BusinessFormation.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormation.tsx
@@ -68,6 +68,11 @@ export const BusinessFormation = (props: Props): ReactElement => {
   const [foreignGoodStandingFile, setForeignGoodStandingFile] = useState<InputFile | undefined>(
     undefined,
   );
+  const [reviewCheckboxes, setReviewCheckboxes] = useState({
+    namesAddressesDatesChecked: false,
+    permanentRecordChecked: false,
+    correctionFeesChecked: false,
+  });
 
   const legalStructureId: FormationLegalType = useMemo(() => {
     return castPublicFilingLegalTypeToFormationType(
@@ -261,6 +266,14 @@ export const BusinessFormation = (props: Props): ReactElement => {
     return Config.formation.intro.default;
   };
 
+  const allConfirmationsChecked = (): boolean => {
+    return (
+      reviewCheckboxes.correctionFeesChecked &&
+      reviewCheckboxes.namesAddressesDatesChecked &&
+      reviewCheckboxes.permanentRecordChecked
+    );
+  };
+
   return (
     <BusinessFormationContext.Provider
       value={{
@@ -275,6 +288,7 @@ export const BusinessFormation = (props: Props): ReactElement => {
           hasBeenSubmitted,
           hasSetStateFirstTime,
           foreignGoodStandingFile,
+          reviewCheckboxes,
         },
         setFormationFormData,
         setBusinessNameAvailability,
@@ -284,6 +298,8 @@ export const BusinessFormation = (props: Props): ReactElement => {
         setFieldsInteracted,
         setHasBeenSubmitted,
         setForeignGoodStandingFile,
+        setReviewCheckboxes,
+        allConfirmationsChecked,
       }}
     >
       <div className="flex flex-column min-height-38rem" data-testid="formation-form">

--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
@@ -568,6 +568,7 @@ describe("<BusinessFormationPaginator />", () => {
         expect(
           screen.queryByText(Config.formation.errorBanner.incompleteStepsError),
         ).not.toBeInTheDocument();
+        await page.checkAllReviewCheckboxes();
         await page.clickSubmit();
 
         expect(page.getStepStateInStepper(LookupStepIndexByName("Name"))).toEqual("ERROR");
@@ -720,6 +721,7 @@ describe("<BusinessFormationPaginator />", () => {
         const page = preparePage({ business: filledInBusiness, displayContent });
         await page.fillAndSubmitBusinessNameStep();
         await page.stepperClickToReviewStep();
+        await page.checkAllReviewCheckboxes();
         await page.clickSubmit();
         await waitFor(() => {
           return expect(mockPush).toHaveBeenCalledWith("www.example.com");
@@ -775,6 +777,7 @@ describe("<BusinessFormationPaginator />", () => {
             );
 
             await page.stepperClickToReviewStep();
+            await page.checkAllReviewCheckboxes();
             await page.clickSubmitAndGetError(filledInBusinessWithApiResponse);
             expect(page.getStepStateInStepper(LookupStepIndexByName(formationStepName))).toEqual(
               "ERROR",
@@ -1398,6 +1401,7 @@ describe("<BusinessFormationPaginator />", () => {
               const page = preparePage({ business: filledInBusiness, displayContent });
               await page.fillAndSubmitBusinessNameStep();
               await page.stepperClickToReviewStep();
+              await page.checkAllReviewCheckboxes();
               await page.clickSubmit();
               expect(page.getStepStateInStepper(LookupStepIndexByName(formationStepName))).toEqual(
                 "ERROR",
@@ -2190,6 +2194,41 @@ describe("<BusinessFormationPaginator />", () => {
           );
         });
       });
+    });
+  });
+
+  describe("review confirmation checkboxes", () => {
+    let page: FormationPageHelpers;
+
+    beforeEach(async () => {
+      page = preparePage({ business, displayContent });
+      await page.stepperClickToBillingStep();
+      page.completeRequiredBillingFields();
+      await page.stepperClickToReviewStep();
+    });
+
+    it("prevents submission when review confirmation checkboxes are not checked", async () => {
+      await page.clickSubmit();
+
+      expect(
+        screen.getByText(Config.formation.sections.review.confirmationBox.confirmationError),
+      ).toBeInTheDocument();
+
+      expect(screen.getByTestId("review-step")).toBeInTheDocument();
+    });
+
+    it("allows submission when all review confirmation checkboxes are checked", async () => {
+      await page.checkAllReviewCheckboxes();
+
+      await page.clickSubmit();
+
+      expect(
+        screen.queryByText(Config.formation.sections.review.confirmationBox.confirmationError),
+      ).not.toBeInTheDocument();
+
+      expect(
+        screen.getByText(Config.formation.errorBanner.incompleteStepsError),
+      ).toBeInTheDocument();
     });
   });
 

--- a/web/src/components/tasks/business-formation/NexusFormation.test.tsx
+++ b/web/src/components/tasks/business-formation/NexusFormation.test.tsx
@@ -166,6 +166,7 @@ describe("<NexusFormationFlow />", () => {
     await page.uploadFile(file);
     await page.completeWillPracticeLaw();
     await page.stepperClickToReviewStep();
+    await page.checkAllReviewCheckboxes();
     await page.clickSubmit();
 
     const base64String = Buffer.from("my cool file contents", "utf8").toString("base64");

--- a/web/src/components/tasks/business-formation/review/ReviewConfirmation.test.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewConfirmation.test.tsx
@@ -1,0 +1,113 @@
+import { generateEmptyFormationData, generateFormationDbaContent } from "@/test/factories";
+import {
+  generateFormationProfileData,
+  preparePage,
+  useSetupInitialMocks,
+} from "@/test/helpers/helpers-formation";
+import { getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const Config = getMergedConfig();
+
+// Minimal mock declarations - useSetupInitialMocks() handles all implementations
+jest.mock("@/lib/data-hooks/useUserData");
+jest.mock("@/lib/data-hooks/useRoadmap");
+jest.mock("@/lib/data-hooks/useDocuments");
+jest.mock("next/compat/router");
+jest.mock("@/lib/api-client/apiClient");
+jest.mock("@mui/material", () => ({
+  ...jest.requireActual("@mui/material"),
+  useMediaQuery: jest.fn(),
+}));
+
+describe("Formation - ReviewConfirmation", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    useSetupInitialMocks();
+  });
+
+  const renderReviewStep = async (): Promise<void> => {
+    const profileData = generateFormationProfileData({
+      legalStructureId: "limited-liability-company",
+    });
+    const formationData = generateEmptyFormationData();
+
+    const page = preparePage({
+      business: { profileData, formationData },
+      displayContent: { formationDbaContent: generateFormationDbaContent({}) },
+    });
+
+    await page.stepperClickToReviewStep();
+  };
+
+  it("renders confirmation title and all checkbox labels", async () => {
+    await renderReviewStep();
+
+    expect(
+      screen.getByText(Config.formation.sections.review.confirmationBox.title),
+    ).toBeInTheDocument();
+
+    expect(
+      within(screen.getByTestId("names-addresses-dates-checkbox-container")).getByRole("checkbox"),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("permanent-record-checkbox-container")).getByRole("checkbox"),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("correction-fees-checkbox-container")).getByRole("checkbox"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show inline error before submission when boxes are unchecked", async () => {
+    await renderReviewStep();
+    expect(
+      screen.queryByText(Config.formation.sections.review.confirmationBox.confirmationError),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows inline error after submit when any checkbox is unchecked", async () => {
+    await renderReviewStep();
+
+    await userEvent.click(screen.getByText(Config.formation.general.submitButtonText));
+
+    expect(
+      screen.getByText(Config.formation.sections.review.confirmationBox.confirmationError),
+    ).toBeInTheDocument();
+  });
+
+  it("removes inline error after checking all three boxes post-submit", async () => {
+    await renderReviewStep();
+
+    await userEvent.click(screen.getByText(Config.formation.general.submitButtonText));
+    expect(
+      screen.getByText(Config.formation.sections.review.confirmationBox.confirmationError),
+    ).toBeInTheDocument();
+
+    const namesDatesBox = within(
+      screen.getByTestId("names-addresses-dates-checkbox-container"),
+    ).getByRole("checkbox");
+    const permanentRecordBox = within(
+      screen.getByTestId("permanent-record-checkbox-container"),
+    ).getByRole("checkbox");
+    const correctionFeesBox = within(
+      screen.getByTestId("correction-fees-checkbox-container"),
+    ).getByRole("checkbox");
+
+    expect(namesDatesBox).not.toBeChecked();
+    expect(permanentRecordBox).not.toBeChecked();
+    expect(correctionFeesBox).not.toBeChecked();
+
+    await userEvent.click(namesDatesBox);
+    await userEvent.click(permanentRecordBox);
+    await userEvent.click(correctionFeesBox);
+
+    expect(namesDatesBox).toBeChecked();
+    expect(permanentRecordBox).toBeChecked();
+    expect(correctionFeesBox).toBeChecked();
+
+    expect(
+      screen.queryByText(Config.formation.sections.review.confirmationBox.confirmationError),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/tasks/business-formation/review/ReviewConfirmation.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewConfirmation.tsx
@@ -1,0 +1,103 @@
+import { Content } from "@/components/Content";
+import { Heading } from "@/components/njwds-extended/Heading";
+import { WithErrorBar } from "@/components/WithErrorBar";
+import { BusinessFormationContext } from "@/contexts/businessFormationContext";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { Checkbox, FormControlLabel } from "@mui/material";
+import { ReactElement, useContext } from "react";
+
+export const ReviewConfirmation = (): ReactElement => {
+  const { state, setReviewCheckboxes, allConfirmationsChecked } =
+    useContext(BusinessFormationContext);
+  const { Config } = useConfig();
+
+  return (
+    <div className="margin-top-4">
+      <div className="bg-base-lightest padding-x-5 padding-y-3 radius-md">
+        <Heading level={2}>{Config.formation.sections.review.confirmationBox.title}</Heading>
+
+        <WithErrorBar hasError={!allConfirmationsChecked() && state.hasBeenSubmitted} type="ALWAYS">
+          <div data-testid="names-addresses-dates-checkbox-container">
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={state.reviewCheckboxes.namesAddressesDatesChecked}
+                  onChange={(event): void =>
+                    setReviewCheckboxes((prev) => ({
+                      ...prev,
+                      namesAddressesDatesChecked: event.target.checked,
+                    }))
+                  }
+                  {...(state.hasBeenSubmitted && !state.reviewCheckboxes.namesAddressesDatesChecked
+                    ? { color: "error" }
+                    : {})}
+                />
+              }
+              label={
+                <Content>
+                  {Config.formation.sections.review.confirmationBox.namesAddressesDatesCheckbox}
+                </Content>
+              }
+            />
+          </div>
+
+          <div data-testid="permanent-record-checkbox-container">
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={state.reviewCheckboxes.permanentRecordChecked}
+                  onChange={(event): void =>
+                    setReviewCheckboxes((prev) => ({
+                      ...prev,
+                      permanentRecordChecked: event.target.checked,
+                    }))
+                  }
+                  {...(state.hasBeenSubmitted && !state.reviewCheckboxes.permanentRecordChecked
+                    ? { color: "error" }
+                    : {})}
+                />
+              }
+              label={
+                <Content>
+                  {Config.formation.sections.review.confirmationBox.permanentRecordCheckbox}
+                </Content>
+              }
+            />
+          </div>
+
+          <div data-testid="correction-fees-checkbox-container">
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={state.reviewCheckboxes.correctionFeesChecked}
+                  onChange={(event): void =>
+                    setReviewCheckboxes((prev) => ({
+                      ...prev,
+                      correctionFeesChecked: event.target.checked,
+                    }))
+                  }
+                  {...(state.hasBeenSubmitted && !state.reviewCheckboxes.correctionFeesChecked
+                    ? { color: "error" }
+                    : {})}
+                />
+              }
+              label={
+                <Content>
+                  {Config.formation.sections.review.confirmationBox.correctionFeesCheckbox}
+                </Content>
+              }
+            />
+          </div>
+
+          {!allConfirmationsChecked() && state.hasBeenSubmitted && (
+            <div className="text-error-dark text-bold">
+              <Content>
+                {Config.formation.sections.review.confirmationBox.confirmationError}
+              </Content>
+            </div>
+          )}
+        </WithErrorBar>
+      </div>
+    </div>
+  );
+};

--- a/web/src/components/tasks/business-formation/review/ReviewStep.tsx
+++ b/web/src/components/tasks/business-formation/review/ReviewStep.tsx
@@ -7,6 +7,7 @@ import { ReviewAdditionalProvisions } from "@/components/tasks/business-formatio
 import { ReviewBillingContact } from "@/components/tasks/business-formation/review/ReviewBillingContact";
 import { ReviewBillingServices } from "@/components/tasks/business-formation/review/ReviewBillingServices";
 import { ReviewBusinessSuffixAndStartDate } from "@/components/tasks/business-formation/review/ReviewBusinessSuffixAndStartDate";
+import { ReviewConfirmation } from "@/components/tasks/business-formation/review/ReviewConfirmation";
 import { ReviewForeignCertificate } from "@/components/tasks/business-formation/review/ReviewForeignCertificate";
 import { ReviewIsVeteranNonprofit } from "@/components/tasks/business-formation/review/ReviewIsVeteranNonprofit";
 import { ReviewMainBusinessLocation } from "@/components/tasks/business-formation/review/ReviewMainBusinessLocation";
@@ -50,6 +51,15 @@ export const ReviewStep = (): ReactElement => {
 
   return (
     <>
+      <Alert variant="warning" className="margin-bottom-4">
+        <Content
+          onClick={(): void => {
+            analytics.event.business_formation_review_amendments_external_link.click.go_to_Treasury_amendments_page();
+          }}
+        >
+          {Config.formation.sections.review.warningAlert}
+        </Content>
+      </Alert>
       <div data-testid="review-step">
         <BusinessFormationReviewSection stepName={"Business"} dataTestId="edit-business-name-step">
           <BusinessNameAndLegalStructure isReviewStep />
@@ -95,15 +105,7 @@ export const ReviewStep = (): ReactElement => {
           <ReviewBillingContact />
           <ReviewBillingServices />
         </BusinessFormationReviewSection>
-        <Alert variant="info">
-          <Content
-            onClick={(): void => {
-              analytics.event.business_formation_review_amendments_external_link.click.go_to_Treasury_amendments_page();
-            }}
-          >
-            {Config.formation.general.amendmentInfo}
-          </Content>
-        </Alert>
+        <ReviewConfirmation />
       </div>
     </>
   );

--- a/web/src/contexts/businessFormationContext.ts
+++ b/web/src/contexts/businessFormationContext.ts
@@ -22,6 +22,7 @@ interface BusinessFormationState {
   interactedFields: FieldsForErrorHandling[];
   hasSetStateFirstTime: boolean;
   foreignGoodStandingFile: InputFile | undefined;
+  reviewCheckboxes: ReviewCheckboxes;
 }
 
 interface BusinessFormationContextType {
@@ -39,6 +40,14 @@ interface BusinessFormationContextType {
     React.SetStateAction<NameAvailability | undefined>
   >;
   setForeignGoodStandingFile: (file: InputFile | undefined) => void;
+  setReviewCheckboxes: React.Dispatch<React.SetStateAction<ReviewCheckboxes>>;
+  allConfirmationsChecked: () => boolean;
+}
+
+interface ReviewCheckboxes {
+  namesAddressesDatesChecked: boolean;
+  permanentRecordChecked: boolean;
+  correctionFeesChecked: boolean;
 }
 
 export const BusinessFormationContext = createContext<BusinessFormationContextType>({
@@ -56,6 +65,11 @@ export const BusinessFormationContext = createContext<BusinessFormationContextTy
     hasSetStateFirstTime: false,
     businessNameAvailability: undefined,
     dbaBusinessNameAvailability: undefined,
+    reviewCheckboxes: {
+      namesAddressesDatesChecked: false,
+      permanentRecordChecked: false,
+      correctionFeesChecked: false,
+    },
   },
   setFormationFormData: () => {},
   setStepIndex: () => {},
@@ -65,4 +79,6 @@ export const BusinessFormationContext = createContext<BusinessFormationContextTy
   setBusinessNameAvailability: () => {},
   setDbaBusinessNameAvailability: () => {},
   setForeignGoodStandingFile: () => {},
+  setReviewCheckboxes: () => {},
+  allConfirmationsChecked: () => false,
 });

--- a/web/stories/Molecules/textfields/TextFieldLabels.stories.tsx
+++ b/web/stories/Molecules/textfields/TextFieldLabels.stories.tsx
@@ -52,6 +52,11 @@ const Template = () => {
           hasSetStateFirstTime: false,
           businessNameAvailability: undefined,
           dbaBusinessNameAvailability: undefined,
+          reviewCheckboxes: {
+            namesAddressesDatesChecked: false,
+            permanentRecordChecked: false,
+            correctionFeesChecked: false,
+          },
         },
         setFormationFormData: () => {},
         setBusinessNameAvailability: () => {},
@@ -61,6 +66,8 @@ const Template = () => {
         setFieldsInteracted: () => {},
         setHasBeenSubmitted: () => {},
         setForeignGoodStandingFile: () => {},
+        setReviewCheckboxes: () => {},
+        allConfirmationsChecked: () => false,
       }}
     >
       <DataFormErrorMapContext.Provider value={formContextState}>

--- a/web/test/helpers/helpers-formation.tsx
+++ b/web/test/helpers/helpers-formation.tsx
@@ -230,6 +230,7 @@ export type FormationPageHelpers = {
     fieldName: string,
   ) => Promise<void>;
   clickSubmit: () => Promise<void>;
+  checkAllReviewCheckboxes: () => Promise<void>;
   selectDate: (
     value: DateObject,
     fieldType: "Business start date" | "Foreign date of formation",
@@ -517,6 +518,22 @@ export const createFormationPageHelpers = (): FormationPageHelpers => {
     });
   };
 
+  const checkAllReviewCheckboxes = async (): Promise<void> => {
+    const namesDatesBox = within(
+      screen.getByTestId("names-addresses-dates-checkbox-container"),
+    ).getByRole("checkbox");
+    const permanentRecordBox = within(
+      screen.getByTestId("permanent-record-checkbox-container"),
+    ).getByRole("checkbox");
+    const correctionFeesBox = within(
+      screen.getByTestId("correction-fees-checkbox-container"),
+    ).getByRole("checkbox");
+
+    await userEvent.click(namesDatesBox);
+    await userEvent.click(permanentRecordBox);
+    await userEvent.click(correctionFeesBox);
+  };
+
   const selectDate = (
     value: DateObject,
     fieldType: "Business start date" | "Foreign date of formation",
@@ -587,6 +604,7 @@ export const createFormationPageHelpers = (): FormationPageHelpers => {
     fillAddressModal,
     fillAndSubmitAddressModal,
     clickSubmit,
+    checkAllReviewCheckboxes,
     clickSubmitAndGetError,
     selectDate,
     stepperClickToBusinessNameStep,


### PR DESCRIPTION


<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#15515](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15515).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

Visit the business formation task (http://localhost:3000/tasks/form-business-entity) and navigate to the Review step. You should be able to observe that the page visually matches the [new design](https://www.figma.com/design/oA6upbAtUmk4L893vWO0jx/86-90-Business-Experience-Sprint-Designs?node-id=59694-71666&t=HLLU3GBaQJ6PJ9gx-0) which includes a new callout alert at the top of the page and a confirmation checkbox section at the bottom. Submission should be prevented if all checkboxes are not checked, and the resulting error should disappear once all checkboxes are checked.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
