### PR TITLE
feat: [AB#17075] auto promotion for non essential questions associate…

### DIFF
--- a/shared/src/types/types.ts
+++ b/shared/src/types/types.ts
@@ -165,7 +165,6 @@ export interface AnytimeActionTask extends AnytimeAction {
   callToActionText?: string;
   issuingAgency?: string;
   moveToRecommendedForYouSection?: boolean;
-  nonEssentialQuestionsMoveToRecommendedAnytimeActionIds?: string[];
   industryIds: string[];
   sectorIds: string[];
   applyToAllUsers: boolean;

--- a/web/decap-config/collections/05-roadmap.yml
+++ b/web/decap-config/collections/05-roadmap.yml
@@ -319,9 +319,12 @@ collections:
                 value_field: "{{fields.id}}"
                 display_fields: [displayname]
                 options_length: 9999
-              - label: Anytime Actions Tasks
+              - label: Anytime Actions Tasks (Added when Non Essential Question is Answered Yes)
                 name: anytimeActions
-                hint: Anytime Actions related to reinstatements are not included in this dropdown
+                hint:
+                  (Anytime Actions chosen will automatically be displayed in the Recommended for You
+                  section for the user)(Anytime Actions related to reinstatements are not included
+                  in this dropdown)
                 required: false
                 default: []
                 widget: relation

--- a/web/decap-config/collections/10-anytime-action.yml
+++ b/web/decap-config/collections/10-anytime-action.yml
@@ -92,18 +92,6 @@ collections:
           widget: "boolean",
           required: false,
         }
-      - label:
-          Non Essential Questions which will move this to recommended for you section if answered
-          yes
-        name: nonEssentialQuestionsMoveToRecommendedAnytimeActionIds
-        widget: relation
-        multiple: true
-        required: false
-        default: []
-        collection: "nonEssentialQuestionsCollection"
-        search_fields: ["nonEssentialQuestionsArray.*.id"]
-        value_field: "nonEssentialQuestionsArray.*.id"
-        display_fields: ["nonEssentialQuestionsArray.*.id"]
       - {
           label: "Url Slug - Internal Routing",
           name: "urlSlug",


### PR DESCRIPTION
…d with anytime actions to recommended for you category

<!-- Please complete the following sections as necessary. -->

## Description

We wanted to make it so that nonEssential Questions associated with anytime actions automatically had their associated anytime actions promoted from their normal categories to the Recommended For You category. 

This is meant to streamline the simplify the content teams work and keep them from having to changing data in multiple places to achieve the same effect. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#17075](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17075).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

1. Run application locally and login
3. set industry to healthcare
4. go to dashboard and open anytime action search
5. see that anytime action search contains nothing regarding x rays
6. go to profile customization and select yes on the xray non essential question
7. go to dashboard and open anytime action search
8. see that recommended for you now has 2 recommended for you tasks involving x rays. 

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
