### PR TITLE
fix: [AB#15848] Fix edge handling for error field on employer rates response

### DIFF
--- a/shared/src/employerRates.ts
+++ b/shared/src/employerRates.ts
@@ -23,5 +23,5 @@ export type EmployerRatesResponse = {
   baseWeekAmt: string;
   numberOfBaseWeeks: string;
   taxableWageBaseDiFli: string;
-  error: string;
+  error?: string;
 };

--- a/web/src/components/employer-rates/EmployerRates.test.tsx
+++ b/web/src/components/employer-rates/EmployerRates.test.tsx
@@ -491,6 +491,35 @@ describe("EmployerRates", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("goes to the success table if response does not contain error field", async () => {
+    const response = generateEmployerRatesResponse({});
+    delete response.error;
+    mockApi.checkEmployerRates.mockResolvedValue(response);
+
+    renderComponentsWithOwning({
+      employerAccessRegistration: true,
+      deptOfLaborEin: "123451234512345",
+      businessName: "Test Business",
+    });
+
+    const submit = await screen.findByRole("button", {
+      name: Config.employerRates.employerAccessYesButtonText,
+    });
+
+    await userEvent.click(submit);
+
+    expect(screen.getByRole("alert", { name: "success" })).toBeInTheDocument();
+    expect(screen.getByRole("table", { name: "Quarterly Contribution Rates" })).toBeInTheDocument();
+    expect(screen.getByRole("table", { name: "Total Contribution Rates" })).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("heading", { name: Config.employerRates.employerAccessHeaderText }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: Config.employerRates.employerAccessYesButtonText }),
+    ).not.toBeInTheDocument();
+  });
+
   it("goes back to the question view if user edits quarter", async () => {
     mockApi.checkEmployerRates.mockResolvedValue(
       generateEmployerRatesResponse({

--- a/web/src/components/employer-rates/EmployerRatesQuestions.tsx
+++ b/web/src/components/employer-rates/EmployerRatesQuestions.tsx
@@ -106,7 +106,7 @@ export const EmployerRatesQuestions = (props: Props): ReactElement => {
       .checkEmployerRates({ employerRates, userData })
       .then((results: EmployerRatesResponse) => {
         setLoading(false);
-        if (results.error.length > 0) {
+        if (results.error) {
           setNoAccountError(true);
           return;
         }


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
This resolves an issue with the employer rates success table not showing when the response from the API does not have an error field.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#15848](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15848).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
