### PR TITLE
chore: [AB#17441] remove automated health checks against endpoints for cigarette license

### DIFF
--- a/api/src/functions/express/app.ts
+++ b/api/src/functions/express/app.ts
@@ -536,9 +536,8 @@ app.use(
       ["webservice/formation", formationHealthCheckClient],
       ["tax-clearance", taxClearanceHealthCheckClient],
       ["xray-registration", xrayRegistrationHealthCheckClient],
-      // TODO: The following need CloudWatch metrics
-      ["cigarette-license", cigaretteLicenseHealthCheckClient],
-      ["cigarette-email-client", cigaretteLicenseEmailClient.health],
+      ["cigarette-license", cigaretteLicenseHealthCheckClient], // This endpoint is not being hit by the HealthCheck Lambda
+      ["cigarette-email-client", cigaretteLicenseEmailClient.health], // This endpoint is not being hit by the HealthCheck Lambda
       ["messaging-service", messagingServiceClient.health],
       ["tax-filing-client", taxFilingClient.health],
     ]),

--- a/api/src/libs/healthCheck.test.ts
+++ b/api/src/libs/healthCheck.test.ts
@@ -1,6 +1,5 @@
 import { runHealthChecks } from "@libs/healthCheck";
 import { DummyLogWriter } from "@libs/logWriter";
-import { CONFIG_VARS, getConfigValue } from "@libs/ssmUtils";
 import axios from "axios";
 
 jest.mock("axios");
@@ -10,17 +9,8 @@ jest.mock("@libs/ssmUtils", () => ({
   getConfigValue: jest.fn(),
 }));
 
-const mockGetConfigValue = getConfigValue as jest.MockedFunction<typeof getConfigValue>;
-
 describe("healthCheck", () => {
   const logger = DummyLogWriter;
-
-  beforeEach(() => {
-    mockGetConfigValue.mockImplementation(async (paramName: CONFIG_VARS) => {
-      if (paramName === "FEATURE_CIGARETTE_LICENSE") return "true";
-      return "false";
-    });
-  });
 
   it("returns an object with pass statuses if success is true", async () => {
     mockAxios.get.mockResolvedValue({ data: { success: true } });
@@ -34,8 +24,6 @@ describe("healthCheck", () => {
       webserviceFormation: "PASS",
       taxClearance: "PASS",
       xrayRegistration: "PASS",
-      cigaretteLicense: "PASS",
-      cigaretteEmailClient: "PASS",
       taxFilingClient: "PASS",
     });
   });
@@ -52,8 +40,6 @@ describe("healthCheck", () => {
       webserviceFormation: "FAIL",
       taxClearance: "FAIL",
       xrayRegistration: "FAIL",
-      cigaretteLicense: "FAIL",
-      cigaretteEmailClient: "FAIL",
       taxFilingClient: "FAIL",
     });
   });
@@ -70,27 +56,7 @@ describe("healthCheck", () => {
       webserviceFormation: "ERROR",
       taxClearance: "ERROR",
       xrayRegistration: "ERROR",
-      cigaretteLicense: "ERROR",
-      cigaretteEmailClient: "ERROR",
       taxFilingClient: "ERROR",
-    });
-  });
-
-  describe("flagged health checks", () => {
-    it("includes cigarette health checks when feature flag is on", async () => {
-      const result = await runHealthChecks(logger);
-      expect(Object.keys(result)).toContain("cigaretteLicense");
-      expect(Object.keys(result)).toContain("cigaretteEmailClient");
-    });
-
-    it("excludes cigarette health checks when feature flag is off", async () => {
-      mockGetConfigValue.mockImplementation(async () => {
-        return "false";
-      });
-
-      const result = await runHealthChecks(logger);
-      expect(Object.keys(result)).not.toContain("cigaretteLicense");
-      expect(Object.keys(result)).not.toContain("cigaretteEmailClient");
     });
   });
 });


### PR DESCRIPTION
## Description

This work removes the cigarette license application endpoints from the list of endpoints referenced by the health check Lambda.

Currently, calls to the endpoints fail on every request because the integrations they are testing do not have configuration details, and they will not for some time. As a result, alarms for these endpoints are consistently firing and making it difficult for us to identify true issues in our `production` environment.

### Ticket

This pull request resolves [#17441](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17441).

### Approach

- Remove the endpoints from the list of `healthCheckEndPoints` referenced by the Health Check Lambda
- The routes defined in the main application backend still exist, as well as the associated CloudWatch topics.
  - Adding these in the future when they are needed will be simple and straight-forward.

### Steps to Test

We will know this is successful when we are no longer receiving notifications about these failing checks in CloudWatch and in the alarms Slack channel.

### Notes
n/a

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [ ] I have added the `request-reviewer` tag on github to request reviews
