### PR TITLE
feat: [AB#15961] remove before you start modal from dba formation step 3

### DIFF
--- a/content/src/display-content/business-formation/nexus/authorize-business-entity.md
+++ b/content/src/display-content/business-formation/nexus/authorize-business-entity.md
@@ -6,7 +6,7 @@ urlSlug: authorize-business-entity
 displayname: authorize-business-entity
 name: Authorize Your Business Entity
 id: authorize-business-entity
-callToActionLink: https://www.nj.gov/treasury/revenue/pdf/2000.pdf
+callToActionLink: https://www.nj.gov/treasury/revenue/pdf/NJ_Public_Records_Filing.pdf
 callToActionText: Authorize My Business
 agencyId: nj-revenue-enterprise-services
 required: true

--- a/web/src/components/tasks/business-formation/DbaFormationPaginator.tsx
+++ b/web/src/components/tasks/business-formation/DbaFormationPaginator.tsx
@@ -1,5 +1,3 @@
-import { Content } from "@/components/Content";
-import { ModalTwoButton } from "@/components/ModalTwoButton";
 import { CtaContainer } from "@/components/njwds-extended/cta/CtaContainer";
 import { HorizontalStepper } from "@/components/njwds-extended/HorizontalStepper";
 import { LiveChatHelpButton } from "@/components/njwds-extended/LiveChatHelpButton";
@@ -27,7 +25,6 @@ export const DbaFormationPaginator = (): ReactElement => {
 
   const stepperRef = useRef<HTMLDivElement>(null);
   const isMounted = useRef(false);
-  const [showCtaModal, setShowCtaModal] = useState<boolean>(false);
 
   const [stepperState, setStepperState] = useState(
     DbaFormationStepsConfiguration.map((value, index) => {
@@ -186,11 +183,7 @@ export const DbaFormationPaginator = (): ReactElement => {
             <div className="margin-top-2 mobile-lg:margin-top-0">
               <BackButton />
             </div>
-            <a
-              href={state.dbaContent.Authorize.callToActionLink}
-              target="_blank"
-              rel="noreferrer noopener"
-            >
+            <div className={"margin-top-1"}>
               <PrimaryButton
                 isColor="primary"
                 isRightMarginRemoved={true}
@@ -200,13 +193,13 @@ export const DbaFormationPaginator = (): ReactElement => {
                       Config.taskDefaults.defaultCallToActionText,
                     state.dbaContent.Authorize.callToActionLink as string,
                   );
-                  setShowCtaModal(true);
+                  openInNewTab(state.dbaContent.Authorize.callToActionLink);
                 }}
               >
                 {state.dbaContent.Authorize.callToActionText ||
                   Config.taskDefaults.defaultCallToActionText}
               </PrimaryButton>
-            </a>
+            </div>
           </ActionBarLayout>
         </CtaContainer>
       );
@@ -216,18 +209,6 @@ export const DbaFormationPaginator = (): ReactElement => {
   return (
     <>
       <div ref={stepperRef}>
-        <ModalTwoButton
-          isOpen={showCtaModal}
-          close={(): void => setShowCtaModal(false)}
-          title={Config.DbaFormationTask.dbaCtaModalHeader}
-          primaryButtonText={Config.DbaFormationTask.dbaCtaModalContinueButtonText}
-          primaryButtonOnClick={(): void => {
-            openInNewTab(state.dbaContent.Authorize.callToActionLink);
-          }}
-          secondaryButtonText={Config.DbaFormationTask.dbaCtaModalCancelButtonText}
-        >
-          <Content>{Config.DbaFormationTask.dbaCtaModalBody}</Content>
-        </ModalTwoButton>
         {DbaFormationStepsConfiguration[state.stepIndex].disableStepper ? (
           <></>
         ) : (

--- a/web/src/components/tasks/business-formation/NexusFormation.test.tsx
+++ b/web/src/components/tasks/business-formation/NexusFormation.test.tsx
@@ -314,20 +314,6 @@ describe("<NexusFormationFlow />", () => {
           "INCOMPLETE-ACTIVE",
         );
       });
-
-      it("shows modal when clicking CTA", () => {
-        clickNext();
-        fireEvent.click(
-          screen.getByText(displayContent.formationDbaContent.Authorize.callToActionText),
-        );
-        expect(screen.getByText(Config.DbaFormationTask.dbaCtaModalHeader)).toBeInTheDocument();
-        expect(
-          screen.getByText(Config.DbaFormationTask.dbaCtaModalContinueButtonText),
-        ).toBeInTheDocument();
-        expect(
-          screen.getByText(Config.DbaFormationTask.dbaCtaModalCancelButtonText),
-        ).toBeInTheDocument();
-      });
     });
   });
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Updates the "Authorize my Business" external link on the third step of formation for an out of state business registering a DBA name, and removes the modal that appears upon clicking the "Authorize my Business" CTA button.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#15961](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15961).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

See the ADO ticket for steps to get to this formation step:

https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15961

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
