### PR TITLE
chore: [AB#12988] consolidate webflow sync helpers & helpers2

### DIFF
--- a/web/src/scripts/webflow/fundingSync.mjs
+++ b/web/src/scripts/webflow/fundingSync.mjs
@@ -7,8 +7,8 @@ import {
   contentToStrings,
   getHtml,
   resolveApiPromises,
+  wait,
 } from "./helpers.mjs";
-import { wait } from "./helpers2.mjs";
 import { createItem, deleteItem, getAllItems, getCollection, modifyItem } from "./methods.mjs";
 import { allIndustryId, getCurrentSectors, syncSectors } from "./sectorSync.mjs";
 import { certificationCollectionId, fundingCollectionId } from "./webflowIds.mjs";
@@ -184,7 +184,7 @@ const getFundingFromMd = (i, sectors) => {
   })?.id;
   if (fundingType === undefined) {
     throw new Error(
-      `Funding Types for funding type ${i.fundingType} are mis-matched in ${i.id}. Please check with Webflow.`
+      `Funding Types for funding type ${i.fundingType} are mis-matched in ${i.id}. Please check with Webflow.`,
     );
   }
   const agency = agencyMap[i.agency[0]]?.id;
@@ -193,7 +193,7 @@ const getFundingFromMd = (i, sectors) => {
         You will have to create the agency in Webflow, then call the collection details endpoint
         with the fundingCollectionId to get the ID of the option, then adding it to agencyMap. */
     throw new Error(
-      `Agency Types for agency ${i.agency[0]} are mis-matched in ${i.id}. Please check with Webflow.`
+      `Agency Types for agency ${i.agency[0]} are mis-matched in ${i.id}. Please check with Webflow.`,
     );
   }
   const status = fundingStatusMap.find((v) => {
@@ -201,7 +201,7 @@ const getFundingFromMd = (i, sectors) => {
   })?.id;
   if (status === undefined) {
     throw new Error(
-      `Funding Status Types for funding status type ${i.status} are mis-matched in ${i.id}. Please check with Webflow.`
+      `Funding Status Types for funding status type ${i.status} are mis-matched in ${i.id}. Please check with Webflow.`,
     );
   }
 
@@ -210,7 +210,7 @@ const getFundingFromMd = (i, sectors) => {
       (cert) =>
         fundingCertificationsMap.find((v) => {
           return v.slug === cert;
-        })?.id
+        })?.id,
     ) ?? [];
 
   return {
@@ -225,7 +225,8 @@ const getFundingFromMd = (i, sectors) => {
     "last-updated": new Date(Date.now()).toISOString(),
     "funding-status": status,
     "funding-type": fundingType,
-    "industry-reference": industryReferenceArray.length > 0 ? industryReferenceArray : [allIndustryId],
+    "industry-reference":
+      industryReferenceArray.length > 0 ? industryReferenceArray : [allIndustryId],
   };
 };
 
@@ -246,7 +247,7 @@ const getNewFundings = async () => {
   const currentIdArray = new Set(
     current.map((sec) => {
       return sec.fieldData.slug;
-    })
+    }),
   );
   return getFilteredFundings()
     .filter((i) => {
@@ -292,7 +293,7 @@ const updateFundings = async () => {
       fundings.find((i) => {
         return i.id === item.fieldData.slug;
       }),
-      sectors
+      sectors,
     );
     console.info(`Attempting to modify ${funding.slug}`);
     try {

--- a/web/src/scripts/webflow/helpers.mjs
+++ b/web/src/scripts/webflow/helpers.mjs
@@ -6,7 +6,6 @@ import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import { unified } from "unified";
-import { wait } from "./helpers2.mjs";
 
 const RATE_LIMIT_WAIT_SECONDS = 20;
 
@@ -114,4 +113,10 @@ export const getHtml = (arrayOfStrings, start, stop) => {
     })
     .join(" ")
     .trim();
+};
+
+export const wait = (milliseconds = 10000) => {
+  return new Promise((resolve) => {
+    return setTimeout(resolve, milliseconds);
+  });
 };

--- a/web/src/scripts/webflow/helpers2.mjs
+++ b/web/src/scripts/webflow/helpers2.mjs
@@ -1,5 +1,0 @@
-export const wait = (milliseconds = 10000) => {
-  return new Promise((resolve) => {
-    return setTimeout(resolve, milliseconds);
-  });
-};

--- a/web/src/scripts/webflow/licenseSync.mjs
+++ b/web/src/scripts/webflow/licenseSync.mjs
@@ -17,8 +17,8 @@ import {
   contentToStrings,
   getHtml,
   resolveApiPromises,
+  wait,
 } from "./helpers.mjs";
-import { wait } from "./helpers2.mjs";
 import { LicenseClassificationLookup } from "./licenseClassifications.mjs";
 import { createItem, deleteItem, getAllItems, modifyItem } from "./methods.mjs";
 import { licenseCollectionId } from "./webflowIds.mjs";

--- a/web/src/scripts/webflow/sectorSync.mjs
+++ b/web/src/scripts/webflow/sectorSync.mjs
@@ -4,12 +4,12 @@ import fs from "fs";
 import orderBy from "lodash";
 import path from "path";
 import { fileURLToPath } from "url";
-import { wait } from "./helpers2.mjs";
+import { wait } from "./helpers.mjs";
 import { createItem, deleteItem, getAllItems, modifyItem } from "./methods.mjs";
 import { allIndustryId, sectorCollectionId } from "./webflowIds.mjs";
 
 const sectorDir = path.resolve(
-  `${path.dirname(fileURLToPath(import.meta.url))}/../../../../content/src/mappings`
+  `${path.dirname(fileURLToPath(import.meta.url))}/../../../../content/src/mappings`,
 );
 const getSectors = () => {
   return JSON.parse(fs.readFileSync(path.join(sectorDir, "sectors.json"), "utf8")).arrayOfSectors;
@@ -24,7 +24,7 @@ const getOverlappingSectorsFunc = (currentSectors) => {
     return new Set(
       getSectors().map((item) => {
         return item.id;
-      })
+      }),
     ).has(item.fieldData.slug);
   });
 };
@@ -37,7 +37,7 @@ const getUpdatedSectors = async () => {
   const sectorNames = new Set(
     getSectors().map((item) => {
       return item.name;
-    })
+    }),
   );
   const overlappingSectors = await getOverlappingSectors();
 


### PR DESCRIPTION
## Description

Consolidates the functionality within Webflow sync files `helpers.mjs` and `helpers2.mjs`.

### Ticket

This pull request resolves [#12988](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12988).

### Approach

- Moved the lone function in `helpers2.mjs` into `helpers.mjs`
- Made updates to the associated test files to retain logic and integrity while accommodating for the new pattern
  - Because the `wait` function was being used by other functions within `helpers.mjs`, I opted to no longer mock the function, but rather to use jest timers and spy on `setTimeout` to validate the anticipated behavior.

### Steps to Test

- All tests should pass
- Running the Webflow sync should still work as expected

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
  - These files all contain relative imports and I did not change this behavior
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
