### PR TITLE
feat: [AB#16202] anytime action search QA for no options and icon spa…

### DIFF
--- a/content/src/fieldConfig/dashboard-defaults.json
+++ b/content/src/fieldConfig/dashboard-defaults.json
@@ -15,6 +15,7 @@
     "searchFieldHeaderText": "Find What Your Business Needs",
     "searchFieldHintText": "Search for what your business needs",
     "commonBusinessTasksHeader": "Common Business Tasks",
-    "recommendedForYouCategoryHeader": "Recommended For You"
+    "recommendedForYouCategoryHeader": "Recommended For You",
+    "searchHasNoOptionsText": "*No Options For \"${inputValue}\"*"
   }
 }

--- a/web/decap-config/collections/09-dashboard.yml
+++ b/web/decap-config/collections/09-dashboard.yml
@@ -71,6 +71,11 @@ collections:
                     action,
                   widget: string,
                 }
+              - {
+                  label: Search has No Options Text,
+                  name: searchHasNoOptionsText,
+                  widget: markdown,
+                }
 
       - label: "Snackbars"
         name: "dashboard-config-snackbars"

--- a/web/src/components/dashboard/AnytimeActionSearch.test.tsx
+++ b/web/src/components/dashboard/AnytimeActionSearch.test.tsx
@@ -629,6 +629,9 @@ describe("<AnytimeActionSearch />", () => {
     it("returns no searched elements when nothing matches", async () => {
       anytimeActionTasks = anytimeActionTasksAlternate;
 
+      const inputText = "test-title-33333";
+      const noOptionsInputValue = `No Options For "${inputText}"`;
+
       renderAnytimeActionSearch();
       fireEvent.click(screen.getByLabelText("Open"));
       expect(screen.getByText("test-title-3")).toBeInTheDocument();
@@ -636,14 +639,15 @@ describe("<AnytimeActionSearch />", () => {
       expect(screen.getByText("test-title-2")).toBeInTheDocument();
       expect(screen.getByText("test-title-1")).toBeInTheDocument();
       expect(screen.getByText("Category 1")).toBeInTheDocument();
-      expect(screen.queryByText("No options")).not.toBeInTheDocument();
-      await userEvent.type(screen.getByRole("combobox"), "test-title-33333");
+      expect(screen.queryByText(noOptionsInputValue)).not.toBeInTheDocument();
+      await userEvent.type(screen.getByRole("combobox"), inputText);
+
       expect(screen.queryByText("test-title-3")).not.toBeInTheDocument();
       expect(screen.queryByText("Category 3")).not.toBeInTheDocument();
       expect(screen.queryByText("test-title-2")).not.toBeInTheDocument();
       expect(screen.queryByText("test-title-1")).not.toBeInTheDocument();
       expect(screen.queryByText("Category 1")).not.toBeInTheDocument();
-      expect(screen.getByText("No options")).toBeInTheDocument();
+      expect(screen.getByText(noOptionsInputValue)).toBeInTheDocument();
     });
 
     it("renders an anytime actions that match search value to a description with correct bolding", async () => {

--- a/web/src/components/dashboard/AnytimeActionSearch.tsx
+++ b/web/src/components/dashboard/AnytimeActionSearch.tsx
@@ -1,9 +1,11 @@
-import { MenuOptionUnselected } from "@/components/MenuOptionUnselected";
+import { Content } from "@/components/Content";
+import { AnytimeActionSearchElement } from "@/components/dashboard/AnytimeActionSearchElement";
 import { MediaQueries } from "@/lib/PageSizes";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { ROUTES } from "@/lib/domain-logic/routes";
 import analytics from "@/lib/utils/analytics";
+import { templateEval } from "@/lib/utils/helpers";
 import {
   AnytimeActionCategory,
   AnytimeActionLicenseReinstatement,
@@ -171,6 +173,7 @@ export const AnytimeActionSearch = (props: Props): ReactElement => {
 
   const [isFocused, setIsFocused] = useState(false);
   const [open, setOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
 
   const handleAnytimeActionClick = (value: AnytimeActionWithTypeAndCategory): void => {
     if (router && value && typeof value !== "string") {
@@ -221,6 +224,10 @@ export const AnytimeActionSearch = (props: Props): ReactElement => {
               />
             );
           }}
+          onInputChange={(event, newInputValue) => {
+            setInputValue(newInputValue);
+          }}
+          inputValue={inputValue}
           componentsProps={{
             popper: {
               modifiers: [
@@ -244,7 +251,7 @@ export const AnytimeActionSearch = (props: Props): ReactElement => {
           renderGroup={(params) => {
             return (
               <li key={params.key} className="anytime-action-header-group">
-                <div className="padding-left-2 text-base">{params.group}</div>
+                <div className="padding-left-2 font-body-2xs text-base">{params.group}</div>
                 <ul className="anytime-action-dropdown-ul-list-container">{params.children}</ul>
               </li>
             );
@@ -274,6 +281,13 @@ export const AnytimeActionSearch = (props: Props): ReactElement => {
               handleAnytimeActionClick(value);
             }
           }}
+          noOptionsText={
+            <Content>
+              {templateEval(Config.dashboardAnytimeActionDefaults.searchHasNoOptionsText, {
+                inputValue: inputValue,
+              })}
+            </Content>
+          }
           renderOption={(
             _props,
             option: AnytimeActionWithTypeAndCategory,
@@ -306,9 +320,9 @@ export const AnytimeActionSearch = (props: Props): ReactElement => {
                   key={"subdirectory_arrow"}
                 />
                 <div className="fdc" key={option.filename}>
-                  <MenuOptionUnselected secondaryText={descriptionText}>
+                  <AnytimeActionSearchElement secondaryText={descriptionText}>
                     {titleText}
-                  </MenuOptionUnselected>
+                  </AnytimeActionSearchElement>
                 </div>
               </li>
             );

--- a/web/src/components/dashboard/AnytimeActionSearchElement.tsx
+++ b/web/src/components/dashboard/AnytimeActionSearchElement.tsx
@@ -1,0 +1,22 @@
+import { ReactElement, ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  secondaryText?: ReactNode;
+}
+
+export const AnytimeActionSearchElement = (props: Props): ReactElement => {
+  return (
+    <>
+      <div className={`padding-left-1 text-wrap padding-right-205`} data-testid="option">
+        {props.children}
+      </div>
+
+      {props.secondaryText && (
+        <div className={`padding-left-1 font-body-2xs text-base text-wrap`}>
+          {props.secondaryText}
+        </div>
+      )}
+    </>
+  );
+};

--- a/web/src/styles/components/anytime-action-dropdown.scss
+++ b/web/src/styles/components/anytime-action-dropdown.scss
@@ -49,6 +49,10 @@ li.anytime-action-dropdown-option.MuiAutocomplete-option {
   }
 }
 
+.MuiAutocomplete-noOptions {
+  background-color: variables.$cool-extra-light;
+}
+
 .anytime-action-header-group {
   margin: 0;
 }


### PR DESCRIPTION
…cing

<!-- Please complete the following sections as necessary. -->

## Description

updated some of the QA items associated with this ticket. 

Specifically, the "No Option" text being updated as per the ticket comments
The background color of this element

Category Heading text size
return icon padding being smaller

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#16202](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16202).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

You can use the cards to get to the anytime action search bar

Type nonsense into the search field

See that the no option text reads "No Options for ${input text}", see that the background color is not slightly off white towards blue

See the enter icon is spaced naturally 

See that the heading and subtext sizes and colors are the same


<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
