### PR TITLE
chore: [AB#15850] employer rates no account match

### DIFF
--- a/content/src/fieldConfig/employer-rates.json
+++ b/content/src/fieldConfig/employer-rates.json
@@ -19,6 +19,7 @@
     "dolEinAlertLabelText": "DOL EIN",
     "dolEinLabelText": "***`DOL EIN|dol-ein`***",
     "dolEinErrorText": "DOL EIN must be 15 digits.",
-    "serverErrorText": "**This service is temporarily unavailable.** Try again later."
+    "serverErrorText": "**This service is temporarily unavailable.** Try again later.",
+    "noAccountErrorText": "**No account could be found.**"
   }
 }

--- a/web/decap-config/collections/12-misc.yml
+++ b/web/decap-config/collections/12-misc.yml
@@ -2953,6 +2953,11 @@ collections:
                 }
               - { label: DOL EIN Alert Label Text, name: dolEinAlertLabelText, widget: string }
               - { label: Server Error Alert Text, name: serverErrorText, widget: markdown }
+              - {
+                  label: Unable To Perform User Validation Alert Text,
+                  name: noAccountErrorText,
+                  widget: markdown,
+                }
               - { label: Employer Access Question Text, name: employerAccessText, widget: markdown }
               - {
                   label: Employer Access Question Is True Text,


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#15850](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15850).

### Approach
I added the logic needed to handle the error case that comes back from the Employer Rates API. The API returns a 200 response, but inside the response body there can be an error key with a string message. That key-value pair only appears when the business name, email, and EIN do not match what the system expects. In other words, it is a validation mismatch on their side.

I updated our flow so that when this error message is present, we surface it to the user.

I also added logic around the initial radio button that controls when the user is allowed to submit the request. If an Employer Rates validation error is currently visible and the user interacts with that radio button again, the error clears out so they can try again with a clean state.

Finally, I updated the EIN field behavior. If the EIN input shows its own error due to not meeting the fifteen character requirement, that message should override and remove the APR validation error so there is never a stack of competing errors.

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
