### PR TITLE
feat: [AB#12620] WCAG formation required fields not announced as such

### DIFF
--- a/web/src/components/CountryDropdown.tsx
+++ b/web/src/components/CountryDropdown.tsx
@@ -119,6 +119,7 @@ export const CountryDropdown = (props: Props): ReactElement => {
             onSubmit={onValidation}
             autoComplete={props.autoComplete ? "country" : "no"}
             variant="outlined"
+            required={props.required}
             onClick={(): void => {
               if (!props.disabled) {
                 setOpen(true);

--- a/web/src/components/GenericTextField.tsx
+++ b/web/src/components/GenericTextField.tsx
@@ -193,6 +193,7 @@ export const GenericTextField = forwardRef(
             className: `${props.readOnly ? "bg-base-lightest" : ""}`,
             ...props.inputProps,
           }}
+          required={props.required}
           type={props.type}
           onFocus={props.onFocus}
           onKeyDown={props.onKeyDown}

--- a/web/src/components/StateDropdown.tsx
+++ b/web/src/components/StateDropdown.tsx
@@ -138,6 +138,7 @@ export const StateDropdown = (props: Props): ReactElement => {
                 setOpen(true);
               }
             }}
+            required={props.required}
             error={props.error}
             helperText={props.error && props.validationText}
           />

--- a/web/src/components/data-fields/MunicipalityDropdown.tsx
+++ b/web/src/components/data-fields/MunicipalityDropdown.tsx
@@ -19,6 +19,7 @@ interface Props {
   ariaLabel?: string;
   validationLabel?: string;
   hideErrorLabel?: boolean;
+  required?: boolean;
 }
 
 export const MunicipalityDropdown = (props: Props): ReactElement => {
@@ -99,6 +100,7 @@ export const MunicipalityDropdown = (props: Props): ReactElement => {
                   backgroundColor: "#FFFFFF",
                 },
               }}
+              required={props.required}
             />
           </div>
         );

--- a/web/src/components/tasks/business-formation/billing/BillingStep.tsx
+++ b/web/src/components/tasks/business-formation/billing/BillingStep.tsx
@@ -29,7 +29,7 @@ export const BillingStep = (): ReactElement => {
                 label={Config.formation.fields.contactFirstName.label}
                 fieldName="contactFirstName"
                 errorBarType="MOBILE-ONLY"
-                required={true}
+                required
                 validationText={getFieldErrorLabel("contactFirstName")}
               />
             </ScrollableFormFieldWrapper>
@@ -40,7 +40,7 @@ export const BillingStep = (): ReactElement => {
                 label={Config.formation.fields.contactLastName.label}
                 fieldName="contactLastName"
                 errorBarType="MOBILE-ONLY"
-                required={true}
+                required
                 validationText={getFieldErrorLabel("contactLastName")}
               />
             </ScrollableFormFieldWrapper>
@@ -58,6 +58,7 @@ export const BillingStep = (): ReactElement => {
               numericProps={{
                 maxLength: 10,
               }}
+              required
               visualFilter={getPhoneNumberFormat}
             />
           </ScrollableFormFieldWrapper>

--- a/web/src/components/tasks/business-formation/business/FormationDate.tsx
+++ b/web/src/components/tasks/business-formation/business/FormationDate.tsx
@@ -139,6 +139,7 @@ export const FormationDate = (props: Props): ReactElement => {
                     sx={{
                       svg: { fill: "#4b7600" },
                     }}
+                    required
                     inputProps={{
                       ...params.inputProps,
                       placeholder: "",

--- a/web/src/components/tasks/business-formation/business/FormationMunicipality.tsx
+++ b/web/src/components/tasks/business-formation/business/FormationMunicipality.tsx
@@ -25,6 +25,7 @@ export const FormationMunicipality = (): ReactElement => {
       validationLabel="Error"
       value={state.formationFormData.addressMunicipality}
       onSelect={onSelect}
+      required
       helperText={getFieldErrorLabel("addressMunicipality")}
     />
   );

--- a/web/src/components/tasks/business-formation/business/SuffixDropdown.tsx
+++ b/web/src/components/tasks/business-formation/business/SuffixDropdown.tsx
@@ -82,10 +82,16 @@ export const SuffixDropdown = (): ReactElement => {
           autoComplete="no"
           labelId="business-suffix-label"
           id="business-suffix"
-          SelectDisplayProps={{ "data-testid": "business-suffix-main" } as MySelectDisplayProps}
+          SelectDisplayProps={
+            {
+              "data-testid": "business-suffix-main",
+              "aria-required": "true",
+            } as MySelectDisplayProps
+          }
           displayEmpty
           value={state.formationFormData.businessSuffix || ""}
           onChange={handleChange}
+          required
           onBlur={(): void => setFieldsInteracted([FIELD])}
           inputProps={{ "data-testid": "business-suffix" }}
           renderValue={(selected): ReactNode => {

--- a/web/src/components/tasks/business-formation/contacts/AddressModal.tsx
+++ b/web/src/components/tasks/business-formation/contacts/AddressModal.tsx
@@ -3,6 +3,7 @@ import { Content } from "@/components/Content";
 import { GenericTextField } from "@/components/GenericTextField";
 import { ModalTwoButton } from "@/components/ModalTwoButton";
 import { ModifiedContent } from "@/components/ModifiedContent";
+import { LargeCallout } from "@/components/njwds-extended/callout/LargeCallout";
 import { StateDropdown } from "@/components/StateDropdown";
 import { WithErrorBar } from "@/components/WithErrorBar";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -16,7 +17,6 @@ import {
 import { isStartingBusiness } from "@businessnjgovnavigator/shared/domain-logic/businessPersonaHelpers";
 import { Checkbox, FormControlLabel, FormGroup } from "@mui/material";
 import { ReactElement, useEffect, useState } from "react";
-import { LargeCallout } from "@/components/njwds-extended/callout/LargeCallout";
 
 interface DisplayContent {
   modalTitle: string;
@@ -273,7 +273,7 @@ export const AddressModal = <T extends FormationMember | FormationIncorporator>(
               onValidation={onValidation}
               validationText={addressErrorMap["addressName"].label}
               fieldName="addressName"
-              required={true}
+              required
               autoComplete="name"
             />
           </WithErrorBar>
@@ -315,7 +315,7 @@ export const AddressModal = <T extends FormationMember | FormationIncorporator>(
               autoComplete="address-line1"
               validationText={addressErrorMap["addressLine1"].label}
               disabled={shouldBeDisabled("addressLine1")}
-              required={true}
+              required
             />
           </WithErrorBar>
           <WithErrorBar
@@ -368,7 +368,7 @@ export const AddressModal = <T extends FormationMember | FormationIncorporator>(
                     autoComplete="address-level2"
                     value={addressData.addressCity}
                     disabled={shouldBeDisabled("addressCity")}
-                    required={true}
+                    required
                     handleChange={(value: string): void => {
                       setAddressData((prevAddressData) => {
                         return { ...prevAddressData, addressCity: value };
@@ -408,7 +408,7 @@ export const AddressModal = <T extends FormationMember | FormationIncorporator>(
                         autoComplete
                         disabled={shouldBeDisabled("addressState")}
                         onValidation={onValidation}
-                        required={true}
+                        required
                         excludeTerritories={isStarting}
                       />
                     </div>
@@ -435,7 +435,7 @@ export const AddressModal = <T extends FormationMember | FormationIncorporator>(
                         value={addressData.addressZipCode}
                         validationText={addressErrorMap["addressZipCode"].label}
                         onValidation={onValidation}
-                        required={true}
+                        required
                       />
                     </div>
                   </div>

--- a/web/src/components/tasks/business-formation/contacts/RegisteredAgent.tsx
+++ b/web/src/components/tasks/business-formation/contacts/RegisteredAgent.tsx
@@ -110,7 +110,7 @@ const RegisteredAgentManualEntryFields = (): ReactElement => {
             <ScrollableFormFieldWrapper fieldName="agentName">
               <BusinessFormationTextField
                 label={Config.formation.fields.agentName.label}
-                required={true}
+                required
                 validationText={getFieldErrorLabel("agentName")}
                 errorBarType="MOBILE-ONLY"
                 fieldName="agentName"
@@ -126,7 +126,7 @@ const RegisteredAgentManualEntryFields = (): ReactElement => {
                 label={Config.formation.fields.agentEmail.label}
                 fieldName="agentEmail"
                 errorBarType="MOBILE-ONLY"
-                required={true}
+                required
                 validationText={getFieldErrorLabel("agentEmail")}
                 readOnly={shouldBeDisabled("agentEmail", "ACCOUNT")}
                 type="text"
@@ -154,7 +154,7 @@ const RegisteredAgentManualEntryFields = (): ReactElement => {
         <BusinessFormationTextField
           label={Config.formation.fields.agentOfficeAddressLine1.label}
           fieldName="agentOfficeAddressLine1"
-          required={true}
+          required
           validationText={getFieldErrorLabel("agentOfficeAddressLine1")}
           disabled={shouldBeDisabled("agentOfficeAddressLine1", "ADDRESS")}
           errorBarType="ALWAYS"
@@ -184,7 +184,7 @@ const RegisteredAgentManualEntryFields = (): ReactElement => {
                 <BusinessFormationTextField
                   label={Config.formation.fields.agentOfficeAddressCity.label}
                   fieldName="agentOfficeAddressCity"
-                  required={true}
+                  required
                   validationText={getFieldErrorLabel("agentOfficeAddressCity")}
                   disabled={shouldBeDisabled("agentOfficeAddressCity", "ADDRESS")}
                   errorBarType="NEVER"
@@ -222,7 +222,7 @@ const RegisteredAgentManualEntryFields = (): ReactElement => {
                       fieldName="agentOfficeAddressZipCode"
                       label={Config.formation.fields.agentOfficeAddressZipCode.label}
                       validationText={Config.formation.fields.agentOfficeAddressZipCode.error}
-                      required={true}
+                      required
                       disabled={shouldBeDisabled("agentOfficeAddressZipCode", "ADDRESS")}
                     />
                   </ScrollableFormFieldWrapper>
@@ -355,7 +355,7 @@ export const RegisteredAgent = (): ReactElement => {
                     secondaryLabel={Config.formation.registeredAgent.agentNumberLabelSecondary}
                     numericProps={{ minLength: 4, maxLength: 7 }}
                     fieldName="agentNumber"
-                    required={true}
+                    required
                     validationText={Config.formation.fields.agentNumber.error}
                     errorBarType="ALWAYS"
                     disabled={state.formationFormData.showManualEntry}

--- a/web/src/components/tasks/business-formation/contacts/Signatures.tsx
+++ b/web/src/components/tasks/business-formation/contacts/Signatures.tsx
@@ -3,6 +3,7 @@ import { Content } from "@/components/Content";
 import { ScrollableFormFieldWrapper } from "@/components/data-fields/ScrollableFormFieldWrapper";
 import { GenericTextField } from "@/components/GenericTextField";
 import { ModifiedContent } from "@/components/ModifiedContent";
+import { LargeCallout } from "@/components/njwds-extended/callout/LargeCallout";
 import { Heading } from "@/components/njwds-extended/Heading";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { Icon } from "@/components/njwds/Icon";
@@ -24,7 +25,6 @@ import {
 } from "@businessnjgovnavigator/shared";
 import { Checkbox, FormHelperText, MenuItem, Select, useMediaQuery } from "@mui/material";
 import { ChangeEvent, ReactElement, ReactNode, useContext, useMemo } from "react";
-import { LargeCallout } from "@/components/njwds-extended/callout/LargeCallout";
 
 export const Signatures = (): ReactElement => {
   const FIELD_NAME = "signers";
@@ -195,6 +195,8 @@ export const Signatures = (): ReactElement => {
             "aria-label": `Signer title ${index}`,
             "data-testid": `signer-title-${index}`,
           }}
+          SelectDisplayProps={{ "aria-required": "true" }}
+          required
           renderValue={(selected): ReactNode => {
             if (!selected) {
               return <></>;
@@ -288,7 +290,7 @@ export const Signatures = (): ReactElement => {
             fieldName="signer"
             className={`margin-top-0`}
             ariaLabel={`Signer ${index}`}
-            required={true}
+            required
           />
         </ScrollableFormFieldWrapper>
       </>

--- a/web/src/components/tasks/business-formation/name/BusinessName.tsx
+++ b/web/src/components/tasks/business-formation/name/BusinessName.tsx
@@ -18,8 +18,8 @@ import {
   ReactElement,
   useContext,
   useEffect,
-  useState,
   useRef,
+  useState,
 } from "react";
 
 export const BusinessName = (): ReactElement => {
@@ -95,6 +95,7 @@ export const BusinessName = (): ReactElement => {
                   });
                   setConfirmationValue("");
                 }}
+                required
                 variant="outlined"
                 inputProps={{
                   "aria-label": "Search business name",
@@ -125,6 +126,7 @@ export const BusinessName = (): ReactElement => {
                       state.formationFormData.businessName === event.target.value,
                   });
                 }}
+                required
                 variant="outlined"
                 inputProps={{
                   "aria-label": "Confirm business name",

--- a/web/src/components/tasks/search-business-name/SearchBusinessNameForm.tsx
+++ b/web/src/components/tasks/search-business-name/SearchBusinessNameForm.tsx
@@ -210,6 +210,7 @@ export const SearchBusinessNameForm = (props: Props): ReactElement => {
                     onChange={(event): void => {
                       onChangeNameField(event.target.value);
                     }}
+                    required
                     variant="outlined"
                     inputProps={{
                       "aria-label": props.config.inputLabel ?? "Search business name",


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

This ticket was to address issues with required fields not being announced correctly to screen readers. 

This is important for accessibility sake, to make sure our website is in compliance and is generally accessible for the good of our users. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#12620](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12620).

### Approach

This was an issue largely composed of 2 parts.
First our components weren't passing props down correctly to our lowest level of text field, so the required prop wasn't getting set for inputs some of the time. 
Second our dropdowns needed some special care regarding displayProps which allowed props to be set at the right part of the hierarchy to trigger the screen readers to notify the user that the desired field was required. 

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

1. Go to formation as a logged in user
2. Turn on your screen reader of choice (Mac OS voice over is an option for many of our devs)
3. Navigate through formation and see the fields that create errors on blur are announced as required when read out

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
