### PR TITLE
chore: add next-env.d.ts to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -49,3 +49,4 @@ web/amplifyconfiguration.json
 web/amplify-build-config.json
 web/amplify-gradle-config.json
 web/amplifytools.xcconfig
+web/next-env.d.ts

--- a/web/.eslintignore
+++ b/web/.eslintignore
@@ -22,3 +22,5 @@ amplifyconfiguration.json
 amplify-build-config.json
 amplify-gradle-config.json
 amplifytools.xcconfig
+
+next-env.d.ts

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#0000](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000).

### Approach

### Why that reference line appears
- Next.js auto-generates `web/next-env.d.ts` every time you run `yarn dev` or `yarn build`.
- Recent Next.js versions generate route type definitions at build time in `.next/types/routes.d.ts` and then inject this line into `next-env.d.ts`. The latest update to NextJs (v15.5.6) indicates there were [TypeScript Improvements](https://nextjs.org/blog/next-15-5#typescript-improvements) that allows a typedRoute feature. 
- This makes the `Route` type and related helpers available to TypeScript so editors and tooling can “see” them. It happens even if `experimental.typedRoutes` is not enabled; that flag only enforces strict checking in `Link`/navigation APIs, not the generation of the types.
- The file itself is marked “should not be edited,” because Next.js will overwrite it on each run.

### Why adding it to `.eslintignore` is the right fix
- The ESLint warning you’re seeing is triggered by rules like `@typescript-eslint/triple-slash-reference`, which typically allow `types` references (lines 1–2) but flag `path` references (line 3).
- Since `next-env.d.ts` is a generated file that Next.js rewrites, any inline `/* eslint-disable */` comments would be discarded on the next build.
- Ignoring the file via `.eslintignore` prevents lint from analyzing a file you don’t control, eliminating noisy or recurring errors in local dev and CI.
- Net effect: you keep lint enforcement on your source files while avoiding churn from a tool-managed file.

### If you prefer alternatives
- Add an ESLint override just for `**/next-env.d.ts` to disable `@typescript-eslint/triple-slash-reference` for that file.
- Loosen the rule globally to allow `path` references, but that widens the allowance beyond this single generated file.

### Summary
- The reference appears because Next.js exposes build-time route types by adding a triple‑slash `path` reference to its generated `.next/types/routes.d.ts`.
- The stable, low-friction solution is to ignore `next-env.d.ts` in ESLint, since it’s regenerated and not meant to be edited.

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
