### PR TITLE
fix: [AB#17076] add stage to config set names

### DIFF
--- a/api/cdk/lib/apiStack.ts
+++ b/api/cdk/lib/apiStack.ts
@@ -1,7 +1,7 @@
 import {
   API_SERVICE_NAME,
-  REMINDER_EMAIL_CONFIG_SET_NAME,
-  WELCOME_EMAIL_CONFIG_SET_NAME,
+  REMINDER_EMAIL_CONFIG_SET_BASE,
+  WELCOME_EMAIL_CONFIG_SET_BASE,
 } from "@businessnjgovnavigator/api/src/libs/constants";
 import { CfnOutput, Stack, StackProps } from "aws-cdk-lib";
 import * as apigateway from "aws-cdk-lib/aws-apigateway";
@@ -97,8 +97,8 @@ export class ApiStack extends Stack {
       exportName: `${API_SERVICE_NAME}-${props.stage}-ApiGatewayId`,
     });
 
-    createSesConfigSet(this, WELCOME_EMAIL_CONFIG_SET_NAME);
-    createSesConfigSet(this, REMINDER_EMAIL_CONFIG_SET_NAME);
+    createSesConfigSet(this, `${WELCOME_EMAIL_CONFIG_SET_BASE}-${props.stage}`);
+    createSesConfigSet(this, `${REMINDER_EMAIL_CONFIG_SET_BASE}-${props.stage}`);
   }
 
   private addGatewayResponses() {

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -9,7 +9,7 @@ import {
   XrayRegistrationEntry,
   XrayRegistrationStatusResponse,
 } from "@businessnjgovnavigator/shared";
-import { REMINDER_EMAIL_CONFIG_SET_NAME, WELCOME_EMAIL_CONFIG_SET_NAME } from "@libs/constants";
+import { REMINDER_EMAIL_CONFIG_SET_BASE, WELCOME_EMAIL_CONFIG_SET_BASE } from "@libs/constants";
 import { NameAvailability, NameAvailabilityResponse } from "@shared/businessNameSearch";
 import { BusinessUser, NewsletterResponse, UserTestingResponse } from "@shared/businessUser";
 import { TaxFilingCalendarEvent } from "@shared/calendarEvent";
@@ -48,12 +48,15 @@ import { AxiosResponse } from "axios";
 import { ReasonPhrases } from "http-status-codes";
 import * as https from "node:https";
 
+type Environment = "dev" | "content" | "testing" | "staging" | "prod";
+
 export type MessageChannel = "email" | "sms" | "tts" | "whatsapp";
 export type MessageTemplateId = "welcome_version-B" | "test-reminder-v1";
 export type MessageTopic = "welcome" | "reminder";
+
 export type EmailType =
-  | typeof WELCOME_EMAIL_CONFIG_SET_NAME
-  | typeof REMINDER_EMAIL_CONFIG_SET_NAME;
+  | `${typeof WELCOME_EMAIL_CONFIG_SET_BASE}-${Environment}`
+  | `${typeof REMINDER_EMAIL_CONFIG_SET_BASE}-${Environment}`;
 
 export interface MessageData {
   taskId: string;

--- a/api/src/functions/messagingService/app.ts
+++ b/api/src/functions/messagingService/app.ts
@@ -22,7 +22,7 @@ import {
   STAGE,
   USERS_TABLE,
 } from "@functions/config";
-import { REMINDER_EMAIL_CONFIG_SET_NAME, WELCOME_EMAIL_CONFIG_SET_NAME } from "@libs/constants";
+import { REMINDER_EMAIL_CONFIG_SET_BASE, WELCOME_EMAIL_CONFIG_SET_BASE } from "@libs/constants";
 import { LogWriter, LogWriterType } from "@libs/logWriter";
 import { getConfigValue, USER_MESSAGING_CONFIG_VARS } from "@libs/ssmUtils";
 import { v4 as uuidv4 } from "uuid";
@@ -161,7 +161,7 @@ export const handler = async (
 const buildWelcomeEmail = (props: { toEmail: string }): SendEmailCommand => {
   return buildSesEmailCommand({
     toEmail: props.toEmail,
-    emailType: WELCOME_EMAIL_CONFIG_SET_NAME,
+    emailType: `${WELCOME_EMAIL_CONFIG_SET_BASE}-${STAGE}` as EmailType,
     subject: "Welcome to Business.NJ.gov",
     htmlBody: welcomeEmailShortVersionTemplate,
     fallbackText: welcomeEmailShortVersionPlaintext,
@@ -171,7 +171,7 @@ const buildWelcomeEmail = (props: { toEmail: string }): SendEmailCommand => {
 const buildReminderEmail = (props: { toEmail: string }): SendEmailCommand => {
   return buildSesEmailCommand({
     toEmail: props.toEmail,
-    emailType: REMINDER_EMAIL_CONFIG_SET_NAME,
+    emailType: `${REMINDER_EMAIL_CONFIG_SET_BASE}-${STAGE}` as EmailType,
     subject: "Incomplete Tasks Reminder - Business.NJ.gov",
     htmlBody: testReminderHtmlTemplate,
   });

--- a/api/src/libs/constants.ts
+++ b/api/src/libs/constants.ts
@@ -1,3 +1,3 @@
 export const API_SERVICE_NAME = "businessnjgov-api-v2";
-export const WELCOME_EMAIL_CONFIG_SET_NAME = "welcome-email";
-export const REMINDER_EMAIL_CONFIG_SET_NAME = "reminder-email";
+export const WELCOME_EMAIL_CONFIG_SET_BASE = "welcome-email";
+export const REMINDER_EMAIL_CONFIG_SET_BASE = "reminder-email";


### PR DESCRIPTION
                                                                 

## Description

The [recent change to email configuration sets](https://github.com/newjersey/navigator.business.nj.gov/pull/12487) broke [deploy to dev](https://github.com/newjersey/navigator.business.nj.gov/actions/runs/21964656929/job/63453744617) because of a name collision between the `testing` and `dev` environment. This PR changes the naming scheme to include the environment name to avoid this name collision.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#17076](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17076).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
I've deployed this to testing and verified that it creates the config sets with the new name:
<img width="1292" height="795" alt="Screenshot 2026-02-13 at 1 39 39 PM" src="https://github.com/user-attachments/assets/3f2f3a42-b23d-47dc-9806-4b7b2e158bb8" />

To test that the config set is attached to the welcome email, you can follow the same steps [from the original PR ](https://github.com/newjersey/navigator.business.nj.gov/pull/12487), sign up for a new account on testing.business.nj.gov, log into the console and verify in Amazon Simple Email Service > Virtual Deliverability Manager that the email was associated with `welcome-email-testing`.
<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->



### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [ ] I have added the `request-reviewer` tag on github to request reviews
