### PR TITLE
fix: [AB#16898] prevent react email conflict when starting dev server, modify links

### DIFF
--- a/api/src/functions/messagingService/reactEmail/README.md
+++ b/api/src/functions/messagingService/reactEmail/README.md
@@ -8,10 +8,10 @@ Each `.tsx` file in the `./emails` folder is treated as an email. To preview and
 
 ```bash
 cd api/src/functions/messagingService/reactEmail
-yarn dev
+yarn dev:email
 ```
 
-This starts a preview app at `localhost:3000` where you can view emails, check compatibility across email clients, and check for spam / abuse indicators.
+This starts a preview app at `localhost:3001` where you can view emails, check compatibility across email clients, and check for spam / abuse indicators.
 
 ## Building
 

--- a/api/src/functions/messagingService/reactEmail/emails/welcomeEmailShortVersion.tsx
+++ b/api/src/functions/messagingService/reactEmail/emails/welcomeEmailShortVersion.tsx
@@ -42,7 +42,7 @@ export const WelcomeEmailShortVersion = (): JSX.Element => {
           <Row>
             <Markdown markdownCustomStyles={{ link: { color: "black" } }}>
               Congratulations on creating your account with
-              **[Business.NJ.gov](https://account.business.nj.gov/dashboard?utm_source=myaccount-welcome-email&utm_medium=email&utm_campaign=welcome-email&utm_content=welcome-email-B-version1-inline-message-business.nj.gov)**.
+              **[Business.NJ.gov](https://business.nj.gov/?utm_source=myaccount-welcome-email&utm_medium=email&utm_campaign=welcome-email&utm_content=welcome-email-B-version1-inline-message-business.nj.gov)**.
             </Markdown>
             <Markdown markdownContainerStyles={{ paddingBottom: "18px" }}>
               You've joined **200,000+ business owners** who've used the site to start, operate, and
@@ -72,7 +72,7 @@ export const WelcomeEmailShortVersion = (): JSX.Element => {
                 Log In to Get Started
               </h2>
               <Button
-                href="https://account.business.nj.gov/dashboard?utm_source=myaccount-welcome-email&utm_medium=email&utm_campaign=welcome-email&utm_content=welcome-email-B-version1-green-cta"
+                href="https://account.business.nj.gov/login?utm_source=myaccount-welcome-email&utm_medium=email&utm_campaign=welcome-email&utm_content=welcome-email-B-version1-green-cta"
                 style={{
                   background: "#4b7600",
                   color: "#fff",
@@ -86,10 +86,10 @@ export const WelcomeEmailShortVersion = (): JSX.Element => {
             <Row>
               <Text>
                 <Link
-                  href="https://account.business.nj.gov/dashboard"
+                  href="https://account.business.nj.gov/login"
                   style={{ textDecoration: "underline", color: "#3D4551" }}
                 >
-                  https://account.business.nj.gov/dashboard
+                  https://account.business.nj.gov/login
                 </Link>
               </Text>
             </Row>

--- a/api/src/functions/messagingService/reactEmail/package.json
+++ b/api/src/functions/messagingService/reactEmail/package.json
@@ -9,12 +9,11 @@
   "dependencies": {
     "@react-email/components": "1.0.1",
     "@react-email/render": "2.0.0",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "react": "18.3.1",
     "tsx": "4.21.0"
   },
   "scripts": {
-    "dev": "email dev",
+    "dev:email": "email dev --port 3001",
     "build": "tsx build.tsx"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4699,8 +4699,7 @@ __metadata:
     "@react-email/components": 1.0.1
     "@react-email/preview-server": 5.0.6
     "@react-email/render": 2.0.0
-    react: 18.2.0
-    react-dom: 18.2.0
+    react: 18.3.1
     react-email: 5.0.6
     tsx: 4.21.0
   languageName: unknown
@@ -32642,18 +32641,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:18.2.0":
-  version: 18.2.0
-  resolution: "react-dom@npm:18.2.0"
-  dependencies:
-    loose-envify: ^1.1.0
-    scheduler: ^0.23.0
-  peerDependencies:
-    react: ^18.2.0
-  checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
-  languageName: node
-  linkType: hard
-
 "react-dom@npm:18.3.1":
   version: 18.3.1
   resolution: "react-dom@npm:18.3.1"
@@ -33139,15 +33126,6 @@ __metadata:
     react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 04f0835869fbc1dc69637416e91bd7dfd462dcb9bf33ed2db4b4a515116c7a1c1ded3ca5e6df8d9a9ea3ec4f34e8e05f642d50f969bb495a9e11906d6a8cc418
-  languageName: node
-  linkType: hard
-
-"react@npm:18.2.0":
-  version: 18.2.0
-  resolution: "react@npm:18.2.0"
-  dependencies:
-    loose-envify: ^1.1.0
-  checksum: 88e38092da8839b830cda6feef2e8505dec8ace60579e46aa5490fc3dc9bba0bd50336507dc166f43e3afc1c42939c09fe33b25fae889d6f402721dcd78fca1b
   languageName: node
   linkType: hard
 
@@ -34485,7 +34463,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.23.0, scheduler@npm:^0.23.2":
+"scheduler@npm:^0.23.2":
   version: 0.23.2
   resolution: "scheduler@npm:0.23.2"
   dependencies:


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Previously, the introduction of React Email caused problems for developers running `yarn start:dev` from root because yarn would run the `dev` script defined for each workspace, and React Email's dev server would try to use the same port as the My Account web app. This change makes sure that `yarn start:dev` does not start React Email's dev server, and also changes React Email's default port so that conflicts will be avoided in the future.

Additionally, some links have been modified after consulting content and design, and react-dom was removed from React Email's dependencies.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request is a fix for a bug caused by [#16898](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
