### PR TITLE
fix: [AB#14055] error handling bar css fix

### DIFF
--- a/web/src/components/data-fields/tax-id/SingleTaxId.tsx
+++ b/web/src/components/data-fields/tax-id/SingleTaxId.tsx
@@ -2,12 +2,10 @@
 
 import { GenericTextField } from "@/components/GenericTextField";
 import { ShowHideStatus } from "@/components/ShowHideToggleButton";
-import { WithErrorBar } from "@/components/WithErrorBar";
 import { ProfileDataFieldProps } from "@/components/data-fields/ProfileDataField";
 import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { MediaQueries } from "@/lib/PageSizes";
-import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
 import { formatTaxId } from "@/lib/domain-logic/formatTaxId";
 import { InputAdornment, useMediaQuery } from "@mui/material";
 import { ReactElement, useContext } from "react";
@@ -30,7 +28,6 @@ export const SingleTaxId = ({
   const isTabletAndUp = useMediaQuery(MediaQueries.tabletAndUp);
 
   const { state, setProfileData } = useContext(ProfileDataContext);
-  const { isFormFieldInvalid } = useFormContextFieldHelpers(fieldName, DataFormErrorMapContext);
 
   const handleChange = (value: string): void => {
     if (handleChangeOverride) {
@@ -45,29 +42,27 @@ export const SingleTaxId = ({
 
   return (
     <div className={isTabletAndUp ? "" : "flex flex-column"}>
-      <WithErrorBar hasError={isFormFieldInvalid} type="ALWAYS">
-        <GenericTextField
-          allowMasking={true}
-          disabled={props.taxIdDisplayStatus === "password-view"}
-          fieldName={fieldName}
-          formContext={DataFormErrorMapContext}
-          handleChange={handleChange}
-          inputProps={{
-            endAdornment: (
-              <InputAdornment position="end">
-                {isTabletAndUp && props.getShowHideToggleButton()}
-              </InputAdornment>
-            ),
-          }}
-          inputWidth={"reduced"}
-          numericProps={{ minLength: 12, maxLength: 12 }}
-          type={props.taxIdDisplayStatus === "text-view" ? "text" : "password"}
-          validationText={validationText}
-          value={state.profileData[fieldName] as string | undefined}
-          visualFilter={formatTaxId}
-          {...props}
-        />
-      </WithErrorBar>
+      <GenericTextField
+        allowMasking={true}
+        disabled={props.taxIdDisplayStatus === "password-view"}
+        fieldName={fieldName}
+        formContext={DataFormErrorMapContext}
+        handleChange={handleChange}
+        inputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              {isTabletAndUp && props.getShowHideToggleButton()}
+            </InputAdornment>
+          ),
+        }}
+        inputWidth={"reduced"}
+        numericProps={{ minLength: 12, maxLength: 12 }}
+        type={props.taxIdDisplayStatus === "text-view" ? "text" : "password"}
+        validationText={validationText}
+        value={state.profileData[fieldName] as string | undefined}
+        visualFilter={formatTaxId}
+        {...props}
+      />
 
       {!isTabletAndUp && (
         <div className="flex flex-justify-center margin-bottom-3">

--- a/web/src/styles/components/errors.scss
+++ b/web/src/styles/components/errors.scss
@@ -1,8 +1,5 @@
 .input-error-bar {
-  left: -13px !important;
   margin-left: 0 !important;
-  padding-left: 13px !important;
-  margin-right: -17px !important;
   position: relative;
 }
 
@@ -10,6 +7,8 @@
   border-left-width: 4px;
   border-left-color: #d54309;
   border-left-style: solid;
+  padding-left: 13px !important;
   left: -17px !important;
+  width: calc(100% + 17px);
   margin-bottom: 1em;
 }


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

In tax access, we had an issue where inputs were not aligning with the end of their containers. This fixes that. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14055](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14055).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Go to tax access, notice how the inputs endings align with the rest of the content

trigger errors by not filling in inputs. Notice that that inputs still align with the end of the content

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
