### PR TITLE
fix: DOL EIN encryption

### DIFF
--- a/api/src/api/userRouter.test.ts
+++ b/api/src/api/userRouter.test.ts
@@ -1284,7 +1284,7 @@ describe("userRouter", () => {
           const encryptedValues: { [key: string]: string } = {
             "123456789000": "encrypted-tax-id",
             "1234": "encrypted-tax-pin",
-            "54321": "encrypted-dol-ein",
+            "123456789012345": "encrypted-dol-ein",
           };
           return Promise.resolve(encryptedValues[valueToBeEncrypted] ?? "unexpected value");
         });
@@ -1301,7 +1301,7 @@ describe("userRouter", () => {
               encryptedTaxId: undefined,
               taxPin: "1234",
               encryptedTaxPin: undefined,
-              deptOfLaborEin: "54321",
+              deptOfLaborEin: "123456789012345",
             }),
           }),
           { user: oldUserData.user },

--- a/api/src/domain/user/encryptFieldsFactory.test.ts
+++ b/api/src/domain/user/encryptFieldsFactory.test.ts
@@ -270,4 +270,21 @@ describe("encryptFieldsFactory", () => {
     );
     expect(response).toEqual(expectedUserData);
   });
+
+  it("does not encrypt dol ein if it is already encrypted", async () => {
+    const userData = generateUnencryptedUserData({ deptOfLaborEin: encryptedDeptOfLaborEin });
+    const response = await encryptTaxId(userData);
+    expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(profileTaxId);
+    expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(profileTaxPin);
+    expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxId);
+    expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(taxClearanceTaxPin);
+    expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledWith(cigaretteTaxId);
+    expect(stubCryptoEncryptionClient.encryptValue).not.toHaveBeenCalledWith(deptOfLaborEin);
+    expect(stubCryptoEncryptionClient.encryptValue).toHaveBeenCalledTimes(numFieldsToEncrypt - 1);
+
+    const expectedUserData = getExpectedEncryptedCurrentBusiness(userData, {
+      deptOfLaborEin: encryptedDeptOfLaborEin,
+    });
+    expect(response).toEqual(expectedUserData);
+  });
 });

--- a/api/src/domain/user/encryptFieldsFactory.ts
+++ b/api/src/domain/user/encryptFieldsFactory.ts
@@ -4,6 +4,7 @@ import { getCurrentBusiness } from "@shared/domain-logic/getCurrentBusiness";
 import { modifyCurrentBusiness } from "@shared/domain-logic/modifyCurrentBusiness";
 import { maskingCharacter } from "@shared/profileData";
 import { Business, UserData } from "@shared/userData";
+import { DOL_EIN_CHARACTERS } from "@shared/employerRates";
 
 export const encryptFieldsFactory = (
   encryptionDecryptionClient: CryptoClient,
@@ -201,7 +202,7 @@ const encryptDeptOfLaborEin = async (
   cryptoClient: CryptoClient,
 ): Promise<UserData> => {
   const currentBusiness = getCurrentBusiness(userData);
-  if (!currentBusiness.profileData.deptOfLaborEin) {
+  if (currentBusiness.profileData.deptOfLaborEin.length !== DOL_EIN_CHARACTERS) {
     return userData;
   }
   const encryptedDolEin = await cryptoClient.encryptValue(

--- a/shared/src/employerRates.ts
+++ b/shared/src/employerRates.ts
@@ -1,3 +1,5 @@
+export const DOL_EIN_CHARACTERS = 15;
+
 export type EmployerRatesRequest = {
   businessName: string;
   email: string;

--- a/web/src/components/data-fields/DolEin.tsx
+++ b/web/src/components/data-fields/DolEin.tsx
@@ -9,6 +9,7 @@ import { InputAdornment } from "@mui/material";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { decryptValue } from "@/lib/api-client/apiClient";
 import { useMountEffect } from "@/lib/utils/helpers";
+import { DOL_EIN_CHARACTERS } from "@businessnjgovnavigator/shared";
 
 interface Props {
   editable?: boolean;
@@ -20,7 +21,6 @@ interface Props {
   startHidden?: boolean;
 }
 
-export const DOL_EIN_CHARACTERS = 15;
 export const DOL_EIN_CHARACTERS_WITH_FORMATTING = 20;
 
 export const DolEin = (props: Props): ReactElement => {

--- a/web/test/pages/profile/profile-shared.test.tsx
+++ b/web/test/pages/profile/profile-shared.test.tsx
@@ -23,6 +23,7 @@ import {
   Business,
   BusinessPersona,
   businessPersonas,
+  DOL_EIN_CHARACTERS,
   ForeignBusinessTypeId,
   generateBusiness,
   generateMunicipality,
@@ -40,8 +41,6 @@ import {
   generateTaxFilingData,
 } from "@businessnjgovnavigator/shared/test";
 import { useRouter } from "next/compat/router";
-
-import { DOL_EIN_CHARACTERS } from "@/components/data-fields/DolEin";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import {
   chooseTab,
@@ -940,7 +939,7 @@ describe("profile - shared", () => {
 
       const employerRatesSection = screen.getByTestId("employerAccess");
       const textbox = within(employerRatesSection).getByRole("textbox");
-      const newEin = "1".repeat(15);
+      const newEin = "1".repeat(DOL_EIN_CHARACTERS);
       await userEvent.type(textbox, newEin);
 
       await userEvent.click(screen.getByRole("button", { name: "Save" }));


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
Fixes an issue with encryption where the encrypted value was sent to the API rather than the correct, unencrypted one.

This PR fixes a couple of issues with DOL Encryption.

The first is it now properly submits the unencrypted value to the API rather than the encrypted value, which would never work. 

The second is that values were being encrypted multiple times if the user saved multiple times. This PR fixes that issue and will only encrypt the value once. 

It also reorganizes some test files for improved readability.

<!-- Summary of the changes, related issue, relevant motivation, and context -->


### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->
1. Create a new existing business in any sector
2. Go to the numbers section of the profile and enter a DOL EIN value
3. Save and return to the page, and you should be able to see your DOLEIN
4. No matter how many times you save and return to the page, you should still be able to see your unencrypted DOL EIN

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
