### PR TITLE
chore: [AB#15849] employer rates server error

### DIFF
--- a/content/src/fieldConfig/employer-rates.json
+++ b/content/src/fieldConfig/employer-rates.json
@@ -18,6 +18,7 @@
     "quarterDropdownTooltipText": "Rates for the upcoming year will be available on October 1.",
     "dolEinAlertLabelText": "DOL EIN",
     "dolEinLabelText": "***`DOL EIN|dol-ein`***",
-    "dolEinErrorText": "DOL EIN must be 15 digits."
+    "dolEinErrorText": "DOL EIN must be 15 digits.",
+    "serverErrorText": "**This service is temporarily unavailable.** Try again later."
   }
 }

--- a/web/decap-config/collections/12-misc.yml
+++ b/web/decap-config/collections/12-misc.yml
@@ -2951,6 +2951,8 @@ collections:
                   name: employerAccessHeaderText,
                   widget: string,
                 }
+              - { label: DOL EIN Alert Label Text, name: dolEinAlertLabelText, widget: string }
+              - { label: Server Error Alert Text, name: serverErrorText, widget: markdown }
               - { label: Employer Access Question Text, name: employerAccessText, widget: markdown }
               - {
                   label: Employer Access Question Is True Text,
@@ -2962,7 +2964,6 @@ collections:
                   name: employerAccessFalseText,
                   widget: string,
                 }
-              - { label: DOL EIN Alert Label Text, name: dolEinAlertLabelText, widget: string }
               - { label: DOL EIN Label Text, name: dolEinLabelText, widget: markdown }
               - { label: DOL EIN Error Text, name: dolEinErrorText, widget: string }
               - {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#15849](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15849).

### Approach
This ticket adds functionality to display a server error alert whenever a server error occurs. Since we’re currently unable to connect to the database, the endpoint returns a server error, making this feature testable.

We’ve separated the alert system so that the server error alert is distinct from the input field alert. The server error alert appears only when there’s a server-side issue and clears under specific conditions:
	•	Selecting the first radio button
	•	Triggering an input error
	•	Navigating away from the tab and returning

Additional logic was added to handle these edge cases, and corresponding tests were written to verify each scenario.
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
