### PR TITLE
chore: [AB#15915] remove unused secondary index encryptedTaxId

### DIFF
--- a/api/businesses-dynamodb-schema.json
+++ b/api/businesses-dynamodb-schema.json
@@ -18,10 +18,6 @@
       "AttributeType": "S"
     },
     {
-      "AttributeName": "encryptedTaxId",
-      "AttributeType": "S"
-    },
-    {
       "AttributeName": "hashedTaxId",
       "AttributeType": "S"
     }
@@ -62,18 +58,6 @@
       "KeySchema": [
         {
           "AttributeName": "industry",
-          "KeyType": "HASH"
-        }
-      ],
-      "Projection": {
-        "ProjectionType": "ALL"
-      }
-    },
-    {
-      "IndexName": "EncryptedTaxId",
-      "KeySchema": [
-        {
-          "AttributeName": "encryptedTaxId",
           "KeyType": "HASH"
         }
       ],

--- a/api/jest-dynalite-config.js
+++ b/api/jest-dynalite-config.js
@@ -67,10 +67,6 @@ module.exports = {
           AttributeType: "S",
         },
         {
-          AttributeName: "encryptedTaxId",
-          AttributeType: "S",
-        },
-        {
           AttributeName: "hashedTaxId",
           AttributeType: "S",
         },
@@ -119,22 +115,6 @@ module.exports = {
           KeySchema: [
             {
               AttributeName: "industry",
-              KeyType: "HASH",
-            },
-          ],
-          Projection: {
-            ProjectionType: "ALL",
-          },
-          ProvisionedThroughput: {
-            ReadCapacityUnits: 1,
-            WriteCapacityUnits: 1,
-          },
-        },
-        {
-          IndexName: "EncryptedTaxId",
-          KeySchema: [
-            {
-              AttributeName: "encryptedTaxId",
               KeyType: "HASH",
             },
           ],

--- a/api/src/db/DynamoBusinessDataClient.test.ts
+++ b/api/src/db/DynamoBusinessDataClient.test.ts
@@ -27,7 +27,6 @@ describe("DynamoBusinessesDataClient", () => {
   const dateOfFormation = dayjs().subtract(3, "year").add(1, "month").day(1).format("YYYY-MM-DD");
   const naicsCode = "12345";
   const industryId = "test-industry";
-  const encryptedTaxId = "test-id-12345";
   const hashedTaxId = `some-hashed-tax-id-${randomInt()}`;
 
   const businessData = generateBusiness({
@@ -37,7 +36,6 @@ describe("DynamoBusinessesDataClient", () => {
       legalStructureId: "limited-liability-company",
       naicsCode,
       industryId,
-      encryptedTaxId,
       hashedTaxId,
     }),
     taxFilingData: generateTaxFilingData({
@@ -128,20 +126,6 @@ describe("DynamoBusinessesDataClient", () => {
     expect(expectedValue).toHaveLength(1);
     expect(expectedValue[0]).toBeDefined();
     expect(expectedValue[0]).toEqual(businessData);
-  });
-
-  it("should return undefined for a non-existent encrypted tax ID", async () => {
-    const randomEncryptedTaxId = `some-encryptedId-${randomInt()}`;
-    expect(
-      await dynamoBusinessesDataClient.findByEncryptedTaxId(randomEncryptedTaxId),
-    ).toBeUndefined();
-  });
-
-  it("finds a business by the encryptedId", async () => {
-    await dynamoBusinessesDataClient.put(businessData);
-    const expectedValue = await dynamoBusinessesDataClient.findByEncryptedTaxId(encryptedTaxId);
-    expect(expectedValue).toBeDefined();
-    expect(expectedValue).toEqual(businessData);
   });
 
   it("deletes a business by the ID", async () => {

--- a/api/src/db/DynamoBusinessDataClient.ts
+++ b/api/src/db/DynamoBusinessDataClient.ts
@@ -103,12 +103,6 @@ export const DynamoBusinessDataClient = (
     });
   };
 
-  const findByEncryptedTaxId = (encryptedTaxId: string): Promise<Business | undefined> => {
-    return findSingleBusinessByIndex("EncryptedTaxId", "encryptedTaxId = :encryptedTaxId", {
-      ":encryptedTaxId": { S: encryptedTaxId },
-    });
-  };
-
   const findAllByHashedTaxId = (hashedTaxId: string): Promise<Business[]> => {
     return findAllBusinessesByIndex("HashedTaxId", "hashedTaxId = :hashedTaxId", {
       ":hashedTaxId": { S: hashedTaxId },
@@ -139,7 +133,6 @@ export const DynamoBusinessDataClient = (
       Item: {
         businessId: businessData.id,
         industry: businessData.profileData.industryId,
-        encryptedTaxId: businessData.profileData.encryptedTaxId,
         hashedTaxId: businessData.profileData.hashedTaxId,
         data: businessData,
         businessName: businessName === "" ? undefined : businessData.profileData.businessName,
@@ -175,7 +168,6 @@ export const DynamoBusinessDataClient = (
     put,
     deleteBusinessById,
     findByBusinessName,
-    findByEncryptedTaxId,
     findAllByIndustry,
     findAllByNAICSCode,
     findBusinessesByNamePrefix,

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -79,7 +79,6 @@ export interface BusinessesDataClient {
   findAllByNAICSCode: (naicsCode: string) => Promise<Business[]>;
   findAllByIndustry: (industry: string) => Promise<Business[]>;
   findBusinessesByNamePrefix: (prefix: string) => Promise<Business[]>;
-  findByEncryptedTaxId: (encryptedTaxId: string) => Promise<Business | undefined>;
   findAllByHashedTaxId: (hashedTaxId: string) => Promise<Business[]>;
 }
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Removes unused EncryptedTaxId GSI (Global Secondary Index) from businesses DynamoDB table. Also removes the associated findByEncryptedTaxId() function and tests. The encryptedTaxId field remains stored in business data. This will help us save on DynamoDB GSI storage and throughput costs.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#15915](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15915).

### Approach

After this application code is deployed, we'll want to update the infrastructure Terraform repo to remove the GSI from there, as well.

### Steps to Test

No behavior changes for the application - automated tests should all still pass

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
