### PR TITLE
fix: duplicate CMS key and casing for login pages

### DIFF
--- a/content/src/fieldConfig/login-support-page.json
+++ b/content/src/fieldConfig/login-support-page.json
@@ -3,7 +3,6 @@
     "unlinkedAccount": "It looks like you haven’t linked your myNewJersey account.",
     "havingTrouble": "Having trouble logging in?",
     "logoutButtonText": "Log out",
-    "logoutButtonTextUnlinked": "log out",
     "logoutAndTryAgain": "~~logoutButton~~ and try again.",
     "logoutAndTryAgainUnlinked": "Please ~~logoutButton~~ and try again.",
     "forMoreAssistance": "For more assistance, visit our [Login Issues Help page](support/login).",
@@ -43,7 +42,6 @@
       }
     ],
     "logoutIfStillHavingTrouble": "If you're still having trouble, ~~logoutButton~~ to reset your session on [account.business.nj.gov](https://account.business.nj.gov), and repeat the steps above.",
-    "logoutButtonText": "log out",
     "supportCallout": {
       "header": "Dedicated Business Experts ready to help",
       "body": "Still having issues? Chat with a business advocate based in New Jersey.",

--- a/web/decap-config/collections/13-support.yml
+++ b/web/decap-config/collections/13-support.yml
@@ -24,11 +24,6 @@ collections:
               - { label: "Unlinked Account", name: "unlinkedAccount", widget: "string" }
               - { label: "Having Trouble", name: "havingTrouble", widget: "string" }
               - { label: "Logout Button Text", name: "logoutButtonText", widget: "string" }
-              - {
-                  label: "Logout Button Text Unlinked",
-                  name: "logoutButtonTextUnlinked",
-                  widget: "string",
-                }
               - { label: "Logout And Try Again", name: "logoutAndTryAgain", widget: "string" }
               - {
                   label: "Logout And Try Again Unlinked",

--- a/web/src/components/LoadingPageComponent.tsx
+++ b/web/src/components/LoadingPageComponent.tsx
@@ -33,7 +33,7 @@ export const LoadingPageComponent = ({
         className="logout-button-unstyled"
       >
         {isLinkingError
-          ? Config.loginSupportPage.logoutButtonTextUnlinked
+          ? Config.loginSupportPage.logoutButtonText.toLowerCase()
           : Config.loginSupportPage.logoutButtonText}
       </UnStyledButton>
     ),

--- a/web/src/pages/support/login.tsx
+++ b/web/src/pages/support/login.tsx
@@ -28,7 +28,7 @@ const LoginSupportPage = (): ReactElement => {
         }}
         className="logout-button-unstyled"
       >
-        {loginSupport.logoutButtonText}
+        {loginSupport.logoutButtonText.toLowerCase()}
       </UnStyledButton>
     ),
   };

--- a/web/test/components/LoadingPageComponent.test.tsx
+++ b/web/test/components/LoadingPageComponent.test.tsx
@@ -34,7 +34,9 @@ describe("LoadingPageComponent", () => {
         expect(screen.getByText(Config.loginSupportPage.unlinkedAccount)).toBeInTheDocument();
 
         expect(
-          screen.getByRole("button", { name: Config.loginSupportPage.logoutButtonTextUnlinked }),
+          screen.getByRole("button", {
+            name: Config.loginSupportPage.logoutButtonText.toLowerCase(),
+          }),
         ).toBeInTheDocument();
         expect(screen.getByText(/please/i)).toBeInTheDocument();
         expect(screen.getByText(/and try again/i)).toBeInTheDocument();


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
I'd accidentally added the same CMS key twice. This removes the one and utilizes `.toLowerCase()` for the appropriate cases where it should be all lower case.
### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

Found when acceptance testing for:
- [#16449](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16449).
- [#16647](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16647)

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
