### PR TITLE
fix: [AB#13064] remove edit button from deferred location question

### DIFF
--- a/web/src/components/DeferredLocationQuestion.test.tsx
+++ b/web/src/components/DeferredLocationQuestion.test.tsx
@@ -83,13 +83,29 @@ describe("<DeferredLocationQuestion />", () => {
     expect(screen.queryByTestId("city-success-banner")).not.toBeInTheDocument();
   });
 
-  it("shows inner content without question nor success banner when already location saved", () => {
+  it("shows inner content with success banner when already location saved", () => {
     const municipality = generateMunicipality({});
     const business = generateBusiness({ profileData: generateProfileData({ municipality }) });
     renderComponent({ initialBusiness: business, innerContent: "inner-content" });
     expect(screen.queryByText(Config.deferredLocation.header)).not.toBeInTheDocument();
     expect(screen.getByText("inner-content")).toBeInTheDocument();
+    expect(screen.getByTestId("city-success-banner")).toBeInTheDocument();
+  });
+
+  it("shows question form when Remove City is clicked from saved location", async () => {
+    const municipality = generateMunicipality({ displayName: "Allendale" });
+    const business = generateBusiness({ profileData: generateProfileData({ municipality }) });
+    renderComponent({ initialBusiness: business, innerContent: "inner-content" });
+
+    expect(screen.getByTestId("city-success-banner")).toBeInTheDocument();
+    expect(screen.getByText("inner-content")).toBeInTheDocument();
+    expect(screen.queryByText(Config.deferredLocation.header)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText(Config.deferredLocation.removeText));
+
+    expect(screen.getByText(Config.deferredLocation.header)).toBeInTheDocument();
     expect(screen.queryByTestId("city-success-banner")).not.toBeInTheDocument();
+    expect(screen.queryByText("inner-content")).not.toBeInTheDocument();
   });
 
   describe("when saving location", () => {
@@ -119,22 +135,6 @@ describe("<DeferredLocationQuestion />", () => {
     it("shows inner content and banner on save", async () => {
       await selectNewarkAndSave();
       expect(screen.queryByText(Config.deferredLocation.header)).not.toBeInTheDocument();
-      expect(screen.getByText("inner-content")).toBeInTheDocument();
-    });
-
-    it("shows location question when edit button is clicked", async () => {
-      await selectNewarkAndSave();
-      fireEvent.click(screen.getByText(Config.deferredLocation.editText));
-      expect(screen.getByText(Config.deferredLocation.header)).toBeInTheDocument();
-      expect(screen.queryByTestId("city-success-banner")).not.toBeInTheDocument();
-    });
-
-    it("shows inner content when saving location after editing", async () => {
-      await selectNewarkAndSave();
-      fireEvent.click(screen.getByText(Config.deferredLocation.editText));
-      selectLocationByText("Absecon");
-      fireEvent.click(screen.getByText(Config.deferredLocation.deferredOnboardingSaveButtonText));
-      await screen.findByTestId("city-success-banner");
       expect(screen.getByText("inner-content")).toBeInTheDocument();
     });
 

--- a/web/src/components/DeferredLocationQuestion.tsx
+++ b/web/src/components/DeferredLocationQuestion.tsx
@@ -8,7 +8,7 @@ import { useUserData } from "@/lib/data-hooks/useUserData";
 import analytics from "@/lib/utils/analytics";
 import { templateEval } from "@/lib/utils/helpers";
 import { Business } from "@businessnjgovnavigator/shared/userData";
-import { ReactElement, ReactNode, useState } from "react";
+import { ReactElement, ReactNode } from "react";
 
 interface Props {
   innerContent: string;
@@ -22,10 +22,8 @@ export const DeferredLocationQuestion = (props: Props): ReactElement => {
   const business = props.CMS_ONLY_fakeBusiness ?? userDataFromHook.business;
   const updateQueue = userDataFromHook.updateQueue;
 
-  const [showSuccessBanner, setShowSuccessBanner] = useState<boolean>(
-    props.CMS_ONLY_showSuccessBanner ?? false,
-  );
-  const [showEditLocation, setShowEditLocation] = useState<boolean>(false);
+  const showSuccessBanner =
+    props.CMS_ONLY_showSuccessBanner ?? business?.profileData.municipality !== undefined;
 
   const label = (
     <>
@@ -34,11 +32,9 @@ export const DeferredLocationQuestion = (props: Props): ReactElement => {
     </>
   );
 
-  const shouldShowQuestion = business?.profileData.municipality === undefined || showEditLocation;
+  const shouldShowQuestion = business?.profileData.municipality === undefined;
 
   const onSaveNewLocation = (): void => {
-    setShowSuccessBanner(true);
-    setShowEditLocation(false);
     business?.profileData.municipality === undefined &&
       updateQueue?.currentBusiness().profileData.municipality !== undefined &&
       analytics.event.task_location_question.submit.location_entered_for_first_time();
@@ -65,10 +61,6 @@ export const DeferredLocationQuestion = (props: Props): ReactElement => {
               })}
             </Content>
           </div>
-          <UnStyledButton isUnderline onClick={(): void => setShowEditLocation(true)}>
-            {Config.deferredLocation.editText}
-          </UnStyledButton>
-          <span className="margin-x-105">|</span>
           <UnStyledButton isUnderline onClick={onRemoveLocation}>
             {Config.deferredLocation.removeText}
           </UnStyledButton>


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Removes the edit button on the deferred location question to fix the buggy behavior where the alert would disappear after returning to the page that includes the question.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#13064](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13064).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
