### PR TITLE
feat: [AB#12619] table labels on talkback read column header before c…

### DIFF
--- a/web/src/components/tasks/business-formation/billing/BillingStep.test.tsx
+++ b/web/src/components/tasks/business-formation/billing/BillingStep.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { getDollarValue } from "@/lib/utils/formatters";
 import { generateFormationDbaContent } from "@/test/factories";
 import {
   FormationPageHelpers,
@@ -53,6 +54,14 @@ describe("Formation - BillingStep", () => {
 
   const subtotalLabel = Config.formation.fields.paymentType.costSubtotalLabel;
   const totalLabel = "Total";
+
+  const composeSubTotalAria = (subTotalNumber: number): string => {
+    return `${subtotalLabel} ${getDollarValue(subTotalNumber)}`;
+  };
+
+  const composeTotalAria = (totalNumber: number): string => {
+    return `* ${totalLabel} ${getDollarValue(totalNumber)}`;
+  };
 
   const getPageHelper = async (
     initialProfileData: Partial<ProfileData>,
@@ -160,8 +169,12 @@ describe("Formation - BillingStep", () => {
         const standingCost = Number.parseInt(Config.formation.fields.certificateOfStanding.cost);
         const expectedTotal = officialFormationCost + standingCost;
 
-        expect(screen.getByLabelText(subtotalLabel)).toHaveTextContent(expectedTotal.toString());
-        expect(screen.getByLabelText(totalLabel)).toHaveTextContent(expectedTotal.toString());
+        expect(
+          screen.getByRole("generic", { name: composeTotalAria(expectedTotal) }),
+        ).toHaveTextContent(getDollarValue(expectedTotal));
+        expect(
+          screen.getByRole("generic", { name: composeSubTotalAria(expectedTotal) }),
+        ).toHaveTextContent(getDollarValue(expectedTotal));
       });
     }
 
@@ -185,8 +198,12 @@ describe("Formation - BillingStep", () => {
         );
         const expectedTotal = officialFormationCost + standingCost;
 
-        expect(screen.getByLabelText(subtotalLabel)).toHaveTextContent(expectedTotal.toString());
-        expect(screen.getByLabelText(totalLabel)).toHaveTextContent(expectedTotal.toString());
+        expect(
+          screen.getByRole("generic", { name: composeSubTotalAria(expectedTotal) }),
+        ).toHaveTextContent(expectedTotal.toString());
+        expect(
+          screen.getByRole("generic", { name: composeTotalAria(expectedTotal) }),
+        ).toHaveTextContent(expectedTotal.toString());
       });
     }
   });
@@ -220,35 +237,55 @@ describe("Formation - BillingStep", () => {
       },
     );
 
-    expect(screen.getByLabelText(subtotalLabel)).toHaveTextContent(
-      officialFormationCost.toString(),
-    );
+    expect(
+      screen.getByRole("generic", { name: composeSubTotalAria(officialFormationCost) }),
+    ).toHaveTextContent(officialFormationCost.toString());
     page.selectCheckboxByTestId("certificateOfStanding");
-    expect(screen.getByLabelText(subtotalLabel)).toHaveTextContent(
-      (officialFormationCost + certificateStandingCost).toString(),
-    );
+    expect(
+      screen.getByRole("generic", {
+        name: composeSubTotalAria(officialFormationCost + certificateStandingCost),
+      }),
+    ).toHaveTextContent((officialFormationCost + certificateStandingCost).toString());
     page.selectCheckboxByTestId("certifiedCopyOfFormationDocument");
-    expect(screen.getByLabelText(subtotalLabel)).toHaveTextContent(
+    expect(
+      screen.getByRole("generic", {
+        name: composeSubTotalAria(
+          officialFormationCost + certificateStandingCost + certifiedCopyCost,
+        ),
+      }),
+    ).toHaveTextContent(
       (officialFormationCost + certificateStandingCost + certifiedCopyCost).toString(),
     );
-    expect(screen.getByLabelText(totalLabel)).toHaveTextContent(
+    expect(
+      screen.getByRole("generic", {
+        name: composeTotalAria(officialFormationCost + certificateStandingCost + certifiedCopyCost),
+      }),
+    ).toHaveTextContent(
       (officialFormationCost + certificateStandingCost + certifiedCopyCost).toString(),
     );
     page.selectCheckboxByTestId("certificateOfStanding");
     const finalTotal = officialFormationCost + certifiedCopyCost;
 
-    expect(screen.getByLabelText(subtotalLabel)).toHaveTextContent(finalTotal.toString());
-    expect(screen.getByLabelText(totalLabel)).toHaveTextContent(finalTotal.toString());
+    expect(
+      screen.getByRole("generic", { name: composeSubTotalAria(finalTotal) }),
+    ).toHaveTextContent(finalTotal.toString());
+    expect(screen.getByRole("generic", { name: composeTotalAria(finalTotal) })).toHaveTextContent(
+      finalTotal.toString(),
+    );
 
     fireEvent.click(screen.getByLabelText(Config.formation.fields.paymentType.creditCardLabel));
-    expect(screen.getByLabelText(totalLabel)).toHaveTextContent(
-      (finalTotal + ccInitialCost + ccExtraCost).toString(),
-    );
+    expect(
+      screen.getByRole("generic", {
+        name: composeTotalAria(finalTotal + ccInitialCost + ccExtraCost),
+      }),
+    ).toHaveTextContent((finalTotal + ccInitialCost + ccExtraCost).toString());
     fireEvent.click(screen.getByLabelText(Config.formation.fields.paymentType.achLabel));
     const numberOfDocuments = 2;
-    expect(screen.getByLabelText(totalLabel)).toHaveTextContent(
-      (finalTotal + achCost * numberOfDocuments).toString(),
-    );
+    expect(
+      screen.getByRole("generic", {
+        name: composeTotalAria(finalTotal + achCost * numberOfDocuments),
+      }),
+    ).toHaveTextContent((finalTotal + achCost * numberOfDocuments).toString());
   });
 
   it("uses name from profile when business formation data is not set", async () => {

--- a/web/src/components/tasks/business-formation/billing/FormationChooseDocuments.tsx
+++ b/web/src/components/tasks/business-formation/billing/FormationChooseDocuments.tsx
@@ -61,14 +61,20 @@ export const FormationChooseDocuments = (): ReactElement => {
     });
   };
 
+  const costColumnHeader = Config.formation.fields.paymentType.costColumnLabel;
+
   return (
     <div className={`margin-top-3`}>
-      <table className="business-formation-table business-formation-document">
+      <table className="business-formation-table business-formation-document" role="table">
         <thead>
           <tr>
-            <th className="text-bold">{Config.formation.fields.paymentType.serviceColumnLabel}</th>
+            <th scope="col" role="columnheader" className="text-bold">
+              {Config.formation.fields.paymentType.serviceColumnLabel}
+            </th>
             <th></th>
-            <th className="text-bold">{Config.formation.fields.paymentType.costColumnLabel}</th>
+            <th scope="col" role="columnheader" className="text-bold">
+              {costColumnHeader}
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -90,7 +96,10 @@ export const FormationChooseDocuments = (): ReactElement => {
                 />
               </label>
             </td>
-            <td className={"text-primary-dark text-bold"}>
+            <td
+              className={"text-primary-dark text-bold"}
+              aria-label={`${costColumnHeader} ${getDollarValue(officialFormationCost)}`}
+            >
               {getDollarValue(officialFormationCost)}
             </td>
           </tr>
@@ -129,6 +138,7 @@ export const FormationChooseDocuments = (): ReactElement => {
               className={
                 state.formationFormData.certificateOfStanding ? "text-primary-dark text-bold" : ""
               }
+              aria-label={`${costColumnHeader} ${getDollarValue(certificateStandingCost)}`}
             >
               {getDollarValue(certificateStandingCost)}
             </td>
@@ -173,7 +183,9 @@ export const FormationChooseDocuments = (): ReactElement => {
                   : ""
               }
             >
-              {getDollarValue(certifiedCopyCost)}
+              <div aria-label={`${costColumnHeader} ${getDollarValue(certifiedCopyCost)}`}>
+                {getDollarValue(certifiedCopyCost)}
+              </div>
             </td>
           </tr>
         </tbody>
@@ -188,7 +200,10 @@ export const FormationChooseDocuments = (): ReactElement => {
             </td>
             <td colSpan={1}></td>
             <td colSpan={1}>
-              <div className="text-align-right text-bold" aria-label="Subtotal">
+              <div
+                className="text-align-right text-bold"
+                aria-label={`${Config.formation.fields.paymentType.costSubtotalLabel} ${getDollarValue(totalCost)}`}
+              >
                 {getDollarValue(totalCost)}
               </div>
             </td>

--- a/web/src/components/tasks/business-formation/billing/PaymentTypeTable.tsx
+++ b/web/src/components/tasks/business-formation/billing/PaymentTypeTable.tsx
@@ -77,6 +77,7 @@ export const PaymentTypeTable = (): ReactElement => {
   };
 
   const hasError = doesFieldHaveError(fieldName);
+  const costColumnHeader = Config.formation.fields.paymentType.costColumnLabel;
 
   return (
     <ScrollableFormFieldWrapper fieldName={fieldName}>
@@ -86,7 +87,9 @@ export const PaymentTypeTable = (): ReactElement => {
             <tr>
               <th className="text-bold">{Config.formation.fields.paymentType.label}</th>
               <th></th>
-              <th className="text-bold">{Config.formation.fields.paymentType.costColumnLabel}</th>
+              <th className="text-bold" id="cost-column-header">
+                {costColumnHeader}
+              </th>
             </tr>
             {hasError && (
               <tr>
@@ -130,6 +133,7 @@ export const PaymentTypeTable = (): ReactElement => {
                 className={
                   state.formationFormData.paymentType === "CC" ? "text-primary-dark text-bold" : ""
                 }
+                aria-label={`${costColumnHeader} ${getDollarValue(creditCardCost)}`}
               >
                 {getDollarValue(creditCardCost)}
               </td>
@@ -165,6 +169,7 @@ export const PaymentTypeTable = (): ReactElement => {
                 className={
                   state.formationFormData.paymentType === "ACH" ? "text-primary-dark text-bold" : ""
                 }
+                aria-label={`${costColumnHeader} ${getDollarValue(achCost)}`}
               >
                 {getDollarValue(achCost)}
               </td>
@@ -180,7 +185,11 @@ export const PaymentTypeTable = (): ReactElement => {
                 </div>
               </td>
               <td colSpan={1}>
-                <div className="text-align-right text-bold" aria-label={"Total"}>
+                <div
+                  className="text-align-right text-bold"
+                  data-testid="something"
+                  aria-label={`${Config.formation.fields.paymentType.costTotalLabel} ${getDollarValue(totalCost)}`}
+                >
                   {getDollarValue(totalCost)}
                 </div>
               </td>


### PR DESCRIPTION
…ost content and total and subtotal content

<!-- Please complete the following sections as necessary. -->

## Description

We wanted the total and sub total rows and the cost columns to read correctly on Android Talkback (the android mobile screen reader).

This is important because our application deserves to be accessible for all New Jersey residence and they deserve to access our application and the improved quality of life just as much as anyone else. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#12619](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12619).

### Approach

I ended up trying a number of solutions including modifying table roles and labels. Using aria-labeledBy and aria-describedBy as well as explicit aria-labels and various nesting paradigms to try and get the desired behavior.

I was surprised that aria-labeledBy did not work. In the end the aria-describedBy and aria-labels worked and I chose the latter because aria-describedBy's order was less intuitive and some screen readers treat describedBy differently in a way that I feel is less robust than aria-label (less support in general). 

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

I have tested this functionality extensively and it may be hard for some reviewers to test this functionality so I don't believe testing is explicitly necessary.

If someone wishes to test, steps are as follows. 

1. Tester would have to push this code from local to the testing environment and wait for deploy
1. Tester would navigate to the application on an andoroid device
2. Tester would login to the application
3. Tester would select a business structure that requires formation (LLC for example)
4. Tester would go to the formation Billing step
5. Tester Use android talk back to walk through the table (largely by swiping right to navigate through elements)

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

Layering and grouping/nesting elements deeply doesn't process correctly on android talk back. This is a learning for me. This understanding should influence our coding philosophy moving forward and I would like to bring it up to the broader dev team sometime soon. 

I learned some best practices about grabbing elements by aria-label in React Testing Library. Mainly using getByRole with the name parameter over getByLabelText for robustness and specificity purposes. 

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
