### PR TITLE
chore: [AB#13058] add health check for tax filing API

### DIFF
--- a/api/src/domain/tax-filings/taxFilingsInterfaceFactory.test.ts
+++ b/api/src/domain/tax-filings/taxFilingsInterfaceFactory.test.ts
@@ -38,6 +38,7 @@ describe("TaxFilingsInterfaceFactory", () => {
     taxFilingClient = {
       lookup: jest.fn(),
       onboarding: jest.fn(),
+      health: jest.fn(),
     };
     const dateNowStub = jest.fn(() => {
       return dateNow;

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -140,6 +140,7 @@ export interface TaxFilingClient {
     email: string;
     businessName: string;
   }) => Promise<TaxFilingOnboardingResponse>;
+  health: () => Promise<HealthCheckMetadata>;
 }
 
 export interface TaxFilingInterface {

--- a/api/src/functions/express/app.ts
+++ b/api/src/functions/express/app.ts
@@ -536,9 +536,11 @@ app.use(
       ["webservice/formation", formationHealthCheckClient],
       ["tax-clearance", taxClearanceHealthCheckClient],
       ["xray-registration", xrayRegistrationHealthCheckClient],
+      // TODO: The following need CloudWatch metrics
       ["cigarette-license", cigaretteLicenseHealthCheckClient],
       ["cigarette-email-client", cigaretteLicenseEmailClient.health],
       ["messaging-service", messagingServiceClient.health],
+      ["tax-filing-client", taxFilingClient.health],
     ]),
     logger,
   ),

--- a/api/src/libs/healthCheck.test.ts
+++ b/api/src/libs/healthCheck.test.ts
@@ -22,6 +22,7 @@ describe("healthCheck", () => {
       xrayRegistration: "PASS",
       cigaretteLicense: "PASS",
       cigaretteEmailClient: "PASS",
+      taxFilingClient: "PASS",
     });
   });
 
@@ -39,6 +40,7 @@ describe("healthCheck", () => {
       xrayRegistration: "FAIL",
       cigaretteLicense: "FAIL",
       cigaretteEmailClient: "FAIL",
+      taxFilingClient: "FAIL",
     });
   });
 
@@ -56,6 +58,7 @@ describe("healthCheck", () => {
       xrayRegistration: "ERROR",
       cigaretteLicense: "ERROR",
       cigaretteEmailClient: "ERROR",
+      taxFilingClient: "ERROR",
     });
   });
 });

--- a/api/src/libs/healthCheck.ts
+++ b/api/src/libs/healthCheck.ts
@@ -19,6 +19,7 @@ const healthCheckEndPoints: Record<string, string> = {
   xrayRegistration: "xray-registration",
   cigaretteEmailClient: "cigarette-email-client",
   cigaretteLicense: "cigarette-license",
+  taxFilingClient: "tax-filing-client",
 };
 
 const healthCheck = async (type: string, url: string, logger: LogWriterType): Promise<Status> => {

--- a/api/wiremock/mappings/get-tax-calendar-lookup-success.json
+++ b/api/wiremock/mappings/get-tax-calendar-lookup-success.json
@@ -4,7 +4,7 @@
     "url": "/lookup",
     "bodyPatterns": [
       {
-        "contains": "123456789098"
+        "contains": "777777777771"
       }
     ]
   },

--- a/api/wiremock/mappings/get-tax-calendar-onboarding-success.json
+++ b/api/wiremock/mappings/get-tax-calendar-onboarding-success.json
@@ -4,7 +4,7 @@
     "url": "/onboard",
     "bodyPatterns": [
       {
-        "contains": "123456789098"
+        "contains": "777777777771"
       }
     ]
   },

--- a/web/cypress/e2e/auto-tax-filing.spec.ts
+++ b/web/cypress/e2e/auto-tax-filing.spec.ts
@@ -37,7 +37,7 @@ describe.skip(
       clickModalSaveButton();
 
       onDashboardPage.registerForTaxes();
-      cy.get('input[name="taxId"]').type("123456789098");
+      cy.get('input[name="taxId"]').type("777777777771");
       cy.get("button").contains("Save").click();
       cy.get(`[data-testid="back-to-dashboard"]`).first().click({ force: true });
       cy.get('[data-testid="cta-funding-nudge"]').first().click();
@@ -58,7 +58,7 @@ describe.skip(
       clickModalSaveButton();
 
       onDashboardPage.registerForTaxes();
-      cy.get('input[name="taxId"]').type("123456789098");
+      cy.get('input[name="taxId"]').type("777777777771");
       cy.get("button").contains("Save").click();
       cy.get(`[data-testid="back-to-dashboard"]`).first().click({ force: true });
       cy.get('[data-testid="cta-funding-nudge"]').first().click();

--- a/web/src/components/dashboard/SidebarCardFundingNudge.test.tsx
+++ b/web/src/components/dashboard/SidebarCardFundingNudge.test.tsx
@@ -131,7 +131,7 @@ describe("<SidebarCardFundingNudge />", () => {
 
   const userDataWithPrefilledFields = generateTaxFilingUserData({
     publicFiling: true,
-    taxId: "123456789098",
+    taxId: "777777777771",
     businessName: "MrFakesHotDogBonanza",
     industryId: randomIndustry().id,
   });


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Adds a health check for the Tax Filing API.

### Ticket

This pull request resolves [#13058](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13058).

### Approach

I created a `health` function that when invoked uses existing logic to make requests to the Tax Filing API. Responses from the Tax Filing API result in passing health checks. I also created a new API route that will invoke the health check function when called.

### Steps to Test

In an environment where the application is running (locally, or in the cloud), make a call to the API endpoint to execute this health check. You can do this in the browser or with Postman/Bruno.

```
{base_api_url}/health/tax-filing-client
```

### Notes

This work does not include creating a new metric in CloudWatch to raise alarms in the event of a failing health check. That will need to be done separately via existing patterns in Terraform or by creating metrics via AWS CDK, which has not been previously done. The logs will still appear in the `/HealthCheck` log group.

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
