### PR TITLE
feat: [AB#17071] added feature flag for zod on migration

### DIFF
--- a/api/src/libs/ssmUtils.ts
+++ b/api/src/libs/ssmUtils.ts
@@ -13,7 +13,8 @@ export type CONFIG_VARS =
   | CIGARETTE_EMAIL_CONFIG_VARS
   | ENV_REQ_CONFIG_VARS
   | USER_MESSAGING_CONFIG_VARS
-  | "dep_base_url";
+  | "dep_base_url"
+  | "zod_parsing_on";
 
 export type CIGARETTE_PAYMENT_CONFIG_VARS =
   | "cigarette_license_base_url"


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
This PR introduces a feature flag that controls whether migration parsing and Zod logging are enabled or disabled when migrations run, on a per-environment basis. The feature flags have been added to SSM for each environment.
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#17071](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17071).

### Approach

Design Decision:

After reviewing the code, I decided it made more sense to read the config value when the DynamoDataClient is initialized, since that parameter needs to remain consistent for the entire duration of the migration. This also removes the need to pass it everywhere DynamoDataClient is instantiated, including throughout the tests. Because this is a temporary feature flag—only needed until the data is fully cleansed based on the logs and Zod can parse everything cleanly—centralizing it at initialization felt like the simplest and least intrusive approach.  The flag is placed into SSM, eliminating the need to terraform/put it in the environment files.

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->
Unit tests have been added to DynamoDataClient to cover the zod parsing parameter change.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [X] I have added the `request-reviewer` tag on github to request reviews
