### PR TITLE
feat: [AB#15527] Dashboard restyling - Business Tasks to Stay on Track

### DIFF
--- a/shared/src/static/index.ts
+++ b/shared/src/static/index.ts
@@ -17,4 +17,5 @@ export * from "./loadPageMetadata";
 export * from "./loadTasks";
 export * from "./loadWebflowLicenses";
 export * from "./loadXrayRenewalCalendarEvent";
+export * from "./loadCommonBusinessTasks";
 export * from "./mockHelpers";

--- a/shared/src/static/loadCommonBusinessTasks.test.ts
+++ b/shared/src/static/loadCommonBusinessTasks.test.ts
@@ -1,0 +1,31 @@
+import { loadAnytimeActionTasksByFileName } from "./loadAnytimeActionTasks";
+import { loadCommonBusinessTasks } from "./loadCommonBusinessTasks";
+
+jest.mock("./loadAnytimeActionTasks");
+
+describe("loadCommonBusinessTasks", () => {
+  it("loads tasks for each markdown file in order", () => {
+    // Arrange: predictable mock return values
+    (loadAnytimeActionTasksByFileName as jest.Mock)
+      .mockReturnValueOnce({ id: "task1" })
+      .mockReturnValueOnce({ id: "task2" })
+      .mockReturnValueOnce({ id: "task3" });
+
+    // Act
+    const result = loadCommonBusinessTasks();
+
+    // Assert: calls in correct order
+    expect(loadAnytimeActionTasksByFileName).toHaveBeenNthCalledWith(
+      1,
+      "registry-update-brc-amendment.md",
+    );
+    expect(loadAnytimeActionTasksByFileName).toHaveBeenNthCalledWith(
+      2,
+      "tax-clearance-certificate.md",
+    );
+    expect(loadAnytimeActionTasksByFileName).toHaveBeenNthCalledWith(3, "state-contracting.md");
+
+    // Assert: returned array matches mocked outputs
+    expect(result).toEqual([{ id: "task1" }, { id: "task2" }, { id: "task3" }]);
+  });
+});

--- a/shared/src/static/loadCommonBusinessTasks.ts
+++ b/shared/src/static/loadCommonBusinessTasks.ts
@@ -1,0 +1,14 @@
+import { AnytimeActionTask } from "../types";
+import { loadAnytimeActionTasksByFileName } from "./loadAnytimeActionTasks";
+
+export const loadCommonBusinessTasks = (): AnytimeActionTask[] => {
+  const fileNames = [
+    "registry-update-brc-amendment.md",
+    "tax-clearance-certificate.md",
+    "state-contracting.md",
+  ];
+
+  return fileNames.map((fileName) => {
+    return loadAnytimeActionTasksByFileName(fileName);
+  });
+};

--- a/web/src/components/dashboard/AnytimeActionContainer.tsx
+++ b/web/src/components/dashboard/AnytimeActionContainer.tsx
@@ -32,12 +32,16 @@ export const AnytimeActionContainer = (props: Props): ReactElement => {
       />
       {props.commonBusinessTasks.length > 0 && (
         <>
-          <Heading level={3}>
+          <Heading className={"padding-top-1"} level={3}>
             {Config.dashboardAnytimeActionDefaults.commonBusinessTasksHeader}
           </Heading>
           <ul>
             {props.commonBusinessTasks.map((businessTask) => (
-              <li key={businessTask.urlSlug}>{businessTask.name}</li>
+              <li key={businessTask.urlSlug}>
+                <a className="usa-link" href={`actions/${businessTask.urlSlug}`}>
+                  {businessTask.name}
+                </a>
+              </li>
             ))}
           </ul>
         </>

--- a/web/src/components/dashboard/Dashboard.test.tsx
+++ b/web/src/components/dashboard/Dashboard.test.tsx
@@ -114,6 +114,7 @@ describe("<DashboardOnDesktop />", () => {
           anytimeActionLicenseReinstatements={anytimeActionLicenseReinstatements ?? []}
           licenseEvents={licenseEvents ?? []}
           xrayRenewalEvent={generateXrayRenewalCalendarEvent({})}
+          commonBusinessTasks={[]}
         />
       </ThemeProvider>,
     );
@@ -136,6 +137,7 @@ describe("<DashboardOnDesktop />", () => {
             anytimeActionLicenseReinstatements={[]}
             licenseEvents={[]}
             xrayRenewalEvent={generateXrayRenewalCalendarEvent({})}
+            commonBusinessTasks={[]}
           />
         </ThemeProvider>
       </WithStatefulUserData>,

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -45,6 +45,7 @@ interface Props {
   elevatorViolations?: boolean;
   licenseEvents: LicenseEventType[];
   xrayRenewalEvent: XrayRenewalCalendarEventType;
+  commonBusinessTasks: (AnytimeActionLicenseReinstatement | AnytimeActionTask)[];
 }
 
 export const Dashboard = (props: Props): ReactElement => {
@@ -90,7 +91,7 @@ export const Dashboard = (props: Props): ReactElement => {
                         anytimeActionLicenseReinstatements={
                           props.anytimeActionLicenseReinstatements
                         }
-                        commonBusinessTasks={[]} // this will need value passed in whent he commonBusinessTask logic is added
+                        commonBusinessTasks={props.commonBusinessTasks}
                       />
                     )}
 
@@ -147,7 +148,7 @@ export const Dashboard = (props: Props): ReactElement => {
                         anytimeActionTasksFromNonEssentialQuestions
                       }
                       anytimeActionLicenseReinstatements={props.anytimeActionLicenseReinstatements}
-                      commonBusinessTasks={[]} // this will need value passed in whent he commonBusinessTask logic is added
+                      commonBusinessTasks={props.commonBusinessTasks}
                     />
                   )}
 

--- a/web/src/pages/dashboard.tsx
+++ b/web/src/pages/dashboard.tsx
@@ -25,6 +25,7 @@ import {
   loadOperateReferences,
   loadRoadmapSideBarDisplayContent,
   loadXrayRenewalCalendarEvent,
+  loadCommonBusinessTasks,
 } from "@businessnjgovnavigator/shared/static";
 import {
   AnytimeActionLicenseReinstatement,
@@ -52,6 +53,7 @@ interface Props {
   anytimeActionLicenseReinstatements: AnytimeActionLicenseReinstatement[];
   licenseEvents: LicenseEventType[];
   xrayRenewalEvent: XrayRenewalCalendarEventType;
+  commonBusinessTasks: (AnytimeActionLicenseReinstatement | AnytimeActionTask)[];
 }
 
 const DashboardPage = (props: Props): ReactElement => {
@@ -136,6 +138,7 @@ const DashboardPage = (props: Props): ReactElement => {
               elevatorViolations={hasElevatorViolations}
               licenseEvents={props.licenseEvents}
               xrayRenewalEvent={props.xrayRenewalEvent}
+              commonBusinessTasks={props.commonBusinessTasks}
             />
           )}
         </main>
@@ -156,6 +159,7 @@ export const getStaticProps = (): GetStaticPropsResult<Props> => {
       anytimeActionLicenseReinstatements: loadAllAnytimeActionLicenseReinstatements(),
       licenseEvents: loadAllLicenseCalendarEvents(),
       xrayRenewalEvent: loadXrayRenewalCalendarEvent(),
+      commonBusinessTasks: loadCommonBusinessTasks(),
     },
   };
 };

--- a/web/test/pages/dashboard.test.tsx
+++ b/web/test/pages/dashboard.test.tsx
@@ -74,6 +74,7 @@ describe("dashboard page", () => {
           anytimeActionLicenseReinstatements={[]}
           licenseEvents={[]}
           xrayRenewalEvent={generateXrayRenewalCalendarEvent({})}
+          commonBusinessTasks={[]}
         />
       </ThemeProvider>,
     );
@@ -97,6 +98,7 @@ describe("dashboard page", () => {
             anytimeActionLicenseReinstatements={[]}
             licenseEvents={[]}
             xrayRenewalEvent={generateXrayRenewalCalendarEvent({})}
+            commonBusinessTasks={[]}
           />
         </ThemeProvider>
       </WithStatefulUserData>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -16522,7 +16522,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:14.0.2, commander@npm:^14.0.0, commander@npm:^14.0.2":
+"commander@npm:14.0.2, commander@npm:^14.0.2":
   version: 14.0.2
   resolution: "commander@npm:14.0.2"
   checksum: 0a9e549565d368dde2965821833324069b92b099b415c2106996e47db1f0b8c10c77367e9876873c00a52ca627af4c7472eba9b51dc0d6a3ef152ea063d3e9e9


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description


Under "Common Business Tasks" section in the "Business Tasks to Stay on Track" section of the dashboard when in the up and running phase, we are adding the top 3 anytime actions which are registry-update-brc-amendment, tax-clearance-certificate,
  and the state-contracting.  By clicking on each action it will take u to that specific business task.


<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#15527](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15527).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
1) Place your business in the up and running phase
2) On the dashboard under "Common Business Tasks" you should see three links that you can click on.  Each link should take you to that specific action.

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
