### PR TITLE
feat: [AB#17102] allow some tasks to be synced with Webflow

### DIFF
--- a/web/decap-config/collections/06-tasks.yml
+++ b/web/decap-config/collections/06-tasks.yml
@@ -329,7 +329,15 @@ collections:
           required: false,
         }
       - {
-          label: "Webflow Name (not being synced, only for reference and future expansion)",
+          label: "Sync to Webflow",
+          name: "syncToWebflow",
+          widget: "boolean",
+          required: false,
+          default: false,
+        }
+      - {
+          label: "Webflow Name",
+          hint: Required if "Sync to Webflow" is selected,
           name: "webflowName",
           widget: "string",
           required: false,

--- a/web/src/scripts/licenseLoader.mjs
+++ b/web/src/scripts/licenseLoader.mjs
@@ -4,15 +4,19 @@ import path from "path";
 import { fileURLToPath } from "url";
 
 const webflowLicenseDir = path.resolve(
-  `${path.dirname(fileURLToPath(import.meta.url))}/../../../content/src/webflow-licenses`
+  `${path.dirname(fileURLToPath(import.meta.url))}/../../../content/src/webflow-licenses`,
 );
 
 const navigatorLicenseDir = path.resolve(
-  `${path.dirname(fileURLToPath(import.meta.url))}/../../../content/src/roadmaps/license-tasks`
+  `${path.dirname(fileURLToPath(import.meta.url))}/../../../content/src/roadmaps/license-tasks`,
 );
 
 const municipalDir = path.resolve(
-  `${path.dirname(fileURLToPath(import.meta.url))}/../../../content/src/roadmaps/municipal-tasks`
+  `${path.dirname(fileURLToPath(import.meta.url))}/../../../content/src/roadmaps/municipal-tasks`,
+);
+
+const tasksAllDir = path.resolve(
+  `${path.dirname(fileURLToPath(import.meta.url))}/../../../content/src/roadmaps/tasks`,
 );
 
 const convertLicenseMd = (mdContents, filename) => {
@@ -56,7 +60,15 @@ export const loadAllNavigatorLicenses = () => {
     return loadLicenseByPath(fileName, fullPath);
   });
 
-  return navigatorLicenses.concat(municipalLicenses);
+  const tasksAllFileNames = fs.readdirSync(tasksAllDir);
+  const tasksAllLicenses = tasksAllFileNames
+    .map((fileName) => {
+      const fullPath = path.join(tasksAllDir, `${fileName}`);
+      return loadLicenseByPath(fileName, fullPath);
+    })
+    .filter((license) => license.syncToWebflow === true || license.syncToWebflow === "true");
+
+  return navigatorLicenses.concat(municipalLicenses, tasksAllLicenses);
 };
 
 const loadLicenseByPath = (fileName, fullPath) => {
@@ -75,12 +87,15 @@ const getMarkDownFromNavigatorDir = (fileName, filePath) => {
 export const loadNavigatorLicense = (fileName) => {
   const navigatorLicenseFile = path.join(navigatorLicenseDir, `${fileName}`);
   const municipalLicenseFile = path.join(municipalDir, `${fileName}`);
+  const tasksAllLicenseFile = path.join(tasksAllDir, `${fileName}`);
   const webflowLicenseFile = path.join(webflowLicenseDir, `${fileName}`);
 
   if (fs.existsSync(navigatorLicenseFile)) {
     return getMarkDownFromNavigatorDir(fileName, navigatorLicenseFile);
   } else if (fs.existsSync(municipalLicenseFile)) {
     return getMarkDownFromNavigatorDir(fileName, municipalLicenseFile);
+  } else if (fs.existsSync(tasksAllLicenseFile)) {
+    return getMarkDownFromNavigatorDir(fileName, tasksAllLicenseFile);
   } else if (fs.existsSync(webflowLicenseFile)) {
     return getMarkDownFromNavigatorDir(fileName, webflowLicenseFile);
   } else {
@@ -103,13 +118,17 @@ export const writeMarkdownString = (license) => {
     }${license.callToActionText ? `callToActionText: ${license.callToActionText}\n` : ""}${
       license.agencyId ? `agencyId: ${license.agencyId}\n` : ""
     }${
-      license.agencyAdditionalContext ? `agencyAdditionalContext: ${license.agencyAdditionalContext}\n` : ""
+      license.agencyAdditionalContext
+        ? `agencyAdditionalContext: ${license.agencyAdditionalContext}\n`
+        : ""
     }${license.divisionPhone ? `divisionPhone: ${license.divisionPhone}\n` : ""}${
       license.industryId ? `industryId: ${license.industryId}\n` : ""
     }${
       license.webflowType ? `webflowType: ${license.webflowType}\n` : ""
     }licenseCertificationClassification: ${license.licenseCertificationClassification}\n${
-      license.summaryDescriptionMd ? `summaryDescriptionMd: "${license.summaryDescriptionMd}"\n` : ""
+      license.summaryDescriptionMd
+        ? `summaryDescriptionMd: "${license.summaryDescriptionMd}"\n`
+        : ""
     }---\n` +
     `${license.contentMd}`
   );


### PR DESCRIPTION
## Description

A number of the content items in the "Tasks - All" collection of the CMS have information that pertains to state licenses. This information may be useful to our end users of the static site.

This work enables specified items within this collection to be synced with Webflow.

### Ticket

This pull request resolves [#17102](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17102).

### Approach

- Updated the collection "Tasks - All" so that items can have an optional "Sync to Webflow" property
- Updated `licenseLoader.mjs` to load `.md` files from the "Tasks - All" collection _**if**_ they should be`syncToWebflow`
  - The `licensesSync.mjs` file will create new or modify existing license records in the Webflow CMS with these tasks included.

**Update to Decap CMS Collection "Tasks - All"**
<img width="50%" alt="Screenshot 2026-01-26 at 5 37 16 PM" src="https://github.com/user-attachments/assets/aa62cf8a-0508-4d55-b8d6-cf470c0138f5" />

**Post licenses sync - Content in Webflow CMS**
<img width="50%" alt="Screenshot 2026-01-26 at 5 33 52 PM" src="https://github.com/user-attachments/assets/c3a7ebb7-457b-4278-b792-74807e95417b" />

**Content modified with new webflow id**
<img width="50%" alt="Screenshot 2026-01-26 at 5 33 43 PM" src="https://github.com/user-attachments/assets/b8b04d3e-2337-46ab-a367-1cc1b640f312" />

### Steps to Test

- Create a new or modify an existing content item in "Tasks - All" so that `syncToWebflow` is `true`
- Run the `licensesSync.mjs` script
- A new record should be created in the Webflow CMS within the Licenses collection, and the item you modified should have a `webflowId` associated with it
- Tasks where `syncToWebflow` is not `true` should not be synced

### Notes

"Tasks - All" is very close, but not an exact match to "License Tasks" (the collection being sync'd to Webflow today). Some of the fields that the content team is used to populating do not exist in this collection. I could add these, but without specific guidance to do this, or knowing how the team would like this change made, I am holding off. I will be surfacing this to them in their review of the work.

**Empty fields in Webflow**
<img width="279" height="206" alt="Screenshot 2026-01-26 at 5 35 31 PM" src="https://github.com/user-attachments/assets/1a53ea6f-5aa3-4477-b4ce-2b25bc0afd0b" />


## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [X] I have added the `request-reviewer` tag on github to request reviews
