### PR TITLE
feat: show roadmaps where a task is used in the CMS task preview

### DIFF
--- a/web/src/lib/cms/previews/TaskPreview.tsx
+++ b/web/src/lib/cms/previews/TaskPreview.tsx
@@ -1,8 +1,10 @@
+import { Icon } from "@/components/njwds/Icon";
 import { TaskPageSwitchComponent } from "@/components/TaskPageSwitchComponent";
 import { PreviewProps } from "@/lib/cms/helpers/previewHelpers";
 import { usePageData } from "@/lib/cms/helpers/usePageData";
 import { usePreviewRef } from "@/lib/cms/helpers/usePreviewRef";
 import { generateRoadmap } from "@/test/factories";
+import { getIndustries } from "@businessnjgovnavigator/shared/industry";
 import {
   generateBusiness,
   generateMunicipality,
@@ -12,9 +14,11 @@ import {
   createEmptyTaskDisplayContent,
   TaskWithLicenseTaskId,
 } from "@businessnjgovnavigator/shared/types";
-import { ReactElement } from "react";
+import { Accordion, AccordionDetails, AccordionSummary } from "@mui/material";
+import { ReactElement, useState } from "react";
 
 const TaskPreview = (props: PreviewProps): ReactElement => {
+  const [isOpenRoadmaps, setIsOpenRoadmaps] = useState<boolean>(false);
   const ref = usePreviewRef(props);
   const task = usePageData<TaskWithLicenseTaskId>(props);
 
@@ -28,21 +32,73 @@ const TaskPreview = (props: PreviewProps): ReactElement => {
   const displayContent = createEmptyTaskDisplayContent();
   const roadmap = generateRoadmap({});
 
-  return (
-    <div className="cms" ref={ref} style={{ margin: 40, pointerEvents: "none" }}>
-      <div>
-        <div>This file is mapped to the following license (not enabled if blank):</div>
-        <div className="margin-bottom-10 text-bold">{task?.licenseName}</div>
-      </div>
+  const applicableIndustries = getIndustries({ overrideShowDisabledIndustries: true }).filter(
+    (industry) => {
+      const taskIds = industry.roadmapSteps.map((step) => step.task);
+      return taskIds.includes(task.id);
+    },
+  );
 
-      <TaskPageSwitchComponent
-        task={task}
-        business={fakeBusinessWithMunicipality}
-        displayContent={displayContent}
-        roadmap={roadmap}
-        CMS_ONLY_disable_default_functionality
-      />
-    </div>
+  const industryRoadmaps = (): ReactElement => {
+    return (
+      <Accordion
+        expanded={isOpenRoadmaps}
+        onChange={() => {
+          setIsOpenRoadmaps(!isOpenRoadmaps);
+        }}
+        className="margin-left-1 margin-right-10"
+      >
+        <AccordionSummary
+          expandIcon={
+            <Icon className={"usa-icon--size-5 margin-left-1"} iconName={"expand_more"} />
+          }
+        >
+          <b>Roadmaps</b>
+        </AccordionSummary>
+        <AccordionDetails>
+          <ul>
+            {applicableIndustries.length > 0 ? (
+              applicableIndustries.map((industry) => {
+                return (
+                  <li key={industry.id}>
+                    <a
+                      href={`/mgmt/cms#/collections/roadmaps/entries/${industry.id}`}
+                      target="_top"
+                    >
+                      {industry.name}
+                    </a>
+                  </li>
+                );
+              })
+            ) : (
+              <li>This task is not used in any industry roadmaps.</li>
+            )}
+          </ul>
+        </AccordionDetails>
+      </Accordion>
+    );
+  };
+
+  return (
+    <>
+      {industryRoadmaps()}
+      <div className="cms" ref={ref} style={{ margin: 40, pointerEvents: "none" }}>
+        {task?.licenseName && (
+          <div>
+            <div>This file is mapped to the following license:</div>
+            <div className="margin-bottom-10 text-bold">{task?.licenseName}</div>
+          </div>
+        )}
+
+        <TaskPageSwitchComponent
+          task={task}
+          business={fakeBusinessWithMunicipality}
+          displayContent={displayContent}
+          roadmap={roadmap}
+          CMS_ONLY_disable_default_functionality
+        />
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Description

This work allows a content team member to see what Roadmaps a task is used within from the task preview.

### Ticket

This pull request resolves [#17431](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17431).

### Approach

- Added an `<Accordion>` to the `TaskPreview` component used by the CMS.
- Populate the accordion items with the industries where the task appears in the roadmap
- Each item links to the editor for the associated roadmap
- If no roadmap contains the item, this is explicitly stated

### Steps to Test

- Open the CMS
- Find a task (Tasks - All collection)
- The accordion should be visible in the CMS preview
- Click the accordion
  - A list of relevant industry roadmaps will be visible or
  - A message will be visible stating that the task does not appear in any roadmaps

**Task used in multiple roadmaps**
<img width="1231" height="738" alt="Screenshot 2026-02-12 at 5 57 51 PM" src="https://github.com/user-attachments/assets/1f856c04-48b0-403e-89cf-1564e98323f4" />

**Task used in no roadmaps**
<img width="1236" height="635" alt="Screenshot 2026-02-12 at 5 58 03 PM" src="https://github.com/user-attachments/assets/fec51a69-8b18-4638-a988-212d8f53c97d" />

### Notes

Just because a task is not in any roadmaps does not mean it is unused. The task could be associated with a non-essential question or an industry add-on.

We should add visibility for this information as well.

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [X] I have added the `request-reviewer` tag on github to request reviews
