### PR TITLE
[AB#16768] Cigarette Licnese Application - Add EFT Code for CM-100 as a line item SKU

### DIFF
--- a/api/src/client/ApiCigaretteLicenseClient.test.ts
+++ b/api/src/client/ApiCigaretteLicenseClient.test.ts
@@ -54,6 +54,7 @@ describe("CigaretteLicenseClient", () => {
     cigarette_license_merchant_code: "TEST_MERCHANT",
     cigarette_license_merchant_key: "test-merchant-key",
     cigarette_license_service_code: "TEST_SERVICE",
+    cigarette_license_sku: "TEST_SKU",
   };
   const config: CigaretteLicenseApiConfig = {
     baseUrl: mockValues.cigarette_license_base_url,
@@ -61,6 +62,7 @@ describe("CigaretteLicenseClient", () => {
     merchantCode: mockValues.cigarette_license_merchant_code,
     merchantKey: mockValues.cigarette_license_merchant_key,
     serviceCode: mockValues.cigarette_license_service_code,
+    sku: mockValues.cigarette_license_sku,
   };
   const returnUrl = "fake-return-url";
   const decryptedTaxId = "decrypted-tax-id";

--- a/api/src/client/ApiCigaretteLicenseClient.ts
+++ b/api/src/client/ApiCigaretteLicenseClient.ts
@@ -30,6 +30,7 @@ export const getConfig = async (): Promise<CigaretteLicenseApiConfig> => {
     merchantCode: await getConfigValue("cigarette_license_merchant_code"),
     merchantKey: await getConfigValue("cigarette_license_merchant_key"),
     serviceCode: await getConfigValue("cigarette_license_service_code"),
+    sku: await getConfigValue("cigarette_license_sku"),
   };
 };
 

--- a/api/src/client/ApiCigaretteLicenseHelpers.ts
+++ b/api/src/client/ApiCigaretteLicenseHelpers.ts
@@ -16,6 +16,7 @@ export type CigaretteLicenseApiConfig = {
   merchantCode: string;
   merchantKey: string;
   serviceCode: string;
+  sku: string;
 };
 
 export const makePostBody = (
@@ -33,7 +34,6 @@ export const makePostBody = (
     ServiceCode: config.serviceCode,
     UniqueTransId: uniqueId,
     LocalRef: uniqueId,
-    OrderTotal: 50,
     PaymentType: "CC",
     SuccessUrl: `${returnUrl}?completePayment=success`,
     FailureUrl: `${returnUrl}?completePayment=failure`,
@@ -52,6 +52,14 @@ export const makePostBody = (
       Zip: cigaretteLicenseData?.addressZipCode || "",
       Country: "US",
     },
+    LineItems: [
+      {
+        Sku: config.sku,
+        Description: "CM-100 Cigarette License Application",
+        UnitPrice: 50,
+        Quantity: 1,
+      },
+    ],
   };
 };
 

--- a/api/src/libs/ssmUtils.ts
+++ b/api/src/libs/ssmUtils.ts
@@ -18,7 +18,8 @@ export type CIGARETTE_PAYMENT_CONFIG_VARS =
   | "cigarette_license_api_key"
   | "cigarette_license_merchant_code"
   | "cigarette_license_merchant_key"
-  | "cigarette_license_service_code";
+  | "cigarette_license_service_code"
+  | "cigarette_license_sku";
 
 export type CIGARETTE_EMAIL_CONFIG_VARS =
   | "cigarette_license_email_confirmation_url"

--- a/shared/src/cigaretteLicense.ts
+++ b/shared/src/cigaretteLicense.ts
@@ -83,7 +83,6 @@ export interface PreparePaymentApiSubmission {
   ServiceCode: string;
   UniqueTransId: string;
   LocalRef: string;
-  OrderTotal: number;
   PaymentType: string;
   SuccessUrl: string;
   FailureUrl: string;
@@ -101,6 +100,12 @@ export interface PreparePaymentApiSubmission {
     Zip: string;
     Country: string;
   };
+  LineItems: {
+    Sku: string;
+    Description: string;
+    UnitPrice: number;
+    Quantity: number;
+  }[];
 }
 
 export interface EmailConfirmationSubmission {


### PR DESCRIPTION
## Description

The TLC team recently digitized the CM-100 form, used to apply for a cigarette sales license. To submit the form, users must pay a $50 processing fee, which we are collecting via Tyler Technology's payment portal.

This work adds the EFT code (DORES code) associated with the CM-100 as a line item SKU so that funds can be appropriately tracked in the payment portal.

### Ticket

This pull request resolves [#16768](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16768).

### Approach

Tyler Tech supplied us with an [API spec](https://drive.google.com/file/d/1tAfLTrKfngXWYElzTb8LOqz4_2wtgmuT/view?usp=drive_link), and specific guidance for how this information should be added. In short, I added a key `LineItems` to the request body of our API calls to the payment portal, and passed the EFT Code as a SKU.

### Steps to Test

If a user can submit a Cigarette Sales License application from business.nj.gov, process payment, and a confirmation email is sent to DORES (existing workflow), then this should work.

We have no way to validate that the information is being processed correctly on the Tyler Technology side. I've submitted a test application with the change, and confirmed with their team the information is being received correctly.

**Submitting a Cigarette Sales License Application**
- Start a new business in the retail industry
- Go to the business profile, and answer "yes" to the non-essential question related to cigarette sales
  - This adds the "cigarette sales license application" task to the roadmap
- Complete the cigarette sales license application
- Provide fake payment information details (same information used for business formation, see [cheat sheet](https://docs.google.com/document/d/16HFem_M9kbCs2r-I0wcjH9gsFPLkgF5-SVCCIRBl_5Y/))
- You should be redirected to the Cigarette Sales License Application task screen, the task should be marked complete, and you should be informed that your information is being processed.

### Notes

n/a

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
