### PR TITLE
Dev design

### DIFF
--- a/web/src/components/data-fields/non-essential-questions/NonEssentialQuestion.tsx
+++ b/web/src/components/data-fields/non-essential-questions/NonEssentialQuestion.tsx
@@ -52,8 +52,8 @@ export const NonEssentialQuestion = (props: Props): ReactElement => {
     <>
       {nonEssentialQuestionText && (
         <>
-          <section ref={nonEssentialQuestion}>
-            <Content className={"margin-top-2"}>
+          <section ref={nonEssentialQuestion} className="margin-top-3">
+            <Content>
               {`${convertTextToMarkdownBold(nonEssentialQuestionText)} ${
                 Config.profileDefaults.fields.nonEssentialQuestions.default.optionalText
               }`}

--- a/web/src/components/data-fields/non-essential-questions/nonEssentialQuestionsHelpers.tsx
+++ b/web/src/components/data-fields/non-essential-questions/nonEssentialQuestionsHelpers.tsx
@@ -35,7 +35,7 @@ export const NonEssentialQuestionForPersonas = (props: {
   }, [nonEssentialQuestionInViewPort, hasBeenSeen, nonEssentialQuestionText, props.questionId]);
 
   return (
-    <section ref={nonEssentialQuestion}>
+    <section ref={nonEssentialQuestion} className="margin-top-3">
       <div data-testid="non-essential-questions-wrapper">
         <ProfileField
           fieldName={props.questionId}

--- a/web/src/lib/muiTheme.ts
+++ b/web/src/lib/muiTheme.ts
@@ -78,6 +78,9 @@ export default createTheme({
         content: {
           margin: "0px !important",
         },
+        expandIconWrapper: {
+          alignSelf: "flex-start",
+        },
       },
     },
     MuiButtonBase: {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14839](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14839).

### Approach
I removed the manually padding from the accordion summary at the request of amanda. We changed the positioning of the carat, which caused other wonky UI issues. The removal of the padding fixes this issue.

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
