### PR TITLE
feat: build sectors.json with enriched industries

### DIFF
--- a/shared/src/sector.ts
+++ b/shared/src/sector.ts
@@ -6,6 +6,16 @@ export interface SectorType {
   readonly nonEssentialQuestionsIds: string[];
 }
 
+export interface SectorIndustry {
+  readonly id: string;
+  readonly name: string;
+  readonly naicsCodes?: string;
+}
+
+export interface EnrichedSectorType extends SectorType {
+  readonly industries: SectorIndustry[];
+}
+
 export const LookupSectorTypeById = (id: string | undefined): SectorType => {
   return (
     arrayOfSectors.find((x) => {


### PR DESCRIPTION

<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

This PR adds a new build process for `sectors.json` that enriches sector data with their child industries. The build system now processes 9 content types (up from 8), with sectors being built after industries so they can be enriched with industry data matched by `defaultSectorId`.

**Key changes:**

- Added `buildSectors()` function to enrich sectors with matching industries (based on `defaultSectorId`)
- Added `buildAndWriteSectors()` to generate both minified and pretty-printed JSON outputs
- Extended `BuildResult` interface to include `sectorsCount` statistics
- Added TypeScript interfaces: `IndustryData`, `SectorData`, `EnrichedSector`, `SectorIndustry`, and `EnrichedSectorType`

**Motivation:**
This enables the application to have structured sector data with their associated industries and NAICS codes in a single JSON file, improving data organization and accessibility.

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

No significant dependencies or infrastructure changes. This is an additive feature that follows the existing content build architecture pattern.

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

1. Run the content build script: `yarn build:content` (or equivalent command)
2. Verify `lib/sectors.json` and `lib/sectors.pretty.json` are generated
3. Check that sectors contain an `industries` array with child industries
4. Confirm each industry in a sector has `id`, `name`, and optionally `naicsCodes` fields
5. Verify the build log shows: `✓ Built sectors.json with N sectors`

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

- The build order is important: industries must be built before sectors since sectors depend on industry data
- Each sector is enriched with industries where `industry.defaultSectorId === sector.id`
- The implementation includes comprehensive test coverage with 5 new test cases covering various scenarios (matching industries, no matches, missing NAICS codes, etc.)
- Follows the existing domain/application layer architecture for consistency with other content builders

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `request-reviewer` tag on github to request reviews