### PR TITLE
chore: [AB#17147] disable build for content-repo PRs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -95,7 +95,8 @@ jobs:
     if: >
       github.event_name == 'push' || (
         github.event_name == 'pull_request' &&
-        github.event.pull_request.draft == false
+        github.event.pull_request.draft == false  &&
+        github.event.pull_request.head.ref != 'content-repo'
       ) || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

We are updating our GitHub Actions workflow to prevent CI jobs from running on pull requests originating from the content-repo branch.

This change ensures:
- CI still runs for all normal PRs and pushes to main
- CI does not run for PRs created from content-repo
- Scheduled and manually triggered workflows continue to run as expected

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#17147](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17147).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
- This can be validated when a PR is generated from the content-repo branch. Expectation is that only one build and test workflow is going to run the build job. 

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
