### PR TITLE
feat: add login assistance message, support link on `/loading`

### DIFF
--- a/content/src/fieldConfig/login-support-page.json
+++ b/content/src/fieldConfig/login-support-page.json
@@ -1,5 +1,12 @@
 {
   "loginSupportPage": {
+    "unlinkedAccount": "It looks like you haven’t linked your myNewJersey account.",
+    "havingTrouble": "Having trouble logging in?",
+    "logoutButtonText": "Log out",
+    "logoutButtonTextUnlinked": "log out",
+    "logoutAndTryAgain": "~~logoutButton~~ and try again.",
+    "logoutAndTryAgainUnlinked": "Please ~~logoutButton~~ and try again.",
+    "forMoreAssistance": "For more assistance, visit our [Login Issues Help page](support/login).",
     "pageTitle": "Having trouble logging in to Business.NJ.gov?",
     "lastUpdated": "Nov 5, 2025",
     "multipleAccountsCallout": ":::miniCallout{ calloutType=\"informational\" }\n**If you have multiple myNewJersey accounts, use the email linked to your business.**\n:::",

--- a/web/decap-config/collections/13-support.yml
+++ b/web/decap-config/collections/13-support.yml
@@ -21,6 +21,21 @@ collections:
             collapsed: false
             widget: object
             fields:
+              - { label: "Unlinked Account", name: "unlinkedAccount", widget: "string" }
+              - { label: "Having Trouble", name: "havingTrouble", widget: "string" }
+              - { label: "Logout Button Text", name: "logoutButtonText", widget: "string" }
+              - {
+                  label: "Logout Button Text Unlinked",
+                  name: "logoutButtonTextUnlinked",
+                  widget: "string",
+                }
+              - { label: "Logout And Try Again", name: "logoutAndTryAgain", widget: "string" }
+              - {
+                  label: "Logout And Try Again Unlinked",
+                  name: "logoutAndTryAgainUnlinked",
+                  widget: "string",
+                }
+              - { label: "For More Assistance", name: "forMoreAssistance", widget: "string" }
               - { label: "Page Title", name: "pageTitle", widget: "string" }
               - { label: "Last Updated Date", name: "lastUpdated", widget: "string" }
               - {

--- a/web/src/components/LoadingPageComponent.tsx
+++ b/web/src/components/LoadingPageComponent.tsx
@@ -1,14 +1,76 @@
+import { Content } from "@/components/Content";
+import { UnStyledButton } from "@/components/njwds-extended/UnStyledButton";
 import { PageSkeleton } from "@/components/njwds-layout/PageSkeleton";
 import { SingleColumnContainer } from "@/components/njwds/SingleColumnContainer";
 import { PageCircularIndicator } from "@/components/PageCircularIndicator";
-import { ReactElement } from "react";
+import { AuthContext } from "@/contexts/authContext";
+import { IsAuthenticated } from "@/lib/auth/AuthContext";
+import { configureAmplify, triggerSignOut } from "@/lib/auth/sessionHelper";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { ReactElement, useContext } from "react";
 
-export const LoadingPageComponent = (): ReactElement => {
+interface Props {
+  hasError?: boolean;
+  isLinkingError?: boolean;
+}
+
+export const LoadingPageComponent = ({
+  hasError = false,
+  isLinkingError = false,
+}: Props): ReactElement => {
+  const { Config } = useConfig();
+  const { state: authState } = useContext(AuthContext);
+
+  const isLoggedIn = authState.isAuthenticated === IsAuthenticated.TRUE;
+
+  const customComponents = {
+    logoutButton: (
+      <UnStyledButton
+        onClick={async () => {
+          configureAmplify();
+          await triggerSignOut();
+        }}
+        className="logout-button-unstyled"
+      >
+        {isLinkingError
+          ? Config.loginSupportPage.logoutButtonTextUnlinked
+          : Config.loginSupportPage.logoutButtonText}
+      </UnStyledButton>
+    ),
+  };
+
+  const renderErrorState = (): JSX.Element => {
+    const titleMessage = isLinkingError
+      ? Config.loginSupportPage.unlinkedAccount
+      : Config.loginSupportPage.havingTrouble;
+
+    const titleClassName = isLinkingError ? undefined : "text-bold";
+
+    return (
+      <div className="margin-top-neg-4 text-center">
+        <p className={titleClassName}>{titleMessage}</p>
+
+        {isLoggedIn && (
+          <Content customComponents={customComponents}>
+            {isLinkingError
+              ? Config.loginSupportPage.logoutAndTryAgainUnlinked
+              : Config.loginSupportPage.logoutAndTryAgain}
+          </Content>
+        )}
+
+        <Content className="margin-y-3" showLaunchIcon={false}>
+          {Config.loginSupportPage.forMoreAssistance}
+        </Content>
+      </div>
+    );
+  };
+
   return (
     <PageSkeleton showNavBar logoOnly="NAVIGATOR_LOGO">
       <main className="usa-section padding-top-0 desktop:padding-top-8" id="main">
         <SingleColumnContainer>
           <PageCircularIndicator />
+          {hasError && renderErrorState()}
         </SingleColumnContainer>
       </main>
     </PageSkeleton>

--- a/web/src/lib/auth/signinHelper.ts
+++ b/web/src/lib/auth/signinHelper.ts
@@ -151,8 +151,10 @@ export const onGuestSignIn = async ({
         break;
       }
       case ROUTES.loading: {
-        setRegistrationDimension("Began Onboarding");
-        push(ROUTES.onboarding);
+        if (!encounteredMyNjLinkingError) {
+          setRegistrationDimension("Began Onboarding");
+          push(ROUTES.onboarding);
+        }
         break;
       }
       case ROUTES.login: {

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -5,10 +5,12 @@ import { IntercomScript } from "@/components/IntercomScript";
 import { NeedsAccountModal } from "@/components/auth/NeedsAccountModal";
 
 import { RegistrationStatusSnackbar } from "@/components/auth/RegistrationStatusSnackbar";
+import { RemoveBusinessModal } from "@/components/dashboard/RemoveBusinessModal";
 import { AuthContext, initialState } from "@/contexts/authContext";
 import { ContextualInfoContext } from "@/contexts/contextualInfoContext";
 import { IntercomContext } from "@/contexts/intercomContext";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
+import { RemoveBusinessContext } from "@/contexts/removeBusinessContext";
 import { RoadmapContext } from "@/contexts/roadmapContext";
 import { UpdateQueueContext } from "@/contexts/updateQueueContext";
 import { UserDataErrorContext } from "@/contexts/userDataErrorContext";
@@ -40,8 +42,6 @@ import Script from "next/script";
 import { ReactElement, useEffect, useReducer, useState } from "react";
 import { SWRConfig } from "swr";
 import "../styles/main.scss";
-import { RemoveBusinessContext } from "@/contexts/removeBusinessContext";
-import { RemoveBusinessModal } from "@/components/dashboard/RemoveBusinessModal";
 
 AuthContext.displayName = "Authentication";
 RoadmapContext.displayName = "Roadmap";
@@ -97,7 +97,7 @@ const App = ({ Component, pageProps }: AppProps): ReactElement => {
     event:
       | "signedIn"
       | "signUp"
-      | "signOut"
+      | "signedOut"
       | "signIn_failure"
       | "tokenRefresh"
       | "tokenRefresh_failure"
@@ -115,7 +115,7 @@ const App = ({ Component, pageProps }: AppProps): ReactElement => {
         break;
       case "signUp":
         break;
-      case "signOut":
+      case "signedOut":
         break;
       case "signIn_failure":
         console.error("user sign in failed");
@@ -128,7 +128,7 @@ const App = ({ Component, pageProps }: AppProps): ReactElement => {
       case "configured":
         break;
       default:
-        console.error("unknown payload type");
+        console.error(`unknown payload type: ${data.payload.event}`);
         break;
     }
   };

--- a/web/test/components/LoadingPageComponent.test.tsx
+++ b/web/test/components/LoadingPageComponent.test.tsx
@@ -1,0 +1,128 @@
+import { LoadingPageComponent } from "@/components/LoadingPageComponent";
+import { IsAuthenticated } from "@/lib/auth/AuthContext";
+import { withAuth } from "@/test/helpers/helpers-renderers";
+import { getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
+import { render, screen } from "@testing-library/react";
+
+const Config = getMergedConfig();
+
+jest.mock("next/compat/router", () => ({ useRouter: jest.fn() }));
+
+describe("LoadingPageComponent", () => {
+  describe("when there are no errors", () => {
+    it("shows only the loading indicator", () => {
+      render(
+        withAuth(<LoadingPageComponent hasError={false} />, {
+          isAuthenticated: IsAuthenticated.TRUE,
+        }),
+      );
+
+      expect(screen.queryByText(Config.loginSupportPage.havingTrouble)).not.toBeInTheDocument();
+      expect(screen.queryByText(Config.loginSupportPage.unlinkedAccount)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when there are errors", () => {
+    describe("user is logged in and has a myNJ linking error", () => {
+      it("shows unlinked account message, logout instructions, and help link", () => {
+        render(
+          withAuth(<LoadingPageComponent hasError={true} isLinkingError={true} />, {
+            isAuthenticated: IsAuthenticated.TRUE,
+          }),
+        );
+
+        expect(screen.getByText(Config.loginSupportPage.unlinkedAccount)).toBeInTheDocument();
+
+        expect(
+          screen.getByRole("button", { name: Config.loginSupportPage.logoutButtonTextUnlinked }),
+        ).toBeInTheDocument();
+        expect(screen.getByText(/please/i)).toBeInTheDocument();
+        expect(screen.getByText(/and try again/i)).toBeInTheDocument();
+
+        expect(screen.getByRole("link", { name: /login issues help page/i })).toBeInTheDocument();
+      });
+
+      it("'unlinked account' message is not bold", () => {
+        render(
+          withAuth(<LoadingPageComponent hasError={true} isLinkingError={true} />, {
+            isAuthenticated: IsAuthenticated.TRUE,
+          }),
+        );
+
+        const UnlinkedAccountMessage = screen.getByText(Config.loginSupportPage.unlinkedAccount);
+        expect(UnlinkedAccountMessage).not.toHaveClass("text-bold");
+      });
+    });
+
+    describe("user is logged in and has no myNJ linking error", () => {
+      it("shows bolded 'having trouble' message, logout instructions, and help link", () => {
+        render(
+          withAuth(<LoadingPageComponent hasError={true} isLinkingError={false} />, {
+            isAuthenticated: IsAuthenticated.TRUE,
+          }),
+        );
+
+        const havingTroubleMessage = screen.getByText(Config.loginSupportPage.havingTrouble);
+        expect(havingTroubleMessage).toBeInTheDocument();
+        expect(havingTroubleMessage).toHaveClass("text-bold");
+
+        expect(
+          screen.getByRole("button", { name: Config.loginSupportPage.logoutButtonText }),
+        ).toBeInTheDocument();
+        expect(screen.getByText(/and try again/i)).toBeInTheDocument();
+
+        expect(screen.getByRole("link", { name: /login issues help page/i })).toBeInTheDocument();
+      });
+
+      it("does not show the 'Please' text from the unlinked 'log out' message'", () => {
+        render(
+          withAuth(<LoadingPageComponent hasError={true} isLinkingError={false} />, {
+            isAuthenticated: IsAuthenticated.TRUE,
+          }),
+        );
+
+        expect(screen.queryByText(/please/i)).not.toBeInTheDocument();
+      });
+    });
+
+    describe("user is logged out and has a myNJ linking error", () => {
+      it("shows unlinked account message and help link, but no logout link", () => {
+        render(
+          withAuth(<LoadingPageComponent hasError={true} isLinkingError={true} />, {
+            isAuthenticated: IsAuthenticated.FALSE,
+          }),
+        );
+
+        expect(screen.getByText(Config.loginSupportPage.unlinkedAccount)).toBeInTheDocument();
+
+        expect(
+          screen.queryByRole("button", { name: Config.loginSupportPage.logoutButtonText }),
+        ).not.toBeInTheDocument();
+        // "please" is only in the "logged in and unlinked" error copy
+        expect(screen.queryByText(/please/i)).not.toBeInTheDocument();
+
+        expect(screen.getByRole("link", { name: /login issues help page/i })).toBeInTheDocument();
+      });
+    });
+
+    describe("user is logged out and has no myNJ linking error", () => {
+      it("shows bolded 'having trouble' message and help link, but no logout link", () => {
+        render(
+          withAuth(<LoadingPageComponent hasError={true} isLinkingError={false} />, {
+            isAuthenticated: IsAuthenticated.FALSE,
+          }),
+        );
+
+        const havingTroubleMessage = screen.getByText(Config.loginSupportPage.havingTrouble);
+        expect(havingTroubleMessage).toBeInTheDocument();
+        expect(havingTroubleMessage).toHaveClass("text-bold");
+
+        expect(
+          screen.queryByRole("button", { name: Config.loginSupportPage.logoutButtonText }),
+        ).not.toBeInTheDocument();
+
+        expect(screen.getByRole("link", { name: /login issues help page/i })).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/web/test/pages/loading.test.tsx
+++ b/web/test/pages/loading.test.tsx
@@ -23,7 +23,7 @@ import {
   generateProfileData,
   generateUserDataForBusiness,
 } from "@businessnjgovnavigator/shared/test";
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 
 jest.mock("next/compat/router", () => ({ useRouter: jest.fn() }));
 jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
@@ -110,7 +110,7 @@ describe("loading page", () => {
     expect(mockPush).toHaveBeenCalledWith("/tasks/some-task");
   });
 
-  it("triggers onGuestSignIn with encounteredMyNjLinkingError param when user has signin error", async () => {
+  it("triggers error message when user has a myNJ linking signin error", async () => {
     setMockUserDataResponse(generateUseUserDataResponse({ userData: undefined }));
     useMockRouter({ isReady: true, asPath: signInSamlError });
     mockSigninHelper.onGuestSignIn.mockResolvedValue();
@@ -118,12 +118,7 @@ describe("loading page", () => {
     render(withAuth(<LoadingPage />, { isAuthenticated: IsAuthenticated.FALSE }));
 
     expect(mockAnalytics.event.landing_page.arrive.get_unlinked_myNJ_account).toHaveBeenCalled();
-    return expect(mockSigninHelper.onGuestSignIn).toHaveBeenCalledWith({
-      push: expect.anything(),
-      pathname: expect.anything(),
-      dispatch: expect.anything(),
-      encounteredMyNjLinkingError: true,
-    });
+    expect(screen.getByText("Login Issues Help page")).toBeInTheDocument();
   });
 
   it("redirects to the email check login page as a fallback if other conditions aren't met and the login page is enabled", async () => {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
This one updates the loading page to better help users if the the loading page hangs for some unknown reason or, more likely, they're encountering the unlinked myNJ account error.
### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#16647](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16647)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
This one changed a little bit as I worked on it due to what error states I thought were or were not possible.

#### Some backstory

I had previously observed some behavior with unlinked accounts where the following was happening:
1. you log into myNJ with an unlinked account
2. A Cognito session *would* be established, but with an invalid state where the `id` from Cognito would be the same as the logged in user's email, e.g. something like this:
```json
{
	id: 'dan@example.com',
	email: 'dan@example.com'
	// other attributes in the JWT response from Cognito
}
```
3. The infinite loading state would occur because the code would detect both that a user was authenticated, but then fetching by that invalid ID would fail to find a user.

I'm not sure if something changed in myNJ more accurately sending back proper SAML failures, or something else in how I was testing things, but in building out this feature, the aforementioned state no longer appears to be replicated. Rather, we will encounter a flow previously expected for and (somewhat) handled:
1. you log into myNJ with an unlinked account
2. on the chained redirects of myNJ -> Cognito -> navigator, a Cognito session fails to be established , and we get redirected to the loading page with some type of url like this: https://account.business.nj.gov/loading?error_description=Invalid+SAML+response+received%3A+Name+ID+value+was+not+found+in+SAML+Assertion+&state=qJs69qH5i5Jfn7Jb3OWp4eyqYQ8r6mXm&error=server_error
3.  `Name+ID+value+was+not+found+in+SAML` is detected in the query params and we show the appropriate error copy
Where this previously would trigger a modal, this PR makes updates so that we're now showing an error message with links to the new static help page
### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->
1. Log in with a local account you know is unlinked (this will require either bypassing the interstitial login page or the unlinked account using an email you've already used for a linked account
2. The error message should appear on the redirected loading page

The other states are accounted for in the loading component and unit tests, but the only one that's easy to replicate naturally (to my knowledge is that one). The four possible states accounted for:

| Logged in user? | Unlinked myNJ? | Is this testable? |
| --- | --- | --- |
| ❌ | ✅ | Follow the aforementioned testing steps |
| ❌ | ❌ | Accounted for in code and unit tests but can't naturally replicate |
| ✅ | ✅ | Accounted for in code and unit tests but can't naturally replicate |
| ✅ | ❌ | Accounted for in code and unit tests but can't naturally replicate |

TL;DR we only expect users to naturally encounter hitting the loading page with an error state of "unauthenticated in navigator (i.e., no Cognito session) + an unlinked myNJ account", but we still account for the other error states _in the unlikely case that they occur_.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->
For a cleaner diff, I've made my `dh-static-login-page` branch, which is currently unmerged, the base branch (see https://github.com/newjersey/navigator.business.nj.gov/pull/11876 for those changes, which are related but independent of these)

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
