### PR TITLE
fix: [AB#17340] automatic biz name availability search should use formationFormData.businessName

### DIFF
--- a/api/src/api/userRouter.ts
+++ b/api/src/api/userRouter.ts
@@ -418,7 +418,14 @@ export const userRouterFactory = (
       const needsDba = determineIfNexusDbaNameNeeded(currentBusiness);
       const nameToSearch = needsDba
         ? currentBusiness.profileData.nexusDbaName
-        : currentBusiness.profileData.businessName;
+        : currentBusiness.formationData.formationFormData.businessName;
+
+      if (nameToSearch === "") {
+        logger.LogInfo("Skipping name availability search - no name entered yet");
+        return userData;
+      }
+      logger.LogInfo(`Executing name availability search for ${nameToSearch}`);
+
       const response = await timeStampBusinessSearch.search(nameToSearch);
 
       const nameAvailability: NameAvailability = {

--- a/api/src/libs/logWriter.ts
+++ b/api/src/libs/logWriter.ts
@@ -29,7 +29,8 @@ export const DummyLogWriter: LogWriterType = {
 export const ConsoleLogWriter: LogWriterType = {
   LogError: async (message: string, details?: AxiosError): Promise<void> => {
     try {
-      console.error(`${message} - ${JSON.stringify(details?.toJSON())}`);
+      const jsonDetails = typeof details?.toJSON === "function" ? details.toJSON() : details;
+      console.error(`${message} - ${JSON.stringify(jsonDetails)}`);
     } catch (error) {
       console.error(`Error with LogError:${error}`);
     }


### PR DESCRIPTION
## Description

Resolves an error caused by checking the business name availability of an empty string.

### Ticket

This pull request resolves [#17340](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17340).

### Approach

When you make a request to the NICUSA Business Name Search API with an empty string, the API responds with a 200 code and an empty body. The error message we're seeing on the backend is a result of us trying to reference a key inside this object that does not exist.

I addressed this in 2 steps:
1. Do not execute a search if the business name is an empty string.
1. Use the business name stored in `formationFormData` instead of `profileData`.
    - This is the field that would be used by the frontend, and is the one that would be used on the business formation form submission.

### Steps to Test

I listed repro steps in the linked ticket. Follow these. Assert that errors are not logged, and multiple GET requests do not trigger an alert in the #bizx-alerts-bot Slack channel.

### Notes

I documented the diagnostic process [in Slack](https://njcio.slack.com/archives/C04J8MTJNS2/p1769630480380619)

There's a case that I should have also handled for the NICUSA API returning an empty object, because that's what was triggering the error in the first place. I opted not to do this. Here's my reasoning why I didn't:
- The API should never do this if we're supplying a non-empty string
- If the API does do this, I'd like to be aware. The log messages surrounding this error may give us more information about a different edge case that we may want to handle differently.
- Handling for an empty object would have been more disruptive to the logic of the API client and would have been a larger lift.
  - I'd have to modify the function declaration and touch more files. This fix has a smaller scope and should be plenty adequate for us.

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [X] I have added the `request-reviewer` tag on github to request reviews
