### PR TITLE
fix: [AB#16139] Fix bug where trying to decrypt on first render when DOL EIN is not encrypted

### DIFF
--- a/web/src/components/data-fields/DolEin.test.tsx
+++ b/web/src/components/data-fields/DolEin.test.tsx
@@ -108,8 +108,8 @@ describe("<DolEin />", () => {
     expect(screen.getByRole("textbox", { name: "Dol ein" })).toBeDisabled();
   });
 
-  it("decrypts einValue if it is filled out in userData on first render", async () => {
-    const einValue = "123456789012345";
+  it("decrypts einValue if it is filled out in userData on first render and encrypted", async () => {
+    const einValue = "encrypted:123456789012345";
     const decryptedEinValue = "111111111111111";
     mockApi.decryptValue.mockResolvedValue(decryptedEinValue);
     renderComponent(generateProfileData({ deptOfLaborEin: einValue }), {
@@ -126,6 +126,22 @@ describe("<DolEin />", () => {
     expect(screen.getByRole("textbox", { name: "Dol ein" })).toHaveValue(
       formatDolEin(decryptedEinValue),
     );
+  });
+
+  it("does not decrypt einValue if it is filled out in userData on first render and unencrypted", async () => {
+    const einValue = "123456789012345";
+    renderComponent(generateProfileData({ deptOfLaborEin: einValue }), {
+      startHidden: true,
+      editable: true,
+    });
+    expect(screen.getByRole("textbox", { name: "Dol ein" })).toHaveValue(formattedHiddenEin);
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: Config.profileDefaults.fields.deptOfLaborEin.default.showButtonText,
+      }),
+    );
+    expect(mockApi.decryptValue).not.toHaveBeenCalled();
+    expect(screen.getByRole("textbox", { name: "Dol ein" })).toHaveValue(formatDolEin(einValue));
   });
 
   it("does not decrypt on first render if userData has no einValue", async () => {

--- a/web/src/components/data-fields/DolEin.tsx
+++ b/web/src/components/data-fields/DolEin.tsx
@@ -8,7 +8,6 @@ import { ShowHideStatus, ShowHideToggleButton } from "@/components/ShowHideToggl
 import { InputAdornment } from "@mui/material";
 import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { decryptValue } from "@/lib/api-client/apiClient";
-import { useMountEffect } from "@/lib/utils/helpers";
 import { DOL_EIN_CHARACTERS } from "@businessnjgovnavigator/shared";
 
 interface Props {
@@ -29,22 +28,21 @@ export const DolEin = (props: Props): ReactElement => {
   const [showHideStatus, setShowHideStatus] = useState<ShowHideStatus>(
     props.startHidden ? "password-view" : "text-view",
   );
-  const [isEncrypted, setIsEncrypted] = useState(false);
   const value = props.value ?? state?.profileData.deptOfLaborEin;
 
-  useMountEffect(() => {
-    if (state.profileData.deptOfLaborEin.length > 0) {
-      setIsEncrypted(true);
-    }
-  });
+  const isEncrypted = (): boolean => {
+    return (
+      state.profileData.deptOfLaborEin.length > 0 &&
+      state.profileData.deptOfLaborEin.length !== DOL_EIN_CHARACTERS
+    );
+  };
 
   const toggleShowHide = async (): Promise<void> => {
-    if (showHideStatus === "password-view" && isEncrypted) {
+    if (showHideStatus === "password-view" && isEncrypted()) {
       await decryptValue({
         encryptedValue: state.profileData.deptOfLaborEin as string,
       }).then((decryptedValue) => {
         setProfileData({ ...state.profileData, deptOfLaborEin: decryptedValue });
-        setIsEncrypted(false);
       });
     }
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Fixes a bug where the DOL EIN field will try to decrypt a non-encrypted value and throw an error

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#16139](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16139).

### Approach

I changed `isEncrypted` from a state variable to a function that operates on state instead. There really wasn't a need to store the state when it's so easy to calculate each time. I also now check the length of the string to determine if the DOL EIN value is encrypted, since encrypted values will be much longer than non-encrypted values

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `request-reviewer` tag on github to request reviews
