### PR TITLE
chore: [AB#17076] create configuration sets for each email type

### DIFF
--- a/api/.dependency-cruiser.js
+++ b/api/.dependency-cruiser.js
@@ -270,6 +270,10 @@ module.exports = {
       to: { path: "src/api" },
     },
     {
+      from: { path: "src/domain/types" },
+      to: { path: "src/libs/constants" },
+    },
+    {
       from: { path: "src/domain" },
       to: { path: "src/client" },
     },

--- a/api/cdk/lib/apiStack.ts
+++ b/api/cdk/lib/apiStack.ts
@@ -1,10 +1,14 @@
-import { API_SERVICE_NAME } from "@businessnjgovnavigator/api/src/libs/constants";
+import {
+  API_SERVICE_NAME,
+  REMINDER_EMAIL_CONFIG_SET_NAME,
+  WELCOME_EMAIL_CONFIG_SET_NAME,
+} from "@businessnjgovnavigator/api/src/libs/constants";
 import { CfnOutput, Stack, StackProps } from "aws-cdk-lib";
 import * as apigateway from "aws-cdk-lib/aws-apigateway";
 import * as cognito from "aws-cdk-lib/aws-cognito";
 import { IFunction } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
-import { applyStandardTags, attachLambdaToResource } from "./stackUtils";
+import { applyStandardTags, attachLambdaToResource, createSesConfigSet } from "./stackUtils";
 
 interface LambdaConfig {
   lambda?: IFunction;
@@ -92,6 +96,9 @@ export class ApiStack extends Stack {
       value: this.restApi.restApiId,
       exportName: `${API_SERVICE_NAME}-${props.stage}-ApiGatewayId`,
     });
+
+    createSesConfigSet(this, WELCOME_EMAIL_CONFIG_SET_NAME);
+    createSesConfigSet(this, REMINDER_EMAIL_CONFIG_SET_NAME);
   }
 
   private addGatewayResponses() {

--- a/api/cdk/lib/iamStack.ts
+++ b/api/cdk/lib/iamStack.ts
@@ -93,7 +93,10 @@ export class IamStack extends Stack {
     const sendEmailPolicy = new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: ["ses:sendEmail", "ses:sendRawEmail"],
-      resources: [`arn:aws:ses:${this.region}:${this.account}:identity/business.nj.gov`],
+      resources: [
+        `arn:aws:ses:${this.region}:${this.account}:identity/business.nj.gov`,
+        `arn:aws:ses:${this.region}:${this.account}:configuration-set/*`,
+      ],
     });
 
     const kmsEncryptPolicy = new iam.PolicyStatement({

--- a/api/cdk/lib/stackUtils.ts
+++ b/api/cdk/lib/stackUtils.ts
@@ -12,6 +12,7 @@ import { Role } from "aws-cdk-lib/aws-iam";
 import { IFunction, Runtime } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction, NodejsFunctionProps } from "aws-cdk-lib/aws-lambda-nodejs";
 import * as logs from "aws-cdk-lib/aws-logs";
+import { ConfigurationSet } from "aws-cdk-lib/aws-ses";
 import { Construct, IConstruct } from "constructs";
 import path from "node:path";
 
@@ -163,3 +164,9 @@ export const exportLambdaArn = (
     exportName: `${id}LambdaArn-${stage}`,
   });
 };
+
+export function createSesConfigSet(scope: Construct, name: string) {
+  return new ConfigurationSet(scope, name, {
+    configurationSetName: name,
+  });
+}

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -9,6 +9,7 @@ import {
   XrayRegistrationEntry,
   XrayRegistrationStatusResponse,
 } from "@businessnjgovnavigator/shared";
+import { REMINDER_EMAIL_CONFIG_SET_NAME, WELCOME_EMAIL_CONFIG_SET_NAME } from "@libs/constants";
 import { NameAvailability, NameAvailabilityResponse } from "@shared/businessNameSearch";
 import { BusinessUser, NewsletterResponse, UserTestingResponse } from "@shared/businessUser";
 import { TaxFilingCalendarEvent } from "@shared/calendarEvent";
@@ -50,6 +51,9 @@ import * as https from "node:https";
 export type MessageChannel = "email" | "sms" | "tts" | "whatsapp";
 export type MessageTemplateId = "welcome_version-B" | "test-reminder-v1";
 export type MessageTopic = "welcome" | "reminder";
+export type EmailType =
+  | typeof WELCOME_EMAIL_CONFIG_SET_NAME
+  | typeof REMINDER_EMAIL_CONFIG_SET_NAME;
 
 export interface MessageData {
   taskId: string;

--- a/api/src/functions/messagingService/app.ts
+++ b/api/src/functions/messagingService/app.ts
@@ -5,6 +5,7 @@ import { createDynamoDbClient } from "@db/config/dynamoDbConfig";
 import { DynamoMessagesDataClient } from "@db/DynamoMessagesDataClient";
 import { DynamoUserDataClient } from "@db/DynamoUserDataClient";
 import {
+  EmailType,
   MessageData,
   type MessageChannel,
   type MessageTemplateId,
@@ -21,6 +22,7 @@ import {
   STAGE,
   USERS_TABLE,
 } from "@functions/config";
+import { REMINDER_EMAIL_CONFIG_SET_NAME, WELCOME_EMAIL_CONFIG_SET_NAME } from "@libs/constants";
 import { LogWriter, LogWriterType } from "@libs/logWriter";
 import { getConfigValue, USER_MESSAGING_CONFIG_VARS } from "@libs/ssmUtils";
 import { v4 as uuidv4 } from "uuid";
@@ -159,7 +161,7 @@ export const handler = async (
 const buildWelcomeEmail = (props: { toEmail: string }): SendEmailCommand => {
   return buildSesEmailCommand({
     toEmail: props.toEmail,
-    emailType: "welcome-email",
+    emailType: WELCOME_EMAIL_CONFIG_SET_NAME,
     subject: "Welcome to Business.NJ.gov",
     htmlBody: welcomeEmailShortVersionTemplate,
     fallbackText: welcomeEmailShortVersionPlaintext,
@@ -169,7 +171,7 @@ const buildWelcomeEmail = (props: { toEmail: string }): SendEmailCommand => {
 const buildReminderEmail = (props: { toEmail: string }): SendEmailCommand => {
   return buildSesEmailCommand({
     toEmail: props.toEmail,
-    emailType: "test-reminder-email",
+    emailType: REMINDER_EMAIL_CONFIG_SET_NAME,
     subject: "Incomplete Tasks Reminder - Business.NJ.gov",
     htmlBody: testReminderHtmlTemplate,
   });
@@ -199,7 +201,7 @@ const buildMessageRecord = (props: {
 
 const buildSesEmailCommand = (props: {
   toEmail: string;
-  emailType: string;
+  emailType: EmailType;
   subject: string;
   fallbackText?: string;
   htmlBody: string;
@@ -234,6 +236,7 @@ const buildSesEmailCommand = (props: {
         Value: props.emailType,
       },
     ],
+    ConfigurationSetName: props.emailType,
   };
   return new SendEmailCommand(input);
 };

--- a/api/src/libs/constants.ts
+++ b/api/src/libs/constants.ts
@@ -1,1 +1,3 @@
 export const API_SERVICE_NAME = "businessnjgov-api-v2";
+export const WELCOME_EMAIL_CONFIG_SET_NAME = "welcome-email";
+export const REMINDER_EMAIL_CONFIG_SET_NAME = "reminder-email";


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description


Attaching a configuration set to our emails will allow us to track engagement metrics of each type of email we send. We can currently use VDM to see the open rate and click rate, but these metrics are only viewable at the account-level and in the future, when we do A/B testing, we would like to see more granularly how welcome email version A compares with welcome version B, for instance. This PR sets it up so that each email gets sent out with a configuration set that corresponds to the type of email it is (`welcome-email` or `reminder-email`).


### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#17076](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17076).

### Approach
Configuration sets can be created manually in the console or via API, but since they are AWS resources I figured it was appropriate to add to our CDK code, so that they are standard across environments and tied to deployment instead of application logic. 

There seemed to be some redundancy between `messageType` (an argument in `sendMessage` from `AwsMessagingServiceClient.ts`, which calls the lambda), `messageTopic` (stored in the Messages table) and `emailType` (used to add tags to emails). Originally:
- `messageType` is typed as `string`, but the only value it ever takes is  `"welcome-email"`
- `messageTopic` is typed as `"welcome" | "reminder"`
- `emailType` is typed as `string`,  and takes the values `"test-reminder-email"` and `"welcome-email"`

I decided to repurpose the `emailType` property as the name for the config sets, because it seemed ill-defined and not consistently used. This changes `emailType` to be more specific: now it must be `"welcome-email" | "reminder-email"`.

We might want to consider a followup to standardize `messageType` and `messageTopic` too.

### Steps to Test
The easiest way to test would be to deploy to testing and seeing in the console that the configuration sets for welcome email a, b, and reminder email were created.


While this change is live on testing, you can also create a new account with myNJ to receive a welcome email, and then go to the AWS console > Amazon Simple Email Service  > Virtual Deliverability Manager and see that it increments the stats for welcome-email on the Configuration Sets tab.
<img width="1288" height="791" alt="Screenshot 2026-02-11 at 11 45 19 AM" src="https://github.com/user-attachments/assets/e804faa5-6dd5-44d0-affe-30ccd99b32cb" />

<img width="1288" height="710" alt="Screenshot 2026-02-11 at 11 45 47 AM" src="https://github.com/user-attachments/assets/4af5b0fa-c5c8-4ab0-99be-a2defbc1d9a0" />



### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in both `.env-template` and in Bitwarden
