### PR TITLE
[AB#16848] Pass Power Automate API key as a body param

### DIFF
--- a/api/src/client/ApiCigaretteLicenseClient.test.ts
+++ b/api/src/client/ApiCigaretteLicenseClient.test.ts
@@ -13,7 +13,7 @@ import {
 import { PreparePaymentApiSubmission } from "@shared/cigaretteLicense";
 import { getCurrentBusiness } from "@shared/index";
 
-import { CigaretteLicenseClient, EmailClient } from "@domain/types";
+import { CigaretteLicenseClient, PowerAutomateEmailClient } from "@domain/types";
 import { DummyLogWriter } from "@libs/logWriter";
 import { CIGARETTE_PAYMENT_CONFIG_VARS, getConfigValue } from "@libs/ssmUtils";
 import { modifyCurrentBusiness } from "@shared/domain-logic/modifyCurrentBusiness";
@@ -42,7 +42,7 @@ const mockGetConfigValue = getConfigValue as jest.MockedFunction<
   (paramName: CIGARETTE_PAYMENT_CONFIG_VARS) => Promise<string>
 >;
 
-const mockEmailClient: jest.Mocked<EmailClient> = {
+const mockEmailClient: jest.Mocked<PowerAutomateEmailClient> = {
   sendEmail: jest.fn(),
   health: jest.fn(),
 };

--- a/api/src/client/ApiCigaretteLicenseClient.ts
+++ b/api/src/client/ApiCigaretteLicenseClient.ts
@@ -6,9 +6,9 @@ import {
 } from "@client/ApiCigaretteLicenseHelpers";
 import {
   CigaretteLicenseClient,
-  EmailClient,
   HealthCheckMetadata,
   HealthCheckMethod,
+  PowerAutomateEmailClient,
 } from "@domain/types";
 import { LogWriterType } from "@libs/logWriter";
 import { getConfigValue } from "@libs/ssmUtils";
@@ -35,7 +35,7 @@ export const getConfig = async (): Promise<CigaretteLicenseApiConfig> => {
 };
 
 export const ApiCigaretteLicenseClient = (
-  emailClient: EmailClient,
+  emailClient: PowerAutomateEmailClient,
   logger: LogWriterType,
 ): CigaretteLicenseClient => {
   const preparePayment = async (

--- a/api/src/client/ApiPowerAutomateClientFactory.test.ts
+++ b/api/src/client/ApiPowerAutomateClientFactory.test.ts
@@ -27,36 +27,10 @@ describe("ApiPowerAutomateClient", () => {
 
       expect(mockAxios.post).toHaveBeenCalledWith(
         "some-base-url",
-        { some: "data" },
+        { "api-key": "some-api-key", "health-check": false, some: "data" },
         {
           headers: {
             "Content-Type": "application/json",
-            "x-api-key": "some-api-key",
-          },
-        },
-      );
-    });
-
-    it("making a post request with headers does not override the API key or Content-Type", async () => {
-      mockAxios.post.mockResolvedValue({ data: {} });
-
-      await client.startWorkflow({
-        body: { some: "data" },
-        headers: {
-          "some-header": "some-value",
-          "x-api-key": "wrong-api-key",
-          "Content-Type": "something/else",
-        },
-      });
-
-      expect(mockAxios.post).toHaveBeenCalledWith(
-        "some-base-url",
-        { some: "data" },
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "x-api-key": "some-api-key",
-            "some-header": "some-value",
           },
         },
       );
@@ -95,18 +69,20 @@ describe("ApiPowerAutomateClient", () => {
       });
     });
 
-    it("requests to start the workflow include the health-check header", async () => {
+    it("requests to start the workflow include the health-check body param", async () => {
       mockAxios.post.mockResolvedValue({});
 
       await client.health();
 
-      expect(mockAxios.post).toHaveBeenCalledWith("some-base-url", undefined, {
-        headers: {
-          "Content-Type": "application/json",
-          "x-api-key": "some-api-key",
-          "health-check": "active",
+      expect(mockAxios.post).toHaveBeenCalledWith(
+        "some-base-url",
+        { "api-key": "some-api-key", "health-check": true },
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
         },
-      });
+      );
     });
   });
 });

--- a/api/src/client/ApiPowerAutomateClientFactory.ts
+++ b/api/src/client/ApiPowerAutomateClientFactory.ts
@@ -14,16 +14,22 @@ export const ApiPowerAutomateClientFactory = (config: Config): PowerAutomateClie
 
   const startWorkflow = async (props: {
     body?: object;
-    headers?: object;
+    isHealthCheck?: boolean;
   }): Promise<AxiosResponse> => {
     return axios
-      .post(config.baseUrl, props.body, {
-        headers: {
-          ...props.headers,
-          "Content-Type": "application/json",
-          "x-api-key": config.apiKey,
+      .post(
+        config.baseUrl,
+        {
+          ...props.body,
+          "api-key": config.apiKey,
+          "health-check": props.isHealthCheck ? true : false,
         },
-      })
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      )
       .then((response: AxiosResponse) => {
         config.logger.LogInfo(
           `Power Automate Client - Id:${logId} - Response received: ${JSON.stringify(response.data)}`,
@@ -39,7 +45,7 @@ export const ApiPowerAutomateClientFactory = (config: Config): PowerAutomateClie
   };
 
   const health = async (): Promise<HealthCheckMetadata> => {
-    return startWorkflow({ headers: { "health-check": "active" } })
+    return startWorkflow({ isHealthCheck: true })
       .then((response) => {
         config.logger.LogInfo(
           `Power Automate Health Check - Id:${logId} - Response received: ${JSON.stringify(

--- a/api/src/client/CigaretteLicenseEmailClient.ts
+++ b/api/src/client/CigaretteLicenseEmailClient.ts
@@ -3,7 +3,7 @@ import {
   EmailConfirmationSubmission,
 } from "@businessnjgovnavigator/shared";
 import { ApiPowerAutomateClientFactory } from "@client/ApiPowerAutomateClientFactory";
-import { EmailClient, HealthCheckMetadata } from "@domain/types";
+import { HealthCheckMetadata, PowerAutomateEmailClient } from "@domain/types";
 import { LogWriterType } from "@libs/logWriter";
 import { getConfigValue } from "@libs/ssmUtils";
 import { ReasonPhrases, StatusCodes } from "http-status-codes";
@@ -18,7 +18,7 @@ const getConfig = async (): Promise<{
   };
 };
 
-export const CigaretteLicenseEmailClient = (logger: LogWriterType): EmailClient => {
+export const CigaretteLicenseEmailClient = (logger: LogWriterType): PowerAutomateEmailClient => {
   const logId = logger.GetId();
 
   const sendEmail = async (

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -272,7 +272,7 @@ export interface PowerAutomateClient {
   health: () => Promise<HealthCheckMetadata>;
 }
 
-export interface EmailClient {
+export interface PowerAutomateEmailClient {
   sendEmail: (postBody: EmailConfirmationSubmission) => Promise<EmailConfirmationResponse>;
   health: () => Promise<HealthCheckMetadata>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16522,7 +16522,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:14.0.2, commander@npm:^14.0.0, commander@npm:^14.0.2":
+"commander@npm:14.0.2, commander@npm:^14.0.2":
   version: 14.0.2
   resolution: "commander@npm:14.0.2"
   checksum: 0a9e549565d368dde2965821833324069b92b099b415c2106996e47db1f0b8c10c77367e9876873c00a52ca627af4c7472eba9b51dc0d6a3ef152ea063d3e9e9


### PR DESCRIPTION
## Description

Power Automate seems to be stripping custom header parameters out of API requests. This work moves the API key from the header to the body.

While not included in these code changes, the Power Automate workflow being used to trigger the Cigarette License Application confirmation email has been modified to expect the API key in the body, and the health check logic is now behind the API key logical branch to hopefully catch any issues earlier.

### Ticket

This pull request resolves [#16848](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16848).

### Approach

- Moved the `health-check` param to the request body
  - Now passing a boolean instead of a string `"active"`
- Moved the `api-key` param to the request body

### Steps to Test

The process to complete a cigarette sales license application has been covered multiple times. If you need instructions, please see other documentation such as [this PR](https://github.com/newjersey/navigator.business.nj.gov/pull/11796).

- Complete the cigarette sales license application
- After providing payment, and the user is redirected to "My Account", you should see messaging indicating your application was submitted successfully
<img width="657" height="420" alt="Screenshot 2025-11-24 at 4 17 12 PM" src="https://github.com/user-attachments/assets/1938e28f-c9d2-4472-996f-4281d3ce60b6" />


### Notes

I would much prefer passing the API key as a header param. It would be good to understand exactly why custom headers are being stripped. As of today, I cannot find documentation from Microsoft indicating why this is happening.

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
