### PR TITLE
feat: [AB#12618] formation billing cost column header added

### DIFF
--- a/web/src/components/tasks/business-formation/billing/PaymentTypeTable.tsx
+++ b/web/src/components/tasks/business-formation/billing/PaymentTypeTable.tsx
@@ -1,5 +1,5 @@
-import { getCost } from "@/components/tasks/business-formation/billing/getCost";
 import { ScrollableFormFieldWrapper } from "@/components/data-fields/ScrollableFormFieldWrapper";
+import { getCost } from "@/components/tasks/business-formation/billing/getCost";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -86,19 +86,17 @@ export const PaymentTypeTable = (): ReactElement => {
             <tr>
               <th className="text-bold">{Config.formation.fields.paymentType.label}</th>
               <th></th>
-              <th></th>
+              <th className="text-bold">{Config.formation.fields.paymentType.costColumnLabel}</th>
             </tr>
-            <tr>
-              <th colSpan={3}>
-                {hasError ? (
+            {hasError && (
+              <tr>
+                <th colSpan={3}>
                   <FormHelperText className={"text-error-dark"}>
                     {Config.formation.fields.paymentType.error}
                   </FormHelperText>
-                ) : (
-                  " "
-                )}
-              </th>
-            </tr>
+                </th>
+              </tr>
+            )}
           </thead>
           <tbody>
             <tr>


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Added cost header column to formation billing step

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#12618](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12618).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

go to formation billing step
run screen reader
on section sub table
see that cost column exists when going through it
see that on subsequent col 3 entries cost is announced with price

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
