### PR TITLE
Update "Tasks - All" collection name

### DIFF
--- a/web/decap-config/collections/06-tasks.yml
+++ b/web/decap-config/collections/06-tasks.yml
@@ -298,7 +298,7 @@ collections:
                 }
 
   - name: "tasks"
-    label: "Tasks - All (not mapped to Webflow/static site)"
+    label: "Tasks - All (option to map to Webflow/static site)"
     folder: "content/src/roadmaps/tasks"
     summary: "{{displayname}} - {{name}}"
     identifier_field: "{{id}}"
@@ -334,6 +334,7 @@ collections:
           widget: "boolean",
           required: false,
           default: false,
+          hint: "You must provide a 'Webflow Name' if this is selected",
         }
       - {
           label: "Webflow Name",


### PR DESCRIPTION
## Description

This is a follow-on to #12441, and updates the name of the "Tasks - All" collection to indicate that this information can be sync'd to the Webflow CMS.

### Ticket

Did not create a ticket.

### Approach

Updates the collection name in the Decap CMS config.

### Steps to Test

Confirm the collection name looks correct in the Decap CMS.

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [ ] I have added the `request-reviewer` tag on github to request reviews
