### PR TITLE
chore: [AB#14839] remove manually added padding from accordion summar…

### DIFF
--- a/web/src/components/ResultsSectionAccordion.tsx
+++ b/web/src/components/ResultsSectionAccordion.tsx
@@ -8,7 +8,6 @@ interface Props {
   title: string;
   titleIcon?: ReactNode;
   headingStyleOverride?: string;
-  summaryClass?: string;
   children: ReactNode;
   onOpenFunc?: () => void;
 }
@@ -30,7 +29,6 @@ export const ResultsSectionAccordion = (props: Props): ReactElement => {
           }}
         >
           <AccordionSummary
-            className={props.summaryClass}
             expandIcon={
               <Icon className={"usa-icon--size-5 margin-left-1"} iconName={"expand_more"} />
             }

--- a/web/src/components/dashboard/SectionAccordion.tsx
+++ b/web/src/components/dashboard/SectionAccordion.tsx
@@ -59,14 +59,12 @@ export const SectionAccordion = (props: Props): ReactElement => {
             id={`${sectionName}-header`}
             data-testid={`${sectionName}-header`}
           >
-            <div className="margin-y-05">
-              <Heading
-                level={3}
-                className={`flex flex-align-center margin-0-override ${headerClasses}`}
-              >
-                <div className="inline">{Config.sectionHeaders[props.sectionType]}</div>
-              </Heading>
-            </div>
+            <Heading
+              level={3}
+              className={`flex flex-align-center margin-0-override ${headerClasses}`}
+            >
+              <div className="inline">{Config.sectionHeaders[props.sectionType]}</div>
+            </Heading>
           </AccordionSummary>
           <AccordionDetails>{props.children}</AccordionDetails>
         </Accordion>

--- a/web/src/components/dashboard/SidebarCardsList.tsx
+++ b/web/src/components/dashboard/SidebarCardsList.tsx
@@ -186,13 +186,11 @@ export const SidebarCardsList = (props: SidebarCardsListProps): ReactElement => 
                 id="hidden-opportunity-header"
                 data-testid="hidden-opportunity-header"
               >
-                <div className="margin-y-2">
-                  <div className="flex flex-align-center margin-0-override text-normal">
-                    <div className="inline">
-                      {templateEval(Config.dashboardDefaults.hiddenOpportunitiesHeader, {
-                        count: String(hiddenOpportunitiesCount()),
-                      })}
-                    </div>
+                <div className="flex flex-align-center margin-0-override text-normal">
+                  <div className="inline">
+                    {templateEval(Config.dashboardDefaults.hiddenOpportunitiesHeader, {
+                      count: String(hiddenOpportunitiesCount()),
+                    })}
                   </div>
                 </div>
               </AccordionSummary>

--- a/web/src/components/tasks/cannabis/CannabisApplicationRequirementsTab.tsx
+++ b/web/src/components/tasks/cannabis/CannabisApplicationRequirementsTab.tsx
@@ -46,7 +46,7 @@ export const CannabisApplicationRequirementsTab = (props: Props): ReactElement =
                 aria-controls={`${Config.cannabisApplyForLicense.generalApplicationNeeds}-content`}
                 expandIcon={expandIcon()}
               >
-                <Heading level={2} className="margin-y-3-override">
+                <Heading level={2} className="margin-0-override">
                   {Config.cannabisApplyForLicense.generalApplicationNeeds}
                 </Heading>
               </AccordionSummary>
@@ -65,7 +65,7 @@ export const CannabisApplicationRequirementsTab = (props: Props): ReactElement =
                 aria-controls={`${Config.cannabisApplyForLicense.generalApplicationNeeds}-content`}
                 expandIcon={expandIcon()}
               >
-                <Heading level={2} className="margin-y-3-override">
+                <Heading level={2} className="margin-0-override">
                   {Config.cannabisApplyForLicense.generalApplicationNeeds}
                 </Heading>
               </AccordionSummary>
@@ -85,7 +85,7 @@ export const CannabisApplicationRequirementsTab = (props: Props): ReactElement =
                 aria-controls={`${Config.cannabisApplyForLicense.microbusinessApplicationNeeds}-content`}
                 expandIcon={expandIcon()}
               >
-                <Heading level={2} className="margin-y-3-override">
+                <Heading level={2} className="margin-0-override">
                   {Config.cannabisApplyForLicense.microbusinessApplicationNeeds}
                 </Heading>
               </AccordionSummary>
@@ -105,7 +105,7 @@ export const CannabisApplicationRequirementsTab = (props: Props): ReactElement =
                 aria-controls={`${Config.cannabisApplyForLicense.priorityStatusApplicationNeeds}-content`}
                 expandIcon={expandIcon()}
               >
-                <Heading level={2} className="margin-y-3-override">
+                <Heading level={2} className="margin-0-override">
                   {Config.cannabisApplyForLicense.priorityStatusApplicationNeeds}
                 </Heading>
               </AccordionSummary>

--- a/web/src/components/tasks/cannabis/CannabisPriorityRequirements.tsx
+++ b/web/src/components/tasks/cannabis/CannabisPriorityRequirements.tsx
@@ -149,7 +149,7 @@ export const CannabisPriorityRequirements = (props: Props): ReactElement => {
                 expandIcon={expandMoreIcon()}
                 aria-controls={`${Config.cannabisPriorityStatus.minorityOrWomenHeaderText}-content`}
               >
-                <Heading level={3} className="margin-y-3-override">
+                <Heading level={3} className="margin-0-override">
                   {Config.cannabisPriorityStatus.minorityOrWomenHeaderText}
                 </Heading>
               </AccordionSummary>
@@ -167,7 +167,7 @@ export const CannabisPriorityRequirements = (props: Props): ReactElement => {
                 expandIcon={expandMoreIcon()}
                 aria-controls={`${Config.cannabisPriorityStatus.veteranHeaderText}-content`}
               >
-                <Heading level={3} className="margin-y-3-override">
+                <Heading level={3} className="margin-0-override">
                   {Config.cannabisPriorityStatus.veteranHeaderText}
                 </Heading>
               </AccordionSummary>
@@ -185,7 +185,7 @@ export const CannabisPriorityRequirements = (props: Props): ReactElement => {
                 expandIcon={expandMoreIcon()}
                 aria-controls={`${Config.cannabisPriorityStatus.socialEquityHeaderText}-content`}
               >
-                <Heading level={3} className="margin-y-3-override">
+                <Heading level={3} className="margin-0-override">
                   {Config.cannabisPriorityStatus.socialEquityHeaderText}
                 </Heading>
               </AccordionSummary>
@@ -202,7 +202,7 @@ export const CannabisPriorityRequirements = (props: Props): ReactElement => {
               <AccordionSummary
                 aria-controls={`${Config.cannabisPriorityStatus.impactZoneHeaderText}-content`}
               >
-                <Heading level={3} className="margin-y-3-override">
+                <Heading level={3} className="margin-0-override">
                   {Config.cannabisPriorityStatus.impactZoneHeaderText}
                 </Heading>
               </AccordionSummary>

--- a/web/src/components/xray/XraySummary.tsx
+++ b/web/src/components/xray/XraySummary.tsx
@@ -97,7 +97,6 @@ export const XraySummary = (props: Props): ReactElement => {
         <ResultsSectionAccordion
           title={Config.xrayRegistrationTask.equipmentText}
           headingStyleOverride={"font-open-sans-7"}
-          summaryClass={"height-5"}
           titleIcon={
             <Icon
               iconName={"build"}

--- a/web/src/pages/filings/[filingUrlSlug].tsx
+++ b/web/src/pages/filings/[filingUrlSlug].tsx
@@ -181,7 +181,7 @@ export const FilingElement = (props: {
                   .toLowerCase()
                   .replaceAll(" ", "-")}-content`}
               >
-                <Heading level={3} className="margin-y-3-override">
+                <Heading level={3} className="margin-0-override">
                   {Config.filingDefaults.additionalInfo}
                 </Heading>
               </AccordionSummary>


### PR DESCRIPTION
…y components

<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [14839](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14839).

### Approach
I removed the manually padding from the accordion summary at the request of amanda. We changed the positioning of the carat, which caused other wonky UI issues. The removal of the padding fixes this issue.
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
