### PR TITLE
chore: [AB#17385] add concurrency to prevent overlapping deploys

### DIFF
--- a/.github/workflows/deploy-content-environment.yml
+++ b/.github/workflows/deploy-content-environment.yml
@@ -3,6 +3,10 @@ name: "Deploy Content Environment"
 on:
   workflow_call:
 
+concurrency:
+  group: deploy-content
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-dev-environment.yml
+++ b/.github/workflows/deploy-dev-environment.yml
@@ -3,6 +3,10 @@ name: "Deploy Dev Environment"
 on:
   workflow_call:
 
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-staging-environment.yml
+++ b/.github/workflows/deploy-staging-environment.yml
@@ -3,6 +3,10 @@ name: Deploy Staging Environment
 on:
   workflow_call:
 
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
 jobs:
   deploy-staging:
     runs-on: ubuntu-latest

--- a/.github/workflows/merge-content.yml
+++ b/.github/workflows/merge-content.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+concurrency:
+  group: merge-main-into-content-repo
+  cancel-in-progress: false
 
 jobs:
   merge-content:

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -6,6 +6,10 @@ on:
       - "release-*"
   workflow_dispatch:
 
+concurrency:
+  group: release-pipeline
+  cancel-in-progress: false
+
 jobs:
   deploy-staging:
     uses: ./.github/workflows/deploy-staging-environment.yml
@@ -20,7 +24,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    environment: prod
+    environment: prod-hold
     steps:
       - run: echo "Awaiting approval for production release."
 

--- a/.github/workflows/sync-testing-repo-with-main.yml
+++ b/.github/workflows/sync-testing-repo-with-main.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 12 * * 6"
   workflow_dispatch:
 
+concurrency:
+  group: sync-testing-repo
+  cancel-in-progress: false
+
 jobs:
   sync-testing-repo-weekly-from-main:
     name: Sync testing-repo from main weekly

--- a/.github/workflows/testing-deployment-trigger.yml
+++ b/.github/workflows/testing-deployment-trigger.yml
@@ -6,6 +6,10 @@ on:
       - testing-repo
   workflow_dispatch:
 
+concurrency:
+  group: deploy-testing
+  cancel-in-progress: true
+
 jobs:
   deploy-testing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
This PR introduces GitHub Actions concurrency controls across all deployment workflows to prevent overlapping runs for the same branch/tag and ensure we always deploy the most recent commit.
In addition, this PR:
- Updates the release pipeline promotion gate to use a new prod-hold environment
- Aligns approval gates and concurrency behavior across dev, content, testing, staging, and prod environments.

## Problem
Previously, multiple workflow runs could execute concurrently for the same ref (branch/tag). This introduced several risks:
- Duplicate or overlapping deployments to the same environment
- Increased CI/CD minutes and runner consumption
- Potential race conditions
- Slower signal due to unnecessary parallel runs
There was no enforcement of "latest merged commit wins" behavior

## What this PR Does 
1. Adds Concurrency to Deployment Workflows


| Environment               | cancel-in-progress | Behavior                                           |
|--------------------------|--------------------|---------------------------------------------------|
| dev                      | true               | Latest commit cancels prior deployment             |
| content                  | true               | Latest commit cancels prior deployment             |
| testing                  | true               | Latest commit cancels prior deployment             |
| staging                  | false              | Deployments queue (no cancellation mid-release)    |
| production               | false              | Deployments queue (protected release flow)         |
| merge-content-from-main  | false              | Queue merges to prevent branch write conflicts      |

This ensures: 
- Rapid iteration environments always deploy the latest commit
- Release/stable environments avoid mid-deploy cancellation
- Stateful branch sync operations remain safe

2. Release Pipeline Promotion Gate Fix
Updated the production-hold step in the release-pipeline workflow to use:
```
environment: prod-hold
```
This change ensures that once deployment protection rules are configured with required reviewers:
- The approval gate is clearly separated from the actual production deployment
- The promotion workflow reliably pauses until approval is granted
- The approval step is explicit, traceable, and auditable
- Production cannot be promoted automatically without human review


## Behavior Explained: Dev/Content Deployment
If:
- Engineer A merges to main
- Engineer B merges shortly after
Then:
- Both build-and-test workflows will run
- The first deployment may begin
- The second deployment cancels the in-progress run
- The final deployed version includes both A and B’s changes

**This ensures we always deploy the latest merged state, not intermediate commits.**

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#17385](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17385).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [X] I have added the `request-reviewer` tag on github to request reviews
