### PR TITLE
feat: [AB#12866] Remove markdown formatting when searching in search …

### DIFF
--- a/web/src/lib/search/helpers.ts
+++ b/web/src/lib/search/helpers.ts
@@ -1,13 +1,24 @@
 import { LabelledContent, LabelledContentList, Match } from "@/lib/search/typesForSearch";
 
+const removeMarkdownStyling = (markdownInput: string | undefined): string | undefined => {
+  if (markdownInput === undefined) {
+    return undefined;
+  }
+  const nonMarkdownString = markdownInput
+    .replaceAll(/(\*\*|__)(.*?)\1/g, "$2")
+    .replaceAll(/(\*|_)(.*?)\1/g, "$2");
+  return nonMarkdownString;
+};
+
 export const findMatchInBlock = (
   blockTexts: (string | undefined)[],
   term: string,
   match: Match,
 ): Match => {
   for (const blockText of blockTexts) {
-    if (blockText?.includes(term)) {
-      match.snippets.push(makeSnippet(blockText, term));
+    const blockTextProcessed = removeMarkdownStyling(blockText);
+    if (blockTextProcessed?.includes(term)) {
+      match.snippets.push(makeSnippet(blockTextProcessed, term));
     }
   }
   return match;
@@ -26,8 +37,9 @@ export const findMatchInLabelledText = (
   match: Match,
 ): Match => {
   for (const labelledText of labelledTexts) {
-    if (labelledText.content?.includes(term)) {
-      match.snippets.push(`${labelledText.label}: ${labelledText.content}`);
+    const labelTextProcessed = removeMarkdownStyling(labelledText.content);
+    if (labelTextProcessed?.includes(term)) {
+      match.snippets.push(`${labelledText.label}: ${labelTextProcessed}`);
     }
   }
   return match;
@@ -40,8 +52,9 @@ export const findMatchInListText = (
 ): Match => {
   for (const listText of listTexts) {
     for (const item of listText.content) {
-      if (item?.includes(term)) {
-        match.snippets.push(`${listText.label}: ${item}`);
+      const itemProcessed = removeMarkdownStyling(item);
+      if (itemProcessed?.includes(term)) {
+        match.snippets.push(`${listText.label}: ${itemProcessed}`);
       }
     }
   }


### PR DESCRIPTION
…tool

<!-- Please complete the following sections as necessary. -->

## Description

had the search tool remove bold and italics styling from our markdown content when searching

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#12866](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12866).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

In your code editor search for **, find some content that contains it

Then go to the search page and search for that sentence without the ** in it and see that your search matches it

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
