### PR TITLE
feat: [AB#16656] refactor api_submit analytics

### DIFF
--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/Review.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/Review.tsx
@@ -122,12 +122,21 @@ export const Review = (props: Props): ReactElement => {
       const taxClearanceResponse = await api.postTaxClearanceCertificate(userData);
       if ("error" in taxClearanceResponse) {
         analytics.event.tax_clearance.submit.validation_error();
+        analytics.event.api_submit.error(
+          "treasury.taxation.tax_clearance_submission",
+          taxClearanceResponse.error.message,
+        );
         props.setResponseErrorType(taxClearanceResponse.error.type);
         return;
       }
 
       if (taxClearanceResponse.certificatePdfArray) {
         analytics.event.tax_clearance.appears.validation_success();
+        analytics.event.api_submit.success(
+          "treasury.taxation.tax_clearance_submission",
+          "successfully submitted tax clearance certificate",
+        );
+
         const blob = new Blob(
           [
             new Uint8Array(
@@ -144,6 +153,10 @@ export const Review = (props: Props): ReactElement => {
       }
     } catch {
       analytics.event.tax_clearance.submit.validation_error();
+      analytics.event.api_submit.error(
+        "treasury.taxation.tax_clearance_submission",
+        "there was an issue submitting tax clearance",
+      );
       props.setResponseErrorType("SYSTEM_ERROR");
     } finally {
       setIsLoading(false);

--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.tsx
@@ -335,9 +335,17 @@ export const BusinessFormationPaginator = (): ReactElement => {
       router
     ) {
       analytics.event.business_formation.submit.go_to_NIC_formation_processing();
+      analytics.event.api_submit.success(
+        "treasury.revenue.formation_submission",
+        "successfully submitted formation",
+      );
       await router.replace(newBusiness.formationData.formationResponse.redirect);
     } else {
       analytics.event.business_formation.submit.error_remain_at_formation();
+      analytics.event.api_submit.error(
+        "treasury.revenue.formation_submission",
+        "error submitting formation",
+      );
       setIsLoading(false);
     }
   };

--- a/web/src/components/tasks/cigarette-license/CigaretteLicenseReview.tsx
+++ b/web/src/components/tasks/cigarette-license/CigaretteLicenseReview.tsx
@@ -257,12 +257,20 @@ export const CigaretteLicenseReview = (props: Props): ReactElement => {
               },
             })
             .update();
+          analytics.event.api_submit.success(
+            "treasury.revenue.cigarette_prepare_payment",
+            "successfully prepared payment for cigarette license",
+          );
           await router.replace(cigaretteLicenseResponse.paymentInfo?.htmL5RedirectUrl);
         }
       }
     } catch {
       setLoading(false);
       analytics.event.cigarette_license.submit.service_error();
+      analytics.event.api_submit.error(
+        "treasury.revenue.cigarette_prepare_payment",
+        "error preparing payment for cigarette license",
+      );
       props.setSubmissionError("UNAVAILABLE");
       setTimeout(() => {
         if (props.errorAlertRef.current) {

--- a/web/src/components/tasks/cigarette-license/Confirmation.tsx
+++ b/web/src/components/tasks/cigarette-license/Confirmation.tsx
@@ -115,6 +115,10 @@ export const ConfirmationPage = (props: Props): ReactElement => {
 
   if (status === "CONFIRMED") {
     analytics.event.cigarette_license.appears.validation_success();
+    analytics.event.api_submit.success(
+      "treasury.revenue.cigarette_submission",
+      "successfully submitted cigarette license",
+    );
     return (
       <>
         <div className="maxw-tablet margin-x-auto">

--- a/web/src/lib/data-hooks/useBusinessNameSearch.ts
+++ b/web/src/lib/data-hooks/useBusinessNameSearch.ts
@@ -130,16 +130,18 @@ export const useBusinessNameSearch = ({
           });
         }
         setNameAvailability({ ...result });
+        analytics.event.api_submit.success(
+          "treasury.revenue.formation_submission",
+          "name is available",
+        );
         return { nameAvailability: result, submittedName: currentName };
       })
       .catch((api_error) => {
         resetState();
         setIsLoading(false);
-        if (api_error === 400) {
-          setError("BAD_INPUT");
-        } else {
-          setError("SEARCH_FAILED");
-        }
+        const errorMessage = api_error === 400 ? "BAD_INPUT" : "SEARCH_FAILED";
+        setError(errorMessage);
+        analytics.event.api_submit.error("treasury.revenue.formation_submission", errorMessage);
         throw new Error("ERROR");
       });
   };

--- a/web/src/lib/utils/analytics-legacy.ts
+++ b/web/src/lib/utils/analytics-legacy.ts
@@ -1,4 +1,12 @@
+export type LegacyEventApiName =
+  | "treasury.revenue.check_name"
+  | "treasury.revenue.formation_submission"
+  | "treasury.taxation.tax_clearance_submission"
+  | "treasury.revenue.cigarette_prepare_payment"
+  | "treasury.revenue.cigarette_submission";
+
 export type LegacyEventCategory =
+  | LegacyEventApiName
   | "account_menu_myNJ_account"
   | "account_menu_my_profile"
   | "account_name"
@@ -193,6 +201,8 @@ export type LegacyEventAction =
   | "response"
   | "scroll"
   | "submit"
+  | "api_submit_success"
+  | "api_submit_error"
   | string;
 
 export type LegacyEventLabel =

--- a/web/src/lib/utils/analytics.ts
+++ b/web/src/lib/utils/analytics.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import {
   LegacyEventAction,
+  LegacyEventApiName,
   LegacyEventCategory,
   LegacyEventLabel,
 } from "@/lib/utils/analytics-legacy";
@@ -883,6 +884,24 @@ export default {
             item: "roadmap_section",
           });
         },
+      },
+    },
+    api_submit: {
+      success: (apiName: LegacyEventApiName, apiDetails?: string) => {
+        eventRunner.track({
+          event: "form_submits",
+          legacy_event_category: apiName,
+          legacy_event_action: "api_submit_success",
+          legacy_event_label: apiDetails,
+        });
+      },
+      error: (api_name: string, api_details?: string) => {
+        eventRunner.track({
+          event: "form_submits",
+          legacy_event_category: api_name,
+          legacy_event_action: "api_submit_error",
+          legacy_event_label: api_details,
+        });
       },
     },
     profile_save: {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Added a more generalized analytic event for `api_submit` `success` and `error`. This analytic takes in an `apiName` and an optional `apiDetails`. The intention is to use this single analytic event anywhere an api submit happens in the app. The GTM params of clickText, pageUrl, etc help to determine where in the app this occurred, along with passing the appropriate apiName like `treasury.revenue.check_name` and `treasury.revenue.formation_submission`. The details is for error messages and extra info. 

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#16656](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16656).

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
