### PR TITLE
fix: [AB#16870] restrict snsPublishPolicyToCmsAlertTopic to dev

### DIFF
--- a/api/cdk/lib/iamStack.ts
+++ b/api/cdk/lib/iamStack.ts
@@ -8,6 +8,7 @@ import {
   USERS_TABLE,
   BUSINESSES_TABLE,
   AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY,
+  DEV_STAGE,
 } from "./constants";
 
 export interface IamStackProps extends StackProps {
@@ -123,7 +124,6 @@ export class IamStack extends Stack {
 
     const inlinePolicies: iam.PolicyStatement[] = [
       putMetricDataPolicyInCloudwatch,
-      snsPublishPolicyToCmsAlertTopic,
       secretsManagerPolicy,
       s3WritePolicy,
       ssmPolicy,
@@ -153,9 +153,11 @@ export class IamStack extends Stack {
         }),
       );
     }
-
     for (const policy of inlinePolicies) {
       lambdaRole.addToPrincipalPolicy(policy);
+    }
+    if (props.stage === DEV_STAGE) {
+      lambdaRole.addToPrincipalPolicy(snsPublishPolicyToCmsAlertTopic);
     }
     applyStandardTags(lambdaRole, props.stage);
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
This PR restricts the `SnsPublishPolicyToCmsAlertTopic` inline IAM policy so that it is only attached in the dev stage. Previously, this policy was included for all environments because it was added to the shared inlinePolicies array. Since the policy references a dev-specific SNS topic ARN, attaching it to non-dev environments was incorrect and introduced unnecessary cross-environment permissions.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#16870](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16870).

### Approach
- Updated IamStack to attach SnsPublishPolicyToCmsAlertTopic only when props.stage === "dev".
- Removed the policy from the shared inlinePolicies array so it no longer appears in other environments.
- Ensured that non-dev stacks will have the policy removed on deploy.

**Test Updates**
- The test suite now covers both the success and failure paths:
 **Dev environment test**
- Added a dedicated test that synthesizes a dev stage stack and verifies that the SNS publish policy is present.
**Non-dev test**
- Updated/added a test asserting that the SNS publish policy does not exist in non-dev environments (expecting the lookup to throw).
This ensures that environments clearly diverge and enforces the intended permissions model going forward.

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
