### PR TITLE
fix: [AB#17110] allow navigation on profile save: fix industry saving bug

### DIFF
--- a/web/src/pages/profile.tsx
+++ b/web/src/pages/profile.tsx
@@ -299,6 +299,7 @@ const ProfilePage = (props: Props): ReactElement => {
               await router?.push(postSaveRedirectUrl);
               setPostSaveRedirectUrl(null);
             } else {
+              allowNavigation();
               await redirect({ success: true });
             }
           })

--- a/web/test/pages/profile/profile-shared.test.tsx
+++ b/web/test/pages/profile/profile-shared.test.tsx
@@ -361,6 +361,42 @@ describe("profile - shared", () => {
       });
     };
 
+    it("does not show escape modal when saving changes", async () => {
+      const initialIndustry = filterRandomIndustry(() => true);
+      const updatedIndustry = filterRandomIndustry(
+        (industry: Industry) => industry.id !== initialIndustry.id,
+      );
+
+      mockRouter.mockPush.mockImplementation(async (url: string) => {
+        try {
+          mockRouterEvents.emit("routeChangeStart", url);
+        } catch {
+          // expected when navigation is blocked
+        }
+        return {};
+      });
+
+      const business = generateBusinessForProfile({
+        profileData: generateProfileData({
+          businessPersona: "STARTING",
+          industryId: initialIndustry.id,
+        }),
+      });
+
+      renderPage({ business });
+
+      selectByText("Industry", updatedIndustry.name);
+      clickSave();
+
+      await waitFor(() => {
+        expect(mockRouter.mockPush).toHaveBeenCalledWith("/dashboard?success=true");
+      });
+
+      expect(
+        screen.queryByText(Config.profileDefaults.default.escapeModalReturn),
+      ).not.toBeInTheDocument();
+    });
+
     it("shows escape modal when navigation is intercepted by unsaved changes guard", async () => {
       const business = makeBusiness();
       renderPage({ business });


### PR DESCRIPTION


<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#0000](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
