### PR TITLE
feat: [AB#16139] Encrypt DOL EIN field

### DIFF
--- a/api/src/api/userRouter.test.ts
+++ b/api/src/api/userRouter.test.ts
@@ -1290,12 +1290,13 @@ describe("userRouter", () => {
     });
 
     describe("when user changes Tax ID and Tax PIN", () => {
-      it("encrypts and masks the tax id and tax pin before getting put into the user data client", async () => {
+      it("encrypts and masks the tax id and tax pin and dol ein before getting put into the user data client", async () => {
         mockJwt.decode.mockReturnValue(cognitoPayload({ id: "123" }));
         stubCryptoEncryptionClient.encryptValue.mockImplementation((valueToBeEncrypted: string) => {
           const encryptedValues: { [key: string]: string } = {
             "123456789000": "encrypted-tax-id",
             "1234": "encrypted-tax-pin",
+            "54321": "encrypted-dol-ein",
           };
           return Promise.resolve(encryptedValues[valueToBeEncrypted] ?? "unexpected value");
         });
@@ -1312,6 +1313,7 @@ describe("userRouter", () => {
               encryptedTaxId: undefined,
               taxPin: "1234",
               encryptedTaxPin: undefined,
+              deptOfLaborEin: "54321",
             }),
           }),
           { user: oldUserData.user },
@@ -1334,6 +1336,7 @@ describe("userRouter", () => {
           encryptedTaxId: "encrypted-tax-id",
           taxPin: "****",
           encryptedTaxPin: "encrypted-tax-pin",
+          deptOfLaborEin: "encrypted-dol-ein",
         });
       });
     });

--- a/api/src/domain/user/encryptFieldsFactory.test.ts
+++ b/api/src/domain/user/encryptFieldsFactory.test.ts
@@ -14,17 +14,19 @@ describe("encryptFieldsFactory", () => {
   let stubCryptoEncryptionClient: jest.Mocked<CryptoClient>;
   let stubCryptoHashingClient: jest.Mocked<CryptoClient>;
   let encryptTaxId: EncryptTaxId;
-  const numFieldsToEncrypt = 5;
+  const numFieldsToEncrypt = 6;
   const profileTaxId = "123456789000";
   const profileTaxPin = "1234";
   const taxClearanceTaxId = "111111111111";
   const taxClearanceTaxPin = "1111";
   const cigaretteTaxId = "111111111119";
+  const deptOfLaborEin = "555555555555555";
   const encryptedProfileTaxId = "encrypted-123456789000";
   const encryptedProfileTaxPin = "encrypted-1234";
   const encryptedTaxClearanceTaxId = "encrypted-111111111111";
   const encryptedTaxClearanceTaxPin = "encrypted-1111";
   const encryptedCigaretteTaxId = "encrypted-111111111119";
+  const encryptedDeptOfLaborEin = "encrypted-555555555555555";
 
   const generateUnencryptedUserData = (
     profileDataOverrides = {},
@@ -38,6 +40,7 @@ describe("encryptFieldsFactory", () => {
           encryptedTaxId: undefined,
           taxPin: profileTaxPin,
           encryptedTaxPin: undefined,
+          deptOfLaborEin: deptOfLaborEin,
           ...profileDataOverrides,
         }),
         taxClearanceCertificateData: generateTaxClearanceCertificateData({
@@ -70,6 +73,7 @@ describe("encryptFieldsFactory", () => {
         encryptedTaxId: encryptedProfileTaxId,
         taxPin: "****",
         encryptedTaxPin: encryptedProfileTaxPin,
+        deptOfLaborEin: encryptedDeptOfLaborEin,
         ...profileDataOverrides,
       },
       taxClearanceCertificateData: business.taxClearanceCertificateData
@@ -104,6 +108,7 @@ describe("encryptFieldsFactory", () => {
           [taxClearanceTaxId]: encryptedTaxClearanceTaxId,
           [taxClearanceTaxPin]: encryptedTaxClearanceTaxPin,
           [cigaretteTaxId]: encryptedCigaretteTaxId,
+          [deptOfLaborEin]: encryptedDeptOfLaborEin,
         };
         return Promise.resolve(encryptedValues[valueToBeEncrypted] ?? "unexpected value");
       }),
@@ -127,6 +132,7 @@ describe("encryptFieldsFactory", () => {
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxId);
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxPin);
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(cigaretteTaxId);
+    expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(deptOfLaborEin);
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledTimes(numFieldsToEncrypt);
 
     const expectedUserData = getExpectedEncryptedCurrentBusiness(userData);
@@ -144,6 +150,7 @@ describe("encryptFieldsFactory", () => {
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxId);
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxPin);
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(cigaretteTaxId);
+    expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(deptOfLaborEin);
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledTimes(numFieldsToEncrypt - 1);
 
     const expectedUserData = getExpectedEncryptedCurrentBusiness(userData, {
@@ -164,6 +171,7 @@ describe("encryptFieldsFactory", () => {
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxId);
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxPin);
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(cigaretteTaxId);
+    expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(deptOfLaborEin);
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledTimes(numFieldsToEncrypt - 1);
 
     const expectedUserData = getExpectedEncryptedCurrentBusiness(userData, {
@@ -188,6 +196,7 @@ describe("encryptFieldsFactory", () => {
     expect(stubCryptoEncryptionClient.encryptValue).not.toHaveBeenCalledWith(taxClearanceTaxId);
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxPin);
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(cigaretteTaxId);
+    expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(deptOfLaborEin);
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledTimes(numFieldsToEncrypt - 1);
 
     const expectedUserData = getExpectedEncryptedCurrentBusiness(
@@ -217,6 +226,7 @@ describe("encryptFieldsFactory", () => {
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxId);
     expect(stubCryptoEncryptionClient.encryptValue).not.toHaveBeenCalledWith(taxClearanceTaxPin);
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(cigaretteTaxId);
+    expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(deptOfLaborEin);
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledTimes(numFieldsToEncrypt - 1);
 
     const expectedUserData = getExpectedEncryptedCurrentBusiness(
@@ -246,6 +256,7 @@ describe("encryptFieldsFactory", () => {
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxId);
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxPin);
     expect(stubCryptoEncryptionClient.encryptValue).not.toHaveBeenCalledWith(cigaretteTaxId);
+    expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(deptOfLaborEin);
     expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledTimes(numFieldsToEncrypt - 1);
 
     const expectedUserData = getExpectedEncryptedCurrentBusiness(

--- a/api/src/domain/user/encryptFieldsFactory.ts
+++ b/api/src/domain/user/encryptFieldsFactory.ts
@@ -17,6 +17,7 @@ export const encryptFieldsFactory = (
       encryptTaxClearanceTaxId,
       encryptTaxClearanceTaxPin,
       encryptCigaretteLicenseTaxId,
+      encryptDeptOfLaborEin,
     ];
     let encryptedUserData = userDataWithHashedTaxId;
 
@@ -193,4 +194,25 @@ const hashProfileTaxId = async (
     };
   }
   return { ...userData, businesses };
+};
+
+const encryptDeptOfLaborEin = async (
+  userData: UserData,
+  cryptoClient: CryptoClient,
+): Promise<UserData> => {
+  const currentBusiness = getCurrentBusiness(userData);
+  if (!currentBusiness.profileData.deptOfLaborEin) {
+    return userData;
+  }
+  const encryptedDolEin = await cryptoClient.encryptValue(
+    currentBusiness.profileData.deptOfLaborEin,
+  );
+
+  return modifyCurrentBusiness(userData, (business) => ({
+    ...business,
+    profileData: {
+      ...business.profileData,
+      deptOfLaborEin: encryptedDolEin,
+    },
+  }));
 };

--- a/content/src/fieldConfig/profile.json
+++ b/content/src/fieldConfig/profile.json
@@ -128,6 +128,12 @@
           "hideButtonTextMobile": "Hide Tax PIN"
         }
       },
+      "deptOfLaborEin": {
+        "default": {
+          "showButtonText": "Show",
+          "hideButtonText": "Hide"
+        }
+      },
       "elevatorOwningBusiness": {
         "default": {
           "header": "Elevator Owning Business",

--- a/web/src/components/data-fields/DolEin.test.tsx
+++ b/web/src/components/data-fields/DolEin.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen } from "@testing-library/react";
+import { DolEin } from "@/components/data-fields/DolEin";
+import { createEmptyProfileData, ProfileData } from "@businessnjgovnavigator/shared/profileData";
+import { WithStatefulProfileData } from "@/test/mock/withStatefulProfileData";
+import { generateProfileData } from "@businessnjgovnavigator/shared/test/factories";
+import { formatDolEin } from "@/lib/domain-logic/formatDolEin";
+import userEvent from "@testing-library/user-event";
+import * as api from "@/lib/api-client/apiClient";
+import { getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
+
+jest.mock("@/lib/api-client/apiClient", () => ({
+  decryptValue: jest.fn(),
+}));
+
+const mockApi = api as jest.Mocked<typeof api>;
+const Config = getMergedConfig();
+
+describe("<DolEin />", () => {
+  const formattedHiddenEin = formatDolEin("*".repeat(15));
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  interface Props {
+    startHidden?: boolean;
+    editable?: boolean;
+  }
+  const renderComponent = (profileData?: ProfileData, props?: Props): void => {
+    render(
+      <WithStatefulProfileData initialData={profileData || createEmptyProfileData()}>
+        <DolEin value={undefined} startHidden={props?.startHidden} editable={props?.editable} />
+      </WithStatefulProfileData>,
+    );
+  };
+
+  it("starts visible if no prop.startHidden is provided", () => {
+    const einValue = "123456789012345";
+    renderComponent(generateProfileData({ deptOfLaborEin: einValue }), { editable: true });
+    expect(screen.getByRole("textbox", { name: "Dol ein" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: Config.profileDefaults.fields.deptOfLaborEin.default.hideButtonText,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: Config.profileDefaults.fields.deptOfLaborEin.default.showButtonText,
+      }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Dol ein" })).toHaveValue(formatDolEin(einValue));
+  });
+
+  it("starts hidden if startHidden is true", () => {
+    const einValue = "123456789012345";
+    renderComponent(generateProfileData({ deptOfLaborEin: einValue }), {
+      startHidden: true,
+      editable: true,
+    });
+    expect(screen.getByRole("textbox", { name: "Dol ein" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: Config.profileDefaults.fields.deptOfLaborEin.default.showButtonText,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: Config.profileDefaults.fields.deptOfLaborEin.default.hideButtonText,
+      }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Dol ein" })).toHaveValue(formattedHiddenEin);
+    expect(screen.getByRole("textbox", { name: "Dol ein" })).toBeDisabled();
+  });
+
+  it("toggles between hidden and shown when button is pressed", async () => {
+    const einValue = "123456789012345";
+    renderComponent(generateProfileData({ deptOfLaborEin: einValue }), { editable: true });
+    expect(screen.getByRole("textbox", { name: "Dol ein" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: Config.profileDefaults.fields.deptOfLaborEin.default.hideButtonText,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: Config.profileDefaults.fields.deptOfLaborEin.default.showButtonText,
+      }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Dol ein" })).toHaveValue(formatDolEin(einValue));
+    expect(screen.getByRole("textbox", { name: "Dol ein" })).toBeEnabled();
+
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: Config.profileDefaults.fields.deptOfLaborEin.default.hideButtonText,
+      }),
+    );
+    expect(
+      screen.getByRole("button", {
+        name: Config.profileDefaults.fields.deptOfLaborEin.default.showButtonText,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: Config.profileDefaults.fields.deptOfLaborEin.default.hideButtonText,
+      }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Dol ein" })).toHaveValue(formattedHiddenEin);
+    expect(screen.getByRole("textbox", { name: "Dol ein" })).toBeDisabled();
+  });
+
+  it("decrypts einValue if it is filled out in userData on first render", async () => {
+    const einValue = "123456789012345";
+    const decryptedEinValue = "111111111111111";
+    mockApi.decryptValue.mockResolvedValue(decryptedEinValue);
+    renderComponent(generateProfileData({ deptOfLaborEin: einValue }), {
+      startHidden: true,
+      editable: true,
+    });
+    expect(screen.getByRole("textbox", { name: "Dol ein" })).toHaveValue(formattedHiddenEin);
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: Config.profileDefaults.fields.deptOfLaborEin.default.showButtonText,
+      }),
+    );
+    expect(mockApi.decryptValue).toHaveBeenCalledWith({ encryptedValue: einValue });
+    expect(screen.getByRole("textbox", { name: "Dol ein" })).toHaveValue(
+      formatDolEin(decryptedEinValue),
+    );
+  });
+
+  it("does not decrypt on first render if userData has no einValue", async () => {
+    const einValue = "";
+    renderComponent(generateProfileData({ deptOfLaborEin: einValue }), {
+      editable: true,
+    });
+    expect(screen.getByRole("textbox", { name: "Dol ein" })).toHaveValue("");
+    expect(
+      screen.getByRole("button", {
+        name: Config.profileDefaults.fields.deptOfLaborEin.default.hideButtonText,
+      }),
+    ).toBeInTheDocument();
+    expect(mockApi.decryptValue).not.toHaveBeenCalled();
+  });
+
+  it("renders as a span if field is disabled", async () => {
+    const einValue = "123456789012345";
+    renderComponent(generateProfileData({ deptOfLaborEin: einValue }), {
+      startHidden: true,
+      editable: false,
+    });
+    expect(screen.queryByRole("textbox", { name: "Dol ein" })).not.toBeInTheDocument();
+    expect(screen.getByText(formattedHiddenEin)).toBeInTheDocument();
+
+    renderComponent(generateProfileData({ deptOfLaborEin: einValue }), {
+      startHidden: false,
+      editable: false,
+    });
+    expect(screen.queryByRole("textbox", { name: "Dol ein" })).not.toBeInTheDocument();
+    expect(screen.getByText(formatDolEin(einValue))).toBeInTheDocument();
+  });
+});

--- a/web/src/components/data-fields/DolEin.tsx
+++ b/web/src/components/data-fields/DolEin.tsx
@@ -2,45 +2,117 @@ import { Content } from "@/components/Content";
 import { ScrollableFormFieldWrapper } from "@/components/data-fields/ScrollableFormFieldWrapper";
 import { GenericTextField } from "@/components/GenericTextField";
 import { useConfig } from "@/lib/data-hooks/useConfig";
-import { useUserData } from "@/lib/data-hooks/useUserData";
-import { ReactElement } from "react";
+import { ReactElement, useContext, useState } from "react";
+import { formatDolEin } from "@/lib/domain-logic/formatDolEin";
+import { ShowHideStatus, ShowHideToggleButton } from "@/components/ShowHideToggleButton";
+import { InputAdornment } from "@mui/material";
+import { ProfileDataContext } from "@/contexts/profileDataContext";
+import { decryptValue } from "@/lib/api-client/apiClient";
+import { useMountEffect } from "@/lib/utils/helpers";
 
 interface Props {
-  disabled?: boolean;
+  editable?: boolean;
   onValidation?: (fieldName: string, invalid: boolean) => void;
   handleChange?: (value: string) => void;
   value: string | undefined;
   error?: boolean;
   validationText?: string;
+  startHidden?: boolean;
 }
 
 export const DOL_EIN_CHARACTERS = 15;
+export const DOL_EIN_CHARACTERS_WITH_FORMATTING = 20;
 
 export const DolEin = (props: Props): ReactElement => {
   const { Config } = useConfig();
-  const { business } = useUserData();
+  const { state, setProfileData } = useContext(ProfileDataContext);
+  const [showHideStatus, setShowHideStatus] = useState<ShowHideStatus>(
+    props.startHidden ? "password-view" : "text-view",
+  );
+  const [isEncrypted, setIsEncrypted] = useState(false);
+  const value = props.value ?? state?.profileData.deptOfLaborEin;
+
+  useMountEffect(() => {
+    if (state.profileData.deptOfLaborEin.length > 0) {
+      setIsEncrypted(true);
+    }
+  });
+
+  const toggleShowHide = async (): Promise<void> => {
+    if (showHideStatus === "password-view" && isEncrypted) {
+      await decryptValue({
+        encryptedValue: state.profileData.deptOfLaborEin as string,
+      }).then((decryptedValue) => {
+        setProfileData({ ...state.profileData, deptOfLaborEin: decryptedValue });
+        setIsEncrypted(false);
+      });
+    }
+
+    if (showHideStatus === "password-view") {
+      setShowHideStatus("text-view");
+    } else {
+      setShowHideStatus("password-view");
+    }
+  };
+
+  const getShowHideToggleButton = (): ReactElement => {
+    return (
+      <ShowHideToggleButton
+        showText={Config.profileDefaults.fields.deptOfLaborEin.default.showButtonText}
+        hideText={Config.profileDefaults.fields.deptOfLaborEin.default.hideButtonText}
+        status={showHideStatus}
+        toggle={toggleShowHide}
+      />
+    );
+  };
+
+  const getDisplayValue = (value: string | undefined): string => {
+    if (!value) return "";
+    if (showHideStatus === "text-view") {
+      return formatDolEin(value);
+    } else {
+      return formatDolEin("*".repeat(DOL_EIN_CHARACTERS));
+    }
+  };
+
   return (
     <>
       <strong>
         <Content>{Config.employerRates.dolEinLabelText}</Content>
       </strong>
-      <ScrollableFormFieldWrapper fieldName={"dolEin"}>
-        <div className="text-field-width-reduced padding-bottom-2">
-          <GenericTextField
-            numericProps={{
-              maxLength: DOL_EIN_CHARACTERS,
-            }}
-            fieldName={"dolEin"}
-            inputWidth={"default"}
-            disabled={props.disabled}
-            value={props.value ?? business?.profileData.deptOfLaborEin}
-            onValidation={props.onValidation}
-            error={props.error}
-            validationText={props.validationText}
-            onChange={props.handleChange}
-          />
-        </div>
-      </ScrollableFormFieldWrapper>
+
+      {props.editable && (
+        <ScrollableFormFieldWrapper fieldName={"dolEin"}>
+          <div className="text-field-width-reduced padding-bottom-2">
+            <GenericTextField
+              numericProps={{
+                maxLength: DOL_EIN_CHARACTERS,
+              }}
+              fieldName={"dolEin"}
+              inputWidth={"default"}
+              disabled={showHideStatus === "password-view"}
+              value={value}
+              onValidation={props.onValidation}
+              error={props.error}
+              validationText={props.validationText}
+              onChange={props.handleChange}
+              visualFilter={getDisplayValue}
+              inputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">{getShowHideToggleButton()}</InputAdornment>
+                ),
+              }}
+            />
+          </div>
+        </ScrollableFormFieldWrapper>
+      )}
+
+      {!props.editable && (
+        <>
+          <span className={"margin-right-1"}>{getDisplayValue(value)}</span>
+          <span>{getShowHideToggleButton()}</span>
+        </>
+      )}
     </>
   );
 };

--- a/web/src/components/employer-rates/EmployerRates.test.tsx
+++ b/web/src/components/employer-rates/EmployerRates.test.tsx
@@ -16,7 +16,10 @@ import { createTheme, ThemeProvider } from "@mui/material";
 import * as api from "@/lib/api-client/apiClient";
 import { WithStatefulUserData } from "@/test/mock/withStatefulUserData";
 import { WithStatefulProfileData } from "@/test/mock/withStatefulProfileData";
-import { DOL_EIN_CHARACTERS } from "@/components/data-fields/DolEin";
+import {
+  DOL_EIN_CHARACTERS,
+  DOL_EIN_CHARACTERS_WITH_FORMATTING,
+} from "@/components/data-fields/DolEin";
 
 jest.mock("@businessnjgovnavigator/shared/dateHelpers", () => {
   const actual = jest.requireActual("@businessnjgovnavigator/shared/dateHelpers");
@@ -33,6 +36,7 @@ const originalOpen = window.open;
 
 jest.mock("@/lib/api-client/apiClient", () => ({
   checkEmployerRates: jest.fn(),
+  decryptValue: jest.fn(),
 }));
 
 const mockApi = api as jest.Mocked<typeof api>;
@@ -207,7 +211,7 @@ describe("EmployerRates", () => {
     const toType = "1".repeat(DOL_EIN_CHARACTERS + 1);
     await user.type(textbox, toType);
 
-    expect((textbox as HTMLInputElement).value.length).toBe(DOL_EIN_CHARACTERS);
+    expect((textbox as HTMLInputElement).value.length).toBe(DOL_EIN_CHARACTERS_WITH_FORMATTING);
   });
 
   it("renders input error and alert when entering less than DOL_EIN_CHARACTERS and blurring", async () => {
@@ -229,6 +233,7 @@ describe("EmployerRates", () => {
   it("clears input error and alert when input is cleared and blurred", async () => {
     renderComponentsWithOwning({
       employerAccessRegistration: true,
+      deptOfLaborEin: "",
     });
 
     const textbox = screen.getByRole("textbox");
@@ -346,6 +351,7 @@ describe("EmployerRates", () => {
 
   it("removes server error when there is a dol ein error", async () => {
     mockApi.checkEmployerRates.mockRejectedValue(new Error("500"));
+    mockApi.decryptValue.mockResolvedValue("123451234512345");
 
     renderComponentsWithOwning({
       employerAccessRegistration: true,
@@ -364,6 +370,11 @@ describe("EmployerRates", () => {
 
     const textbox = screen.getByRole("textbox");
     const user = userEvent.setup();
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: Config.profileDefaults.fields.deptOfLaborEin.default.showButtonText,
+      }),
+    );
     user.clear(textbox);
     const toType = "1".repeat(DOL_EIN_CHARACTERS - 1);
     await user.type(textbox, toType);
@@ -432,6 +443,7 @@ describe("EmployerRates", () => {
         error: "some error",
       }),
     );
+    mockApi.decryptValue.mockResolvedValue("123451234512345");
 
     renderComponentsWithOwning({
       employerAccessRegistration: true,
@@ -450,6 +462,11 @@ describe("EmployerRates", () => {
 
     const textbox = screen.getByRole("textbox");
     const user = userEvent.setup();
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: Config.profileDefaults.fields.deptOfLaborEin.default.showButtonText,
+      }),
+    );
     user.clear(textbox);
     const toType = "1".repeat(DOL_EIN_CHARACTERS - 1);
     await user.type(textbox, toType);

--- a/web/src/components/employer-rates/EmployerRatesQuestions.tsx
+++ b/web/src/components/employer-rates/EmployerRatesQuestions.tsx
@@ -20,6 +20,8 @@ import * as api from "@/lib/api-client/apiClient";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { EmployerRatesRequest, EmployerRatesResponse } from "@businessnjgovnavigator/shared";
 import { DolEin, DOL_EIN_CHARACTERS } from "@/components/data-fields/DolEin";
+import { useFormContextFieldHelpers } from "@/lib/data-hooks/useFormContextFieldHelpers";
+import { DataFormErrorMapContext } from "@/contexts/dataFormErrorMapContext";
 
 interface Props {
   CMS_ONLY_enable_preview?: boolean;
@@ -32,6 +34,7 @@ export const EmployerRatesQuestions = (props: Props): ReactElement => {
   const { Config } = useConfig();
   const { state, setProfileData } = useContext(ProfileDataContext);
   const { userData, updateQueue } = useUserData();
+  const { setIsValid } = useFormContextFieldHelpers("deptOfLaborEin", DataFormErrorMapContext);
 
   const initialEmployerAccess = isUndefined(state?.profileData.employerAccessRegistration)
     ? ""
@@ -63,6 +66,7 @@ export const EmployerRatesQuestions = (props: Props): ReactElement => {
   const handleRadioChange = (value: string): void => {
     if (value === "false" && dolEinError) {
       setDolEinError(false);
+      setIsValid(true);
     }
     if (value === "false" && noAccountError) {
       setNoAccountError(false);
@@ -74,6 +78,7 @@ export const EmployerRatesQuestions = (props: Props): ReactElement => {
     setProfileData((prev) => ({
       ...prev,
       employerAccessRegistration: value === "true",
+      deptOfLaborEin: "",
     }));
   };
 
@@ -88,6 +93,7 @@ export const EmployerRatesQuestions = (props: Props): ReactElement => {
 
     if (!isDolEinValid(state.profileData.deptOfLaborEin)) {
       setDolEinError(true);
+      setIsValid(false);
       return;
     }
 
@@ -193,11 +199,14 @@ export const EmployerRatesQuestions = (props: Props): ReactElement => {
                   setNoAccountError(false);
                 }
                 setDolEinError(invalid);
+                setIsValid(!invalid);
               }}
               handleChange={handleDolEinChange}
               value={state.profileData.deptOfLaborEin}
               error={dolEinError}
               validationText={Config.employerRates.dolEinErrorText}
+              startHidden={state.profileData.deptOfLaborEin.length > 0}
+              editable
             />
           </WithErrorBar>
           <EmployerRatesQuarterDropdown

--- a/web/src/components/employer-rates/EmployerRatesSuccessResponse.tsx
+++ b/web/src/components/employer-rates/EmployerRatesSuccessResponse.tsx
@@ -3,12 +3,12 @@ import { Alert } from "@/components/njwds-extended/Alert";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { templateEval } from "@/lib/utils/helpers";
 import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
-import { ReactElement } from "react";
+import { ReactElement, useContext } from "react";
 import { EmployerRatesResponse } from "@businessnjgovnavigator/shared/employerRates";
 import { EmployerRatesQuarterObject } from "@/lib/domain-logic/getEmployerAccessQuarterlyDropdownOptions";
 import { Content } from "@/components/Content";
 import { DolEin } from "@/components/data-fields/DolEin";
-import { useUserData } from "@/lib/data-hooks/useUserData";
+import { ProfileDataContext } from "@/contexts/profileDataContext";
 
 interface Props {
   resetQuarter: () => void;
@@ -18,7 +18,7 @@ interface Props {
 
 export const EmployerRatesSuccessResponse = (props: Props): ReactElement => {
   const { Config } = useConfig();
-  const { business } = useUserData();
+  const { state } = useContext(ProfileDataContext);
   return (
     <>
       <Alert className={"margin-y-5"} variant={"success"}>
@@ -32,7 +32,7 @@ export const EmployerRatesSuccessResponse = (props: Props): ReactElement => {
         </UnStyledButton>
       </Alert>
       <div className={"margin-y-5"}>
-        <DolEin disabled value={business?.profileData.deptOfLaborEin} />
+        <DolEin startHidden value={state.profileData.deptOfLaborEin} />
       </div>
       <EmployerRatesSuccessTables response={props.response} quarter={props.quarter} />
     </>

--- a/web/src/lib/domain-logic/formatDolEin.test.ts
+++ b/web/src/lib/domain-logic/formatDolEin.test.ts
@@ -1,0 +1,12 @@
+import { formatDolEin } from "@/lib/domain-logic/formatDolEin";
+
+describe("splitDolEin", () => {
+  it("splits at 2 digits, 5 digits, 8 digits, 11 digits, 14 digits", () => {
+    expect(formatDolEin("1")).toEqual("1");
+    expect(formatDolEin("1234")).toEqual("1-234");
+    expect(formatDolEin("1234567")).toEqual("1-234-567");
+    expect(formatDolEin("1234567890")).toEqual("1-234-567-890");
+    expect(formatDolEin("1234567890123")).toEqual("1-234-567-890/123");
+    expect(formatDolEin("123456789012345")).toEqual("1-234-567-890/123-45");
+  });
+});

--- a/web/src/lib/domain-logic/formatDolEin.ts
+++ b/web/src/lib/domain-logic/formatDolEin.ts
@@ -1,0 +1,19 @@
+export const formatDolEin = (ein: string): string => {
+  const length = ein.length;
+  if (length < 2) {
+    return ein;
+  }
+  if (length < 5) {
+    return `${ein.slice(0, 1)}-${ein.slice(1)}`;
+  }
+  if (length < 8) {
+    return `${ein.slice(0, 1)}-${ein.slice(1, 4)}-${ein.slice(4)}`;
+  }
+  if (length < 11) {
+    return `${ein.slice(0, 1)}-${ein.slice(1, 4)}-${ein.slice(4, 7)}-${ein.slice(7)}`;
+  }
+  if (length < 14) {
+    return `${ein.slice(0, 1)}-${ein.slice(1, 4)}-${ein.slice(4, 7)}-${ein.slice(7, 10)}/${ein.slice(10)}`;
+  }
+  return `${ein.slice(0, 1)}-${ein.slice(1, 4)}-${ein.slice(4, 7)}-${ein.slice(7, 10)}/${ein.slice(10, 13)}-${ein.slice(13)}`;
+};

--- a/web/test/pages/profile/profile-shared.test.tsx
+++ b/web/test/pages/profile/profile-shared.test.tsx
@@ -788,5 +788,87 @@ describe("profile - shared", () => {
         expect(currentBusiness().profileData.deptOfLaborEin).toEqual(newEin);
       });
     });
+
+    it("prevents saving DOL EIN if the number of characters is incorrect", async () => {
+      process.env.FEATURE_EMPLOYER_RATES = "true";
+
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          operatingPhase: OperatingPhaseId.UP_AND_RUNNING_OWNING,
+          businessPersona: "OWNING",
+          employerAccessRegistration: true,
+          deptOfLaborEin: "",
+        }),
+      });
+
+      renderPage({ business });
+      chooseTab("numbers");
+
+      const employerRatesSection = screen.getByTestId("employerAccess");
+      const textbox = within(employerRatesSection).getByRole("textbox");
+      const newEin = "123";
+      await userEvent.type(textbox, newEin);
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+      expect(screen.getAllByRole("alert").length).toBe(2);
+    });
+
+    it("allows save if DOL EIN is the correct number of characters", async () => {
+      process.env.FEATURE_EMPLOYER_RATES = "true";
+
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          operatingPhase: OperatingPhaseId.UP_AND_RUNNING_OWNING,
+          businessPersona: "OWNING",
+          employerAccessRegistration: true,
+          deptOfLaborEin: "",
+        }),
+      });
+
+      renderPage({ business });
+      chooseTab("numbers");
+
+      const employerRatesSection = screen.getByTestId("employerAccess");
+      const textbox = within(employerRatesSection).getByRole("textbox");
+      const newEin = "1".repeat(15);
+      await userEvent.type(textbox, newEin);
+
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+      expect(screen.getByTestId("snackbar-alert-SUCCESS")).toBeInTheDocument();
+    });
+
+    it("allows save if DOL EIN is incorrect number of characters but user changes employer access radio", async () => {
+      process.env.FEATURE_EMPLOYER_RATES = "true";
+
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          operatingPhase: OperatingPhaseId.UP_AND_RUNNING_OWNING,
+          businessPersona: "OWNING",
+          employerAccessRegistration: true,
+          deptOfLaborEin: "",
+        }),
+      });
+
+      renderPage({ business });
+      chooseTab("numbers");
+
+      const employerRatesSection = screen.getByTestId("employerAccess");
+      const textbox = within(employerRatesSection).getByRole("textbox");
+      const newEin = "1".repeat(10);
+      await userEvent.type(textbox, newEin);
+      await userEvent.tab();
+
+      expect(screen.getAllByRole("alert").length).toBe(2);
+
+      await userEvent.click(
+        within(employerRatesSection).getByRole("radio", {
+          name: Config.employerRates.employerAccessFalseText,
+        }),
+      );
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+      expect(screen.getByTestId("snackbar-alert-SUCCESS")).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
Encrypts the DOL EIN on the backend on save, so that we are saving only encrypted values in the database.

On the front end, we decrypt the DOL EIN if it has a value on first render. 

Additionally, this PR introduces masking on the front end for DOL EIN values. This functions identically to Tax PIN and Tax ID on the same page. While on the page, the user is able to hide and show the values at will. If you save and then return to the page, the values will start hidden. On the success page when a successful Employer Rates request has been made, the DOL EIN will no longer be editable, but can still be shown and hidden. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#16139](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16139).

### Approach

This approach largely mirrors the work done for Tax ID and Tax PIN, both in encryption and masking. The major difference is that, for legacy reasons, the Tax ID and Tax PIN have 2 values each in the database (a masked value and an encrypted value), whereas there is only one value for DOL EIN, which is always encrypted if it has value.

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

1. Start the server locally, and onboard as an existing business
2. Go to profile
3. Go to reference numbers tab
4. Click Yes on Employer Contribution Rates Radio Question
5. Enter a value for DOL EIN. It should automatically format itself but not be masked. You can hit "SHOW" or "HIDE" at any time to toggle between shown and masked values
6. Hit Save
7. Return to Reference Numbers tab. Your DOL EIN value should be remembered and hidden
8. Go to the local dynamo db table. You should be able to see your DOL EIN is encrypted in the database.
9. Hit "SHOW". It should decrypt your value and show you what you entered.
10. To test the success response, you can either invert the response check locally or test it on the workspace. The DOL EIN should no longer be editable, but still can be hidden or shown

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
