### PR TITLE
chore: [AB#13063] remove uses of `visibility-hidden`

### DIFF
--- a/web/src/components/njwds-extended/ThreeYearSelector.test.tsx
+++ b/web/src/components/njwds-extended/ThreeYearSelector.test.tsx
@@ -67,9 +67,9 @@ describe("<ThreeYearSelector />", () => {
         years={["2024", "2025", "2026"]}
       />,
     );
-    expect(screen.getByTestId("year-selector-left")).not.toHaveClass("visibility-hidden");
+    expect(screen.getByTestId("year-selector-left")).toBeVisible();
     expect(screen.getByTestId("year-selector-left")).toBeEnabled();
-    expect(screen.getByTestId("year-selector-right")).not.toHaveClass("visibility-hidden");
+    expect(screen.getByTestId("year-selector-right")).toBeVisible();
     expect(screen.getByTestId("year-selector-right")).toBeEnabled();
   });
 
@@ -81,8 +81,7 @@ describe("<ThreeYearSelector />", () => {
         years={["2024", "2025", "2026"]}
       />,
     );
-    expect(screen.getByTestId("year-selector-left")).toHaveClass("visibility-hidden");
-    expect(screen.getByTestId("year-selector-left")).toBeDisabled();
+    expect(screen.queryByTestId("year-selector-left")).not.toBeInTheDocument();
   });
 
   it("hides the right chevron when at the end of the year array", () => {
@@ -93,7 +92,6 @@ describe("<ThreeYearSelector />", () => {
         years={["2024", "2025", "2026"]}
       />,
     );
-    expect(screen.getByTestId("year-selector-right")).toHaveClass("visibility-hidden");
-    expect(screen.getByTestId("year-selector-right")).toBeDisabled();
+    expect(screen.queryByTestId("year-selector-right")).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/njwds-extended/ThreeYearSelector.tsx
+++ b/web/src/components/njwds-extended/ThreeYearSelector.tsx
@@ -24,19 +24,17 @@ export const ThreeYearSelector = (props: Props): ReactElement => {
 
   return (
     <div className={props.className ?? ""}>
-      <IconButton
-        data-testid="year-selector-left"
-        aria-label="previous year"
-        className={`${props.years.indexOf(props.activeYear) === 0 ? "visibility-hidden" : ""}`}
-        disableFocusRipple={props.years.indexOf(props.activeYear) === 0}
-        disabled={props.years.indexOf(props.activeYear) === 0}
-        disableTouchRipple={props.years.indexOf(props.activeYear) === 0}
-        onClick={(): void => {
-          props.onChange(props.years[props.years.indexOf(props.activeYear) - 1]);
-        }}
-      >
-        <Icon className={`usa-icon--size-3 vam text-base`} iconName="navigate_before" />
-      </IconButton>
+      {props.years.indexOf(props.activeYear) !== 0 && (
+        <IconButton
+          data-testid="year-selector-left"
+          aria-label="previous year"
+          onClick={(): void => {
+            props.onChange(props.years[props.years.indexOf(props.activeYear) - 1]);
+          }}
+        >
+          <Icon className={`usa-icon--size-3 vam text-base`} iconName="navigate_before" />
+        </IconButton>
+      )}
       <CalendarButtonDropdown
         dropdownOptions={props.years.map((year) => {
           return {
@@ -64,24 +62,17 @@ export const ThreeYearSelector = (props: Props): ReactElement => {
       >
         <div className="text-base text-bold">{props.activeYear}</div>
       </CalendarButtonDropdown>
-      <IconButton
-        data-testid="year-selector-right"
-        aria-label="next year"
-        className={`${props.years.indexOf(props.activeYear) === 2 ? "visibility-hidden" : ""}`}
-        disableFocusRipple={props.years.indexOf(props.activeYear) === 2}
-        disabled={props.years.indexOf(props.activeYear) === 2}
-        disableTouchRipple={props.years.indexOf(props.activeYear) === 2}
-        onClick={(): void => {
-          props.onChange(props.years[props.years.indexOf(props.activeYear) + 1]);
-        }}
-      >
-        <Icon
-          className={`usa-icon--size-3 vam text-base ${
-            props.years.indexOf(props.activeYear) === 2 ? "visibility-hidden" : ""
-          }`}
-          iconName="navigate_next"
-        />
-      </IconButton>
+      {props.years.indexOf(props.activeYear) !== props.years.length - 1 && (
+        <IconButton
+          data-testid="year-selector-right"
+          aria-label="next year"
+          onClick={(): void => {
+            props.onChange(props.years[props.years.indexOf(props.activeYear) + 1]);
+          }}
+        >
+          <Icon className={`usa-icon--size-3 vam text-base`} iconName="navigate_next" />
+        </IconButton>
+      )}
     </div>
   );
 };

--- a/web/src/components/tasks/business-formation/BusinessFormation.test.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormation.test.tsx
@@ -39,7 +39,7 @@ import { Content } from "@/components/Content";
 import { useMockBusiness } from "@/test/mock/mockUseUserData";
 import { generateStartingProfileData } from "@businessnjgovnavigator/shared/";
 import * as materialUi from "@mui/material";
-import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 function mockMaterialUI(): typeof materialUi {
@@ -332,7 +332,9 @@ describe("<BusinessFormation />", () => {
 
     await page.fillAndSubmitBusinessNameStep("Pizza Joint");
 
-    page.selectByText("Business suffix", "LLC");
+    fireEvent.mouseDown(screen.getByTestId("business-suffix-main"));
+    const listbox = within(screen.getByRole("listbox"));
+    fireEvent.click(listbox.getByText("LLC"));
     const threeDaysFromNow = getCurrentDate().add(3, "days");
     page.selectDate(threeDaysFromNow, "Business start date");
     fireEvent.click(screen.getByText(Config.formation.sections.addressAddButtonText));
@@ -455,7 +457,9 @@ describe("<BusinessFormation />", () => {
 
     await page.fillAndSubmitNexusBusinessNameStep("Pizza Joint");
 
-    page.selectByText("Business suffix", "LLC");
+    fireEvent.mouseDown(screen.getByTestId("business-suffix-main"));
+    const listbox = within(screen.getByRole("listbox"));
+    fireEvent.click(listbox.getByText("LLC"));
     const threeDaysFromNow = getCurrentDate().add(3, "days");
     page.selectDate(threeDaysFromNow, "Foreign date of formation");
     page.fillText("Foreign state of formation", "MA");
@@ -560,7 +564,9 @@ describe("<BusinessFormation />", () => {
 
     await page.fillAndSubmitBusinessNameStep("Pizza Joint");
 
-    page.selectByText("Business suffix", "LLP");
+    fireEvent.mouseDown(screen.getByTestId("business-suffix-main"));
+    const listbox = within(screen.getByRole("listbox"));
+    fireEvent.click(listbox.getByText("LLP"));
     const threeDaysFromNow = getCurrentDate().add(3, "days");
     page.selectDate(threeDaysFromNow, "Business start date");
     fireEvent.click(screen.getByText(Config.formation.sections.addressAddButtonText));
@@ -667,7 +673,9 @@ describe("<BusinessFormation />", () => {
 
     await page.fillAndSubmitNexusBusinessNameStep("Pizza Joint");
 
-    page.selectByText("Business suffix", "LLP");
+    fireEvent.mouseDown(screen.getByTestId("business-suffix-main"));
+    const listbox = within(screen.getByRole("listbox"));
+    fireEvent.click(listbox.getByText("LLP"));
 
     const threeDaysFromNow = getCurrentDate().add(3, "days");
     const oneHundredAndThirtyDaysFromNow = getCurrentDate().add(3, "days");
@@ -781,7 +789,9 @@ describe("<BusinessFormation />", () => {
 
     await page.fillAndSubmitBusinessNameStep("Pizza Joint");
 
-    page.selectByText("Business suffix", "LP");
+    fireEvent.mouseDown(screen.getByTestId("business-suffix-main"));
+    const listbox = within(screen.getByRole("listbox"));
+    fireEvent.click(listbox.getByText("LP"));
     const threeDaysFromNow = getCurrentDate().add(3, "days");
     page.selectDate(threeDaysFromNow, "Business start date");
     fireEvent.click(screen.getByText(Config.formation.sections.addressAddButtonText));
@@ -920,7 +930,9 @@ describe("<BusinessFormation />", () => {
 
     await page.fillAndSubmitBusinessNameStep("Pizza Joint");
 
-    page.selectByText("Business suffix", "CORPORATION");
+    fireEvent.mouseDown(screen.getByTestId("business-suffix-main"));
+    const listbox = within(screen.getByRole("listbox"));
+    fireEvent.click(listbox.getByText("CORPORATION"));
     page.fillText("Business total stock", "123");
     const threeDaysFromNow = getCurrentDate().add(3, "days");
     page.selectDate(threeDaysFromNow, "Business start date");
@@ -1034,7 +1046,9 @@ describe("<BusinessFormation />", () => {
 
     await page.fillAndSubmitBusinessNameStep("Pizza Joint");
 
-    page.selectByText("Business suffix", "A NJ NONPROFIT CORPORATION");
+    fireEvent.mouseDown(screen.getByTestId("business-suffix-main"));
+    const listbox = within(screen.getByRole("listbox"));
+    fireEvent.click(listbox.getByText("A NJ NONPROFIT CORPORATION"));
     const threeDaysFromNow = getCurrentDate().add(3, "days");
     page.selectDate(threeDaysFromNow, "Business start date");
     page.chooseRadio("isVeteranNonprofit-true");
@@ -1154,7 +1168,9 @@ describe("<BusinessFormation />", () => {
 
     await page.fillAndSubmitNexusBusinessNameStep("Pizza Joint");
 
-    page.selectByText("Business suffix", "A NJ NONPROFIT CORPORATION");
+    fireEvent.mouseDown(screen.getByTestId("business-suffix-main"));
+    const listbox = within(screen.getByRole("listbox"));
+    fireEvent.click(listbox.getByText("A NJ NONPROFIT CORPORATION"));
     const threeDaysFromNow = getCurrentDate().add(3, "days");
 
     page.selectDate(threeDaysFromNow, "Foreign date of formation");

--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.test.tsx
@@ -54,7 +54,7 @@ import {
 } from "@businessnjgovnavigator/shared/types";
 import { Business } from "@businessnjgovnavigator/shared/userData";
 import * as materialUi from "@mui/material";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 interface MockApiErrorTestData {
@@ -1571,13 +1571,8 @@ describe("<BusinessFormationPaginator />", () => {
           it.each([businessSuffix])(
             "removes %o API error when user selects from dropdown and then blur",
             async (testTitle, data) => {
-              const {
-                formationFormData,
-                formationResponse,
-                formationStepName,
-                dropDownLabel,
-                dropDownValue,
-              } = data;
+              const { formationFormData, formationResponse, formationStepName, dropDownValue } =
+                data;
               filledInBusiness = {
                 ...business,
                 formationData: {
@@ -1593,10 +1588,15 @@ describe("<BusinessFormationPaginator />", () => {
               if (formationStepName === "Business") await page.stepperClickToBusinessStep();
               expect(screen.getByTestId("alert-error")).toBeInTheDocument();
 
-              page.selectByText(dropDownLabel as string, dropDownValue as string);
-              fireEvent.focusOut(screen.getAllByLabelText(dropDownLabel as string)[0]);
+              const selectButton = screen.getByTestId("business-suffix-main");
+              fireEvent.mouseDown(selectButton);
+              const listbox = within(screen.getByRole("listbox"));
+              fireEvent.click(listbox.getByText(dropDownValue as string));
+              fireEvent.blur(selectButton);
 
-              expect(screen.queryByTestId("alert-error")).not.toBeInTheDocument();
+              await waitFor(() => {
+                expect(screen.queryByTestId("alert-error")).not.toBeInTheDocument();
+              });
               expect(
                 screen.queryByText(Config.formation.errorBanner.errorOnStep),
               ).not.toBeInTheDocument();

--- a/web/src/components/tasks/business-formation/business/SuffixDropdown.test.tsx
+++ b/web/src/components/tasks/business-formation/business/SuffixDropdown.test.tsx
@@ -1,0 +1,97 @@
+import { displayContent } from "@/components/tasks/business-formation/contacts/testHelpers";
+import {
+  FormationPageHelpers,
+  generateFormationProfileData,
+  preparePage,
+  useSetupInitialMocks,
+} from "@/test/helpers/helpers-formation";
+import { getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
+import {
+  FormationFormData,
+  FormationLegalType,
+} from "@businessnjgovnavigator/shared/formationData";
+import { generateBusiness, generateFormationFormData } from "@businessnjgovnavigator/shared/test";
+import * as materialUi from "@mui/material";
+import { screen } from "@testing-library/react";
+
+function mockMaterialUI(): typeof materialUi {
+  return {
+    ...jest.requireActual("@mui/material"),
+    useMediaQuery: jest.fn(),
+  };
+}
+
+const Config = getMergedConfig();
+
+jest.mock("@mui/material", () => mockMaterialUI());
+jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
+jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
+jest.mock("@/lib/data-hooks/useDocuments");
+jest.mock("next/compat/router", () => ({ useRouter: jest.fn() }));
+jest.mock("@/lib/api-client/apiClient", () => ({
+  postBusinessFormation: jest.fn(),
+  getCompletedFiling: jest.fn(),
+  searchBusinessName: jest.fn(),
+}));
+
+describe("<SuffixDropdown />", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    useSetupInitialMocks();
+  });
+
+  const getPageHelper = async (
+    legalType: FormationLegalType,
+    formationFormData?: Partial<FormationFormData>,
+  ): Promise<FormationPageHelpers> => {
+    const profileData = generateFormationProfileData({ legalStructureId: legalType });
+    const formationData = {
+      formationFormData: generateFormationFormData(formationFormData || {}, {
+        legalStructureId: legalType,
+      }),
+      formationResponse: undefined,
+      getFilingResponse: undefined,
+      completedFilingPayment: false,
+      businessNameAvailability: undefined,
+      dbaBusinessNameAvailability: undefined,
+      lastVisitedPageIndex: 0,
+    };
+    const page = preparePage({
+      business: generateBusiness({ profileData, formationData }),
+      displayContent,
+    });
+    await page.stepperClickToBusinessStep();
+    return page;
+  };
+
+  describe("accessibility", () => {
+    it("displays the label text", async () => {
+      await getPageHelper("limited-liability-company");
+
+      expect(screen.getByText(Config.formation.fields.businessSuffix.label)).toBeInTheDocument();
+    });
+
+    it("can be accessed by its label using getByLabelText", async () => {
+      await getPageHelper("limited-liability-company");
+
+      const select = screen.getByLabelText(Config.formation.fields.businessSuffix.label);
+      expect(select).toBeInTheDocument();
+    });
+  });
+
+  describe("display of selected value", () => {
+    it("displays the selected suffix value", async () => {
+      await getPageHelper("limited-liability-company", { businessSuffix: "L.L.C." });
+
+      const select = screen.getByTestId("business-suffix-main");
+      expect(select).toHaveTextContent("L.L.C.");
+    });
+
+    it("displays empty when no suffix is selected", async () => {
+      await getPageHelper("limited-liability-company", { businessSuffix: undefined });
+
+      const select = screen.getByTestId("business-suffix-main");
+      expect(select).toHaveTextContent("");
+    });
+  });
+});

--- a/web/src/components/tasks/business-formation/business/SuffixDropdown.tsx
+++ b/web/src/components/tasks/business-formation/business/SuffixDropdown.tsx
@@ -2,7 +2,6 @@ import { ContextualInfoButton } from "@/components/ContextualInfoButton";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormationErrors } from "@/lib/data-hooks/useFormationErrors";
-import { camelCaseToSentence } from "@/lib/utils/cases-helpers";
 import { isForeignCorporationOrNonprofit } from "@/lib/utils/helpers";
 import {
   BusinessSuffix,
@@ -16,14 +15,7 @@ import {
   LpBusinessSuffix,
   NonprofitBusinessSuffix,
 } from "@businessnjgovnavigator/shared/";
-import {
-  FormControl,
-  FormHelperText,
-  InputLabel,
-  MenuItem,
-  Select,
-  SelectChangeEvent,
-} from "@mui/material";
+import { FormControl, FormHelperText, MenuItem, Select, SelectChangeEvent } from "@mui/material";
 import { ReactElement, ReactNode, useContext } from "react";
 
 interface MySelectDisplayProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -62,7 +54,7 @@ export const SuffixDropdown = (): ReactElement => {
   return (
     <>
       <div>
-        <div>
+        <div id="business-suffix-label">
           <strong>
             <ContextualInfoButton
               text={Config.formation.fields.businessSuffix.label}
@@ -75,12 +67,9 @@ export const SuffixDropdown = (): ReactElement => {
         )}
       </div>
       <FormControl fullWidth error={doesFieldHaveError(FIELD)}>
-        <InputLabel id="business-suffix-label" className="visibility-hidden">
-          {camelCaseToSentence("businessSuffix")}
-        </InputLabel>
         <Select
           autoComplete="no"
-          labelId="business-suffix-label"
+          aria-labelledby="business-suffix-label"
           id="business-suffix"
           SelectDisplayProps={
             {

--- a/web/src/styles/base/global.scss
+++ b/web/src/styles/base/global.scss
@@ -23,14 +23,6 @@ ol {
   }
 }
 
-.visibility-hidden {
-  visibility: hidden;
-}
-
-.visibility-visible {
-  visibility: visible;
-}
-
 .visually-hidden-centered {
   // This is a terrrrrrrrible idea for screen reader purposes
   clip: rect(0 0 0 0);


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
Removes usages of `visibility-hidden` for alternatives that are better practice. See the approach section for more details.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#13063](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13063).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
- `ThreeYearSelector.tsx` was conditionally applying the `visually-hidden`. This was refactored to more straightforward conditional rendering
- `SuffixDropdown.jsx` was using MUI's `InputLabel` component and then hiding it. This was refactored to using `aria-labeledby` with the label we're already still displaying
    - I added a few tests to validate this, as well
- these changes resulting in zero usage of the `visibility-hidden` global CSS class, so I removed that, as well as a visibility-visible` class not being used anywhere

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

  1. Navigate to the Business Formation task (`/tasks/form-business-entity`), i.e., the "Form Your Business" task
  2. Get to the Business step (step 2)
  3. The suffix dropdown is on this page
  4. Tabbing through with voiceover should still announce the "Business Suffix" label

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
