### PR TITLE
feat: [AB#16850] Show encrypted DOL EIN for returning users

### DIFF
--- a/web/src/components/employer-rates/EmployerRates.tsx
+++ b/web/src/components/employer-rates/EmployerRates.tsx
@@ -17,6 +17,7 @@ import { Heading } from "@/components/njwds-extended/Heading";
 
 interface Props {
   CMS_ONLY_enable_preview?: boolean;
+  handleChangeOverride?: (() => void) | undefined;
 }
 
 export const EmployerRates = (props: Props): ReactElement => {
@@ -48,6 +49,7 @@ export const EmployerRates = (props: Props): ReactElement => {
             setQuarter={setQuarter}
             setResponse={setResponse}
             CMS_ONLY_enable_preview={props.CMS_ONLY_enable_preview}
+            handleChangeOverride={props.handleChangeOverride}
           />
         )}
 

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -715,7 +715,9 @@ const ProfilePage = (props: Props): ReactElement => {
             handleChangeOverride={showNeedsAccountModalForGuest()}
           />
         </ProfileField>
-        {FEATURE_EMPLOYER_RATES_ENABLED && <EmployerRates />}
+        {FEATURE_EMPLOYER_RATES_ENABLED && (
+          <EmployerRates handleChangeOverride={showNeedsAccountModalForGuest()} />
+        )}
       </div>
     ),
     documents: (
@@ -869,7 +871,9 @@ const ProfilePage = (props: Props): ReactElement => {
             handleChangeOverride={showNeedsAccountModalForGuest()}
           />
         </ProfileField>
-        {FEATURE_EMPLOYER_RATES_ENABLED && <EmployerRates />}
+        {FEATURE_EMPLOYER_RATES_ENABLED && (
+          <EmployerRates handleChangeOverride={showNeedsAccountModalForGuest()} />
+        )}
       </div>
     ),
     documents: <></>,


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Shows encrypted DOL EIN for users who have entered it in the past.
Also adds the guest mode modal for users who have not signed into myNJ

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#16850](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16850).

### Approach

Used the same `handleOverride` approach as components like `taxPin` and `taxID` to summon the guest mode modal. Used similar methods to those components for encryption/decryption as well

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
1. Onboard as an existing business
2. Go to "Reference Numbers" under profile.
3. Select "TRUE" to the Employer Rates question
4. Try to enter a value for DOL EIN or submit the request, you should see a guest mode modal pop up if you aren't logged in.
5. Log in with myNJ and return, enter a DOL EIN, and either save the page or submit a request.
6. When you return, DOL EIN should no longer be editable and start encrypted (which can be verified in local DB)

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
