### PR TITLE
fix: [AB#17235] preserve query params in onboarding routing

### DIFF
--- a/web/src/components/dashboard/SidebarCardFormationNudge.test.tsx
+++ b/web/src/components/dashboard/SidebarCardFormationNudge.test.tsx
@@ -77,11 +77,11 @@ describe("<SidebarCardFormationNudge />", () => {
       expect(screen.queryByTestId(Config.formationDateModal.header)).not.toBeInTheDocument();
       await waitFor(() => {
         return expect(mockPush).toHaveBeenCalledWith(
-          { query: { fromForming: "true" } },
+          expect.objectContaining({
+            query: expect.objectContaining({ fromForming: "true" }),
+          }),
           undefined,
-          {
-            shallow: true,
-          },
+          { shallow: true },
         );
       });
     });

--- a/web/src/lib/auth/signinHelper.ts
+++ b/web/src/lib/auth/signinHelper.ts
@@ -86,11 +86,13 @@ export const onSelfRegister = ({
 export const onGuestSignIn = async ({
   push,
   pathname,
+  asPath,
   dispatch,
   encounteredMyNjLinkingError,
 }: {
   push: (url: string) => Promise<boolean>;
   pathname: string;
+  asPath?: string;
   dispatch: Dispatch<AuthAction>;
   encounteredMyNjLinkingError?: boolean | undefined;
 }): Promise<void> => {
@@ -128,11 +130,13 @@ export const onGuestSignIn = async ({
     accountLinkingErrorStorage.setEncounteredMyNjLinkingError(encounteredMyNjLinkingError);
   }
   setUserId(activeUser.id, true);
+  const onboardingRoute =
+    asPath && asPath.startsWith(ROUTES.onboarding) ? asPath : ROUTES.onboarding;
   if (userData) {
     setAnalyticsDimensions(getCurrentBusiness(userData).profileData, true);
     if (getCurrentBusiness(userData).onboardingFormProgress === "UNSTARTED") {
       setRegistrationDimension("Began Onboarding");
-      push(ROUTES.onboarding);
+      push(onboardingRoute);
     } else if (pathname === ROUTES.login) {
       setRegistrationDimension("Onboarded Guest");
       push(ROUTES.accountSetup);
@@ -153,13 +157,13 @@ export const onGuestSignIn = async ({
       case ROUTES.loading: {
         if (!encounteredMyNjLinkingError) {
           setRegistrationDimension("Began Onboarding");
-          push(ROUTES.onboarding);
+          push(onboardingRoute);
         }
         break;
       }
       case ROUTES.login: {
         setRegistrationDimension("Began Onboarding");
-        push(ROUTES.onboarding);
+        push(onboardingRoute);
         break;
       }
       case ROUTES.njeda: {

--- a/web/src/lib/domain-logic/routes.ts
+++ b/web/src/lib/domain-logic/routes.ts
@@ -72,7 +72,7 @@ export const routeShallowWithQuery = <K extends keyof QUERY_PARAMS_VALUES>(
   query: K,
   value: QUERY_PARAMS_VALUES[K],
 ): void => {
-  router.push({ query: { [query]: value } }, undefined, { shallow: true });
+  router.push({ query: { ...router.query, [query]: value } }, undefined, { shallow: true });
 };
 
 export const routeWithQuery = <K extends keyof QUERY_PARAMS_VALUES>(

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -150,7 +150,13 @@ const App = ({ Component, pageProps }: AppProps): ReactElement => {
           });
         })
         .catch(() => {
-          router && onGuestSignIn({ push: router.push, pathname: router.pathname, dispatch });
+          router &&
+            onGuestSignIn({
+              push: router.push,
+              pathname: router.pathname,
+              asPath: router.asPath,
+              dispatch,
+            });
         });
     }
   });

--- a/web/src/pages/loading.tsx
+++ b/web/src/pages/loading.tsx
@@ -56,7 +56,7 @@ const LoadingPage = (): ReactElement => {
     if (!updateQueue) return;
     const business = updateQueue.currentBusiness();
     if (business?.onboardingFormProgress && !onboardingCompleted(business)) {
-      router && router.push(ROUTES.onboarding);
+      router && router.push({ pathname: ROUTES.onboarding, query: router.query });
     } else if (business.preferences.returnToLink) {
       const pageLink = business.preferences.returnToLink;
       updateQueue

--- a/web/test/pages/loading.test.tsx
+++ b/web/test/pages/loading.test.tsx
@@ -89,7 +89,7 @@ describe("loading page", () => {
       profileData: generateProfileData({ businessPersona: "STARTING" }),
     });
     render(<LoadingPage />);
-    expect(mockPush).toHaveBeenCalledWith(ROUTES.onboarding);
+    expect(mockPush).toHaveBeenCalledWith(expect.objectContaining({ pathname: ROUTES.onboarding }));
   });
 
   it("redirects user to returnToLink page url if they have one and resets returnToLink", async () => {

--- a/web/test/pages/onboarding/onboarding-additional-business.test.tsx
+++ b/web/test/pages/onboarding/onboarding-additional-business.test.tsx
@@ -48,7 +48,11 @@ describe("onboarding - additional business", () => {
     renderPage({});
 
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith({ query: { page: 1 } }, undefined, { shallow: true });
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.objectContaining({ query: expect.objectContaining({ page: 1 }) }),
+        undefined,
+        { shallow: true },
+      );
     });
 
     const expectedTitle = templateEval(Config.onboardingDefaults.pageTitle, {
@@ -65,7 +69,11 @@ describe("onboarding - additional business", () => {
     const initialData = generateUserDataForBusiness(initialBusiness);
     renderPage({ userData: initialData });
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith({ query: { page: 1 } }, undefined, { shallow: true });
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.objectContaining({ query: expect.objectContaining({ page: 1 }) }),
+        undefined,
+        { shallow: true },
+      );
     });
 
     const previousBusinessName = getNavBarBusinessTitle(
@@ -94,7 +102,11 @@ describe("onboarding - additional business", () => {
     const { page } = renderPage({ userData: initialData });
 
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith({ query: { page: 1 } }, undefined, { shallow: true });
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.objectContaining({ query: expect.objectContaining({ page: 1 }) }),
+        undefined,
+        { shallow: true },
+      );
     });
 
     page.chooseRadio("business-persona-starting");

--- a/web/test/pages/onboarding/onboarding-starting.test.tsx
+++ b/web/test/pages/onboarding/onboarding-starting.test.tsx
@@ -205,9 +205,11 @@ describe("onboarding - starting a business", () => {
     page.chooseRadio("business-persona-starting");
 
     await page.visitStep(2);
-    expect(mockRouter.mockPush).toHaveBeenCalledWith({ query: { page: 2 } }, undefined, {
-      shallow: true,
-    });
+    expect(mockRouter.mockPush).toHaveBeenCalledWith(
+      expect.objectContaining({ query: expect.objectContaining({ page: 2 }) }),
+      undefined,
+      { shallow: true },
+    );
     expect(screen.getByTestId("step-2")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Query params, such as `utm_group`, were being removed when:
- Moving between onboarding steps (Next/Back) via shallow routing
- Refreshing on /onboarding?page=1&utm_*
- Being redirected from /loading to onboarding

As a result, analytics lost attribution.

To fix this I updated:
- Shallow routing (routes.ts - routeShallowWithQuery)
When updating the page param, the full query is preserved instead of replaced.
- Loading → onboarding (loading.tsx)
The redirect to onboarding passes the current query so params are kept
- Refresh / initial load (signinHelper.ts + _app.tsx)
When a guest loads or refreshes on an onboarding URL, we keep that URL instead of replacing it with /onboarding. onGuestSignIn now takes optional asPath and, when the user is already on onboarding, uses that full path (including query) when pushing to onboarding.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#17235](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17235).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

Check this branch out and spin up the app - Any link to onboarding that includes query params should stay as-is when the page loads. You could go to: http://localhost:3000/onboarding?page=1&utm_group=newgroup and observe that the params stay put while navigating through onboarding, including the utm_group param. 

### Notes

Portions drafted with AI assistance; all changes reviewed and verified by me, a human!

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [ ] I have added the `request-reviewer` tag on github to request reviews
