### PR TITLE
fix: [AB#16705] return the entire error from Webservice license search

### DIFF
--- a/api/src/client/dynamics/license-status/RegulatedBusinessDynamicsLicenseStatusClient.ts
+++ b/api/src/client/dynamics/license-status/RegulatedBusinessDynamicsLicenseStatusClient.ts
@@ -19,7 +19,7 @@ interface RgbApiConfiguration {
   rgbChecklistItemsClient: ChecklistItemsForAllApplicationsClient;
 }
 
-const DEBUG_RegulatedBusinessDynamicsLicenseSearch = false; // this variable exists in updateLicenseStatusFactory; enable both for debugging
+const DEBUG = false; // this variable exists in updateLicenseStatusFactory; enable both for debugging
 
 export const RegulatedBusinessDynamicsLicenseStatusClient = (
   rgbApiConfiguration: RgbApiConfiguration,
@@ -35,7 +35,7 @@ export const RegulatedBusinessDynamicsLicenseStatusClient = (
         nameAndAddress.name,
       );
 
-    if (DEBUG_RegulatedBusinessDynamicsLicenseSearch) {
+    if (DEBUG) {
       console.log({
         functionName: "getMatchedBusinessIdsAndNames",
         results: matchedBusinessIdsAndNames,
@@ -48,7 +48,7 @@ export const RegulatedBusinessDynamicsLicenseStatusClient = (
         matchedBusinessIdsAndNames,
       );
 
-    if (DEBUG_RegulatedBusinessDynamicsLicenseSearch) {
+    if (DEBUG) {
       console.log({
         functionName: "getBusinessAddressesForAllBusinessIds",
         results: businessAddressesForAllBusinessIds,
@@ -60,7 +60,7 @@ export const RegulatedBusinessDynamicsLicenseStatusClient = (
       nameAndAddress,
     );
 
-    if (DEBUG_RegulatedBusinessDynamicsLicenseSearch) {
+    if (DEBUG) {
       console.log({
         functionName: "searchBusinessAddressesForMatches",
         results: matchedBusinessIdAndNameByAddress,
@@ -73,7 +73,7 @@ export const RegulatedBusinessDynamicsLicenseStatusClient = (
         matchedBusinessIdAndNameByAddress,
       );
 
-    if (DEBUG_RegulatedBusinessDynamicsLicenseSearch) {
+    if (DEBUG) {
       console.log({
         functionName: "getLicenseApplicationIdsForAllBusinessIds",
         results: applicationIdsForAllBusinessIdsResponse,
@@ -88,7 +88,7 @@ export const RegulatedBusinessDynamicsLicenseStatusClient = (
 
     const results = formatRegulatedBusinessDynamicsApplications(applicationsWithChecklistItems);
 
-    if (DEBUG_RegulatedBusinessDynamicsLicenseSearch) {
+    if (DEBUG) {
       console.log({
         functionName: "formatRegulatedBusinessDynamicsApplications",
         results: results,

--- a/api/src/client/webservice/WebserviceLicenseStatusClient.ts
+++ b/api/src/client/webservice/WebserviceLicenseStatusClient.ts
@@ -32,7 +32,7 @@ export const WebserviceLicenseStatusClient = (
           `Webservice License Status Client - Error. - Id:${logId} - Error:`,
           error,
         );
-        throw error.response?.status;
+        throw error;
       });
   };
 

--- a/api/src/domain/user/updateLicenseStatusFactory.test.ts
+++ b/api/src/domain/user/updateLicenseStatusFactory.test.ts
@@ -262,8 +262,27 @@ describe("updateLicenseStatus", () => {
       );
     });
 
-    it("returns empty license object when data of current task to have error license data when webservice receives NO_MATCH_ERROR and rgb also fails", async () => {
-      stubWebserviceLicenseStatusSearch.mockRejectedValue(new Error(NO_MATCH_ERROR));
+    it("throws error if SearchLicenseStatus client error is missing a message", async () => {
+      const testError = { name: "fake-error" };
+
+      stubWebserviceLicenseStatusSearch.mockRejectedValue(testError);
+      stubRGBLicenseStatusSearch.mockRejectedValue(testError);
+
+      userData = modifyCurrentBusiness(userData, (business) => ({
+        ...business,
+        licenseData: generateLicenseData({}),
+      }));
+
+      await expect(updateLicenseStatus(userData, nameAndAddress)).rejects.toThrow(
+        JSON.stringify({
+          webserviceErrorMessage: testError,
+          rgbErrorMessage: testError,
+        }),
+      );
+    });
+
+    it("returns empty license object when data of current task to have error license data when webservice receives NO_ADDRESS_MATCH_ERROR and rgb also fails", async () => {
+      stubWebserviceLicenseStatusSearch.mockRejectedValue(new Error(NO_ADDRESS_MATCH_ERROR));
       stubRGBLicenseStatusSearch.mockRejectedValue(new Error("fail"));
 
       userData = modifyCurrentBusiness(userData, (business) => ({

--- a/api/src/domain/user/updateLicenseStatusFactory.ts
+++ b/api/src/domain/user/updateLicenseStatusFactory.ts
@@ -21,7 +21,7 @@ import {
 } from "@shared/license";
 import { Business, UserData } from "@shared/userData";
 
-const DEBUG_RegulatedBusinessDynamicsLicenseSearch = false; // this variable exists in RegulatedBusinessDynamicsLicenseStatusClient; enable both for debugging
+const DEBUG = false; // this variable exists in RegulatedBusinessDynamicsLicenseStatusClient; enable both for debugging
 
 const getLicenses = (args: {
   nameAndAddress: LicenseSearchNameAndAddress;
@@ -77,7 +77,8 @@ export const updateLicenseStatusFactory = (
         const webserviceHasError = webserviceLicenseStatusResults.status === "rejected";
         const webserviceHasInvalidMatch =
           webserviceHasError &&
-          [NO_MATCH_ERROR].includes(webserviceLicenseStatusResults.reason.message);
+          webserviceLicenseStatusResults.reason.message === NO_ADDRESS_MATCH_ERROR;
+
         const rgbHasError = rgbLicenseStatusResults.status === "rejected";
         const rgbHasInvalidMatch =
           rgbHasError &&
@@ -85,7 +86,7 @@ export const updateLicenseStatusFactory = (
             rgbLicenseStatusResults.reason.message,
           );
 
-        if (DEBUG_RegulatedBusinessDynamicsLicenseSearch) {
+        if (DEBUG) {
           console.log({
             functionName: "updateLicenseStatusFactory",
             webserviceLicenseStatusResults,


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

License search is currently broken because we are not handling errors from the Webservice license status client correctly. The Webservice tools are currently unreachable, which surfaced an issue in our logic which causes the entire license search feature to fail. This work should allow us to handle those errors more gracefully.

### Ticket

This pull request resolves [#16705](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16705).

### Approach

If the Webservice license search encounters an error, return the entire error, not just the message. Previously, we were just returning the error message which could be undefined in the case of a connection timeout. Because of this, our entire implementation of license search was failing.

### Steps to Test

**Previously**
- All license searches resulted in an error message regardless of license type or data source
- Any license search resulted in a more general error message or return license data
<img width="549" height="210" alt="Screenshot 2025-11-17 at 3 31 34 PM" src="https://github.com/user-attachments/assets/d2d0162e-2f44-4ddc-a29d-d61a1468900e" />


**Webservice**
- Create a business that can conduct a license search using the legacy system (e.g. cosmetology)
- While the service is unreachable, we should get a more general error message
<img width="606" height="169" alt="Screenshot 2025-11-17 at 3 36 22 PM" src="https://github.com/user-attachments/assets/33950fd5-4f78-426c-bcee-dcf86251a8b0" />

**Regulated Businesses**
- Create a business that can conduct a license search using the Dynamics - Regulated Business system (e.g. public movers)
- If there is a matching license, that information should be returned.
<img width="423" height="294" alt="Screenshot 2025-11-17 at 3 31 52 PM" src="https://github.com/user-attachments/assets/2d36d479-4436-46eb-a8d2-828a3bb6dc8c" />

### Notes

We're currently not getting warned via healthchecks that the Webservice is down. I don't know if this change will fix that issue or not. Post deployment, I will continue investigating to figure out if this change was enough or if that needs further focus.

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
