### PR TITLE
16939 simplify profile tab link tests, removes redundant flaky test

### DIFF
--- a/web/test/pages/profile/profile-shared.test.tsx
+++ b/web/test/pages/profile/profile-shared.test.tsx
@@ -885,35 +885,6 @@ describe("profile - shared", () => {
       useMockRouter({ isReady: true, query: {} });
     });
 
-    it("updates the tab query param when navigating between tabs", async () => {
-      const business = generateBusinessForProfile({});
-      renderPage({ business });
-
-      await act(async () => {
-        chooseTab("numbers");
-      });
-
-      await screen.findByRole("tabpanel", {
-        name: Config.profileDefaults.default.profileTabNumbersTitle,
-      });
-
-      await waitFor(() => {
-        expect(window.location.search).toContain(
-          `?${QUERIES.tab}=${Config.profileDefaults.default.profileTabSlugs.numbers}`,
-        );
-      });
-
-      await act(async () => {
-        chooseTab("contact");
-      });
-
-      await waitFor(() => {
-        expect(window.location.search).toContain(
-          `?${QUERIES.tab}=${Config.profileDefaults.default.profileTabSlugs.contact}`,
-        );
-      });
-    });
-
     it("navigates to the correct slug for all tabs defined in Config", async () => {
       const business = generateBusinessForProfile({
         profileData: generateProfileData({


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#0000](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
