### PR TITLE
feat: [AB#16939] profile tab query params

### DIFF
--- a/content/src/fieldConfig/profile.json
+++ b/content/src/fieldConfig/profile.json
@@ -530,7 +530,16 @@
       "certificationDocFileTitle": "Certified Copy of Formation",
       "profileTabInfoTitle": "Business Information",
       "securityMattersText": "- You can update your contact information and notification preferences at any time.\n- We will **never** ask for your password, banking details, or Social Security number in an email or text.\n- All official messages will always come from **address@business.nj.gov** or appear in your account dashboard.\n- If you ever get an email that looks suspicious, report it at [cyber.nj.gov/report](https://cyber.nj.gov/report).",
-      "locationBasedRequirementsSubText": "If you require any permits or licenses based on your businesses location or renovation needs, new tasks will be available for you to complete."
+      "locationBasedRequirementsSubText": "If you require any permits or licenses based on your businesses location or renovation needs, new tasks will be available for you to complete.",
+      "profileTabSlugs": {
+        "info": "business-information",
+        "contact": "contact-notifications",
+        "permits": "permits-licenses",
+        "numbers": "reference-numbers",
+        "documents": "reference-documents",
+        "notes": "notes",
+        "personalize": "personalize"
+      }
     }
   }
 }

--- a/web/decap-config/collections/12-misc.yml
+++ b/web/decap-config/collections/12-misc.yml
@@ -2956,6 +2956,18 @@ collections:
                     }
                   - { label: Cannabis Location Alert, name: cannabisLocationAlert, widget: string }
                   - { label: Contact Tab Title, name: profileTabContactTitle, widget: string }
+                  - label: Profile Tab Slugs
+                    name: profileTabSlugs
+                    collapsed: true
+                    widget: object
+                    fields:
+                      - { label: Info Slug, name: info, widget: no-space }
+                      - { label: Contact Slug, name: contact, widget: no-space }
+                      - { label: Permits Slug, name: permits, widget: no-space }
+                      - { label: Numbers Slug, name: numbers, widget: no-space }
+                      - { label: Documents Slug, name: documents, widget: no-space }
+                      - { label: Notes Slug, name: notes, widget: no-space }
+                      - { label: Personalize Slug, name: personalize, widget: no-space }
                   - {
                       label: Contact And Notifications Heading,
                       name: contactInformationHeading,


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

This re-implements tab deep-linking and URL syncing for the Profile page:

- Tabs now initialize correctly from the query and keep the URL in sync on tab clicks.

- Added slug↔tab mapping so that the new slugs defined by this ticket and legacy enum values both resolve to the correct tab. (for example: /profile?tab=contact ↔ /profile?tab=contact-notifications)

- Also syncs tab changes back to the URL without triggering unsaved-changes navigation, using guarded history.replaceState.

- Updated init-tab tests to use useMockRouter with real URL state so they now test actual behavior.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#16939](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16969).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

- Open each deep link and verify the matching tab loads:
  - /profile?tab=business-information
  - /profile?tab=contact-notifications
  - /profile?tab=permits-licenses
  - /profile?tab=reference-numbers
  - /profile?tab=reference-documents
  - /profile?tab=notes 
  - /profile?tab=personalize
- Click between tabs and confirm the ?tab= slug updates accordingly.
- Refresh on any non-default tab and confirm it stays on that tab after reload.
<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
