### PR TITLE
chore: [AB#16198] improve content link rendering to better handle empty or malformed link markdown

### DIFF
--- a/web/src/components/Content.tsx
+++ b/web/src/components/Content.tsx
@@ -107,10 +107,19 @@ export const Content = (props: ContentProps): ReactNode => {
 const Link = (onClick?: (url?: string) => void): any => {
   return Object.assign(
     (props: any): ReactElement => {
+      const childrenContent =
+        props.children && Array.isArray(props.children) ? props.children[0] : props.children;
+
+      if (!props.href) {
+        return <>{childrenContent || ""}</>;
+      }
+
+      const linkText = childrenContent || props.href;
+
       if (/^https?:\/\/(.*)/.test(props.href)) {
         return (
           <ExternalLink href={props.href} onClick={(): void => onClick && onClick(props.href)}>
-            {props.children[0]}
+            {linkText}
           </ExternalLink>
         );
       }
@@ -120,7 +129,7 @@ const Link = (onClick?: (url?: string) => void): any => {
           className="usa-link"
           onClick={(): void => (onClick ? onClick(props.href) : undefined)}
         >
-          {props.children[0]}
+          {linkText}
         </a>
       );
     },
@@ -170,6 +179,8 @@ const OutlineBox = (props: any): ReactElement => {
 const ListOrCheckbox = (props: any): ReactElement => {
   if (
     props.children &&
+    Array.isArray(props.children) &&
+    props.children.length > 0 &&
     typeof props.children[0] === "string" &&
     props.children[0].startsWith("[]")
   ) {


### PR DESCRIPTION


<!-- Please complete the following sections as necessary. -->

## Description

[Slack thread for context](https://njcio.slack.com/archives/C02AJKBCH38/p1758724413392569)

A malformed link entered into the CMS markdown revealed that our Content component was not handling undefined children gracefully. Empty markdown links like `[](url)` caused runtime crashes with "Cannot read properties of undefined (reading '0')". This adds checks to handle undefined children/link text and displays the URL when link text is missing, ensuring malformed links are visible to content editors rather than silently ignored.


### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#16198](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16198).

### Steps to Test

(http://localhost:3000/mgmt/cms#/collections/contextual-information/entries/certificate-of-amendment) and (http://localhost:3000/mgmt/cms#/collections/contextual-information/entries/certificate-of-correction) should load without error now.


## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
