### PR TITLE
chore: disable the cigarette license health checks in prod

### DIFF
--- a/api/src/libs/ssmUtils.ts
+++ b/api/src/libs/ssmUtils.ts
@@ -14,7 +14,8 @@ export type CONFIG_VARS =
   | ENV_REQ_CONFIG_VARS
   | USER_MESSAGING_CONFIG_VARS
   | "dep_base_url"
-  | "zod_parsing_on";
+  | "zod_parsing_on"
+  | "FEATURE_CIGARETTE_LICENSE";
 
 export type CIGARETTE_PAYMENT_CONFIG_VARS =
   | "cigarette_license_base_url"


### PR DESCRIPTION
## Description

Health checks associated with the cigarette sales license consistently fail in our production environment. We do not plan to utilize this functionality in production for some time. This work moves these health checks behind a feature flag.

### Ticket

This pull request resolves [#17315](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17315).

### Approach

I disabled the health checks by guarding them with a feature flag. They should continue to fire in all non-prod environments where health checks are performed (`dev` and `staging`).

I've added an SSM param for `﻿FEATURE_CIGARETTE_LICENSE` in `dev`, `staging`, and `prod`. The value is set to `false` in production.

### Steps to Test

- All health checks should continue to work as expected
- In **non-prod** environments we should see checks for `cigarette-license` and `cigarette-email-client`
- In **prod** we should **not** see checks for `cigarette-license` and `cigarette-email-client`

### Notes

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [X] I have added the `request-reviewer` tag on github to request reviews
