### PR TITLE
chore: [AB#16180] upgrade serverless to nodejs22.x base

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -41,7 +41,7 @@
     "@aws-sdk/util-base64-node": "3.209.0",
     "@aws-sdk/util-dynamodb": "3.896.0",
     "@businessnjgovnavigator/shared": "*",
-    "@serverless/typescript": "3.38.0",
+    "@serverless/typescript": "4.18.2",
     "@smithy/node-http-handler": "2.5.0",
     "airtable": "0.12.2",
     "axios": "1.12.2",

--- a/api/serverless.ts
+++ b/api/serverless.ts
@@ -142,7 +142,7 @@ const serverlessConfiguration: AWS = {
   provider: {
     name: "aws",
     deploymentBucket: serverlessDeploymentS3Bucket,
-    runtime: "nodejs20.x",
+    runtime: "nodejs22.x",
     stage: stage,
     region: region,
     iam: {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@next/eslint-plugin-next": "15.3.5",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
-    "@serverless/typescript": "3.38.0",
+    "@serverless/typescript": "4.18.2",
     "@storybook/addon-a11y": "7.6.20",
     "@storybook/addon-actions": "7.6.20",
     "@storybook/addon-designs": "7.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4000,7 +4000,7 @@ __metadata:
     "@aws-sdk/util-dynamodb": 3.896.0
     "@businessnjgovnavigator/shared": "*"
     "@jest/types": 29.6.3
-    "@serverless/typescript": 3.38.0
+    "@serverless/typescript": 4.18.2
     "@smithy/node-http-handler": 2.5.0
     "@types/cors": 2.8.19
     "@types/dedent": 0.7.2
@@ -4112,7 +4112,7 @@ __metadata:
     "@next/eslint-plugin-next": 15.3.5
     "@semantic-release/changelog": 6.0.3
     "@semantic-release/git": 10.0.1
-    "@serverless/typescript": 3.38.0
+    "@serverless/typescript": 4.18.2
     "@smithy/node-http-handler": 2.5.0
     "@storybook/addon-a11y": 7.6.20
     "@storybook/addon-actions": 7.6.20
@@ -9014,10 +9014,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@serverless/typescript@npm:3.38.0":
-  version: 3.38.0
-  resolution: "@serverless/typescript@npm:3.38.0"
-  checksum: c2aff1b91c1e5b4ed6639a652607cec49cf941227b764e6e86e29fa3461a89dbc80c3845beaeeff2c4ab366a3b7de70363a8595ce9b6add5243036881d57d4f4
+"@serverless/typescript@npm:4.18.2":
+  version: 4.18.2
+  resolution: "@serverless/typescript@npm:4.18.2"
+  checksum: 4967c787ee5e0683145b0d5bdc08af5ca05d70b2ec2b2cd33f6b13c7d61f3d64d3c9fa27d072291f49b0bfae9e01ec42d96d5159abc0e3a974f0942572cbbd4a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
This PR upgrades the Serverless Framework to version @serverless/typescript@4.18.2 and updates the AWS Lambda runtime for our functions to nodejs22.x.

- Updated the project to use the latest Serverless TypeScript plugin (4.18.2).
- Updated the Lambda runtime in serverless.ts to nodejs22.x, bringing in the newest Node.js runtime supported by AWS.
- Ensures that AwsLambdaRuntime types now include nodejs22.x for TypeScript type safety.
- No functional changes to business logic; this upgrade primarily focuses on runtime and framework improvements.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#16180](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16180).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
