### PR TITLE
chore: [AB#17137] make tax clearance errors more descriptive

### DIFF
--- a/api/src/client/ApiTaxClearanceCertificateClient.test.ts
+++ b/api/src/client/ApiTaxClearanceCertificateClient.test.ts
@@ -240,23 +240,31 @@ describe("TaxClearanceCertificateClient", () => {
 
   it("fires error log when error response is returned", async () => {
     const error = {
-      response: { status: StatusCodes.BAD_REQUEST, data: "Error Message" },
+      response: { status: StatusCodes.BAD_REQUEST, data: FAILED_TAX_ID_AND_PIN_VALIDATION },
     };
 
     const spyOnGetId = jest.spyOn(DummyLogWriter, "GetId").mockReturnValue("test");
     const spyOnLogError = jest.spyOn(DummyLogWriter, "LogError");
     mockAxios.post.mockRejectedValue(error);
-    await expect(
-      client.postTaxClearanceCertificate(
-        userData,
-        stubEncryptionDecryptionClient,
-        stubDatabaseClient,
-      ),
-    ).rejects.toEqual(StatusCodes.BAD_REQUEST);
+
+    const result = await client.postTaxClearanceCertificate(
+      userData,
+      stubEncryptionDecryptionClient,
+      stubDatabaseClient,
+    );
+
+    expect(result).toEqual({
+      error: {
+        message: FAILED_TAX_ID_AND_PIN_VALIDATION,
+        type: "FAILED_TAX_ID_AND_PIN_VALIDATION",
+      },
+    });
 
     expect(spyOnLogError.mock.calls[0]).toEqual([
-      "Tax Clearance Certificate Client - Id:test - Error",
-      error,
+      "Tax Clearance Certificate Client - Id:test - Error: FAILED_TAX_ID_AND_PIN_VALIDATION,",
+      {
+        response: { status: StatusCodes.BAD_REQUEST, data: FAILED_TAX_ID_AND_PIN_VALIDATION },
+      },
     ]);
 
     spyOnGetId.mockRestore();
@@ -265,25 +273,31 @@ describe("TaxClearanceCertificateClient", () => {
 
   it("removes auth object when logging error", async () => {
     const error = {
-      response: { status: StatusCodes.BAD_REQUEST, data: "Error Message" },
+      response: { status: StatusCodes.BAD_REQUEST, data: INELIGIBLE_TAX_CLEARANCE_FORM },
       config: { auth: { username: "username", password: "password" } },
     };
 
     const spyOnGetId = jest.spyOn(DummyLogWriter, "GetId").mockReturnValue("test");
     const spyOnLogError = jest.spyOn(DummyLogWriter, "LogError");
     mockAxios.post.mockRejectedValue(error);
-    await expect(
-      client.postTaxClearanceCertificate(
-        userData,
-        stubEncryptionDecryptionClient,
-        stubDatabaseClient,
-      ),
-    ).rejects.toEqual(StatusCodes.BAD_REQUEST);
+
+    const result = await client.postTaxClearanceCertificate(
+      userData,
+      stubEncryptionDecryptionClient,
+      stubDatabaseClient,
+    );
+
+    expect(result).toEqual({
+      error: {
+        message: INELIGIBLE_TAX_CLEARANCE_FORM,
+        type: "INELIGIBLE_TAX_CLEARANCE_FORM",
+      },
+    });
 
     expect(spyOnLogError.mock.calls[0]).toEqual([
-      "Tax Clearance Certificate Client - Id:test - Error",
+      "Tax Clearance Certificate Client - Id:test - Error: INELIGIBLE_TAX_CLEARANCE_FORM,",
       {
-        response: { status: StatusCodes.BAD_REQUEST, data: "Error Message" },
+        response: { status: StatusCodes.BAD_REQUEST, data: INELIGIBLE_TAX_CLEARANCE_FORM },
         config: {},
       },
     ]);

--- a/api/src/client/ApiTaxClearanceCertificateClient.ts
+++ b/api/src/client/ApiTaxClearanceCertificateClient.ts
@@ -1,5 +1,6 @@
 import {
   TaxClearanceCertificateResponse,
+  TaxClearanceCertificateResponseErrorType,
   UnlinkTaxIdResponse,
 } from "@businessnjgovnavigator/shared";
 import {
@@ -189,14 +190,20 @@ export const ApiTaxClearanceCertificateClient = (
       })
       .catch((error: AxiosError) => {
         const sanitizedError = sanitizeAxiosError(error);
-        logWriter.LogError(
-          `Tax Clearance Certificate Client - Id:${logId} - Error`,
-          sanitizedError,
-        );
+        const logSpecificTaxClearanceError = (
+          errorType: TaxClearanceCertificateResponseErrorType,
+        ): void => {
+          logWriter.LogError(
+            `Tax Clearance Certificate Client - Id:${logId} - Error: ${errorType},`,
+            sanitizedError,
+          );
+        };
+
         const { response } = error;
         if (response?.status === StatusCodes.BAD_REQUEST) {
           const errorMessage = response.data as string;
           if (errorMessage === INELIGIBLE_TAX_CLEARANCE_FORM) {
+            logSpecificTaxClearanceError("INELIGIBLE_TAX_CLEARANCE_FORM");
             return {
               error: {
                 type: "INELIGIBLE_TAX_CLEARANCE_FORM",
@@ -209,6 +216,7 @@ export const ApiTaxClearanceCertificateClient = (
             errorMessage === TAX_ID_MISSING_FIELD_WITH_EXTRA_SPACE ||
             errorMessage === TAX_ID_MISSING_FIELD
           ) {
+            logSpecificTaxClearanceError("MISSING_FIELD");
             return {
               error: {
                 type: "MISSING_FIELD",
@@ -217,6 +225,7 @@ export const ApiTaxClearanceCertificateClient = (
             };
           }
           if (errorMessage === FAILED_TAX_ID_AND_PIN_VALIDATION) {
+            logSpecificTaxClearanceError("FAILED_TAX_ID_AND_PIN_VALIDATION");
             return {
               error: {
                 type: "FAILED_TAX_ID_AND_PIN_VALIDATION",
@@ -225,6 +234,7 @@ export const ApiTaxClearanceCertificateClient = (
             };
           }
           if (errorMessage === BUSINESS_STATUS_VERIFICATION_ERROR) {
+            logSpecificTaxClearanceError("BUSINESS_STATUS_VERIFICATION_ERROR");
             return {
               error: {
                 type: "BUSINESS_STATUS_VERIFICATION_ERROR",
@@ -233,6 +243,7 @@ export const ApiTaxClearanceCertificateClient = (
             };
           }
           if (errorMessage === NATURAL_PROGRAM_ERROR) {
+            logSpecificTaxClearanceError("NATURAL_PROGRAM_ERROR");
             return {
               error: {
                 type: "NATURAL_PROGRAM_ERROR",


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
Previously, almost all errors that we logged for Tax Clearance looked like this: `error - Tax Clearance Certificate Client - Id:xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx - Error Request failed with status code 400`. This would slow us down when troubleshooting for users who reached out for support after encountering errors requesting their Tax Clearance Certificate, as we would have to retry the request ourselves to see what error occurred.

It makes sense to change the log to include the type of error (eg. BUSINESS_STATUS_VERIFICATION_ERROR or FAILED_TAX_ID_AND_PIN_VALIDATION).

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#17137](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17137).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
