### PR TITLE
feat: [AB#16648] Add business name error for users without a business name

### DIFF
--- a/content/src/fieldConfig/employer-rates.json
+++ b/content/src/fieldConfig/employer-rates.json
@@ -41,7 +41,8 @@
     "baseWeekAmountLabelText": "Base Week Amount",
     "numberOfBaseWeeksLabelText": "Number of Base Weeks",
     "editQuarterButtonText": "Edit Quarter",
-    "noEmployerRatesFliText": "None"
+    "noEmployerRatesFliText": "None",
+    "businessNameErrorLink": "/profile?tab=info"
 
   }
 }

--- a/web/decap-config/collections/12-misc.yml
+++ b/web/decap-config/collections/12-misc.yml
@@ -3174,6 +3174,7 @@ collections:
                 }
               - { label: Edit Quarter Button Text, name: editQuarterButtonText, widget: string }
               - { label: No Employer Rates Fli Text, name: noEmployerRatesFliText, widget: string }
+              - { label: Business Name Error Link, name: businessNameErrorLink, widget: string }
 
   - label: "Fundings Onboarding Page"
     name: "business-fundings-onboarding-page"

--- a/web/src/components/employer-rates/EmployerRates.test.tsx
+++ b/web/src/components/employer-rates/EmployerRates.test.tsx
@@ -549,6 +549,49 @@ describe("EmployerRates", () => {
         userData,
       });
     });
+
+    it("shows business name error if user has a valid DOL EIN and submits without a business name", async () => {
+      renderComponentsWithOwning({
+        employerAccessRegistration: true,
+        deptOfLaborEin: "012345678901234",
+        businessName: "",
+      });
+
+      const submit = await screen.findByRole("button", {
+        name: Config.employerRates.employerAccessYesButtonText,
+      });
+      await userEvent.click(submit);
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Business Name" })).toBeInTheDocument();
+      expect(screen.getAllByRole("listitem").length).toBe(1);
+    });
+
+    it("shows combined business name and DOL EIN error if both are invalid", async () => {
+      renderComponentsWithOwning({
+        deptOfLaborEin: "",
+        businessName: "",
+      });
+      const user = userEvent.setup();
+
+      const trueRadio = screen.getByRole("radio", {
+        name: Config.employerRates.employerAccessTrueText,
+      });
+      await userEvent.click(trueRadio);
+
+      const textbox = screen.getByRole("textbox");
+      const toType = "1".repeat(1);
+      await user.type(textbox, toType);
+
+      const submit = await screen.findByRole("button", {
+        name: Config.employerRates.employerAccessYesButtonText,
+      });
+      await userEvent.click(submit);
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Business Name" })).toBeInTheDocument();
+      expect(screen.getAllByRole("listitem").length).toBe(2);
+    });
   });
 
   describe("successful submission response page", () => {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Adds an error specific to a user not having a business name before requesting employer rates

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#16648](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16648).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
