### PR TITLE
chore: [AB#14163] Refactor hard-coded quick references in environmental permitting task

### DIFF
--- a/content/src/fieldConfig/env-questionnaire.json
+++ b/content/src/fieldConfig/env-questionnaire.json
@@ -148,7 +148,7 @@
         "heading": "Wastewater Requirements",
         "bodyLink": "[Division of Water Quality](https://dep.nj.gov/dwq/contact-us/)",
         "contact": {
-          "phoneInfo": "Division of Water Quality",
+          "phoneInfo": "Division of Water Quality:",
           "phone": "(609) 292-9977",
           "form": "",
           "email": "dwq@dep.nj.gov"

--- a/web/src/components/njwds-extended/callout/CalloutIcons.tsx
+++ b/web/src/components/njwds-extended/callout/CalloutIcons.tsx
@@ -12,20 +12,39 @@ const IconTextItem = (props: IconTextProps): ReactElement => {
 
   let content: ReactNode;
 
-  if (props.type === "phone") {
-    content = (
-      <a className="usa-link" href={`tel:${props.text}`}>
-        {props.text}
-      </a>
-    );
-  } else if (props.type === "email") {
-    content = (
-      <a className="usa-link" href={`mailto:${props.text}`}>
-        {props.text}
-      </a>
-    );
-  } else {
-    content = <div className="text-primary-darker">{props.text}</div>;
+  switch (props.type) {
+    case "phone":
+      content = (
+        <>
+          {props.labelText && <span className="margin-right-05">{props.labelText}</span>}
+          <a className="usa-link" href={`tel:${props.text}`}>
+            {props.text}
+          </a>
+        </>
+      );
+      break;
+    case "email":
+      content = (
+        <a className="usa-link" href={`mailto:${props.text}`}>
+          {props.text}
+        </a>
+      );
+      break;
+    case "link": {
+      const match = props.text.match(/\[([^\]]+)]\(([^)]+)\)/);
+      const label = match?.[1] || props.text;
+      const href = match?.[2] || props.text;
+
+      content = (
+        <a className="usa-link" href={href} target="_blank" rel="noreferrer noopener">
+          {label}
+          <Icon className="margin-left-05" iconName="launch" />
+        </a>
+      );
+      break;
+    }
+    default:
+      content = <div className="text-primary-darker">{props.text}</div>;
   }
 
   const ariaLabel =
@@ -51,6 +70,7 @@ export const IconTextList = (props: IconTextListProps): ReactElement | null => {
           text={item.text}
           type={item.type}
           label={item.label}
+          labelText={item.labelText}
         />
       ))}
     </div>

--- a/web/src/components/njwds-extended/callout/calloutHelpers.ts
+++ b/web/src/components/njwds-extended/callout/calloutHelpers.ts
@@ -39,14 +39,16 @@ export const CALLOUT_STYLES: Record<CalloutTypes, CalloutStyling> = {
   },
 };
 
-export type IconType = "phone" | "email" | "text";
+export type IconType = "phone" | "email" | "text" | "link";
 
 export interface IconProps {
   amountIconText?: string;
   filingTypeIconText?: string;
   frequencyIconText?: string;
   phoneIconText?: string;
+  phoneIconLabel?: string;
   emailIconText?: string;
+  linkIconText?: string;
 }
 
 export interface IconTextProps {
@@ -54,6 +56,7 @@ export interface IconTextProps {
   text: string;
   type: IconType;
   label: string;
+  labelText?: string;
 }
 
 interface IconItem {
@@ -94,6 +97,12 @@ export const ICON_ITEMS: IconItem[] = [
     type: "email",
     ariaLabelKey: "emailIconAriaLabel",
   },
+  {
+    propName: "linkIconText",
+    iconName: "language",
+    type: "link",
+    ariaLabelKey: "linkIconAriaLabel",
+  },
 ];
 
 export const getIconItems = <T extends IconProps>(props: T): IconTextProps[] => {
@@ -104,12 +113,18 @@ export const getIconItems = <T extends IconProps>(props: T): IconTextProps[] => 
   for (const item of ICON_ITEMS) {
     const text = props[item.propName];
     if (text) {
-      iconItems.push({
+      const iconItem: IconTextProps = {
         iconName: item.iconName,
         text: text,
         type: item.type,
         label: item.ariaLabelKey,
-      });
+      };
+
+      if (item.propName === "phoneIconText" && props.phoneIconLabel) {
+        iconItem.labelText = props.phoneIconLabel;
+      }
+
+      iconItems.push(iconItem);
     }
   }
 

--- a/web/src/components/tasks/environment-questionnaire/results/ContactDep.tsx
+++ b/web/src/components/tasks/environment-questionnaire/results/ContactDep.tsx
@@ -1,5 +1,5 @@
 import { Content } from "@/components/Content";
-import { Icon } from "@/components/njwds/Icon";
+import { LargeCallout } from "@/components/njwds-extended/callout/LargeCallout";
 import { ResultsSectionAccordion } from "@/components/ResultsSectionAccordion";
 import { EnvPermitContext } from "@/contexts/EnvPermitContext";
 import analytics from "@/lib/utils/analytics";
@@ -14,63 +14,28 @@ export const ContactDep = (): ReactElement => {
 
   const contactCard = (mediaArea: MediaArea): ReactElement => {
     const contactConfig = Config.envResultsPage.contactDep[mediaArea];
+    const bodyText = templateEval(Config.envResultsPage.contactDep.body, {
+      bodyLink: contactConfig.bodyLink,
+    });
+
     return (
-      <div className={"padding-205 margin-y-2 bg-base-extra-light radius-lg"}>
-        <h4>{contactConfig.heading}</h4>
-        <div className={"margin-x-105"}>
-          <Content className={"padding-bottom-1"}>
-            {templateEval(Config.envResultsPage.contactDep.body, {
-              bodyLink: contactConfig.bodyLink,
-            })}
-          </Content>
-          <div className="flex flex-align-center flex-wrap">
-            <Icon className={"margin-right-1"} iconName={"phone"} />
-            {contactConfig.contact.phoneInfo && (
-              <span className="margin-right-05">{contactConfig.contact.phoneInfo}</span>
-            )}
-            <a
-              className={"text-base-darkest"}
-              href={`tel:${contactConfig.contact.phone}`}
-              onMouseEnter={
-                analytics.event.gen_guidance_stepper_contact_info_engagement.mouseover
-                  .general_guidance_contact_info_engage
-              }
-            >
-              {contactConfig.contact.phone}
-            </a>
-          </div>
-          {contactConfig.contact.form && (
-            <div
-              className="flex flex-align-center margin-top-05"
-              onMouseEnter={
-                analytics.event.gen_guidance_stepper_contact_info_engagement.mouseover
-                  .general_guidance_contact_info_engage
-              }
-            >
-              <Icon className={"margin-right-1"} iconName={"language"} />
-              <Content className={"text-underline text-base-darkest"}>
-                {contactConfig.contact.form}
-              </Content>
-            </div>
-          )}
-          {contactConfig.contact.email && (
-            <div
-              className="flex flex-align-center margin-top-05"
-              onMouseEnter={
-                analytics.event.gen_guidance_stepper_contact_info_engagement.mouseover
-                  .general_guidance_contact_info_engage
-              }
-            >
-              <Icon className={"margin-right-1"} iconName={"alternate_email"} />
-              <a
-                href={`mailto:${contactConfig.contact.email}`}
-                className={"text-underline text-base-darkest"}
-              >
-                {contactConfig.contact.email}
-              </a>
-            </div>
-          )}
-        </div>
+      <div
+        onMouseEnter={
+          analytics.event.gen_guidance_stepper_contact_info_engagement.mouseover
+            .general_guidance_contact_info_engage
+        }
+      >
+        <LargeCallout
+          calloutType="quickReference"
+          showHeader={true}
+          headerText={contactConfig.heading}
+          phoneIconText={contactConfig.contact.phone || undefined}
+          phoneIconLabel={contactConfig.contact.phoneInfo || undefined}
+          emailIconText={contactConfig.contact.email || undefined}
+          linkIconText={contactConfig.contact.form || undefined}
+        >
+          <Content>{bodyText}</Content>
+        </LargeCallout>
       </div>
     );
   };

--- a/web/src/components/tasks/environment-questionnaire/results/PersonalizedSupport.tsx
+++ b/web/src/components/tasks/environment-questionnaire/results/PersonalizedSupport.tsx
@@ -70,7 +70,7 @@ export const PersonalizedSupport = (): ReactElement => {
           .general_guidance_sbap_accordion_opened
       }
     >
-      <div className={"padding-205 margin-y-2 bg-base-extra-light text-body radius-lg"}>
+      <div className={"padding-205 margin-y-2 bg-base-lightest text-body radius-lg"}>
         {error && (
           <Alert
             variant="error"

--- a/web/src/lib/cms/editors/large-callout.tsx
+++ b/web/src/lib/cms/editors/large-callout.tsx
@@ -33,35 +33,36 @@ export default {
       label: "Amount Icon Text",
       default: "",
       widget: "string",
-      hint: "This icon should only exist in the quick reference callout",
     },
     {
       name: "filingTypeIconText",
       label: "Filing Type Icon Text",
       default: "",
       widget: "string",
-      hint: "This icon should only exist in the quick reference callout",
     },
     {
       name: "frequencyIconText",
       label: "Frequency Icon Text",
       default: "",
       widget: "string",
-      hint: "This icon should only exist in the quick reference callout",
     },
     {
       name: "phoneIconText",
       label: "Phone Icon Text",
       default: "",
       widget: "string",
-      hint: "This icon should only exist in the quick reference callout; a phone link will render",
+    },
+    {
+      name: "phoneIconLabel",
+      label: "Phone Icon Label",
+      default: "",
+      widget: "string",
     },
     {
       name: "emailIconText",
       label: "Email Icon Text",
       default: "",
       widget: "string",
-      hint: "This icon should only exist in the quick reference callout; an email link will render",
     },
   ],
 
@@ -80,6 +81,7 @@ export default {
     filingTypeIconText: string;
     frequencyIconText: string;
     phoneIconText: string;
+    phoneIconLabel: string;
     emailIconText: string;
   } => {
     // We can safely assume there will be a single match; else we wouldn't be inside this function.
@@ -92,7 +94,7 @@ export default {
 
     // If we just have :::largeCallout {}\n:::, then we need to return some default values instead.
     const defaultCalloutContents =
-      'showHeader="false" headerText="" calloutType="conditional" amountIconText="" filingTypeIconText="" frequencyIconText="" phoneIconText="" emailIconText=""';
+      'showHeader="false" headerText="" calloutType="conditional" amountIconText="" filingTypeIconText="" frequencyIconText="" phoneIconText="" phoneIconLabel="" emailIconText=""';
 
     const calloutParameters = calloutMatch?.groups?.parameters ?? defaultCalloutContents;
     const calloutBody = calloutMatch?.groups?.body.trim() ?? "";
@@ -125,6 +127,11 @@ export default {
     const phoneIconTextMatch = calloutParameters.match(/phoneIconText="(?<phoneIconText>[^"]+)"/);
     const phoneIconTextValue = phoneIconTextMatch?.groups?.phoneIconText?.trim() ?? "";
 
+    const phoneIconLabelMatch = calloutParameters.match(
+      /phoneIconLabel="(?<phoneIconLabel>[^"]+)"/,
+    );
+    const phoneIconLabelValue = phoneIconLabelMatch?.groups?.phoneIconLabel?.trim() ?? "";
+
     const emailIconTextMatch = calloutParameters.match(/emailIconText="(?<emailIconText>[^"]+)"/);
     const emailIconTextValue = emailIconTextMatch?.groups?.emailIconText?.trim() ?? "";
 
@@ -136,6 +143,7 @@ export default {
       filingTypeIconText: filingTypeIconTextValue,
       frequencyIconText: frequencyIconTextValue,
       phoneIconText: phoneIconTextValue,
+      phoneIconLabel: phoneIconLabelValue,
       emailIconText: emailIconTextValue,
       body: calloutBody,
     };
@@ -151,9 +159,10 @@ export default {
     filingTypeIconText: string;
     frequencyIconText: string;
     phoneIconText: string;
+    phoneIconLabel: string;
     emailIconText: string;
   }): string => {
-    return `:::largeCallout{ showHeader="${obj.showHeader}" headerText="${obj.headerText}" calloutType="${obj.calloutType}" amountIconText="${obj.amountIconText}" filingTypeIconText="${obj.filingTypeIconText}" frequencyIconText="${obj.frequencyIconText}" phoneIconText="${obj.phoneIconText}" emailIconText="${obj.emailIconText}" }\n\n${obj.body}\n\n:::`;
+    return `:::largeCallout{ showHeader="${obj.showHeader}" headerText="${obj.headerText}" calloutType="${obj.calloutType}" amountIconText="${obj.amountIconText}" filingTypeIconText="${obj.filingTypeIconText}" frequencyIconText="${obj.frequencyIconText}" phoneIconText="${obj.phoneIconText}" phoneIconLabel="${obj.phoneIconLabel}" emailIconText="${obj.emailIconText}" }\n\n${obj.body}\n\n:::`;
   },
   toPreview: (obj: {
     showHeader: boolean;
@@ -164,8 +173,9 @@ export default {
     filingTypeIconText: string;
     frequencyIconText: string;
     phoneIconText: string;
+    phoneIconLabel: string;
     emailIconText: string;
   }): string => {
-    return `:::largeCallout{ showHeader="${obj.showHeader}" headerText="${obj.headerText}" calloutType="${obj.calloutType}" amountIconText="${obj.amountIconText}" filingTypeIconText="${obj.filingTypeIconText}" frequencyIconText="${obj.frequencyIconText}" phoneIconText="${obj.phoneIconText}" emailIconText="${obj.emailIconText}" }\n${obj.body}\n:::`;
+    return `:::largeCallout{ showHeader="${obj.showHeader}" headerText="${obj.headerText}" calloutType="${obj.calloutType}" amountIconText="${obj.amountIconText}" filingTypeIconText="${obj.filingTypeIconText}" frequencyIconText="${obj.frequencyIconText}" phoneIconText="${obj.phoneIconText}" phoneIconLabel="${obj.phoneIconLabel}" emailIconText="${obj.emailIconText}" }\n${obj.body}\n:::`;
   },
 };


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

This refactors  **ContactDep.tsx** to use the reusable `LargeCallout` component with `quickReference` type, replacing a hardcoded quick reference pattern.

Also:

- Added a `linkIconText` prop to the Callout component to support external links

- **PersonalizedSupport.tsx**: 
  - This is noted in the ticket as needing to be refactored to use the quick reference callout but I believe that recommendation no longer applies since this component has been updated to not act like a quick reference. I did still update the background color to `bg-base-lightest` to match the quick references in `ContactDep` for visual consistency, since these components matched visually before the refactor.


### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#14163](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14163).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Check it out at [localhost:3000/tasks/env-permitting](http://localhost:3000/tasks/env-permitting) 😄 

<img width="936" height="735" alt="Screenshot 2026-01-08 at 3 53 21 PM" src="https://github.com/user-attachments/assets/175e2f76-281c-4e14-b610-fbc108ed54d6" />


### Notes

Portions drafted with AI assistance; all changes reviewed and verified by me, a human!
<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
