### PR TITLE
feat: [AB#16230] add live chat help link in error messsage

### DIFF
--- a/content/src/fieldConfig/tax-clearance-certificate-shared.json
+++ b/content/src/fieldConfig/tax-clearance-certificate-shared.json
@@ -8,6 +8,8 @@
     "singularErrorText": "**Missing or invalid information** \n\nReview the following field in the \"Check Eligibility\" step:",
     "stepperOneLabel": "Requirements",
     "stepperThreeLabel": "Review",
-    "stepperTwoLabel": "Check Eligibility"
+    "stepperTwoLabel": "Check Eligibility",
+    "liveChatLabelText": "Need help?",
+    "liveChatButtonText": "Chat With Us"
   }
 }

--- a/web/decap-config/collections/10-anytime-action.yml
+++ b/web/decap-config/collections/10-anytime-action.yml
@@ -343,13 +343,6 @@ collections:
             widget: object
             fields:
               - {
-                  label: "Pre Header Error Text",
-                  name: "preHeaderErrorText",
-                  widget: "string",
-                  required: true,
-                  hint: Applies to steps 2 and 3,
-                }
-              - {
                   label: "Singular Error Text",
                   name: "singularErrorText",
                   widget: "string",
@@ -408,6 +401,18 @@ collections:
                   widget: "string",
                   required: true,
                   hint: Applies to step 2,
+                }
+              - {
+                  label: "Live Chat Label Text",
+                  name: "liveChatLabelText",
+                  widget: "string",
+                  required: true,
+                }
+              - {
+                  label: "Live Chat Button Text",
+                  name: "liveChatButtonText",
+                  widget: "string",
+                  required: true,
                 }
       - label: "Tax Clearance Download Page"
         name: "taxClearanceCertificate-download"

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.test.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.test.tsx
@@ -1,9 +1,29 @@
 import { AnytimeActionTaxClearanceCertificateAlert } from "@/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert";
+import analytics from "@/lib/utils/analytics";
 import { TaxClearanceCertificateResponseErrorType } from "@businessnjgovnavigator/shared";
 import { getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 const Config = getMergedConfig();
+
+function setupMockAnalytics(): typeof analytics {
+  return {
+    ...jest.requireActual("@/lib/utils/analytics").default,
+    event: {
+      ...jest.requireActual("@/lib/utils/analytics").default.event,
+      tax_clearance_anytime_action_help_button: {
+        click: {
+          open_live_chat: jest.fn(),
+          open_live_chat_from_error_alert: jest.fn(),
+        },
+      },
+    },
+  };
+}
+
+const mockAnalytics = analytics as jest.Mocked<typeof analytics>;
+
+jest.mock("@/lib/utils/analytics", () => setupMockAnalytics());
 
 describe("<AnytimeActionTaxClearanceCertificateAlert>", () => {
   it("displays single field text in header if there is only one error", () => {
@@ -80,5 +100,22 @@ describe("<AnytimeActionTaxClearanceCertificateAlert>", () => {
       expect(screen.getByRole("alert")).toBeInTheDocument();
       expect(screen.getByText(expectedMessage)).toBeInTheDocument();
     });
+  });
+
+  it("fires the correct analytics event when live chat button is clicked", async () => {
+    render(
+      <AnytimeActionTaxClearanceCertificateAlert
+        fieldErrors={["requestingAgencyId"]}
+        setStepIndex={() => {}}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: Config.taxClearanceCertificateShared.liveChatButtonText }),
+    );
+    expect(
+      mockAnalytics.event.tax_clearance_anytime_action_help_button.click
+        .open_live_chat_from_error_alert,
+    ).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/AnytimeActionTaxClearanceCertificateAlert.tsx
@@ -1,8 +1,10 @@
 import { Content } from "@/components/Content";
 import { Alert } from "@/components/njwds-extended/Alert";
+import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { DevOnlyUnlinkTaxIdButton } from "@/components/tasks/anytime-action/tax-clearance-certificate/DevOnlyUnlinkTaxIdButton";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { getProfileConfig } from "@/lib/domain-logic/getProfileConfig";
+import analytics from "@/lib/utils/analytics";
 import { TaxClearanceCertificateResponseErrorType } from "@businessnjgovnavigator/shared";
 import { ProfileContentField } from "@businessnjgovnavigator/shared/types";
 import { ReactElement } from "react";
@@ -95,7 +97,7 @@ export const AnytimeActionTaxClearanceCertificateAlert = (props: Props): ReactEl
               <Content>{Config.taxClearanceCertificateShared.pluralErrorText}</Content>
             )}
           </div>
-          <ul>
+          <ul className="margin-bottom-neg-05">
             {fieldErrors.map((id) => (
               <li key={`${id}`} id={`label-${id}`}>
                 <a
@@ -116,6 +118,20 @@ export const AnytimeActionTaxClearanceCertificateAlert = (props: Props): ReactEl
           <Content>{getTaxClearanceErrorMessage(props.responseErrorType)}</Content>
         </div>
       )}
+      <p>
+        {Config.taxClearanceCertificateShared.liveChatLabelText}{" "}
+        <UnStyledButton
+          className="margin-top-1"
+          isIntercomEnabled
+          isUnderline
+          onClick={
+            analytics.event.tax_clearance_anytime_action_help_button.click
+              .open_live_chat_from_error_alert
+          }
+        >
+          {Config.taxClearanceCertificateShared.liveChatButtonText}
+        </UnStyledButton>
+      </p>
       {props.responseErrorType === "TAX_ID_IN_USE_BY_ANOTHER_BUSINESS_ACCOUNT" && (
         <DevOnlyUnlinkTaxIdButton setResponseErrorType={props.setResponseErrorType} />
       )}

--- a/web/src/lib/utils/analytics.ts
+++ b/web/src/lib/utils/analytics.ts
@@ -2604,6 +2604,16 @@ export default {
             clicked_to: "open_live_chat",
           });
         },
+        open_live_chat_from_error_alert: () => {
+          eventRunner.track({
+            event: "link_clicks",
+            legacy_event_action: "click",
+            legacy_event_category: "tax_clearance_anytime_action_error_alert_help_button",
+            legacy_event_label: "open_live_chat",
+            click_text: "tax_clearance_anytime_action_error_alert_help_button",
+            clicked_to: "open_live_chat",
+          });
+        },
       },
     },
     remove_business_modal_help_button: {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Based on feedback from our stakeholders at Taxation, we would like to surface the live chat as an option to users who are seeing error alerts. This PR adds a button (which looks like a link) to open the chat on all error alerts and allows the content team to edit the copy as well. 

Additionally, users that click this button will trigger an analytics event so we can compare how many users open the chat through this button vs. the button at the bottom of the task. 


### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#16230](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16230).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
On the testing site:

1. Onboard as an existing business
2. Go to Tax Clearance via the anytime actions dropdown
3. Trigger a field validation error by blurring a field on empty and see that  the Need Help? Chat With Us text is there.
4. Trigger a submission error by using 500500500500 as a Tax ID and see that the Need Help? Chat With Us text is there.

Intercom is not enabled on local, so the functionality for the link opening the Intercom chat should verified on testing and dev. 

#### Test that the analytics will fire: 
Follow [instructions in this PR](https://github.com/newjersey/navigator.business.nj.gov/pull/11224) to track the analytics events in Google Tag Manager. Navigate to the Tax Clearance task, trigger a field or submission error, and click on the Chat With Us button. A new analytics_event should appear on GTM, with the following details
<img width="608" height="452" alt="Screenshot 2025-10-03 at 4 04 45 PM" src="https://github.com/user-attachments/assets/54c047eb-03fd-4760-81b4-5cc20a8ff691" />

#### Test that it's editable in the CMS: 
Build the application and go to
http://localhost:3000/mgmt/cms#/collections/tax-clearance-certificate-anytime-action/entries/taxClearanceCertificate-shared and find Live Chat Label Text and  Live Chat Button Text on the bottom.
<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes
To better match the Figma design, I added a negative margin to the field errors list.
https://www.figma.com/design/oV0bkkxxkhaBsQRx7xXCXg/71-75-Business-Experience-Sprint-Designs?node-id=53351-11603&t=AI51lGD8tZUyaaJW-4
<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
