### PR TITLE
feat: [AB#16693] Enable employer rates section for foreign and nexus business with remote workers

### DIFF
--- a/web/src/components/employer-rates/EmployerRates.test.tsx
+++ b/web/src/components/employer-rates/EmployerRates.test.tsx
@@ -102,6 +102,7 @@ describe("EmployerRates", () => {
     renderComponents({
       operatingPhase: OperatingPhaseId.UP_AND_RUNNING,
       businessPersona: "FOREIGN",
+      foreignBusinessTypeIds: ["employeesInNJ"],
     });
     expect(screen.getByText(Config.employerRates.sectionHeaderText)).toBeInTheDocument();
   });

--- a/web/src/components/employer-rates/EmployerRates.tsx
+++ b/web/src/components/employer-rates/EmployerRates.tsx
@@ -14,6 +14,8 @@ import {
 } from "@/lib/domain-logic/getEmployerAccessQuarterlyDropdownOptions";
 import { EmployerRatesQuestions } from "@/components/employer-rates/EmployerRatesQuestions";
 import { Heading } from "@/components/njwds-extended/Heading";
+import { intersection } from "lodash";
+import { RemoteWorkerBusinessTypeIds } from "@businessnjgovnavigator/shared";
 
 interface Props {
   CMS_ONLY_enable_preview?: boolean;
@@ -33,6 +35,13 @@ export const EmployerRates = (props: Props): ReactElement => {
     !operatingPhase.displayEmployerRatesInProfile &&
     !props.CMS_ONLY_enable_preview &&
     !FEATURE_EMPLOYER_RATES_ENABLED
+  ) {
+    return <></>;
+  }
+
+  if (
+    state.profileData.businessPersona === "FOREIGN" &&
+    intersection(state.profileData.foreignBusinessTypeIds, RemoteWorkerBusinessTypeIds).length === 0
   ) {
     return <></>;
   }

--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -485,6 +485,10 @@ const ProfilePage = (props: Props): ReactElement => {
             handleChangeOverride={showNeedsAccountModalForGuest()}
           />
         </ProfileField>
+
+        {FEATURE_EMPLOYER_RATES_ENABLED && (
+          <EmployerRates handleChangeOverride={showNeedsAccountModalForGuest()} />
+        )}
       </div>
     ),
     documents: <></>,
@@ -558,6 +562,9 @@ const ProfilePage = (props: Props): ReactElement => {
             handleChangeOverride={showNeedsAccountModalForGuest()}
           />
         </ProfileField>
+        {FEATURE_EMPLOYER_RATES_ENABLED && (
+          <EmployerRates handleChangeOverride={showNeedsAccountModalForGuest()} />
+        )}
       </div>
     ),
     documents: <></>,

--- a/web/test/pages/profile/profile-foreign.test.tsx
+++ b/web/test/pages/profile/profile-foreign.test.tsx
@@ -638,6 +638,47 @@ describe("profile-foreign", () => {
         ).toBeInTheDocument();
       },
     );
+
+    it("shows the employer rates section if the business has remoteWorker foreignBusinessId", () => {
+      process.env.FEATURE_EMPLOYER_RATES = "true";
+      renderPage({
+        business: generateBusinessForProfile({
+          profileData: generateProfileData({
+            businessPersona: "FOREIGN",
+            foreignBusinessTypeIds: ["employeesInNJ"],
+            operatingPhase: OperatingPhaseId.UP_AND_RUNNING,
+          }),
+        }),
+      });
+      chooseTab("numbers");
+      expect(
+        screen.getByRole("heading", { name: Config.employerRates.sectionHeaderText }),
+      ).toBeInTheDocument();
+    });
+
+    it("doesn't show the employer rates section if the business doesn't have remote workers", () => {
+      process.env.FEATURE_EMPLOYER_RATES = "true";
+      renderPage({
+        business: generateBusinessForProfile({
+          profileData: generateProfileData({
+            businessPersona: "FOREIGN",
+            foreignBusinessTypeIds: [
+              "employeeOrContractorInNJ",
+              "officeInNJ",
+              "propertyInNJ",
+              "companyOperatedVehiclesInNJ",
+              "revenueInNJ",
+              "transactionsInNJ",
+            ],
+            operatingPhase: OperatingPhaseId.UP_AND_RUNNING,
+          }),
+        }),
+      });
+      chooseTab("numbers");
+      expect(
+        screen.queryByRole("heading", { name: Config.employerRates.sectionHeaderText }),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("non essential questions", () => {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
Enables the employer rates section for foreign and nexus businesses with remote workers.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#16693](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16693).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
Create a new out of state business. You can click as many of the checkboxes as you like as long as you also click "employees in NJ". Then, after navigating to the numbers tab of the profile, you should see the employer rates section. 

If you create a new out of state business without the "employees in NJ" checkbox selected, you will not see the employer rates section. 

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
