### PR TITLE
feat: extract release config with ADO changelog transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,656 +1,604 @@
 # [2026.4.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2026.3.0...v2026.4.0) (2026-02-18)
 
-
 ### Bug Fixes
 
-* [AB[#17076](https://github.com/newjersey/navigator.business.nj.gov/issues/17076)] add stage to config set names ([c6074f5](https://github.com/newjersey/navigator.business.nj.gov/commit/c6074f50805946bf67eaaae4c9600cab5a5031cd))
-
+- [AB[#17076](https://github.com/newjersey/navigator.business.nj.gov/issues/17076)] add stage to config set names ([c6074f5](https://github.com/newjersey/navigator.business.nj.gov/commit/c6074f50805946bf67eaaae4c9600cab5a5031cd))
 
 ### Features
 
-* [AB[#16129](https://github.com/newjersey/navigator.business.nj.gov/issues/16129)] crtk business activities email ([022b99b](https://github.com/newjersey/navigator.business.nj.gov/commit/022b99b4b633af64a609247cfca83c3bb92b4db2))
-* build and write sectors.json from content ([a3d1d3f](https://github.com/newjersey/navigator.business.nj.gov/commit/a3d1d3f84cc8620d1209c14cd2d125c68d5118ed))
-* make decap CMS source of truth for spellcheck, add slack alerts ([d544d3b](https://github.com/newjersey/navigator.business.nj.gov/commit/d544d3b30542887fe455150bfa7801ee92944a96))
-* show roadmaps where a task is used in the CMS task preview ([b13aa2c](https://github.com/newjersey/navigator.business.nj.gov/commit/b13aa2cdbd13aa6de26ef5d1f617c3112723d345))
+- [AB[#16129](https://github.com/newjersey/navigator.business.nj.gov/issues/16129)] crtk business activities email ([022b99b](https://github.com/newjersey/navigator.business.nj.gov/commit/022b99b4b633af64a609247cfca83c3bb92b4db2))
+- build and write sectors.json from content ([a3d1d3f](https://github.com/newjersey/navigator.business.nj.gov/commit/a3d1d3f84cc8620d1209c14cd2d125c68d5118ed))
+- make decap CMS source of truth for spellcheck, add slack alerts ([d544d3b](https://github.com/newjersey/navigator.business.nj.gov/commit/d544d3b30542887fe455150bfa7801ee92944a96))
+- show roadmaps where a task is used in the CMS task preview ([b13aa2c](https://github.com/newjersey/navigator.business.nj.gov/commit/b13aa2cdbd13aa6de26ef5d1f617c3112723d345))
 
 # [2026.3.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2026.2.0...v2026.3.0) (2026-02-10)
 
-
 ### Bug Fixes
 
-* [AB[#17340](https://github.com/newjersey/navigator.business.nj.gov/issues/17340)] automatic biz name availability search should use formationFormData.businessName ([2916586](https://github.com/newjersey/navigator.business.nj.gov/commit/2916586836c5e1cc7c2abcfae6ecd6d02fe7f16b))
-* **deps:** update dependency @smithy/node-http-handler to v4 ([5bc43f9](https://github.com/newjersey/navigator.business.nj.gov/commit/5bc43f982a5fdf0050f7538d10b2a8fb1eb4c2c3))
-* **deps:** update dependency @smithy/node-http-handler to v4 ([7e16cfe](https://github.com/newjersey/navigator.business.nj.gov/commit/7e16cfe2f6e53f7fdf3602b2ce43f23bebcab79a))
-* **deps:** update dependency helmet to v8 ([a18b534](https://github.com/newjersey/navigator.business.nj.gov/commit/a18b534c8b6889f0967d2be170e0c9f328704a7f))
-* **deps:** update dependency next to v16.1.5 [security] ([1fdd85a](https://github.com/newjersey/navigator.business.nj.gov/commit/1fdd85a8369389d6ed0a2591d2edd45437851d59))
-
+- [AB#17340](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17340) automatic biz name availability search should use formationFormData.businessName ([2916586](https://github.com/newjersey/navigator.business.nj.gov/commit/2916586836c5e1cc7c2abcfae6ecd6d02fe7f16b))
+- **deps:** update dependency @smithy/node-http-handler to v4 ([5bc43f9](https://github.com/newjersey/navigator.business.nj.gov/commit/5bc43f982a5fdf0050f7538d10b2a8fb1eb4c2c3))
+- **deps:** update dependency @smithy/node-http-handler to v4 ([7e16cfe](https://github.com/newjersey/navigator.business.nj.gov/commit/7e16cfe2f6e53f7fdf3602b2ce43f23bebcab79a))
+- **deps:** update dependency helmet to v8 ([a18b534](https://github.com/newjersey/navigator.business.nj.gov/commit/a18b534c8b6889f0967d2be170e0c9f328704a7f))
+- **deps:** update dependency next to v16.1.5 [security] ([1fdd85a](https://github.com/newjersey/navigator.business.nj.gov/commit/1fdd85a8369389d6ed0a2591d2edd45437851d59))
 
 ### Features
 
-* [AB[#16536](https://github.com/newjersey/navigator.business.nj.gov/issues/16536)] Added CRTK to new industries ([#12455](https://github.com/newjersey/navigator.business.nj.gov/issues/12455)) ([4bf5706](https://github.com/newjersey/navigator.business.nj.gov/commit/4bf57069ffd9542eee7a5953dac60bed1e3eef93))
-* [AB[#16536](https://github.com/newjersey/navigator.business.nj.gov/issues/16536)] Removed CRTK and changed for General Guidance ([#12462](https://github.com/newjersey/navigator.business.nj.gov/issues/12462)) ([e691124](https://github.com/newjersey/navigator.business.nj.gov/commit/e691124a2856a68932c8cc30e12c7b5b059a6962))
-* [AB[#17224](https://github.com/newjersey/navigator.business.nj.gov/issues/17224)] Cypress test for Removing a Business ([e836731](https://github.com/newjersey/navigator.business.nj.gov/commit/e8367315b524241bbaa79c50410c5ee72a6a8125))
-* [AB[#17372](https://github.com/newjersey/navigator.business.nj.gov/issues/17372)] Cspell - do not flag wrapped URLs as misspellings ([cd5b8e5](https://github.com/newjersey/navigator.business.nj.gov/commit/cd5b8e5805e7d2c0d409c9d458d0ce259502c856))
+- [AB#16536](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16536) Added CRTK to new industries ([#12455](https://github.com/newjersey/navigator.business.nj.gov/issues/12455)) ([4bf5706](https://github.com/newjersey/navigator.business.nj.gov/commit/4bf57069ffd9542eee7a5953dac60bed1e3eef93))
+- [AB#16536](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16536) Removed CRTK and changed for General Guidance ([#12462](https://github.com/newjersey/navigator.business.nj.gov/issues/12462)) ([e691124](https://github.com/newjersey/navigator.business.nj.gov/commit/e691124a2856a68932c8cc30e12c7b5b059a6962))
+- [AB#17224](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17224) Cypress test for Removing a Business ([e836731](https://github.com/newjersey/navigator.business.nj.gov/commit/e8367315b524241bbaa79c50410c5ee72a6a8125))
+- [AB#17372](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17372) Cspell - do not flag wrapped URLs as misspellings ([cd5b8e5](https://github.com/newjersey/navigator.business.nj.gov/commit/cd5b8e5805e7d2c0d409c9d458d0ce259502c856))
 
 # [2026.2.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2026.1.0...v2026.2.0) (2026-02-05)
 
-
 ### Bug Fixes
 
-* [AB[#16139](https://github.com/newjersey/navigator.business.nj.gov/issues/16139)] Fix bug where trying to decrypt on first render when DOL EIN is not encrypted ([71e62d6](https://github.com/newjersey/navigator.business.nj.gov/commit/71e62d67cff3b4aa26c1efb840eae59ed026fb71))
-* [AB[#17235](https://github.com/newjersey/navigator.business.nj.gov/issues/17235)] preserve query params in onboarding routing ([19d0da6](https://github.com/newjersey/navigator.business.nj.gov/commit/19d0da63acdc7e45e21bca3ebd66d34f41fff595))
-
+- [AB#16139](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16139) Fix bug where trying to decrypt on first render when DOL EIN is not encrypted ([71e62d6](https://github.com/newjersey/navigator.business.nj.gov/commit/71e62d67cff3b4aa26c1efb840eae59ed026fb71))
+- [AB#17235](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17235) preserve query params in onboarding routing ([19d0da6](https://github.com/newjersey/navigator.business.nj.gov/commit/19d0da63acdc7e45e21bca3ebd66d34f41fff595))
 
 ### Features
 
-* [AB[#17102](https://github.com/newjersey/navigator.business.nj.gov/issues/17102)] allow some tasks to be synced with Webflow ([87698a2](https://github.com/newjersey/navigator.business.nj.gov/commit/87698a2d713f3b22f9d439b98a3cce68a67ff045))
+- [AB#17102](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17102) allow some tasks to be synced with Webflow ([87698a2](https://github.com/newjersey/navigator.business.nj.gov/commit/87698a2d713f3b22f9d439b98a3cce68a67ff045))
 
 # [2026.1.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2026.0.1...v2026.1.0) (2026-01-27)
 
-
 ### Bug Fixes
 
-* [AB[#17143](https://github.com/newjersey/navigator.business.nj.gov/issues/17143)] disable deploy-storybook step ([a925226](https://github.com/newjersey/navigator.business.nj.gov/commit/a925226f18e1e72ee0de93e5cf22c98f416db367))
-* **deps:** update dependency lodash to v4.17.23 [security] ([bfce394](https://github.com/newjersey/navigator.business.nj.gov/commit/bfce39439388a543c126c10f5d7904546d3288bb))
-* extract NavBarVariant to separate file to prevent circular imports ([bead381](https://github.com/newjersey/navigator.business.nj.gov/commit/bead38110edb2832253b723494dbf5d97d7e5d96))
-* Merge remote-trackng branch 'origin/main' into content-repo ([790ec89](https://github.com/newjersey/navigator.business.nj.gov/commit/790ec89c7f72e4f76dcb55d988b9bab9f57e3ccb))
-
+- [AB#17143](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17143) disable deploy-storybook step ([a925226](https://github.com/newjersey/navigator.business.nj.gov/commit/a925226f18e1e72ee0de93e5cf22c98f416db367))
+- **deps:** update dependency lodash to v4.17.23 [security] ([bfce394](https://github.com/newjersey/navigator.business.nj.gov/commit/bfce39439388a543c126c10f5d7904546d3288bb))
+- extract NavBarVariant to separate file to prevent circular imports ([bead381](https://github.com/newjersey/navigator.business.nj.gov/commit/bead38110edb2832253b723494dbf5d97d7e5d96))
+- Merge remote-trackng branch 'origin/main' into content-repo ([790ec89](https://github.com/newjersey/navigator.business.nj.gov/commit/790ec89c7f72e4f76dcb55d988b9bab9f57e3ccb))
 
 ### Features
 
-* [AB[#15786](https://github.com/newjersey/navigator.business.nj.gov/issues/15786)] additional details from review ([6bb341e](https://github.com/newjersey/navigator.business.nj.gov/commit/6bb341ec893227e911e69795255a86e0f44a7139))
-* [AB[#15786](https://github.com/newjersey/navigator.business.nj.gov/issues/15786)] fixed design comments on form ([#12394](https://github.com/newjersey/navigator.business.nj.gov/issues/12394)) ([1c4e92c](https://github.com/newjersey/navigator.business.nj.gov/commit/1c4e92c61e34b3525ded038689e5c16ef8fd4240))
-* [AB[#15786](https://github.com/newjersey/navigator.business.nj.gov/issues/15786)] fixed spinner and underline text ([#12430](https://github.com/newjersey/navigator.business.nj.gov/issues/12430)) ([618ac89](https://github.com/newjersey/navigator.business.nj.gov/commit/618ac896622140738dc013bb3827ce4e84102876))
-* [AB[#15786](https://github.com/newjersey/navigator.business.nj.gov/issues/15786)] missing edit button to go back on form ([#12399](https://github.com/newjersey/navigator.business.nj.gov/issues/12399)) ([4eb0258](https://github.com/newjersey/navigator.business.nj.gov/commit/4eb0258c583810957a91716f9ef789f96772891e))
-* [AB[#15883](https://github.com/newjersey/navigator.business.nj.gov/issues/15883)] integrity tests now trigger via github actions ([a43ee27](https://github.com/newjersey/navigator.business.nj.gov/commit/a43ee279943d52c0ef9ba361b5345b056f7a5b87))
-* [AB[#16661](https://github.com/newjersey/navigator.business.nj.gov/issues/16661)] Automated Test for License Status Check ([d20a08c](https://github.com/newjersey/navigator.business.nj.gov/commit/d20a08c7af3042b23db2c7a4a611f2c8bc78b377))
-* [AB[#17071](https://github.com/newjersey/navigator.business.nj.gov/issues/17071)] added feature flag for zod on migration: ([ecdb9f7](https://github.com/newjersey/navigator.business.nj.gov/commit/ecdb9f746d3d7bd75215004d306e14f50b3c531d))
-* [AB[#17071](https://github.com/newjersey/navigator.business.nj.gov/issues/17071)] Validating User Data  - Implementing ZOD schema (Security ticket) ([64dd04b](https://github.com/newjersey/navigator.business.nj.gov/commit/64dd04b15549d8b31b4074106622656a0f830e10))
-* [AB[#17071](https://github.com/newjersey/navigator.business.nj.gov/issues/17071)] validing and fixing zod data ([a9caafb](https://github.com/newjersey/navigator.business.nj.gov/commit/a9caafba207d5fb2eb1405939d1675c14071075e))
-* [AB[#17071](https://github.com/newjersey/navigator.business.nj.gov/issues/17071)] validing and fixing zod data ([fd1a757](https://github.com/newjersey/navigator.business.nj.gov/commit/fd1a757e592d3ee12927a0371595c2fe3e86d94e))
-* [AB[#17071](https://github.com/newjersey/navigator.business.nj.gov/issues/17071)] validing and fixing zod data base 64 encoding ([64555d9](https://github.com/newjersey/navigator.business.nj.gov/commit/64555d9d58564545037f1c50939edb36c9251a6a))
-* [AB[#17081](https://github.com/newjersey/navigator.business.nj.gov/issues/17081)] sync changes made to the webflow-licenses collection ([80e2b1c](https://github.com/newjersey/navigator.business.nj.gov/commit/80e2b1c68216ca58a63690d15761637ea52581d1))
-* [AB[#17115](https://github.com/newjersey/navigator.business.nj.gov/issues/17115)] update governor and lt. governor's names ([1fa19ab](https://github.com/newjersey/navigator.business.nj.gov/commit/1fa19ab380e3ad6a928ed3a503a53b1a091aa39f))
+- [AB#15786](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15786) additional details from review ([6bb341e](https://github.com/newjersey/navigator.business.nj.gov/commit/6bb341ec893227e911e69795255a86e0f44a7139))
+- [AB#15786](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15786) fixed design comments on form ([#12394](https://github.com/newjersey/navigator.business.nj.gov/issues/12394)) ([1c4e92c](https://github.com/newjersey/navigator.business.nj.gov/commit/1c4e92c61e34b3525ded038689e5c16ef8fd4240))
+- [AB#15786](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15786) fixed spinner and underline text ([#12430](https://github.com/newjersey/navigator.business.nj.gov/issues/12430)) ([618ac89](https://github.com/newjersey/navigator.business.nj.gov/commit/618ac896622140738dc013bb3827ce4e84102876))
+- [AB#15786](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15786) missing edit button to go back on form ([#12399](https://github.com/newjersey/navigator.business.nj.gov/issues/12399)) ([4eb0258](https://github.com/newjersey/navigator.business.nj.gov/commit/4eb0258c583810957a91716f9ef789f96772891e))
+- [AB#15883](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15883) integrity tests now trigger via github actions ([a43ee27](https://github.com/newjersey/navigator.business.nj.gov/commit/a43ee279943d52c0ef9ba361b5345b056f7a5b87))
+- [AB#16661](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16661) Automated Test for License Status Check ([d20a08c](https://github.com/newjersey/navigator.business.nj.gov/commit/d20a08c7af3042b23db2c7a4a611f2c8bc78b377))
+- [AB#17071](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17071) added feature flag for zod on migration: ([ecdb9f7](https://github.com/newjersey/navigator.business.nj.gov/commit/ecdb9f746d3d7bd75215004d306e14f50b3c531d))
+- [AB#17071](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17071) Validating User Data - Implementing ZOD schema (Security ticket) ([64dd04b](https://github.com/newjersey/navigator.business.nj.gov/commit/64dd04b15549d8b31b4074106622656a0f830e10))
+- [AB#17071](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17071) validing and fixing zod data ([a9caafb](https://github.com/newjersey/navigator.business.nj.gov/commit/a9caafba207d5fb2eb1405939d1675c14071075e))
+- [AB#17071](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17071) validing and fixing zod data ([fd1a757](https://github.com/newjersey/navigator.business.nj.gov/commit/fd1a757e592d3ee12927a0371595c2fe3e86d94e))
+- [AB#17071](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17071) validing and fixing zod data base 64 encoding ([64555d9](https://github.com/newjersey/navigator.business.nj.gov/commit/64555d9d58564545037f1c50939edb36c9251a6a))
+- [AB#17081](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17081) sync changes made to the webflow-licenses collection ([80e2b1c](https://github.com/newjersey/navigator.business.nj.gov/commit/80e2b1c68216ca58a63690d15761637ea52581d1))
+- [AB#17115](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17115) update governor and lt. governor's names ([1fa19ab](https://github.com/newjersey/navigator.business.nj.gov/commit/1fa19ab380e3ad6a928ed3a503a53b1a091aa39f))
 
 ## [2026.0.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v2026.0.0...v2026.0.1) (2026-01-20)
 
-
 ### Bug Fixes
 
-* [AB[#17115](https://github.com/newjersey/navigator.business.nj.gov/issues/17115)] update governor and lt. governor's names ([faff255](https://github.com/newjersey/navigator.business.nj.gov/commit/faff255a59ca099153ce564ab3b23d5cc79ba1d0))
+- [AB#17115](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17115) update governor and lt. governor's names ([faff255](https://github.com/newjersey/navigator.business.nj.gov/commit/faff255a59ca099153ce564ab3b23d5cc79ba1d0))
 
 # [2026.0.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.27.0...v2026.0.0) (2026-01-12)
 
-
-* chore!: major version bump to 2026 ([64477be](https://github.com/newjersey/navigator.business.nj.gov/commit/64477be1dea571119eed257bf67895e041bda9b5))
-
+- chore!: major version bump to 2026 ([64477be](https://github.com/newjersey/navigator.business.nj.gov/commit/64477be1dea571119eed257bf67895e041bda9b5))
 
 ### BREAKING CHANGES
 
-* resolve to new year
+- resolve to new year
 
 # [2025.27.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.26.1...v2025.27.0) (2026-01-12)
 
-
 ### Bug Fixes
 
-* [AB[#13064](https://github.com/newjersey/navigator.business.nj.gov/issues/13064)] remove edit button on deferred location question ([d559d0e](https://github.com/newjersey/navigator.business.nj.gov/commit/d559d0ecede03f47eb51b2f47965131fa84ef89f))
-* [AB[#16898](https://github.com/newjersey/navigator.business.nj.gov/issues/16898)] prevent conflict when starting dev server, modify links ([17c42ad](https://github.com/newjersey/navigator.business.nj.gov/commit/17c42adfdab2aee724c897e2e980d6fe221f6764))
-* Fix filing calendar test that fails every Dec 31 ([6afe908](https://github.com/newjersey/navigator.business.nj.gov/commit/6afe908970f07738d2744594a051fb1fcf65ba34))
-
+- [AB#13064](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13064) remove edit button on deferred location question ([d559d0e](https://github.com/newjersey/navigator.business.nj.gov/commit/d559d0ecede03f47eb51b2f47965131fa84ef89f))
+- [AB#16898](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16898) prevent conflict when starting dev server, modify links ([17c42ad](https://github.com/newjersey/navigator.business.nj.gov/commit/17c42adfdab2aee724c897e2e980d6fe221f6764))
+- Fix filing calendar test that fails every Dec 31 ([6afe908](https://github.com/newjersey/navigator.business.nj.gov/commit/6afe908970f07738d2744594a051fb1fcf65ba34))
 
 ### Features
 
-* [AB[#16648](https://github.com/newjersey/navigator.business.nj.gov/issues/16648)] Add business name error for users without a business name ([a4f175d](https://github.com/newjersey/navigator.business.nj.gov/commit/a4f175de030e2fd75796232d8a923ffac4cfdda4))
-* [AB[#16898](https://github.com/newjersey/navigator.business.nj.gov/issues/16898)] add utm links to email, fix styling ([d4ab7de](https://github.com/newjersey/navigator.business.nj.gov/commit/d4ab7de3f074fce3278fe9227ea0187d5a429752))
-* [AB[#16898](https://github.com/newjersey/navigator.business.nj.gov/issues/16898)] reimplement simple welcome email in React Email ([d5307b1](https://github.com/newjersey/navigator.business.nj.gov/commit/d5307b175092343805ffd027802621a54df7b1c0))
-* [AB[#16939](https://github.com/newjersey/navigator.business.nj.gov/issues/16939)] add/fix profile tab query params ([91a2c66](https://github.com/newjersey/navigator.business.nj.gov/commit/91a2c6682c0f1345a289d17b75f7edf7602886b8))
-* [AB[#16939](https://github.com/newjersey/navigator.business.nj.gov/issues/16939)] simplify profile tab link tests, removes flaky test ([2c7a47f](https://github.com/newjersey/navigator.business.nj.gov/commit/2c7a47ff63cccb788ef1db1eb12d71a8195d15f4))
+- [AB#16648](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16648) Add business name error for users without a business name ([a4f175d](https://github.com/newjersey/navigator.business.nj.gov/commit/a4f175de030e2fd75796232d8a923ffac4cfdda4))
+- [AB#16898](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16898) add utm links to email, fix styling ([d4ab7de](https://github.com/newjersey/navigator.business.nj.gov/commit/d4ab7de3f074fce3278fe9227ea0187d5a429752))
+- [AB#16898](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16898) reimplement simple welcome email in React Email ([d5307b1](https://github.com/newjersey/navigator.business.nj.gov/commit/d5307b175092343805ffd027802621a54df7b1c0))
+- [AB#16939](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16939) add/fix profile tab query params ([91a2c66](https://github.com/newjersey/navigator.business.nj.gov/commit/91a2c6682c0f1345a289d17b75f7edf7602886b8))
+- [AB#16939](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16939) simplify profile tab link tests, removes flaky test ([2c7a47f](https://github.com/newjersey/navigator.business.nj.gov/commit/2c7a47ff63cccb788ef1db1eb12d71a8195d15f4))
 
 ## [2025.26.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.26.0...v2025.26.1) (2025-12-30)
 
-
 ### Bug Fixes
 
-* [AB[#17110](https://github.com/newjersey/navigator.business.nj.gov/issues/17110)] allow navigation on profile save: fixes industry saving bug ([b14d273](https://github.com/newjersey/navigator.business.nj.gov/commit/b14d273e80f8ba53fb64dee49770016be6809f00))
-* [AB[#17114](https://github.com/newjersey/navigator.business.nj.gov/issues/17114)] adds MLO license check and xray endpoints as vars ([a074228](https://github.com/newjersey/navigator.business.nj.gov/commit/a0742285edbd7a3d93f20ba688fd78488a65cfcd))
-* [AB[#17114](https://github.com/newjersey/navigator.business.nj.gov/issues/17114)] fixes missing configuration values ([6d9b3bb](https://github.com/newjersey/navigator.business.nj.gov/commit/6d9b3bb7b3d6b4576fcb8a09723eac053eb60ef6))
+- [AB#17110](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17110) allow navigation on profile save: fixes industry saving bug ([b14d273](https://github.com/newjersey/navigator.business.nj.gov/commit/b14d273e80f8ba53fb64dee49770016be6809f00))
+- [AB#17114](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17114) adds MLO license check and xray endpoints as vars ([a074228](https://github.com/newjersey/navigator.business.nj.gov/commit/a0742285edbd7a3d93f20ba688fd78488a65cfcd))
+- [AB#17114](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17114) fixes missing configuration values ([6d9b3bb](https://github.com/newjersey/navigator.business.nj.gov/commit/6d9b3bb7b3d6b4576fcb8a09723eac053eb60ef6))
 
 # [2025.26.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.25.3...v2025.26.0) (2025-12-29)
 
-
 ### Bug Fixes
 
-* [AB[#17106](https://github.com/newjersey/navigator.business.nj.gov/issues/17106)] add missing env var needed for signup ([8395207](https://github.com/newjersey/navigator.business.nj.gov/commit/83952079147833da8aafd95f437e26a299ec4001))
-* add gtm secret to release pipeline ([02d6ec9](https://github.com/newjersey/navigator.business.nj.gov/commit/02d6ec9d7d6371b1727af2405d17126b6676f2a3))
-* change stage to content in deploy-content ([d3ba14f](https://github.com/newjersey/navigator.business.nj.gov/commit/d3ba14f7b26d0f4514c9df48cf58b846d4f2f019))
-* DOL EIN encryption ([b68e15d](https://github.com/newjersey/navigator.business.nj.gov/commit/b68e15dd65d2ed0d0f8526aaf095de886c586570))
-* duplicate CMS key and casing for login pages ([12eabb8](https://github.com/newjersey/navigator.business.nj.gov/commit/12eabb8b292d4666e90e470d73ce864caff79196))
-* duplicate field name in Decap YAML ([9e23622](https://github.com/newjersey/navigator.business.nj.gov/commit/9e2362259d151ca19ce9e775c5414f29cb32d50b))
-* reuse dev aws credentials for testing ([3db2c68](https://github.com/newjersey/navigator.business.nj.gov/commit/3db2c681d11f9c2a3496b2b339a583eeb09fa178))
-
+- [AB#17106](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17106) add missing env var needed for signup ([8395207](https://github.com/newjersey/navigator.business.nj.gov/commit/83952079147833da8aafd95f437e26a299ec4001))
+- add gtm secret to release pipeline ([02d6ec9](https://github.com/newjersey/navigator.business.nj.gov/commit/02d6ec9d7d6371b1727af2405d17126b6676f2a3))
+- change stage to content in deploy-content ([d3ba14f](https://github.com/newjersey/navigator.business.nj.gov/commit/d3ba14f7b26d0f4514c9df48cf58b846d4f2f019))
+- DOL EIN encryption ([b68e15d](https://github.com/newjersey/navigator.business.nj.gov/commit/b68e15dd65d2ed0d0f8526aaf095de886c586570))
+- duplicate CMS key and casing for login pages ([12eabb8](https://github.com/newjersey/navigator.business.nj.gov/commit/12eabb8b292d4666e90e470d73ce864caff79196))
+- duplicate field name in Decap YAML ([9e23622](https://github.com/newjersey/navigator.business.nj.gov/commit/9e2362259d151ca19ce9e775c5414f29cb32d50b))
+- reuse dev aws credentials for testing ([3db2c68](https://github.com/newjersey/navigator.business.nj.gov/commit/3db2c681d11f9c2a3496b2b339a583eeb09fa178))
 
 ### Features
 
-* [AB[#16364](https://github.com/newjersey/navigator.business.nj.gov/issues/16364)] check user subcription before reminder emails ([da960cf](https://github.com/newjersey/navigator.business.nj.gov/commit/da960cf29d2cd73aef4554be91a1b94a1da2d9ec))
-* [AB[#16676](https://github.com/newjersey/navigator.business.nj.gov/issues/16676)] design updates for unsaved changes modal in profile ([bfe889d](https://github.com/newjersey/navigator.business.nj.gov/commit/bfe889dcce8666fdf0725662704b729ca2368567))
-* [AB[#16693](https://github.com/newjersey/navigator.business.nj.gov/issues/16693)] Enable employer rates section for foreign and nexus remote workers ([218a935](https://github.com/newjersey/navigator.business.nj.gov/commit/218a935fb4a11a078bc41e1444f9ff6de4192d4a))
-* [AB[#16989](https://github.com/newjersey/navigator.business.nj.gov/issues/16989)] Add UTM analytics urls to welcome email B ([bc6b5fc](https://github.com/newjersey/navigator.business.nj.gov/commit/bc6b5fc27a6be9bb04c17030c2b07810db5727ff))
-* [AB[#17075](https://github.com/newjersey/navigator.business.nj.gov/issues/17075)] auto promotion for non essential questions associated with anytime actions to recommended for you category ([5a23a91](https://github.com/newjersey/navigator.business.nj.gov/commit/5a23a914b547b578eacb920a1bf237bf08fdbfd4))
-* add login help page ([542e810](https://github.com/newjersey/navigator.business.nj.gov/commit/542e81005668b842022fb7969a15f66fc9d3ec2b))
-* improve login  error handling on `/loading` ([43c36be](https://github.com/newjersey/navigator.business.nj.gov/commit/43c36be2cd9807e23561ee0dcbdd57105a79e69d))
+- [AB#16364](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16364) check user subcription before reminder emails ([da960cf](https://github.com/newjersey/navigator.business.nj.gov/commit/da960cf29d2cd73aef4554be91a1b94a1da2d9ec))
+- [AB#16676](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16676) design updates for unsaved changes modal in profile ([bfe889d](https://github.com/newjersey/navigator.business.nj.gov/commit/bfe889dcce8666fdf0725662704b729ca2368567))
+- [AB#16693](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16693) Enable employer rates section for foreign and nexus remote workers ([218a935](https://github.com/newjersey/navigator.business.nj.gov/commit/218a935fb4a11a078bc41e1444f9ff6de4192d4a))
+- [AB#16989](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16989) Add UTM analytics urls to welcome email B ([bc6b5fc](https://github.com/newjersey/navigator.business.nj.gov/commit/bc6b5fc27a6be9bb04c17030c2b07810db5727ff))
+- [AB#17075](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17075) auto promotion for non essential questions associated with anytime actions to recommended for you category ([5a23a91](https://github.com/newjersey/navigator.business.nj.gov/commit/5a23a914b547b578eacb920a1bf237bf08fdbfd4))
+- add login help page ([542e810](https://github.com/newjersey/navigator.business.nj.gov/commit/542e81005668b842022fb7969a15f66fc9d3ec2b))
+- improve login error handling on `/loading` ([43c36be](https://github.com/newjersey/navigator.business.nj.gov/commit/43c36be2cd9807e23561ee0dcbdd57105a79e69d))
 
 ## [2025.25.3](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.25.2...v2025.25.3) (2025-12-29)
 
-
 ### Bug Fixes
 
-* enable gtm in production ([33c30a0](https://github.com/newjersey/navigator.business.nj.gov/commit/33c30a0274f3b4631fe24e8f3716c7840d23a030))
+- enable gtm in production ([33c30a0](https://github.com/newjersey/navigator.business.nj.gov/commit/33c30a0274f3b4631fe24e8f3716c7840d23a030))
 
 ## [2025.25.2](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.25.1...v2025.25.2) (2025-12-29)
 
-
 ### Bug Fixes
 
-* add gtm secret to release pipeline ([8d42927](https://github.com/newjersey/navigator.business.nj.gov/commit/8d4292798a56b4091f4b15be4f8cef15f8e04cf6))
+- add gtm secret to release pipeline ([8d42927](https://github.com/newjersey/navigator.business.nj.gov/commit/8d4292798a56b4091f4b15be4f8cef15f8e04cf6))
 
 ## [2025.25.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.25.0...v2025.25.1) (2025-12-23)
 
-
 ### Bug Fixes
 
-* adding missing env vars ([5fd3189](https://github.com/newjersey/navigator.business.nj.gov/commit/5fd3189964968a7016022e4dac6f841219f46c74))
+- adding missing env vars ([5fd3189](https://github.com/newjersey/navigator.business.nj.gov/commit/5fd3189964968a7016022e4dac6f841219f46c74))
 
 # [2025.25.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.24.0...v2025.25.0) (2025-12-23)
 
-
 ### Bug Fixes
 
-* [AB[#15848](https://github.com/newjersey/navigator.business.nj.gov/issues/15848)] Fix edge handling for error field ([d224c67](https://github.com/newjersey/navigator.business.nj.gov/commit/d224c676453d700f21d87ec2c17f3fc61137332b))
-* [AB[#16685](https://github.com/newjersey/navigator.business.nj.gov/issues/16685)] remove FEATURE_SHOW_REMOVE_BUSINESS flag ([25e2511](https://github.com/newjersey/navigator.business.nj.gov/commit/25e2511a9d0851c8ad6c9d618e1878dc6d8f0b32))
-* **deps:** update dependency next to v15.5.7 [security] ([7275983](https://github.com/newjersey/navigator.business.nj.gov/commit/7275983ab84948926de60b825e9bdafef144faea))
-* **deps:** update dependency next to v15.5.8 [security] ([8bcd277](https://github.com/newjersey/navigator.business.nj.gov/commit/8bcd277383b268e14e958a27caadfc13734ec20d))
-* **deps:** update dependency next to v15.5.9 [security] ([23a3a47](https://github.com/newjersey/navigator.business.nj.gov/commit/23a3a47f4a14bf94a596eae65cba223c9b0a2160))
-* remove deploy content from merge-content ([5580ffa](https://github.com/newjersey/navigator.business.nj.gov/commit/5580ffa31b40c665231d597f903d813b7e0c1019))
-* update deployment for content-repo ([a2b52b3](https://github.com/newjersey/navigator.business.nj.gov/commit/a2b52b39549440f42fad456dfc85905518f1ee43))
-
+- [AB#15848](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15848) Fix edge handling for error field ([d224c67](https://github.com/newjersey/navigator.business.nj.gov/commit/d224c676453d700f21d87ec2c17f3fc61137332b))
+- [AB#16685](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16685) remove FEATURE_SHOW_REMOVE_BUSINESS flag ([25e2511](https://github.com/newjersey/navigator.business.nj.gov/commit/25e2511a9d0851c8ad6c9d618e1878dc6d8f0b32))
+- **deps:** update dependency next to v15.5.7 [security] ([7275983](https://github.com/newjersey/navigator.business.nj.gov/commit/7275983ab84948926de60b825e9bdafef144faea))
+- **deps:** update dependency next to v15.5.8 [security] ([8bcd277](https://github.com/newjersey/navigator.business.nj.gov/commit/8bcd277383b268e14e958a27caadfc13734ec20d))
+- **deps:** update dependency next to v15.5.9 [security] ([23a3a47](https://github.com/newjersey/navigator.business.nj.gov/commit/23a3a47f4a14bf94a596eae65cba223c9b0a2160))
+- remove deploy content from merge-content ([5580ffa](https://github.com/newjersey/navigator.business.nj.gov/commit/5580ffa31b40c665231d597f903d813b7e0c1019))
+- update deployment for content-repo ([a2b52b3](https://github.com/newjersey/navigator.business.nj.gov/commit/a2b52b39549440f42fad456dfc85905518f1ee43))
 
 ### Features
 
-* [AB[#15848](https://github.com/newjersey/navigator.business.nj.gov/issues/15848)] Add success response for employer rates call ([8ccd113](https://github.com/newjersey/navigator.business.nj.gov/commit/8ccd113f8a8cb6a902e2d88cedfb27bf74f42390))
-* [AB[#16118](https://github.com/newjersey/navigator.business.nj.gov/issues/16118)] implement simple welcome email in html ([772f698](https://github.com/newjersey/navigator.business.nj.gov/commit/772f69869f21fa255e4725dc1b73b5afd8ac2cc2))
-* [AB[#16139](https://github.com/newjersey/navigator.business.nj.gov/issues/16139)] Encrypt DOL EIN field ([4d3c4d6](https://github.com/newjersey/navigator.business.nj.gov/commit/4d3c4d63a4001c0350ec5fa1b0d754c3aa700f81))
-* [AB[#16676](https://github.com/newjersey/navigator.business.nj.gov/issues/16676)] Replace stale handling of unsaved changes on profile with new modal and updated navigation interception logic ([771c947](https://github.com/newjersey/navigator.business.nj.gov/commit/771c9479f4b7c0b01096054460a99b96d9226eef))
-* [AB[#16850](https://github.com/newjersey/navigator.business.nj.gov/issues/16850)] Show encrypted DOL EIN for returning users ([f090534](https://github.com/newjersey/navigator.business.nj.gov/commit/f0905341c6e2589c0da4c9fe7f30feea73680dcf))
+- [AB#15848](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15848) Add success response for employer rates call ([8ccd113](https://github.com/newjersey/navigator.business.nj.gov/commit/8ccd113f8a8cb6a902e2d88cedfb27bf74f42390))
+- [AB#16118](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16118) implement simple welcome email in html ([772f698](https://github.com/newjersey/navigator.business.nj.gov/commit/772f69869f21fa255e4725dc1b73b5afd8ac2cc2))
+- [AB#16139](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16139) Encrypt DOL EIN field ([4d3c4d6](https://github.com/newjersey/navigator.business.nj.gov/commit/4d3c4d63a4001c0350ec5fa1b0d754c3aa700f81))
+- [AB#16676](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16676) Replace stale handling of unsaved changes on profile with new modal and updated navigation interception logic ([771c947](https://github.com/newjersey/navigator.business.nj.gov/commit/771c9479f4b7c0b01096054460a99b96d9226eef))
+- [AB#16850](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16850) Show encrypted DOL EIN for returning users ([f090534](https://github.com/newjersey/navigator.business.nj.gov/commit/f0905341c6e2589c0da4c9fe7f30feea73680dcf))
 
 # [2025.24.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.23.0...v2025.24.0) (2025-12-05)
 
-
 ### Bug Fixes
 
-* [AB[#15527](https://github.com/newjersey/navigator.business.nj.gov/issues/15527)] fix styling for Dashboard ([a66f3e2](https://github.com/newjersey/navigator.business.nj.gov/commit/a66f3e2db61184c3cc6fc4db419b550a7846a134))
-* [AB[#16705](https://github.com/newjersey/navigator.business.nj.gov/issues/16705)] return the entire error from Webservice license search ([d9a7f0a](https://github.com/newjersey/navigator.business.nj.gov/commit/d9a7f0a78fedfc373d17b0c307d555d8b5c3a7c1))
-* [AB[#16848](https://github.com/newjersey/navigator.business.nj.gov/issues/16848)] reconfigures PowerAutomate client to pass API key as a body param ([d298f3f](https://github.com/newjersey/navigator.business.nj.gov/commit/d298f3fb5f91b2b534ec14a218bf4fd624837275))
-* [AB[#16870](https://github.com/newjersey/navigator.business.nj.gov/issues/16870)] restrict snsPublishPolicyToCmsAlertTopic to dev ([24bccde](https://github.com/newjersey/navigator.business.nj.gov/commit/24bccdebd36b3e5badfad68538b8446eac04a048))
-* **deps:** update dependency aws-amplify to v6.15.8 ([00e04b3](https://github.com/newjersey/navigator.business.nj.gov/commit/00e04b365208f93a3874e7167a4a442574b4d6b1))
-* **deps:** update dependency dayjs to v1.11.19 ([aa44718](https://github.com/newjersey/navigator.business.nj.gov/commit/aa44718cc39f58f255b1010fcf3b615e7cb30a26))
-* **deps:** update dependency js-yaml to v4.1.1 [security] ([2c887c0](https://github.com/newjersey/navigator.business.nj.gov/commit/2c887c08e4b01b11dacca8d75bd3c0a071e5113a))
-* **deps:** update dependency rehype-rewrite to v4.0.3 ([e97d9c1](https://github.com/newjersey/navigator.business.nj.gov/commit/e97d9c155fe9feb34a63f07f63e363876acb3f13))
-* retrigger wofkflow in circleCI ([cd7490c](https://github.com/newjersey/navigator.business.nj.gov/commit/cd7490cf5ff10593cf6889796c441777f76787c4))
-
+- [AB#15527](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15527) fix styling for Dashboard ([a66f3e2](https://github.com/newjersey/navigator.business.nj.gov/commit/a66f3e2db61184c3cc6fc4db419b550a7846a134))
+- [AB#16705](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16705) return the entire error from Webservice license search ([d9a7f0a](https://github.com/newjersey/navigator.business.nj.gov/commit/d9a7f0a78fedfc373d17b0c307d555d8b5c3a7c1))
+- [AB#16848](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16848) reconfigures PowerAutomate client to pass API key as a body param ([d298f3f](https://github.com/newjersey/navigator.business.nj.gov/commit/d298f3fb5f91b2b534ec14a218bf4fd624837275))
+- [AB#16870](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16870) restrict snsPublishPolicyToCmsAlertTopic to dev ([24bccde](https://github.com/newjersey/navigator.business.nj.gov/commit/24bccdebd36b3e5badfad68538b8446eac04a048))
+- **deps:** update dependency aws-amplify to v6.15.8 ([00e04b3](https://github.com/newjersey/navigator.business.nj.gov/commit/00e04b365208f93a3874e7167a4a442574b4d6b1))
+- **deps:** update dependency dayjs to v1.11.19 ([aa44718](https://github.com/newjersey/navigator.business.nj.gov/commit/aa44718cc39f58f255b1010fcf3b615e7cb30a26))
+- **deps:** update dependency js-yaml to v4.1.1 [security] ([2c887c0](https://github.com/newjersey/navigator.business.nj.gov/commit/2c887c08e4b01b11dacca8d75bd3c0a071e5113a))
+- **deps:** update dependency rehype-rewrite to v4.0.3 ([e97d9c1](https://github.com/newjersey/navigator.business.nj.gov/commit/e97d9c155fe9feb34a63f07f63e363876acb3f13))
+- retrigger wofkflow in circleCI ([cd7490c](https://github.com/newjersey/navigator.business.nj.gov/commit/cd7490cf5ff10593cf6889796c441777f76787c4))
 
 ### Features
 
-* [AB[#12619](https://github.com/newjersey/navigator.business.nj.gov/issues/12619)] table labels on talkback read column header before cost content and total and subtotal content ([97d5407](https://github.com/newjersey/navigator.business.nj.gov/commit/97d5407c5ab9b5cf3df084dfc58da23a9118a55d))
-* [AB[#12620](https://github.com/newjersey/navigator.business.nj.gov/issues/12620)] WCAG formation required fields not announced as such ([d614e78](https://github.com/newjersey/navigator.business.nj.gov/commit/d614e78e62df590387b942c5950c37f40bd8702a))
-* [AB[#15527](https://github.com/newjersey/navigator.business.nj.gov/issues/15527)] Dashboard restyling - Business Tasks to Stay on Track ([c9d2f8f](https://github.com/newjersey/navigator.business.nj.gov/commit/c9d2f8f3718ea91acdd5d2dd519fb8d33a768c20))
-* [AB[#15816](https://github.com/newjersey/navigator.business.nj.gov/issues/15816)] create CDK resources ([8d36602](https://github.com/newjersey/navigator.business.nj.gov/commit/8d3660281eff87004714660f323874bb6195b654))
-* [AB[#16133](https://github.com/newjersey/navigator.business.nj.gov/issues/16133)] Add Contact & Notifications profile tab ([9244eb2](https://github.com/newjersey/navigator.business.nj.gov/commit/9244eb2ad3b63c359cdf9ecbff5ec67b9214ef5b))
-* [AB[#16133](https://github.com/newjersey/navigator.business.nj.gov/issues/16133)] Fix styling in your security matters box ([be38697](https://github.com/newjersey/navigator.business.nj.gov/commit/be38697a9d8420c5c717d28f733b0b3939b3c06b))
-* [AB[#16357](https://github.com/newjersey/navigator.business.nj.gov/issues/16357)] Add 'updates and reminders' notification option and phone number to account creation page ([ef5ab92](https://github.com/newjersey/navigator.business.nj.gov/commit/ef5ab9264c320611732e4583e0867ebc21e8f7b4))
-* [AB[#16471](https://github.com/newjersey/navigator.business.nj.gov/issues/16471)] create messaging service lambda ([3a8e2fa](https://github.com/newjersey/navigator.business.nj.gov/commit/3a8e2fabb89b5b38120dcd7ebec77f5329f8dace))
-* [AB[#16473](https://github.com/newjersey/navigator.business.nj.gov/issues/16473)] Add feature flag for welcome email and update SSM utils to look at local env ([31cccc5](https://github.com/newjersey/navigator.business.nj.gov/commit/31cccc58473043a2dc887f44c805d49110929af3))
-* [AB[#16629](https://github.com/newjersey/navigator.business.nj.gov/issues/16629)] remove the reseller addon ([1470c72](https://github.com/newjersey/navigator.business.nj.gov/commit/1470c722ff9fea6590e44baccb255060c6b78124))
+- [AB#12619](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12619) table labels on talkback read column header before cost content and total and subtotal content ([97d5407](https://github.com/newjersey/navigator.business.nj.gov/commit/97d5407c5ab9b5cf3df084dfc58da23a9118a55d))
+- [AB#12620](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12620) WCAG formation required fields not announced as such ([d614e78](https://github.com/newjersey/navigator.business.nj.gov/commit/d614e78e62df590387b942c5950c37f40bd8702a))
+- [AB#15527](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15527) Dashboard restyling - Business Tasks to Stay on Track ([c9d2f8f](https://github.com/newjersey/navigator.business.nj.gov/commit/c9d2f8f3718ea91acdd5d2dd519fb8d33a768c20))
+- [AB#15816](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15816) create CDK resources ([8d36602](https://github.com/newjersey/navigator.business.nj.gov/commit/8d3660281eff87004714660f323874bb6195b654))
+- [AB#16133](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16133) Add Contact & Notifications profile tab ([9244eb2](https://github.com/newjersey/navigator.business.nj.gov/commit/9244eb2ad3b63c359cdf9ecbff5ec67b9214ef5b))
+- [AB#16133](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16133) Fix styling in your security matters box ([be38697](https://github.com/newjersey/navigator.business.nj.gov/commit/be38697a9d8420c5c717d28f733b0b3939b3c06b))
+- [AB#16357](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16357) Add 'updates and reminders' notification option and phone number to account creation page ([ef5ab92](https://github.com/newjersey/navigator.business.nj.gov/commit/ef5ab9264c320611732e4583e0867ebc21e8f7b4))
+- [AB#16471](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16471) create messaging service lambda ([3a8e2fa](https://github.com/newjersey/navigator.business.nj.gov/commit/3a8e2fabb89b5b38120dcd7ebec77f5329f8dace))
+- [AB#16473](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16473) Add feature flag for welcome email and update SSM utils to look at local env ([31cccc5](https://github.com/newjersey/navigator.business.nj.gov/commit/31cccc58473043a2dc887f44c805d49110929af3))
+- [AB#16629](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16629) remove the reseller addon ([1470c72](https://github.com/newjersey/navigator.business.nj.gov/commit/1470c722ff9fea6590e44baccb255060c6b78124))
 
 # [2025.23.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.22.0...v2025.23.0) (2025-11-13)
 
-
 ### Bug Fixes
 
-* [AB[#6215](https://github.com/newjersey/navigator.business.nj.gov/issues/6215)] continue without saving ([062aebc](https://github.com/newjersey/navigator.business.nj.gov/commit/062aebc359028c65f6b4ba6aeafab64e093a0e05))
-* [AB[#6215](https://github.com/newjersey/navigator.business.nj.gov/issues/6215)] env permit UI ([f3b6c85](https://github.com/newjersey/navigator.business.nj.gov/commit/f3b6c8566daf7ff8605769026c2fe3ca863aafa5))
-* [AB[#6215](https://github.com/newjersey/navigator.business.nj.gov/issues/6215)] update route for env permit email ([ab5f272](https://github.com/newjersey/navigator.business.nj.gov/commit/ab5f272003063408c17f014f30c2444251a6fe28))
-
+- [AB#6215](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/6215) continue without saving ([062aebc](https://github.com/newjersey/navigator.business.nj.gov/commit/062aebc359028c65f6b4ba6aeafab64e093a0e05))
+- [AB#6215](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/6215) env permit UI ([f3b6c85](https://github.com/newjersey/navigator.business.nj.gov/commit/f3b6c8566daf7ff8605769026c2fe3ca863aafa5))
+- [AB#6215](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/6215) update route for env permit email ([ab5f272](https://github.com/newjersey/navigator.business.nj.gov/commit/ab5f272003063408c17f014f30c2444251a6fe28))
 
 ### Features
 
-* [AB[#16369](https://github.com/newjersey/navigator.business.nj.gov/issues/16369)] ID's added to all clickable elements ([be505d6](https://github.com/newjersey/navigator.business.nj.gov/commit/be505d6bc60878d1e60f2ad44a6d278aafd3144f))
-* [AB[#16377](https://github.com/newjersey/navigator.business.nj.gov/issues/16377)] stepper step query params ([8a5fbcb](https://github.com/newjersey/navigator.business.nj.gov/commit/8a5fbcb23bbc8493eafb80ae9361cd25572bda8c))
-* [AB[#16473](https://github.com/newjersey/navigator.business.nj.gov/issues/16473)] Add AWS Messaging Service Client for Email Communications ([a6f58bf](https://github.com/newjersey/navigator.business.nj.gov/commit/a6f58bf607c561e0b95b6417a8ca0cbae03faa86))
-* [AB[#16473](https://github.com/newjersey/navigator.business.nj.gov/issues/16473)] Add feature flag for welcome email and update SSM utils to look at local env ([14af574](https://github.com/newjersey/navigator.business.nj.gov/commit/14af574a33f093badf32079b7ad65677fe41c867))
-* [AB[#16656](https://github.com/newjersey/navigator.business.nj.gov/issues/16656)] refactor api_submit analytics ([559a41f](https://github.com/newjersey/navigator.business.nj.gov/commit/559a41fc089bf84e66ebd888b4af7f0c10ecc434))
-* [AB[#6215](https://github.com/newjersey/navigator.business.nj.gov/issues/6215)] env permit email req ([c458769](https://github.com/newjersey/navigator.business.nj.gov/commit/c4587693932e6c4b48ead96c2e084b505bff2f37))
+- [AB#16369](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16369) ID's added to all clickable elements ([be505d6](https://github.com/newjersey/navigator.business.nj.gov/commit/be505d6bc60878d1e60f2ad44a6d278aafd3144f))
+- [AB#16377](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16377) stepper step query params ([8a5fbcb](https://github.com/newjersey/navigator.business.nj.gov/commit/8a5fbcb23bbc8493eafb80ae9361cd25572bda8c))
+- [AB#16473](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16473) Add AWS Messaging Service Client for Email Communications ([a6f58bf](https://github.com/newjersey/navigator.business.nj.gov/commit/a6f58bf607c561e0b95b6417a8ca0cbae03faa86))
+- [AB#16473](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16473) Add feature flag for welcome email and update SSM utils to look at local env ([14af574](https://github.com/newjersey/navigator.business.nj.gov/commit/14af574a33f093badf32079b7ad65677fe41c867))
+- [AB#16656](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16656) refactor api_submit analytics ([559a41f](https://github.com/newjersey/navigator.business.nj.gov/commit/559a41fc089bf84e66ebd888b4af7f0c10ecc434))
+- [AB#6215](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/6215) env permit email req ([c458769](https://github.com/newjersey/navigator.business.nj.gov/commit/c4587693932e6c4b48ead96c2e084b505bff2f37))
 
 # [2025.22.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.21.0...v2025.22.0) (2025-10-29)
 
-
 ### Bug Fixes
 
-* [AB[#16202](https://github.com/newjersey/navigator.business.nj.gov/issues/16202)] minor copy change to text ([104031b](https://github.com/newjersey/navigator.business.nj.gov/commit/104031b398f152a1bc5ece83dac06351ca7e2016))
-* [AB[#16202](https://github.com/newjersey/navigator.business.nj.gov/issues/16202)] test fix inline with copy change ([c20c5e1](https://github.com/newjersey/navigator.business.nj.gov/commit/c20c5e17b8fa9e0cf26811cdc018b88776af9438))
-* [AB[#16352](https://github.com/newjersey/navigator.business.nj.gov/issues/16352)] tax-clearance loading spinner ([a4ec889](https://github.com/newjersey/navigator.business.nj.gov/commit/a4ec889ccf04c1147ee7983fc61624441db59d25))
-* **deps:** update nextjs monorepo to v15.5.6 ([180cb59](https://github.com/newjersey/navigator.business.nj.gov/commit/180cb59fd8f25d54a820d5161a0747d880ab299b))
-
+- [AB#16202](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16202) minor copy change to text ([104031b](https://github.com/newjersey/navigator.business.nj.gov/commit/104031b398f152a1bc5ece83dac06351ca7e2016))
+- [AB#16202](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16202) test fix inline with copy change ([c20c5e1](https://github.com/newjersey/navigator.business.nj.gov/commit/c20c5e17b8fa9e0cf26811cdc018b88776af9438))
+- [AB#16352](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16352) tax-clearance loading spinner ([a4ec889](https://github.com/newjersey/navigator.business.nj.gov/commit/a4ec889ccf04c1147ee7983fc61624441db59d25))
+- **deps:** update nextjs monorepo to v15.5.6 ([180cb59](https://github.com/newjersey/navigator.business.nj.gov/commit/180cb59fd8f25d54a820d5161a0747d880ab299b))
 
 ### Features
 
-* [AB[#12618](https://github.com/newjersey/navigator.business.nj.gov/issues/12618)] formation billing cost column header added ([04c1e21](https://github.com/newjersey/navigator.business.nj.gov/commit/04c1e21e85704ce4d38a929831523aeeac729fef))
-* [AB[#16087](https://github.com/newjersey/navigator.business.nj.gov/issues/16087)] remove business functionality ([9e4966e](https://github.com/newjersey/navigator.business.nj.gov/commit/9e4966eac24dc6ce78c50331fe1194865455e11b))
-* [AB[#16087](https://github.com/newjersey/navigator.business.nj.gov/issues/16087)] remove business functionality ([b459323](https://github.com/newjersey/navigator.business.nj.gov/commit/b4593233ac4d9ced4910e8faf1ec8ea431bbae66))
-* [AB[#16202](https://github.com/newjersey/navigator.business.nj.gov/issues/16202)] anytime action search QA for no options and icon spacing ([184317d](https://github.com/newjersey/navigator.business.nj.gov/commit/184317d9eeeefb071b1917589dc7ae5d966ad8df))
-* [AB[#16202](https://github.com/newjersey/navigator.business.nj.gov/issues/16202)] dashboard anytime action dropdown to search field ([9d88ca3](https://github.com/newjersey/navigator.business.nj.gov/commit/9d88ca38074a9bcd825dfdb2df1a27c917d000fc))
-* [AB[#16205](https://github.com/newjersey/navigator.business.nj.gov/issues/16205)] added recommended for you section and CMS controls ([92b818d](https://github.com/newjersey/navigator.business.nj.gov/commit/92b818d10bb88c93afac72b88bba56d069b1e3d8))
-* [AB[#16230](https://github.com/newjersey/navigator.business.nj.gov/issues/16230)] add live chat help link in error messsage ([d31212e](https://github.com/newjersey/navigator.business.nj.gov/commit/d31212e7f8f2815ba3de38661d63d69545f12528))
+- [AB#12618](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12618) formation billing cost column header added ([04c1e21](https://github.com/newjersey/navigator.business.nj.gov/commit/04c1e21e85704ce4d38a929831523aeeac729fef))
+- [AB#16087](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16087) remove business functionality ([9e4966e](https://github.com/newjersey/navigator.business.nj.gov/commit/9e4966eac24dc6ce78c50331fe1194865455e11b))
+- [AB#16087](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16087) remove business functionality ([b459323](https://github.com/newjersey/navigator.business.nj.gov/commit/b4593233ac4d9ced4910e8faf1ec8ea431bbae66))
+- [AB#16202](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16202) anytime action search QA for no options and icon spacing ([184317d](https://github.com/newjersey/navigator.business.nj.gov/commit/184317d9eeeefb071b1917589dc7ae5d966ad8df))
+- [AB#16202](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16202) dashboard anytime action dropdown to search field ([9d88ca3](https://github.com/newjersey/navigator.business.nj.gov/commit/9d88ca38074a9bcd825dfdb2df1a27c917d000fc))
+- [AB#16205](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16205) added recommended for you section and CMS controls ([92b818d](https://github.com/newjersey/navigator.business.nj.gov/commit/92b818d10bb88c93afac72b88bba56d069b1e3d8))
+- [AB#16230](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16230) add live chat help link in error messsage ([d31212e](https://github.com/newjersey/navigator.business.nj.gov/commit/d31212e7f8f2815ba3de38661d63d69545f12528))
 
 # [2025.21.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.20.0...v2025.21.0) (2025-10-03)
 
-
 ### Bug Fixes
 
-* [AB[#13780](https://github.com/newjersey/navigator.business.nj.gov/issues/13780)] design qa updates ([77b2c19](https://github.com/newjersey/navigator.business.nj.gov/commit/77b2c19ed8bbbed75cb019483f65d8b9011bfe0c))
-* [AB[#14055](https://github.com/newjersey/navigator.business.nj.gov/issues/14055)] error handling bar css fix ([f237c45](https://github.com/newjersey/navigator.business.nj.gov/commit/f237c45950d25b26598e171033fdb50dcfcaaf49))
-* [AB[#15155](https://github.com/newjersey/navigator.business.nj.gov/issues/15155)] remove conditional rendering for profile callout and update copy ([288e3a8](https://github.com/newjersey/navigator.business.nj.gov/commit/288e3a8eccbb602df5c303c136f652ea9aedd7a3))
-* [AB[#15306](https://github.com/newjersey/navigator.business.nj.gov/issues/15306)] PR fixes for remove business modal ([22ffe38](https://github.com/newjersey/navigator.business.nj.gov/commit/22ffe389d1fb5330c07f568c17cb66c710209c24))
-* [AB[#15448](https://github.com/newjersey/navigator.business.nj.gov/issues/15448)] content acceptance ([1e55e5b](https://github.com/newjersey/navigator.business.nj.gov/commit/1e55e5b63e67405c73e70b76b26c994a57f05443))
-* [AB[#15448](https://github.com/newjersey/navigator.business.nj.gov/issues/15448)] content acceptance changes ([42121d3](https://github.com/newjersey/navigator.business.nj.gov/commit/42121d36347df17a1988f0115cc75c2058d67014))
-* [AB[#15515](https://github.com/newjersey/navigator.business.nj.gov/issues/15515)] address design corrections for review confirmation component ([f0f3816](https://github.com/newjersey/navigator.business.nj.gov/commit/f0f3816147dd0beb2a79c3d4e5d93591f7d2de6a))
-* [AB[#15884](https://github.com/newjersey/navigator.business.nj.gov/issues/15884)] fixing utc date and email html ([df25049](https://github.com/newjersey/navigator.business.nj.gov/commit/df250491a71610efffd91d6f0f76f7ef5bafae67))
-* [AB[#15907](https://github.com/newjersey/navigator.business.nj.gov/issues/15907)] add automatic rerun to mitigate ECONNRESET failures ([d9c3af6](https://github.com/newjersey/navigator.business.nj.gov/commit/d9c3af684d2adef0bf12be6925f09ce4153d073d))
-* [AB[#15921](https://github.com/newjersey/navigator.business.nj.gov/issues/15921)] content comment fixes ([6c01775](https://github.com/newjersey/navigator.business.nj.gov/commit/6c01775eea76245b0cc805c16a312b9515b90a41))
-* [AB[#15922](https://github.com/newjersey/navigator.business.nj.gov/issues/15922)] test-fixes ([7344354](https://github.com/newjersey/navigator.business.nj.gov/commit/73443548b850c5b95f8602fb349af8be3009227d))
-* [AB[#15942](https://github.com/newjersey/navigator.business.nj.gov/issues/15942)] fix start date of cig sales bug ([67b6eee](https://github.com/newjersey/navigator.business.nj.gov/commit/67b6eee14bba0bfb4cdafe68442c9b7f0b88a0ef))
-* [AB[#15980](https://github.com/newjersey/navigator.business.nj.gov/issues/15980)] make summary description optional in webflow licenses ([be72698](https://github.com/newjersey/navigator.business.nj.gov/commit/be726981784d5a2cd1d2486522309dcdae05e025))
-* [AB[#15980](https://github.com/newjersey/navigator.business.nj.gov/issues/15980)] make summary description optional in webflow licenses ([aeca1a0](https://github.com/newjersey/navigator.business.nj.gov/commit/aeca1a02cbbe6d87bc315c196f642d2028a94b0d))
-* allow 404 icon to display properly ([7b833ad](https://github.com/newjersey/navigator.business.nj.gov/commit/7b833adbf232506f4e6cf9ef482e79e1218d76d2))
-* **deps:** update aws-sdk ([a18017d](https://github.com/newjersey/navigator.business.nj.gov/commit/a18017d074e7c4fab8f91f2327212a16d77dda1d))
-* **deps:** update aws-sdk to v3.896.0 ([1347e08](https://github.com/newjersey/navigator.business.nj.gov/commit/1347e08370a91d963c8f2c91aea3cad5e64c9d24))
-* **deps:** update dependency aws-amplify to v6.15.6 ([96b2160](https://github.com/newjersey/navigator.business.nj.gov/commit/96b21605b77fb5f01d6394db49e60a02b41c98c5))
-* **deps:** update dependency axios to v1.12.0 [security] ([9520d6d](https://github.com/newjersey/navigator.business.nj.gov/commit/9520d6df89b778223e231a30a7630e06bcb1a729))
-* **deps:** update dependency axios to v1.12.2 ([2ed74c9](https://github.com/newjersey/navigator.business.nj.gov/commit/2ed74c9b306b6946fd8c19471234f8ec90413830))
-* **deps:** update dependency cypress-axe to v1.7.0 ([832af0f](https://github.com/newjersey/navigator.business.nj.gov/commit/832af0f948b40262f9b7feac1d754faaf0bbb419))
-* **deps:** update dependency dayjs to v1.11.18 ([d8d7b59](https://github.com/newjersey/navigator.business.nj.gov/commit/d8d7b595c645af32120a06a266576659048de58d))
-* **deps:** update dependency dedent to v1.7.0 ([08cc22b](https://github.com/newjersey/navigator.business.nj.gov/commit/08cc22b30e914cd6cf8e7a806fc552b7426c9664))
-* fix incorrectly formatted metadata on dental-waste-registration ([50cd0e7](https://github.com/newjersey/navigator.business.nj.gov/commit/50cd0e7dc8e5090069081831c7aa9019ec207d33))
-* replace existing dashes with hyphen-minus ([04d4fcb](https://github.com/newjersey/navigator.business.nj.gov/commit/04d4fcb0842801bb1ed3d1a928a89e643d9b2024))
-* selfgenerator anytime action ([68baed3](https://github.com/newjersey/navigator.business.nj.gov/commit/68baed385202ae153876835da946d5154b1b422d))
-* updating serveless.ts to fix systems manager vars ([300bf91](https://github.com/newjersey/navigator.business.nj.gov/commit/300bf9185fce0a7b9dff254f0b8a719bcbe66e12))
-
+- [AB#13780](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13780) design qa updates ([77b2c19](https://github.com/newjersey/navigator.business.nj.gov/commit/77b2c19ed8bbbed75cb019483f65d8b9011bfe0c))
+- [AB#14055](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14055) error handling bar css fix ([f237c45](https://github.com/newjersey/navigator.business.nj.gov/commit/f237c45950d25b26598e171033fdb50dcfcaaf49))
+- [AB#15155](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15155) remove conditional rendering for profile callout and update copy ([288e3a8](https://github.com/newjersey/navigator.business.nj.gov/commit/288e3a8eccbb602df5c303c136f652ea9aedd7a3))
+- [AB#15306](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15306) PR fixes for remove business modal ([22ffe38](https://github.com/newjersey/navigator.business.nj.gov/commit/22ffe389d1fb5330c07f568c17cb66c710209c24))
+- [AB#15448](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15448) content acceptance ([1e55e5b](https://github.com/newjersey/navigator.business.nj.gov/commit/1e55e5b63e67405c73e70b76b26c994a57f05443))
+- [AB#15448](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15448) content acceptance changes ([42121d3](https://github.com/newjersey/navigator.business.nj.gov/commit/42121d36347df17a1988f0115cc75c2058d67014))
+- [AB#15515](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15515) address design corrections for review confirmation component ([f0f3816](https://github.com/newjersey/navigator.business.nj.gov/commit/f0f3816147dd0beb2a79c3d4e5d93591f7d2de6a))
+- [AB#15884](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15884) fixing utc date and email html ([df25049](https://github.com/newjersey/navigator.business.nj.gov/commit/df250491a71610efffd91d6f0f76f7ef5bafae67))
+- [AB#15907](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15907) add automatic rerun to mitigate ECONNRESET failures ([d9c3af6](https://github.com/newjersey/navigator.business.nj.gov/commit/d9c3af684d2adef0bf12be6925f09ce4153d073d))
+- [AB#15921](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15921) content comment fixes ([6c01775](https://github.com/newjersey/navigator.business.nj.gov/commit/6c01775eea76245b0cc805c16a312b9515b90a41))
+- [AB#15922](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15922) test-fixes ([7344354](https://github.com/newjersey/navigator.business.nj.gov/commit/73443548b850c5b95f8602fb349af8be3009227d))
+- [AB#15942](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15942) fix start date of cig sales bug ([67b6eee](https://github.com/newjersey/navigator.business.nj.gov/commit/67b6eee14bba0bfb4cdafe68442c9b7f0b88a0ef))
+- [AB#15980](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15980) make summary description optional in webflow licenses ([be72698](https://github.com/newjersey/navigator.business.nj.gov/commit/be726981784d5a2cd1d2486522309dcdae05e025))
+- [AB#15980](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15980) make summary description optional in webflow licenses ([aeca1a0](https://github.com/newjersey/navigator.business.nj.gov/commit/aeca1a02cbbe6d87bc315c196f642d2028a94b0d))
+- allow 404 icon to display properly ([7b833ad](https://github.com/newjersey/navigator.business.nj.gov/commit/7b833adbf232506f4e6cf9ef482e79e1218d76d2))
+- **deps:** update aws-sdk ([a18017d](https://github.com/newjersey/navigator.business.nj.gov/commit/a18017d074e7c4fab8f91f2327212a16d77dda1d))
+- **deps:** update aws-sdk to v3.896.0 ([1347e08](https://github.com/newjersey/navigator.business.nj.gov/commit/1347e08370a91d963c8f2c91aea3cad5e64c9d24))
+- **deps:** update dependency aws-amplify to v6.15.6 ([96b2160](https://github.com/newjersey/navigator.business.nj.gov/commit/96b21605b77fb5f01d6394db49e60a02b41c98c5))
+- **deps:** update dependency axios to v1.12.0 [security] ([9520d6d](https://github.com/newjersey/navigator.business.nj.gov/commit/9520d6df89b778223e231a30a7630e06bcb1a729))
+- **deps:** update dependency axios to v1.12.2 ([2ed74c9](https://github.com/newjersey/navigator.business.nj.gov/commit/2ed74c9b306b6946fd8c19471234f8ec90413830))
+- **deps:** update dependency cypress-axe to v1.7.0 ([832af0f](https://github.com/newjersey/navigator.business.nj.gov/commit/832af0f948b40262f9b7feac1d754faaf0bbb419))
+- **deps:** update dependency dayjs to v1.11.18 ([d8d7b59](https://github.com/newjersey/navigator.business.nj.gov/commit/d8d7b595c645af32120a06a266576659048de58d))
+- **deps:** update dependency dedent to v1.7.0 ([08cc22b](https://github.com/newjersey/navigator.business.nj.gov/commit/08cc22b30e914cd6cf8e7a806fc552b7426c9664))
+- fix incorrectly formatted metadata on dental-waste-registration ([50cd0e7](https://github.com/newjersey/navigator.business.nj.gov/commit/50cd0e7dc8e5090069081831c7aa9019ec207d33))
+- replace existing dashes with hyphen-minus ([04d4fcb](https://github.com/newjersey/navigator.business.nj.gov/commit/04d4fcb0842801bb1ed3d1a928a89e643d9b2024))
+- selfgenerator anytime action ([68baed3](https://github.com/newjersey/navigator.business.nj.gov/commit/68baed385202ae153876835da946d5154b1b422d))
+- updating serveless.ts to fix systems manager vars ([300bf91](https://github.com/newjersey/navigator.business.nj.gov/commit/300bf9185fce0a7b9dff254f0b8a719bcbe66e12))
 
 ### Features
 
-* [AB[#12866](https://github.com/newjersey/navigator.business.nj.gov/issues/12866)] Remove markdown formatting when searching in search tool ([b224fc1](https://github.com/newjersey/navigator.business.nj.gov/commit/b224fc1f4ef51a5d2031292fb753ea3dd132a828))
-* [AB[#14081](https://github.com/newjersey/navigator.business.nj.gov/issues/14081)] Enhancing Error Handling on X-Ray Status ([#11627](https://github.com/newjersey/navigator.business.nj.gov/issues/11627)) ([4d7d01c](https://github.com/newjersey/navigator.business.nj.gov/commit/4d7d01c14f070ae4baa31252ec2b411450d302f6))
-* [AB[#14787](https://github.com/newjersey/navigator.business.nj.gov/issues/14787)] health check lambda integration for slack cms integrity tests ([664ce1e](https://github.com/newjersey/navigator.business.nj.gov/commit/664ce1e09d584847fef4fa2873486f789f88681d))
-* [AB[#15155](https://github.com/newjersey/navigator.business.nj.gov/issues/15155)] convert alert on business profile page to callout ([ab50089](https://github.com/newjersey/navigator.business.nj.gov/commit/ab50089424336356fb295f704bd6aed0d2e4df42))
-* [AB[#15306](https://github.com/newjersey/navigator.business.nj.gov/issues/15306)] Add remove business modal ([24172fb](https://github.com/newjersey/navigator.business.nj.gov/commit/24172fbac5dd49f6bfc7b736e3b147d03ebca8ce))
-* [AB[#15448](https://github.com/newjersey/navigator.business.nj.gov/issues/15448)] additions to formation business name ([b46cfef](https://github.com/newjersey/navigator.business.nj.gov/commit/b46cfef8ade5cd546fb4732c74cffba952239340))
-* [AB[#15515](https://github.com/newjersey/navigator.business.nj.gov/issues/15515)] add confirmation checks and callout to business formation review ([e78b97c](https://github.com/newjersey/navigator.business.nj.gov/commit/e78b97cd1416b2020cff0ea0aa94f88e5bad8c11))
-* [AB[#15822](https://github.com/newjersey/navigator.business.nj.gov/issues/15822)] add Python script to parse content collections and generate CSV ([df13683](https://github.com/newjersey/navigator.business.nj.gov/commit/df13683317ed6c4d223c328176b498b14df5b5c6))
-* [AB[#15885](https://github.com/newjersey/navigator.business.nj.gov/issues/15885)] add analytics events for cigarette license ([5bd6414](https://github.com/newjersey/navigator.business.nj.gov/commit/5bd64141e9def37273c19c26a62c9252f98f0627))
-* [AB[#15921](https://github.com/newjersey/navigator.business.nj.gov/issues/15921)] adding business name confirmation ([29d8915](https://github.com/newjersey/navigator.business.nj.gov/commit/29d8915c2d7acea9161884a6489a7ba114abe4d4))
-* [AB[#15925](https://github.com/newjersey/navigator.business.nj.gov/issues/15925)] add analytics to Business Name Reservation Selection ([610a011](https://github.com/newjersey/navigator.business.nj.gov/commit/610a01166690b771aba2ac7c51d9b4e249625670))
-* [AB[#15926](https://github.com/newjersey/navigator.business.nj.gov/issues/15926)] updates to license-tasks CMS collection ([8e060bf](https://github.com/newjersey/navigator.business.nj.gov/commit/8e060bfcc842a2f47e4066d457ee64681924d012))
-* [AB[#15929](https://github.com/newjersey/navigator.business.nj.gov/issues/15929)] alert users to errant dashes ([d0994fa](https://github.com/newjersey/navigator.business.nj.gov/commit/d0994fa570bceb61524c0cb9a61b7d8b9420ad81))
-* [AB[#15961](https://github.com/newjersey/navigator.business.nj.gov/issues/15961)] remove before you start modal from dba formation step 3 ([229c5e7](https://github.com/newjersey/navigator.business.nj.gov/commit/229c5e70e4d3c6f96de9162bf898758cdd35f792))
-* [AB[#15998](https://github.com/newjersey/navigator.business.nj.gov/issues/15998)] add profile icon and remove business link under business dropdown ([fddbb83](https://github.com/newjersey/navigator.business.nj.gov/commit/fddbb8384028ec3cb4693296ded3172ede42de14))
-* [AB[#15998](https://github.com/newjersey/navigator.business.nj.gov/issues/15998)] add profile icon and remove business link under business dropdown ([c905c03](https://github.com/newjersey/navigator.business.nj.gov/commit/c905c0399d33a877f0502d5b3d513618e07707a1))
-* [AB[#15998](https://github.com/newjersey/navigator.business.nj.gov/issues/15998)] add profile icon and remove business link under business dropdown ([830a5f7](https://github.com/newjersey/navigator.business.nj.gov/commit/830a5f74362eadf4aa2f59b15d04102592504808))
-* [AB[#16241](https://github.com/newjersey/navigator.business.nj.gov/issues/16241)] Update analytics for live chat help buttons on non-formation pages ([d3ee442](https://github.com/newjersey/navigator.business.nj.gov/commit/d3ee442acce1d66d4f57d9f008be895e27909c04))
-* [AB[#7845](https://github.com/newjersey/navigator.business.nj.gov/issues/7845)] update header styles and H2 and H3 in CMS ([044a09e](https://github.com/newjersey/navigator.business.nj.gov/commit/044a09ed57aa00e8e88363c14d1af5cd6e485041))
+- [AB#12866](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12866) Remove markdown formatting when searching in search tool ([b224fc1](https://github.com/newjersey/navigator.business.nj.gov/commit/b224fc1f4ef51a5d2031292fb753ea3dd132a828))
+- [AB#14081](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14081) Enhancing Error Handling on X-Ray Status ([#11627](https://github.com/newjersey/navigator.business.nj.gov/issues/11627)) ([4d7d01c](https://github.com/newjersey/navigator.business.nj.gov/commit/4d7d01c14f070ae4baa31252ec2b411450d302f6))
+- [AB#14787](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14787) health check lambda integration for slack cms integrity tests ([664ce1e](https://github.com/newjersey/navigator.business.nj.gov/commit/664ce1e09d584847fef4fa2873486f789f88681d))
+- [AB#15155](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15155) convert alert on business profile page to callout ([ab50089](https://github.com/newjersey/navigator.business.nj.gov/commit/ab50089424336356fb295f704bd6aed0d2e4df42))
+- [AB#15306](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15306) Add remove business modal ([24172fb](https://github.com/newjersey/navigator.business.nj.gov/commit/24172fbac5dd49f6bfc7b736e3b147d03ebca8ce))
+- [AB#15448](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15448) additions to formation business name ([b46cfef](https://github.com/newjersey/navigator.business.nj.gov/commit/b46cfef8ade5cd546fb4732c74cffba952239340))
+- [AB#15515](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15515) add confirmation checks and callout to business formation review ([e78b97c](https://github.com/newjersey/navigator.business.nj.gov/commit/e78b97cd1416b2020cff0ea0aa94f88e5bad8c11))
+- [AB#15822](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15822) add Python script to parse content collections and generate CSV ([df13683](https://github.com/newjersey/navigator.business.nj.gov/commit/df13683317ed6c4d223c328176b498b14df5b5c6))
+- [AB#15885](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15885) add analytics events for cigarette license ([5bd6414](https://github.com/newjersey/navigator.business.nj.gov/commit/5bd64141e9def37273c19c26a62c9252f98f0627))
+- [AB#15921](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15921) adding business name confirmation ([29d8915](https://github.com/newjersey/navigator.business.nj.gov/commit/29d8915c2d7acea9161884a6489a7ba114abe4d4))
+- [AB#15925](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15925) add analytics to Business Name Reservation Selection ([610a011](https://github.com/newjersey/navigator.business.nj.gov/commit/610a01166690b771aba2ac7c51d9b4e249625670))
+- [AB#15926](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15926) updates to license-tasks CMS collection ([8e060bf](https://github.com/newjersey/navigator.business.nj.gov/commit/8e060bfcc842a2f47e4066d457ee64681924d012))
+- [AB#15929](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15929) alert users to errant dashes ([d0994fa](https://github.com/newjersey/navigator.business.nj.gov/commit/d0994fa570bceb61524c0cb9a61b7d8b9420ad81))
+- [AB#15961](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15961) remove before you start modal from dba formation step 3 ([229c5e7](https://github.com/newjersey/navigator.business.nj.gov/commit/229c5e70e4d3c6f96de9162bf898758cdd35f792))
+- [AB#15998](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15998) add profile icon and remove business link under business dropdown ([fddbb83](https://github.com/newjersey/navigator.business.nj.gov/commit/fddbb8384028ec3cb4693296ded3172ede42de14))
+- [AB#15998](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15998) add profile icon and remove business link under business dropdown ([c905c03](https://github.com/newjersey/navigator.business.nj.gov/commit/c905c0399d33a877f0502d5b3d513618e07707a1))
+- [AB#15998](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15998) add profile icon and remove business link under business dropdown ([830a5f7](https://github.com/newjersey/navigator.business.nj.gov/commit/830a5f74362eadf4aa2f59b15d04102592504808))
+- [AB#16241](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/16241) Update analytics for live chat help buttons on non-formation pages ([d3ee442](https://github.com/newjersey/navigator.business.nj.gov/commit/d3ee442acce1d66d4f57d9f008be895e27909c04))
+- [AB#7845](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7845) update header styles and H2 and H3 in CMS ([044a09e](https://github.com/newjersey/navigator.business.nj.gov/commit/044a09ed57aa00e8e88363c14d1af5cd6e485041))
 
 # [2025.20.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.19.0...v2025.20.0) (2025-09-10)
 
-
 ### Bug Fixes
 
-* [AB[#14930](https://github.com/newjersey/navigator.business.nj.gov/issues/14930)] Step 2 Contact name bugfix ([56380d4](https://github.com/newjersey/navigator.business.nj.gov/commit/56380d48bfa80519749852c6e32e4be82f7dc61e))
-* [AB[#14931](https://github.com/newjersey/navigator.business.nj.gov/issues/14931)] correct Suppliers and Start Date Labels ([9a11eda](https://github.com/newjersey/navigator.business.nj.gov/commit/9a11eda25cbe6387d46c44ece6b13dc7c1a1579d))
-* [AB[#14931](https://github.com/newjersey/navigator.business.nj.gov/issues/14931)] label correction for step4 cig license ([ce33bc2](https://github.com/newjersey/navigator.business.nj.gov/commit/ce33bc2d744ad70a2e554cc4e48392af54709936))
-* [AB[#14932](https://github.com/newjersey/navigator.business.nj.gov/issues/14932)] removing false from apiclient ([408de63](https://github.com/newjersey/navigator.business.nj.gov/commit/408de63610acbdecd493cbe56f9515c3583bc9b7))
-* [AB[#15791](https://github.com/newjersey/navigator.business.nj.gov/issues/15791)] add isComplete stepper validation for cigarette license ([#11146](https://github.com/newjersey/navigator.business.nj.gov/issues/11146)) ([41babdb](https://github.com/newjersey/navigator.business.nj.gov/commit/41babdbc854b054f97dc419f607cd0ce4988c3fa))
-* [AB[#15791](https://github.com/newjersey/navigator.business.nj.gov/issues/15791)] cig license E2E ([a9edb35](https://github.com/newjersey/navigator.business.nj.gov/commit/a9edb35ff0c065df848b6ea75934b4d1da02eb0e))
-* [AB[#15791](https://github.com/newjersey/navigator.business.nj.gov/issues/15791)] End to end updates: page jump on alerts, mailing address updates ([16eec7a](https://github.com/newjersey/navigator.business.nj.gov/commit/16eec7a9dbe4570fd0ebe2be6064c9701fef1027))
-* [AB[#15791](https://github.com/newjersey/navigator.business.nj.gov/issues/15791)] format start date on CigLicenseReview ([1957f17](https://github.com/newjersey/navigator.business.nj.gov/commit/1957f1799e10ea574dd69a0f1c0cee538b54d671))
-* [AB[#15791](https://github.com/newjersey/navigator.business.nj.gov/issues/15791)] update cigarette signatures header to h2 ([329ea0e](https://github.com/newjersey/navigator.business.nj.gov/commit/329ea0ea7be15383e36875d4e2cfe2115db203c2))
-* [AB[#15809](https://github.com/newjersey/navigator.business.nj.gov/issues/15809)] force login for cigarette license ([e8c57a1](https://github.com/newjersey/navigator.business.nj.gov/commit/e8c57a1228abaec859d1d06ada09eee736f16787))
-* [AB[#15812](https://github.com/newjersey/navigator.business.nj.gov/issues/15812)] fix locked tax clearance address fields ([a6acc4f](https://github.com/newjersey/navigator.business.nj.gov/commit/a6acc4f01f67cb70d082cb3faea3b39e631a6804))
-* **deps:** update dependency next to v15.4.7 [security] ([56048ca](https://github.com/newjersey/navigator.business.nj.gov/commit/56048ca3126b0c90a3b84c8047c7669e302961b0))
-
+- [AB#14930](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14930) Step 2 Contact name bugfix ([56380d4](https://github.com/newjersey/navigator.business.nj.gov/commit/56380d48bfa80519749852c6e32e4be82f7dc61e))
+- [AB#14931](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14931) correct Suppliers and Start Date Labels ([9a11eda](https://github.com/newjersey/navigator.business.nj.gov/commit/9a11eda25cbe6387d46c44ece6b13dc7c1a1579d))
+- [AB#14931](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14931) label correction for step4 cig license ([ce33bc2](https://github.com/newjersey/navigator.business.nj.gov/commit/ce33bc2d744ad70a2e554cc4e48392af54709936))
+- [AB#14932](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14932) removing false from apiclient ([408de63](https://github.com/newjersey/navigator.business.nj.gov/commit/408de63610acbdecd493cbe56f9515c3583bc9b7))
+- [AB#15791](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15791) add isComplete stepper validation for cigarette license ([#11146](https://github.com/newjersey/navigator.business.nj.gov/issues/11146)) ([41babdb](https://github.com/newjersey/navigator.business.nj.gov/commit/41babdbc854b054f97dc419f607cd0ce4988c3fa))
+- [AB#15791](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15791) cig license E2E ([a9edb35](https://github.com/newjersey/navigator.business.nj.gov/commit/a9edb35ff0c065df848b6ea75934b4d1da02eb0e))
+- [AB#15791](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15791) End to end updates: page jump on alerts, mailing address updates ([16eec7a](https://github.com/newjersey/navigator.business.nj.gov/commit/16eec7a9dbe4570fd0ebe2be6064c9701fef1027))
+- [AB#15791](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15791) format start date on CigLicenseReview ([1957f17](https://github.com/newjersey/navigator.business.nj.gov/commit/1957f1799e10ea574dd69a0f1c0cee538b54d671))
+- [AB#15791](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15791) update cigarette signatures header to h2 ([329ea0e](https://github.com/newjersey/navigator.business.nj.gov/commit/329ea0ea7be15383e36875d4e2cfe2115db203c2))
+- [AB#15809](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15809) force login for cigarette license ([e8c57a1](https://github.com/newjersey/navigator.business.nj.gov/commit/e8c57a1228abaec859d1d06ada09eee736f16787))
+- [AB#15812](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15812) fix locked tax clearance address fields ([a6acc4f](https://github.com/newjersey/navigator.business.nj.gov/commit/a6acc4f01f67cb70d082cb3faea3b39e631a6804))
+- **deps:** update dependency next to v15.4.7 [security] ([56048ca](https://github.com/newjersey/navigator.business.nj.gov/commit/56048ca3126b0c90a3b84c8047c7669e302961b0))
 
 ### Features
 
-* [AB[#13453](https://github.com/newjersey/navigator.business.nj.gov/issues/13453)] cig license payment redirect ([1f14995](https://github.com/newjersey/navigator.business.nj.gov/commit/1f14995d42e2b831e5e60044b6ca14f9b26eefc9))
-* [AB[#14007](https://github.com/newjersey/navigator.business.nj.gov/issues/14007)] lock cig license fields ([7f7b812](https://github.com/newjersey/navigator.business.nj.gov/commit/7f7b81287fdcdf0edb933fb4c8d3e8e775fba0b7))
-* [AB[#14787](https://github.com/newjersey/navigator.business.nj.gov/issues/14787)] create slack messages for CMS integrity tests ([6575321](https://github.com/newjersey/navigator.business.nj.gov/commit/657532170b82e4b02a3f39ea94093b853aeaf6ef))
-* [AB[#14931](https://github.com/newjersey/navigator.business.nj.gov/issues/14931)] step 3 of cigarette license ([6009256](https://github.com/newjersey/navigator.business.nj.gov/commit/6009256f5ed3361014e34250f05e4bdfdf62bbd1))
-* [AB[#14932](https://github.com/newjersey/navigator.business.nj.gov/issues/14932)] Cigarette License Step 4 ([be8a07e](https://github.com/newjersey/navigator.business.nj.gov/commit/be8a07e86603a08a0c77eca8394f1d3b53febe27))
-* [AB[#15109](https://github.com/newjersey/navigator.business.nj.gov/issues/15109)] removed date and profile link from dashbaord ([3d51823](https://github.com/newjersey/navigator.business.nj.gov/commit/3d51823a07c2beff217d9ca5ef0c67bf6ce69b8a))
-* [AB[#15307](https://github.com/newjersey/navigator.business.nj.gov/issues/15307)] remove informational callout from business profile ([233ac42](https://github.com/newjersey/navigator.business.nj.gov/commit/233ac42ae02c255d2a8b1c841fd4e9fadb7bd95a))
-* [AB[#15381](https://github.com/newjersey/navigator.business.nj.gov/issues/15381)] added GA to env perm stepper ([c1610f2](https://github.com/newjersey/navigator.business.nj.gov/commit/c1610f23cbd7646f5aa3b6216a244988db120cf2))
-* [AB[#15656](https://github.com/newjersey/navigator.business.nj.gov/issues/15656)] adding cig license email html ([1e0bef3](https://github.com/newjersey/navigator.business.nj.gov/commit/1e0bef312971311b7c34d240c7ae96e29fe0c432))
-* [AB[#15791](https://github.com/newjersey/navigator.business.nj.gov/issues/15791)] encrypt cig sales tax id ([98e5ad6](https://github.com/newjersey/navigator.business.nj.gov/commit/98e5ad68d2013939b149c133d5a9a0985a6963f0))
-* [AB[#8305](https://github.com/newjersey/navigator.business.nj.gov/issues/8305)] add license checks for architecture and real eastate appraisal ([db36f15](https://github.com/newjersey/navigator.business.nj.gov/commit/db36f15d166fdbd2a6d7d4387df7e20289799823))
+- [AB#13453](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13453) cig license payment redirect ([1f14995](https://github.com/newjersey/navigator.business.nj.gov/commit/1f14995d42e2b831e5e60044b6ca14f9b26eefc9))
+- [AB#14007](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14007) lock cig license fields ([7f7b812](https://github.com/newjersey/navigator.business.nj.gov/commit/7f7b81287fdcdf0edb933fb4c8d3e8e775fba0b7))
+- [AB#14787](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14787) create slack messages for CMS integrity tests ([6575321](https://github.com/newjersey/navigator.business.nj.gov/commit/657532170b82e4b02a3f39ea94093b853aeaf6ef))
+- [AB#14931](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14931) step 3 of cigarette license ([6009256](https://github.com/newjersey/navigator.business.nj.gov/commit/6009256f5ed3361014e34250f05e4bdfdf62bbd1))
+- [AB#14932](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14932) Cigarette License Step 4 ([be8a07e](https://github.com/newjersey/navigator.business.nj.gov/commit/be8a07e86603a08a0c77eca8394f1d3b53febe27))
+- [AB#15109](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15109) removed date and profile link from dashbaord ([3d51823](https://github.com/newjersey/navigator.business.nj.gov/commit/3d51823a07c2beff217d9ca5ef0c67bf6ce69b8a))
+- [AB#15307](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15307) remove informational callout from business profile ([233ac42](https://github.com/newjersey/navigator.business.nj.gov/commit/233ac42ae02c255d2a8b1c841fd4e9fadb7bd95a))
+- [AB#15381](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15381) added GA to env perm stepper ([c1610f2](https://github.com/newjersey/navigator.business.nj.gov/commit/c1610f23cbd7646f5aa3b6216a244988db120cf2))
+- [AB#15656](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15656) adding cig license email html ([1e0bef3](https://github.com/newjersey/navigator.business.nj.gov/commit/1e0bef312971311b7c34d240c7ae96e29fe0c432))
+- [AB#15791](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15791) encrypt cig sales tax id ([98e5ad6](https://github.com/newjersey/navigator.business.nj.gov/commit/98e5ad68d2013939b149c133d5a9a0985a6963f0))
+- [AB#8305](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8305) add license checks for architecture and real eastate appraisal ([db36f15](https://github.com/newjersey/navigator.business.nj.gov/commit/db36f15d166fdbd2a6d7d4387df7e20289799823))
 
 # [2025.19.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.18.0...v2025.19.0) (2025-08-28)
 
-
 ### Features
 
-* [AB[#14930](https://github.com/newjersey/navigator.business.nj.gov/issues/14930)] content fixes for cigarette step 2 ([09cc62b](https://github.com/newjersey/navigator.business.nj.gov/commit/09cc62bf1d0311fe6c946f3dfef4d1ce85b135a2))
-* [AB[#15475](https://github.com/newjersey/navigator.business.nj.gov/issues/15475)] Webflow - update custom dropdown links ([4ec3dc6](https://github.com/newjersey/navigator.business.nj.gov/commit/4ec3dc60c9afb5512be62c5fc1206364361106dc))
-* [AB[#8391](https://github.com/newjersey/navigator.business.nj.gov/issues/8391)] Add analytics events to CMS generated non-essential questions ([0d8ff85](https://github.com/newjersey/navigator.business.nj.gov/commit/0d8ff85eb4f37b49f2f3cb7d5e13a3d1b1376c3f))
+- [AB#14930](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14930) content fixes for cigarette step 2 ([09cc62b](https://github.com/newjersey/navigator.business.nj.gov/commit/09cc62bf1d0311fe6c946f3dfef4d1ce85b135a2))
+- [AB#15475](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15475) Webflow - update custom dropdown links ([4ec3dc6](https://github.com/newjersey/navigator.business.nj.gov/commit/4ec3dc60c9afb5512be62c5fc1206364361106dc))
+- [AB#8391](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8391) Add analytics events to CMS generated non-essential questions ([0d8ff85](https://github.com/newjersey/navigator.business.nj.gov/commit/0d8ff85eb4f37b49f2f3cb7d5e13a3d1b1376c3f))
 
 # [2025.18.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.17.0...v2025.18.0) (2025-08-21)
 
-
 ### Bug Fixes
 
-* [#AB00000] move cig license env vars ([2611b86](https://github.com/newjersey/navigator.business.nj.gov/commit/2611b860b7cd21813f9c0dd7526e95c53c3ba79e)), closes [#AB00000](https://github.com/newjersey/navigator.business.nj.gov/issues/AB00000)
-* [#AB15504] adding ssm setup for cigarette_license_email_confirmation_url ([b86593f](https://github.com/newjersey/navigator.business.nj.gov/commit/b86593fc23e00691a37bd536b488413eab28bc49)), closes [#AB15504](https://github.com/newjersey/navigator.business.nj.gov/issues/AB15504)
-* [#AB15504] adding ssm setup for cigarette_license_email_confirmation_url ([188a0be](https://github.com/newjersey/navigator.business.nj.gov/commit/188a0befae8d16e55d98f66efe86ce812341624d)), closes [#AB15504](https://github.com/newjersey/navigator.business.nj.gov/issues/AB15504)
-* [AB[#14009](https://github.com/newjersey/navigator.business.nj.gov/issues/14009)] update cigLicense submission errors ([6b18da2](https://github.com/newjersey/navigator.business.nj.gov/commit/6b18da2cbd699b1838786b198f4bfa99f6a61f09))
-* [AB[#14388](https://github.com/newjersey/navigator.business.nj.gov/issues/14388)] User can bypass checkboxes on Out-of-State business Onboarding Step 2 ([a0eaa7d](https://github.com/newjersey/navigator.business.nj.gov/commit/a0eaa7d12fe09719cf3b260e22974faeccf9ca80))
-* [AB[#14930](https://github.com/newjersey/navigator.business.nj.gov/issues/14930)] update AddressComponents for CigLicense ([4d28382](https://github.com/newjersey/navigator.business.nj.gov/commit/4d28382d58d510cda2c92ed84b8045089c7b79a7))
-* [AB[#14930](https://github.com/newjersey/navigator.business.nj.gov/issues/14930)] update nj address for cig license ([8b88e62](https://github.com/newjersey/navigator.business.nj.gov/commit/8b88e624b4d004a5144900d49e2296382826a965))
-* [AB[#15313](https://github.com/newjersey/navigator.business.nj.gov/issues/15313)] log firewall errors and fix health check ([cbe814c](https://github.com/newjersey/navigator.business.nj.gov/commit/cbe814c4da80713739ef9da9634abb73ff686932))
-* [AB[#15336](https://github.com/newjersey/navigator.business.nj.gov/issues/15336)] prevent duplicate myNJ self-registration calls ([b8dc0ff](https://github.com/newjersey/navigator.business.nj.gov/commit/b8dc0ff99ed808f7b94acadc6f24e4d46213de5a))
-* [AB[#15336](https://github.com/newjersey/navigator.business.nj.gov/issues/15336)] prevent duplicate myNJ self-registration calls ([ff226cd](https://github.com/newjersey/navigator.business.nj.gov/commit/ff226cd63e97d8faf067d7e88a4e4e386a39aeb7))
-* [AB[#15397](https://github.com/newjersey/navigator.business.nj.gov/issues/15397)] env permit none of the above option and test refactors ([85a733e](https://github.com/newjersey/navigator.business.nj.gov/commit/85a733ed8a50a45381b12e4bff89f7ce29c66b73))
-* [AB[#15504](https://github.com/newjersey/navigator.business.nj.gov/issues/15504)] add cig license env vars to serverless ([7ad529a](https://github.com/newjersey/navigator.business.nj.gov/commit/7ad529af9623636327c96d76c0b8fcd11f9b78a4))
-* non-essential questions ([41aea6d](https://github.com/newjersey/navigator.business.nj.gov/commit/41aea6d6d7097c4bd7aacf9a6d3ce07369273db5))
-* xray timestamp styling ([4004968](https://github.com/newjersey/navigator.business.nj.gov/commit/40049689cb8e991367d961fb11fb43b527f2b1c6))
-
+- [#AB00000] move cig license env vars ([2611b86](https://github.com/newjersey/navigator.business.nj.gov/commit/2611b860b7cd21813f9c0dd7526e95c53c3ba79e)), closes [#AB00000](https://github.com/newjersey/navigator.business.nj.gov/issues/AB00000)
+- [#AB15504] adding ssm setup for cigarette_license_email_confirmation_url ([b86593f](https://github.com/newjersey/navigator.business.nj.gov/commit/b86593fc23e00691a37bd536b488413eab28bc49)), closes [#AB15504](https://github.com/newjersey/navigator.business.nj.gov/issues/AB15504)
+- [#AB15504] adding ssm setup for cigarette_license_email_confirmation_url ([188a0be](https://github.com/newjersey/navigator.business.nj.gov/commit/188a0befae8d16e55d98f66efe86ce812341624d)), closes [#AB15504](https://github.com/newjersey/navigator.business.nj.gov/issues/AB15504)
+- [AB#14009](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14009) update cigLicense submission errors ([6b18da2](https://github.com/newjersey/navigator.business.nj.gov/commit/6b18da2cbd699b1838786b198f4bfa99f6a61f09))
+- [AB#14388](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14388) User can bypass checkboxes on Out-of-State business Onboarding Step 2 ([a0eaa7d](https://github.com/newjersey/navigator.business.nj.gov/commit/a0eaa7d12fe09719cf3b260e22974faeccf9ca80))
+- [AB#14930](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14930) update AddressComponents for CigLicense ([4d28382](https://github.com/newjersey/navigator.business.nj.gov/commit/4d28382d58d510cda2c92ed84b8045089c7b79a7))
+- [AB#14930](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14930) update nj address for cig license ([8b88e62](https://github.com/newjersey/navigator.business.nj.gov/commit/8b88e624b4d004a5144900d49e2296382826a965))
+- [AB#15313](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15313) log firewall errors and fix health check ([cbe814c](https://github.com/newjersey/navigator.business.nj.gov/commit/cbe814c4da80713739ef9da9634abb73ff686932))
+- [AB#15336](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15336) prevent duplicate myNJ self-registration calls ([b8dc0ff](https://github.com/newjersey/navigator.business.nj.gov/commit/b8dc0ff99ed808f7b94acadc6f24e4d46213de5a))
+- [AB#15336](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15336) prevent duplicate myNJ self-registration calls ([ff226cd](https://github.com/newjersey/navigator.business.nj.gov/commit/ff226cd63e97d8faf067d7e88a4e4e386a39aeb7))
+- [AB#15397](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15397) env permit none of the above option and test refactors ([85a733e](https://github.com/newjersey/navigator.business.nj.gov/commit/85a733ed8a50a45381b12e4bff89f7ce29c66b73))
+- [AB#15504](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15504) add cig license env vars to serverless ([7ad529a](https://github.com/newjersey/navigator.business.nj.gov/commit/7ad529af9623636327c96d76c0b8fcd11f9b78a4))
+- non-essential questions ([41aea6d](https://github.com/newjersey/navigator.business.nj.gov/commit/41aea6d6d7097c4bd7aacf9a6d3ce07369273db5))
+- xray timestamp styling ([4004968](https://github.com/newjersey/navigator.business.nj.gov/commit/40049689cb8e991367d961fb11fb43b527f2b1c6))
 
 ### Features
 
-* [#AB15554] cigarette license confirmation page ([9674b75](https://github.com/newjersey/navigator.business.nj.gov/commit/9674b75e2d31197b3c40d4b5ce949d6186d54cbc)), closes [#AB15554](https://github.com/newjersey/navigator.business.nj.gov/issues/AB15554)
-* [AB[#11351](https://github.com/newjersey/navigator.business.nj.gov/issues/11351)] xray registration health check ([fdce5d6](https://github.com/newjersey/navigator.business.nj.gov/commit/fdce5d61a185982895fbd877e73294775a50782b))
-* [AB[#13035](https://github.com/newjersey/navigator.business.nj.gov/issues/13035)] added CMS Preview for Emergency Trip Permit, legal message, self registration ([f1f6bbe](https://github.com/newjersey/navigator.business.nj.gov/commit/f1f6bbec23ab2f6c6bf4726f09061d96db0066cd))
-* [AB[#14009](https://github.com/newjersey/navigator.business.nj.gov/issues/14009)] cig license alert box ([b21b9d3](https://github.com/newjersey/navigator.business.nj.gov/commit/b21b9d341bbb874b4ff6df8a20dc68efb1892485))
-* [AB[#14214](https://github.com/newjersey/navigator.business.nj.gov/issues/14214)] add client/route/helpers for cigarette-license ([ed32106](https://github.com/newjersey/navigator.business.nj.gov/commit/ed3210638a22acac5c3bf88d671d2d5403e63341))
-* [AB[#14772](https://github.com/newjersey/navigator.business.nj.gov/issues/14772)] xray analytics events ([bf3605b](https://github.com/newjersey/navigator.business.nj.gov/commit/bf3605b69d47f9acfe187a360ade00b92e19f6ce))
-* [AB[#14930](https://github.com/newjersey/navigator.business.nj.gov/issues/14930)] lock state input for business address in cigarette step 2 ([e8bd56f](https://github.com/newjersey/navigator.business.nj.gov/commit/e8bd56f33b15bd7b7cb756a608f69f320cddfe4f))
-* [AB[#14930](https://github.com/newjersey/navigator.business.nj.gov/issues/14930)] step 2 of cigarette license ([e0c8ef2](https://github.com/newjersey/navigator.business.nj.gov/commit/e0c8ef258b9816fa67dd9f4a93471c03aba8fff2))
-* [AB[#15038](https://github.com/newjersey/navigator.business.nj.gov/issues/15038)] added miniCallout to the CMS ([922be8a](https://github.com/newjersey/navigator.business.nj.gov/commit/922be8a84414166d4f6d599b13cdb3031b374000))
-* [AB[#15038](https://github.com/newjersey/navigator.business.nj.gov/issues/15038)] renamed callout to largeCallout throughout the code base ([5bd4cee](https://github.com/newjersey/navigator.business.nj.gov/commit/5bd4cee967b6dcb1fc2aeebb4241508a4b182363))
-* [AB[#6519](https://github.com/newjersey/navigator.business.nj.gov/issues/6519)] dental waste & addOnWhenNo ([4ebfdf6](https://github.com/newjersey/navigator.business.nj.gov/commit/4ebfdf67e805fa55fd48f4e0fa983abecde3b301))
-* [AB[#8748](https://github.com/newjersey/navigator.business.nj.gov/issues/8748)] added timestamp to status check of xray ([1ed1a5d](https://github.com/newjersey/navigator.business.nj.gov/commit/1ed1a5dc94c17bd68d9d24d12f551f5fdc6747bb))
+- [#AB15554] cigarette license confirmation page ([9674b75](https://github.com/newjersey/navigator.business.nj.gov/commit/9674b75e2d31197b3c40d4b5ce949d6186d54cbc)), closes [#AB15554](https://github.com/newjersey/navigator.business.nj.gov/issues/AB15554)
+- [AB#11351](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/11351) xray registration health check ([fdce5d6](https://github.com/newjersey/navigator.business.nj.gov/commit/fdce5d61a185982895fbd877e73294775a50782b))
+- [AB#13035](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13035) added CMS Preview for Emergency Trip Permit, legal message, self registration ([f1f6bbe](https://github.com/newjersey/navigator.business.nj.gov/commit/f1f6bbec23ab2f6c6bf4726f09061d96db0066cd))
+- [AB#14009](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14009) cig license alert box ([b21b9d3](https://github.com/newjersey/navigator.business.nj.gov/commit/b21b9d341bbb874b4ff6df8a20dc68efb1892485))
+- [AB#14214](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14214) add client/route/helpers for cigarette-license ([ed32106](https://github.com/newjersey/navigator.business.nj.gov/commit/ed3210638a22acac5c3bf88d671d2d5403e63341))
+- [AB#14772](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14772) xray analytics events ([bf3605b](https://github.com/newjersey/navigator.business.nj.gov/commit/bf3605b69d47f9acfe187a360ade00b92e19f6ce))
+- [AB#14930](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14930) lock state input for business address in cigarette step 2 ([e8bd56f](https://github.com/newjersey/navigator.business.nj.gov/commit/e8bd56f33b15bd7b7cb756a608f69f320cddfe4f))
+- [AB#14930](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14930) step 2 of cigarette license ([e0c8ef2](https://github.com/newjersey/navigator.business.nj.gov/commit/e0c8ef258b9816fa67dd9f4a93471c03aba8fff2))
+- [AB#15038](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15038) added miniCallout to the CMS ([922be8a](https://github.com/newjersey/navigator.business.nj.gov/commit/922be8a84414166d4f6d599b13cdb3031b374000))
+- [AB#15038](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15038) renamed callout to largeCallout throughout the code base ([5bd4cee](https://github.com/newjersey/navigator.business.nj.gov/commit/5bd4cee967b6dcb1fc2aeebb4241508a4b182363))
+- [AB#6519](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/6519) dental waste & addOnWhenNo ([4ebfdf6](https://github.com/newjersey/navigator.business.nj.gov/commit/4ebfdf67e805fa55fd48f4e0fa983abecde3b301))
+- [AB#8748](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8748) added timestamp to status check of xray ([1ed1a5d](https://github.com/newjersey/navigator.business.nj.gov/commit/1ed1a5dc94c17bd68d9d24d12f551f5fdc6747bb))
 
 # [2025.17.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.16.0...v2025.17.0) (2025-07-31)
 
-
 ### Bug Fixes
 
-* [AB[#14389](https://github.com/newjersey/navigator.business.nj.gov/issues/14389)] Replace snack bar with page level error on onboarding ([ab54ab7](https://github.com/newjersey/navigator.business.nj.gov/commit/ab54ab7ebd3a32941927fc244517f7a2384a74b1))
-* [AB[#14929](https://github.com/newjersey/navigator.business.nj.gov/issues/14929)] remove unused alert body field from cms ([fcb693c](https://github.com/newjersey/navigator.business.nj.gov/commit/fcb693c3db91db3ae28b34cbe5f755639db6d764))
-* [AB[#14930](https://github.com/newjersey/navigator.business.nj.gov/issues/14930)] flatten cigarette license object ([efa0b7e](https://github.com/newjersey/navigator.business.nj.gov/commit/efa0b7ee1a44784311b0b04bf2112bd877908d53))
-* [AB[#15014](https://github.com/newjersey/navigator.business.nj.gov/issues/15014)] Resolve Untracked Sections in CMS ([c2f3f02](https://github.com/newjersey/navigator.business.nj.gov/commit/c2f3f0295d9d8822c3cf4df5e92ba75d5263061f))
-* [AB[#15014](https://github.com/newjersey/navigator.business.nj.gov/issues/15014)] Resolve Untracked Sections in CMS ([4aef9bf](https://github.com/newjersey/navigator.business.nj.gov/commit/4aef9bf6ace0271b027b63454a5ffea3d9272e94))
-* [AB[#7218](https://github.com/newjersey/navigator.business.nj.gov/issues/7218)] content updates for env permit ([45ba861](https://github.com/newjersey/navigator.business.nj.gov/commit/45ba861cca3f32a9dcf8a7ab28d51c6e35d15dad))
-* added ERISA to cspell words ([15498c6](https://github.com/newjersey/navigator.business.nj.gov/commit/15498c6de0b050d6583b753541bd279c51035ae8))
-* **deps:** update dependency axios to v1.11.0 [security] ([f54ffe7](https://github.com/newjersey/navigator.business.nj.gov/commit/f54ffe74e359cc4cc39c89df959ca88427db19e3))
-
+- [AB#14389](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14389) Replace snack bar with page level error on onboarding ([ab54ab7](https://github.com/newjersey/navigator.business.nj.gov/commit/ab54ab7ebd3a32941927fc244517f7a2384a74b1))
+- [AB#14929](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14929) remove unused alert body field from cms ([fcb693c](https://github.com/newjersey/navigator.business.nj.gov/commit/fcb693c3db91db3ae28b34cbe5f755639db6d764))
+- [AB#14930](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14930) flatten cigarette license object ([efa0b7e](https://github.com/newjersey/navigator.business.nj.gov/commit/efa0b7ee1a44784311b0b04bf2112bd877908d53))
+- [AB#15014](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15014) Resolve Untracked Sections in CMS ([c2f3f02](https://github.com/newjersey/navigator.business.nj.gov/commit/c2f3f0295d9d8822c3cf4df5e92ba75d5263061f))
+- [AB#15014](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15014) Resolve Untracked Sections in CMS ([4aef9bf](https://github.com/newjersey/navigator.business.nj.gov/commit/4aef9bf6ace0271b027b63454a5ffea3d9272e94))
+- [AB#7218](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7218) content updates for env permit ([45ba861](https://github.com/newjersey/navigator.business.nj.gov/commit/45ba861cca3f32a9dcf8a7ab28d51c6e35d15dad))
+- added ERISA to cspell words ([15498c6](https://github.com/newjersey/navigator.business.nj.gov/commit/15498c6de0b050d6583b753541bd279c51035ae8))
+- **deps:** update dependency axios to v1.11.0 [security] ([f54ffe7](https://github.com/newjersey/navigator.business.nj.gov/commit/f54ffe74e359cc4cc39c89df959ca88427db19e3))
 
 ### Features
 
-* [AB[#13035](https://github.com/newjersey/navigator.business.nj.gov/issues/13035)] Preview Improvements, Formation Date Deletion Modal ([4987f8e](https://github.com/newjersey/navigator.business.nj.gov/commit/4987f8e026903f144f3f69661a8e87a65ed1921b))
-* [AB[#13035](https://github.com/newjersey/navigator.business.nj.gov/issues/13035)] Preview Improvements, NJEDA and Email Login Check ([5dd8611](https://github.com/newjersey/navigator.business.nj.gov/commit/5dd86110e81e653f148478faa856231f27d58184))
-* [AB[#13035](https://github.com/newjersey/navigator.business.nj.gov/issues/13035)] Preview Improvements, starter kits page ([8c92af1](https://github.com/newjersey/navigator.business.nj.gov/commit/8c92af18110f714a6eeb5371f0305f9c1698513b))
-* [AB[#13423](https://github.com/newjersey/navigator.business.nj.gov/issues/13423)] fixed registration status enablement ([b3a1a47](https://github.com/newjersey/navigator.business.nj.gov/commit/b3a1a4767d8e94c8615515d0a0aa582d6638f907))
-* [AB[#13902](https://github.com/newjersey/navigator.business.nj.gov/issues/13902)] Add Tax Clearance Cypress Test ([977b341](https://github.com/newjersey/navigator.business.nj.gov/commit/977b341e8ae0231591c3732b684f2525955a4e4f))
-* [AB[#14389](https://github.com/newjersey/navigator.business.nj.gov/issues/14389)] Replace snack bar with page level error on onboarding ([036cfff](https://github.com/newjersey/navigator.business.nj.gov/commit/036cfffac8810ff45644689ee3148cb040dca5c6))
-* [AB[#15159](https://github.com/newjersey/navigator.business.nj.gov/issues/15159)] add non-essential questions to industry sectors ([d05e044](https://github.com/newjersey/navigator.business.nj.gov/commit/d05e044bdf9b68a28ade2d5134e0e2902f9aa96a))
+- [AB#13035](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13035) Preview Improvements, Formation Date Deletion Modal ([4987f8e](https://github.com/newjersey/navigator.business.nj.gov/commit/4987f8e026903f144f3f69661a8e87a65ed1921b))
+- [AB#13035](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13035) Preview Improvements, NJEDA and Email Login Check ([5dd8611](https://github.com/newjersey/navigator.business.nj.gov/commit/5dd86110e81e653f148478faa856231f27d58184))
+- [AB#13035](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13035) Preview Improvements, starter kits page ([8c92af1](https://github.com/newjersey/navigator.business.nj.gov/commit/8c92af18110f714a6eeb5371f0305f9c1698513b))
+- [AB#13423](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13423) fixed registration status enablement ([b3a1a47](https://github.com/newjersey/navigator.business.nj.gov/commit/b3a1a4767d8e94c8615515d0a0aa582d6638f907))
+- [AB#13902](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13902) Add Tax Clearance Cypress Test ([977b341](https://github.com/newjersey/navigator.business.nj.gov/commit/977b341e8ae0231591c3732b684f2525955a4e4f))
+- [AB#14389](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14389) Replace snack bar with page level error on onboarding ([036cfff](https://github.com/newjersey/navigator.business.nj.gov/commit/036cfffac8810ff45644689ee3148cb040dca5c6))
+- [AB#15159](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15159) add non-essential questions to industry sectors ([d05e044](https://github.com/newjersey/navigator.business.nj.gov/commit/d05e044bdf9b68a28ade2d5134e0e2902f9aa96a))
 
 # [2025.16.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.15.1...v2025.16.0) (2025-07-21)
 
-
 ### Bug Fixes
 
-* [AB[#14397](https://github.com/newjersey/navigator.business.nj.gov/issues/14397)] updates from content ([ec91b72](https://github.com/newjersey/navigator.business.nj.gov/commit/ec91b72cbf0f9ffa2ad209f760e4e63222d4daee))
-* [AB[#15189](https://github.com/newjersey/navigator.business.nj.gov/issues/15189)] changing formatting for tax clearance error message ([ee9cf42](https://github.com/newjersey/navigator.business.nj.gov/commit/ee9cf4284c233e4008229fc2fe0ba994ae286cfb))
-* [AB[#15204](https://github.com/newjersey/navigator.business.nj.gov/issues/15204)] Add callout to Step 3 of Emergency Trip Permit ([1675d4b](https://github.com/newjersey/navigator.business.nj.gov/commit/1675d4bb1a32a8cf0c2a5c4958f7f0f5d1ec16b9))
-* [AB[#15241](https://github.com/newjersey/navigator.business.nj.gov/issues/15241)] define formation contact email as user's email ([33a907c](https://github.com/newjersey/navigator.business.nj.gov/commit/33a907c2f034c3cd90fad2ddbd40479941570fb7))
-* [AB[#7218](https://github.com/newjersey/navigator.business.nj.gov/issues/7218)] content, reroute, and stepper update ([27ecad3](https://github.com/newjersey/navigator.business.nj.gov/commit/27ecad3dddaf67c1f19df7b8de0c9e65d4f9cc77))
-* **deps:** update aws-sdk ([2085321](https://github.com/newjersey/navigator.business.nj.gov/commit/2085321077d41613a8123cc3eb3a0de67118c679))
-* **deps:** update dependency @emotion/styled to v11.14.1 ([4d7bc2f](https://github.com/newjersey/navigator.business.nj.gov/commit/4d7bc2fe76b232bbf9a260a0565e97130ba28e5c))
-* **deps:** update dependency aws-amplify to v6.15.3 ([ae6f4a0](https://github.com/newjersey/navigator.business.nj.gov/commit/ae6f4a021caaf0acc5de7c9ecab7a6c66536237f))
-* **deps:** update dependency axios to v1.10.0 ([73ce9ac](https://github.com/newjersey/navigator.business.nj.gov/commit/73ce9ac6fd2575753db00034d3bbe7224b946ec4))
-* **deps:** update dependency next-seo to v6.8.0 ([cf3d1d9](https://github.com/newjersey/navigator.business.nj.gov/commit/cf3d1d9a062c8a87d1109ebd637d8d2ef8cf3bd7))
-* **deps:** update material-ui ([e33ff33](https://github.com/newjersey/navigator.business.nj.gov/commit/e33ff33b10b10825a9ce19809aea63476402cada))
-* **deps:** update nextjs monorepo to v15.3.5 ([8d8ec0f](https://github.com/newjersey/navigator.business.nj.gov/commit/8d8ec0fa35691ce35a45e283578e543590e006e1))
-* merge conflict ([1c4fb65](https://github.com/newjersey/navigator.business.nj.gov/commit/1c4fb65f318dc46f380cafaecc521d5070a6e7f2))
-* remove duplicate CMS config field ([0fb0c0c](https://github.com/newjersey/navigator.business.nj.gov/commit/0fb0c0ca4b6e803128a6f29870d1e254e5666c83))
-
+- [AB#14397](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14397) updates from content ([ec91b72](https://github.com/newjersey/navigator.business.nj.gov/commit/ec91b72cbf0f9ffa2ad209f760e4e63222d4daee))
+- [AB#15189](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15189) changing formatting for tax clearance error message ([ee9cf42](https://github.com/newjersey/navigator.business.nj.gov/commit/ee9cf4284c233e4008229fc2fe0ba994ae286cfb))
+- [AB#15204](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15204) Add callout to Step 3 of Emergency Trip Permit ([1675d4b](https://github.com/newjersey/navigator.business.nj.gov/commit/1675d4bb1a32a8cf0c2a5c4958f7f0f5d1ec16b9))
+- [AB#15241](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15241) define formation contact email as user's email ([33a907c](https://github.com/newjersey/navigator.business.nj.gov/commit/33a907c2f034c3cd90fad2ddbd40479941570fb7))
+- [AB#7218](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7218) content, reroute, and stepper update ([27ecad3](https://github.com/newjersey/navigator.business.nj.gov/commit/27ecad3dddaf67c1f19df7b8de0c9e65d4f9cc77))
+- **deps:** update aws-sdk ([2085321](https://github.com/newjersey/navigator.business.nj.gov/commit/2085321077d41613a8123cc3eb3a0de67118c679))
+- **deps:** update dependency @emotion/styled to v11.14.1 ([4d7bc2f](https://github.com/newjersey/navigator.business.nj.gov/commit/4d7bc2fe76b232bbf9a260a0565e97130ba28e5c))
+- **deps:** update dependency aws-amplify to v6.15.3 ([ae6f4a0](https://github.com/newjersey/navigator.business.nj.gov/commit/ae6f4a021caaf0acc5de7c9ecab7a6c66536237f))
+- **deps:** update dependency axios to v1.10.0 ([73ce9ac](https://github.com/newjersey/navigator.business.nj.gov/commit/73ce9ac6fd2575753db00034d3bbe7224b946ec4))
+- **deps:** update dependency next-seo to v6.8.0 ([cf3d1d9](https://github.com/newjersey/navigator.business.nj.gov/commit/cf3d1d9a062c8a87d1109ebd637d8d2ef8cf3bd7))
+- **deps:** update material-ui ([e33ff33](https://github.com/newjersey/navigator.business.nj.gov/commit/e33ff33b10b10825a9ce19809aea63476402cada))
+- **deps:** update nextjs monorepo to v15.3.5 ([8d8ec0f](https://github.com/newjersey/navigator.business.nj.gov/commit/8d8ec0fa35691ce35a45e283578e543590e006e1))
+- merge conflict ([1c4fb65](https://github.com/newjersey/navigator.business.nj.gov/commit/1c4fb65f318dc46f380cafaecc521d5070a6e7f2))
+- remove duplicate CMS config field ([0fb0c0c](https://github.com/newjersey/navigator.business.nj.gov/commit/0fb0c0ca4b6e803128a6f29870d1e254e5666c83))
 
 ### Features
 
-* [AB[#14929](https://github.com/newjersey/navigator.business.nj.gov/issues/14929)] step 1 of cigarette license ([#10716](https://github.com/newjersey/navigator.business.nj.gov/issues/10716)) ([8040d04](https://github.com/newjersey/navigator.business.nj.gov/commit/8040d047e585d2a367f187afbb533808b6567125))
-* [AB[#14974](https://github.com/newjersey/navigator.business.nj.gov/issues/14974)] Personalize My Experience CTA ([3922d09](https://github.com/newjersey/navigator.business.nj.gov/commit/3922d09d6374236539c64aa384d72b194408228f))
-* [AB[#15108](https://github.com/newjersey/navigator.business.nj.gov/issues/15108)] Remove home-based business question from dashboard ([a98b2a2](https://github.com/newjersey/navigator.business.nj.gov/commit/a98b2a299ddd99016564a97c9bf22226aa98b2ae))
-* [AB[#15159](https://github.com/newjersey/navigator.business.nj.gov/issues/15159)] add anytime actions based on non-essential questions ([15fb2bd](https://github.com/newjersey/navigator.business.nj.gov/commit/15fb2bdd7a7bd8580b2110a93b143cc464696596))
-* [AB[#15159](https://github.com/newjersey/navigator.business.nj.gov/issues/15159)] remove anytime actions when users answer 'no' to non-essential questions ([ad3b2de](https://github.com/newjersey/navigator.business.nj.gov/commit/ad3b2de30930e000a8b5779251991cc4f4adae82))
-* [AB[#15225](https://github.com/newjersey/navigator.business.nj.gov/issues/15225)] Add python script for generating a contextual information ([c7f7d47](https://github.com/newjersey/navigator.business.nj.gov/commit/c7f7d479c804f072977ab3382a461437ddd45d2e))
-* [AB[#7218](https://github.com/newjersey/navigator.business.nj.gov/issues/7218)] multi step env permit ([963304f](https://github.com/newjersey/navigator.business.nj.gov/commit/963304fc6b751fbddca39d122d489c0f8547e3a0))
+- [AB#14929](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14929) step 1 of cigarette license ([#10716](https://github.com/newjersey/navigator.business.nj.gov/issues/10716)) ([8040d04](https://github.com/newjersey/navigator.business.nj.gov/commit/8040d047e585d2a367f187afbb533808b6567125))
+- [AB#14974](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14974) Personalize My Experience CTA ([3922d09](https://github.com/newjersey/navigator.business.nj.gov/commit/3922d09d6374236539c64aa384d72b194408228f))
+- [AB#15108](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15108) Remove home-based business question from dashboard ([a98b2a2](https://github.com/newjersey/navigator.business.nj.gov/commit/a98b2a299ddd99016564a97c9bf22226aa98b2ae))
+- [AB#15159](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15159) add anytime actions based on non-essential questions ([15fb2bd](https://github.com/newjersey/navigator.business.nj.gov/commit/15fb2bdd7a7bd8580b2110a93b143cc464696596))
+- [AB#15159](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15159) remove anytime actions when users answer 'no' to non-essential questions ([ad3b2de](https://github.com/newjersey/navigator.business.nj.gov/commit/ad3b2de30930e000a8b5779251991cc4f4adae82))
+- [AB#15225](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15225) Add python script for generating a contextual information ([c7f7d47](https://github.com/newjersey/navigator.business.nj.gov/commit/c7f7d479c804f072977ab3382a461437ddd45d2e))
+- [AB#7218](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7218) multi step env permit ([963304f](https://github.com/newjersey/navigator.business.nj.gov/commit/963304fc6b751fbddca39d122d489c0f8547e3a0))
 
 ## [2025.15.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.15.0...v2025.15.1) (2025-07-18)
 
-
 ### Bug Fixes
 
-* [AB[#15241](https://github.com/newjersey/navigator.business.nj.gov/issues/15241)] define formation contact email as user's email ([6dca238](https://github.com/newjersey/navigator.business.nj.gov/commit/6dca238f92e965aa05d5c92892fb848d950bfd78))
+- [AB#15241](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15241) define formation contact email as user's email ([6dca238](https://github.com/newjersey/navigator.business.nj.gov/commit/6dca238f92e965aa05d5c92892fb848d950bfd78))
 
 # [2025.15.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.14.0...v2025.15.0) (2025-07-17)
 
-
 ### Bug Fixes
 
-* [AB[#14397](https://github.com/newjersey/navigator.business.nj.gov/issues/14397)] Address design and content discrepancies for new registered agent content ([05531f8](https://github.com/newjersey/navigator.business.nj.gov/commit/05531f80308e47d359270ec81447e65ba419897f))
-* [AB[#14397](https://github.com/newjersey/navigator.business.nj.gov/issues/14397)] migration 167 to include business version ([76abaa4](https://github.com/newjersey/navigator.business.nj.gov/commit/76abaa4cf0e456520a40f1f6c070f9da540b2b27))
-* [AB[#14397](https://github.com/newjersey/navigator.business.nj.gov/issues/14397)] update migration to follow generator pattern ([7750125](https://github.com/newjersey/navigator.business.nj.gov/commit/775012571409726eb90c078ba59b0fc2bc937b3f))
-* [AB[#14619](https://github.com/newjersey/navigator.business.nj.gov/issues/14619)] alert pops up for reference numbers ([e2defb6](https://github.com/newjersey/navigator.business.nj.gov/commit/e2defb62f6df5c19b416bd27d29dc92881ab89ab))
-* [AB[#14619](https://github.com/newjersey/navigator.business.nj.gov/issues/14619)] fix error copy ([05b98b0](https://github.com/newjersey/navigator.business.nj.gov/commit/05b98b0fd177e8d17a9a00271ade21b8bf0f13f2))
-* [AB[#14619](https://github.com/newjersey/navigator.business.nj.gov/issues/14619)] Replace error snackbar with page level alert on Business Profile page ([c13a7bb](https://github.com/newjersey/navigator.business.nj.gov/commit/c13a7bb72906817b010d191e95a65a2ba4a00b88))
-* [AB[#15167](https://github.com/newjersey/navigator.business.nj.gov/issues/15167)] fix copy in emergency permit ([aef5741](https://github.com/newjersey/navigator.business.nj.gov/commit/aef57419460c9d6699ef204e79777db42c4798aa))
-* Refine contactEmail in Formation API request and update test ([a9aa096](https://github.com/newjersey/navigator.business.nj.gov/commit/a9aa0962f304f884e8f49c8fc90bbfdbab3acc9c))
-* resolve webservice/formation bug ([0ef8837](https://github.com/newjersey/navigator.business.nj.gov/commit/0ef88379b6ad08ef0e1e2149cb39cac60ffde3d8))
-
+- [AB#14397](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14397) Address design and content discrepancies for new registered agent content ([05531f8](https://github.com/newjersey/navigator.business.nj.gov/commit/05531f80308e47d359270ec81447e65ba419897f))
+- [AB#14397](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14397) migration 167 to include business version ([76abaa4](https://github.com/newjersey/navigator.business.nj.gov/commit/76abaa4cf0e456520a40f1f6c070f9da540b2b27))
+- [AB#14397](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14397) update migration to follow generator pattern ([7750125](https://github.com/newjersey/navigator.business.nj.gov/commit/775012571409726eb90c078ba59b0fc2bc937b3f))
+- [AB#14619](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14619) alert pops up for reference numbers ([e2defb6](https://github.com/newjersey/navigator.business.nj.gov/commit/e2defb62f6df5c19b416bd27d29dc92881ab89ab))
+- [AB#14619](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14619) fix error copy ([05b98b0](https://github.com/newjersey/navigator.business.nj.gov/commit/05b98b0fd177e8d17a9a00271ade21b8bf0f13f2))
+- [AB#14619](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14619) Replace error snackbar with page level alert on Business Profile page ([c13a7bb](https://github.com/newjersey/navigator.business.nj.gov/commit/c13a7bb72906817b010d191e95a65a2ba4a00b88))
+- [AB#15167](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15167) fix copy in emergency permit ([aef5741](https://github.com/newjersey/navigator.business.nj.gov/commit/aef57419460c9d6699ef204e79777db42c4798aa))
+- Refine contactEmail in Formation API request and update test ([a9aa096](https://github.com/newjersey/navigator.business.nj.gov/commit/a9aa0962f304f884e8f49c8fc90bbfdbab3acc9c))
+- resolve webservice/formation bug ([0ef8837](https://github.com/newjersey/navigator.business.nj.gov/commit/0ef88379b6ad08ef0e1e2149cb39cac60ffde3d8))
 
 ### Features
 
-* [AB[#14270](https://github.com/newjersey/navigator.business.nj.gov/issues/14270)] fixing broken analytics ([227db94](https://github.com/newjersey/navigator.business.nj.gov/commit/227db947c5c4c935c4f76077be8de1ec9b3d7f65))
-* [AB[#14397](https://github.com/newjersey/navigator.business.nj.gov/issues/14397)] Update Registered Agent fields in the formation form to accept 'myself' 'authorized rep' or 'professional service' options ([b41ed7a](https://github.com/newjersey/navigator.business.nj.gov/commit/b41ed7a27349eb8e34cb3e0c40756778906d23a7))
-* [AB[#14934](https://github.com/newjersey/navigator.business.nj.gov/issues/14934)] add business name contextual link ([d063f38](https://github.com/newjersey/navigator.business.nj.gov/commit/d063f380bd8c34b142fabd0de576a8e42368e389))
-* [AB[#15150](https://github.com/newjersey/navigator.business.nj.gov/issues/15150)] add cigarette license data object ([389a046](https://github.com/newjersey/navigator.business.nj.gov/commit/389a046a2d97ebad0dcadbaed72bb7b6e8d8a76b))
-* [AB[#7340](https://github.com/newjersey/navigator.business.nj.gov/issues/7340)] search for usage(s) of tasks ([6411731](https://github.com/newjersey/navigator.business.nj.gov/commit/6411731a95f2946d3a899211b93475a1e46815d6))
+- [AB#14270](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14270) fixing broken analytics ([227db94](https://github.com/newjersey/navigator.business.nj.gov/commit/227db947c5c4c935c4f76077be8de1ec9b3d7f65))
+- [AB#14397](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14397) Update Registered Agent fields in the formation form to accept 'myself' 'authorized rep' or 'professional service' options ([b41ed7a](https://github.com/newjersey/navigator.business.nj.gov/commit/b41ed7a27349eb8e34cb3e0c40756778906d23a7))
+- [AB#14934](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14934) add business name contextual link ([d063f38](https://github.com/newjersey/navigator.business.nj.gov/commit/d063f380bd8c34b142fabd0de576a8e42368e389))
+- [AB#15150](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/15150) add cigarette license data object ([389a046](https://github.com/newjersey/navigator.business.nj.gov/commit/389a046a2d97ebad0dcadbaed72bb7b6e8d8a76b))
+- [AB#7340](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7340) search for usage(s) of tasks ([6411731](https://github.com/newjersey/navigator.business.nj.gov/commit/6411731a95f2946d3a899211b93475a1e46815d6))
 
 # [2025.14.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.13.2...v2025.14.0) (2025-07-08)
 
-
 ### Bug Fixes
 
-* [AB[#114979](https://github.com/newjersey/navigator.business.nj.gov/issues/114979)] prevent 'details?.toJSON is not a function' error ([5d2402d](https://github.com/newjersey/navigator.business.nj.gov/commit/5d2402d514c0cbe34c24b3356c9497bd8076ad61))
-* [AB[#14383](https://github.com/newjersey/navigator.business.nj.gov/issues/14383)] fix accordion date of formation bug ([401f04f](https://github.com/newjersey/navigator.business.nj.gov/commit/401f04f74edd330f5d5eed16ad9f625416b5bba0))
-* [AB[#14384](https://github.com/newjersey/navigator.business.nj.gov/issues/14384)] Change error placement for personalize my tasks tab ([2cdb460](https://github.com/newjersey/navigator.business.nj.gov/commit/2cdb46053c05d0398fc3f60e065870eca5b36482))
-* [AB[#14796](https://github.com/newjersey/navigator.business.nj.gov/issues/14796)] Change copy from Personalize My Tasks to Personalize My Experience ([29c5968](https://github.com/newjersey/navigator.business.nj.gov/commit/29c59684bdfff0c0152cfd891ae8b6d029868cb4))
-* fix failing reseller test ([d93c6fc](https://github.com/newjersey/navigator.business.nj.gov/commit/d93c6fcdc9365e7938afee76d3419bb3b023c730))
-
+- [AB#114979](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/114979) prevent 'details?.toJSON is not a function' error ([5d2402d](https://github.com/newjersey/navigator.business.nj.gov/commit/5d2402d514c0cbe34c24b3356c9497bd8076ad61))
+- [AB#14383](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14383) fix accordion date of formation bug ([401f04f](https://github.com/newjersey/navigator.business.nj.gov/commit/401f04f74edd330f5d5eed16ad9f625416b5bba0))
+- [AB#14384](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14384) Change error placement for personalize my tasks tab ([2cdb460](https://github.com/newjersey/navigator.business.nj.gov/commit/2cdb46053c05d0398fc3f60e065870eca5b36482))
+- [AB#14796](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14796) Change copy from Personalize My Tasks to Personalize My Experience ([29c5968](https://github.com/newjersey/navigator.business.nj.gov/commit/29c59684bdfff0c0152cfd891ae8b6d029868cb4))
+- fix failing reseller test ([d93c6fc](https://github.com/newjersey/navigator.business.nj.gov/commit/d93c6fcdc9365e7938afee76d3419bb3b023c730))
 
 ### Features
 
-* [#AB14918] [#AB12944] refactor govt contracting anytime action and remove alerts ([8d465bf](https://github.com/newjersey/navigator.business.nj.gov/commit/8d465bf643977cb9d05297071b94ef4951bc0b11)), closes [#AB14918](https://github.com/newjersey/navigator.business.nj.gov/issues/AB14918) [#AB12944](https://github.com/newjersey/navigator.business.nj.gov/issues/AB12944)
-* [#AB15063] manage business vehicle cta updated to use primary button ([1f712b3](https://github.com/newjersey/navigator.business.nj.gov/commit/1f712b393d327fbc95a54d3bc10ac595f8d5e18e)), closes [#AB15063](https://github.com/newjersey/navigator.business.nj.gov/issues/AB15063)
-* [AB[#14132](https://github.com/newjersey/navigator.business.nj.gov/issues/14132)] add manage business vehicles task page ([ec4f64a](https://github.com/newjersey/navigator.business.nj.gov/commit/ec4f64a9cf67bec9309914135dd82efbfbd86c16))
-* [AB[#14383](https://github.com/newjersey/navigator.business.nj.gov/issues/14383)] Implement Add Your Annual Report Deadline ([9dd1fe3](https://github.com/newjersey/navigator.business.nj.gov/commit/9dd1fe3ee91610c4a29a4c1e72436e347d9f9aec))
-* [AB[#14384](https://github.com/newjersey/navigator.business.nj.gov/issues/14384)] Add certifications and funding accordion details ([9f89c53](https://github.com/newjersey/navigator.business.nj.gov/commit/9f89c5352bad7e78caf54e13d1ada453dacc7160))
-* [AB[#14869](https://github.com/newjersey/navigator.business.nj.gov/issues/14869)] Add links to CMS search results ([ae2115e](https://github.com/newjersey/navigator.business.nj.gov/commit/ae2115e84fdee6700abe55ad9d088207230e0b23))
-* [AB[#14870](https://github.com/newjersey/navigator.business.nj.gov/issues/14870)] add loading spinner to tax clearance ([1b9ecd0](https://github.com/newjersey/navigator.business.nj.gov/commit/1b9ecd04a3cb329fbf3404ebe5f61f5052194781))
-* [AB[#14933](https://github.com/newjersey/navigator.business.nj.gov/issues/14933)] unlink taxId function in Dev ([a3bb10b](https://github.com/newjersey/navigator.business.nj.gov/commit/a3bb10ba689770abbc3492b3669ac60d8acd07fb))
+- [#AB14918] [#AB12944] refactor govt contracting anytime action and remove alerts ([8d465bf](https://github.com/newjersey/navigator.business.nj.gov/commit/8d465bf643977cb9d05297071b94ef4951bc0b11)), closes [#AB14918](https://github.com/newjersey/navigator.business.nj.gov/issues/AB14918) [#AB12944](https://github.com/newjersey/navigator.business.nj.gov/issues/AB12944)
+- [#AB15063] manage business vehicle cta updated to use primary button ([1f712b3](https://github.com/newjersey/navigator.business.nj.gov/commit/1f712b393d327fbc95a54d3bc10ac595f8d5e18e)), closes [#AB15063](https://github.com/newjersey/navigator.business.nj.gov/issues/AB15063)
+- [AB#14132](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14132) add manage business vehicles task page ([ec4f64a](https://github.com/newjersey/navigator.business.nj.gov/commit/ec4f64a9cf67bec9309914135dd82efbfbd86c16))
+- [AB#14383](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14383) Implement Add Your Annual Report Deadline ([9dd1fe3](https://github.com/newjersey/navigator.business.nj.gov/commit/9dd1fe3ee91610c4a29a4c1e72436e347d9f9aec))
+- [AB#14384](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14384) Add certifications and funding accordion details ([9f89c53](https://github.com/newjersey/navigator.business.nj.gov/commit/9f89c5352bad7e78caf54e13d1ada453dacc7160))
+- [AB#14869](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14869) Add links to CMS search results ([ae2115e](https://github.com/newjersey/navigator.business.nj.gov/commit/ae2115e84fdee6700abe55ad9d088207230e0b23))
+- [AB#14870](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14870) add loading spinner to tax clearance ([1b9ecd0](https://github.com/newjersey/navigator.business.nj.gov/commit/1b9ecd04a3cb329fbf3404ebe5f61f5052194781))
+- [AB#14933](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14933) unlink taxId function in Dev ([a3bb10b](https://github.com/newjersey/navigator.business.nj.gov/commit/a3bb10ba689770abbc3492b3669ac60d8acd07fb))
 
 ## [2025.13.2](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.13.1...v2025.13.2) (2025-06-25)
 
-
 ### Bug Fixes
 
-* enable tax clearance certificate feature via ff ([cf35d2f](https://github.com/newjersey/navigator.business.nj.gov/commit/cf35d2f896fef5399b1b657648144174cdad4a28))
+- enable tax clearance certificate feature via ff ([cf35d2f](https://github.com/newjersey/navigator.business.nj.gov/commit/cf35d2f896fef5399b1b657648144174cdad4a28))
 
 ## [2025.13.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.13.0...v2025.13.1) (2025-06-25)
 
-
 ### Bug Fixes
 
-* disable tax clearance certificate feature via ff ([ade300b](https://github.com/newjersey/navigator.business.nj.gov/commit/ade300b23bd7136cecabdee15fac0f4533b6c7de))
+- disable tax clearance certificate feature via ff ([ade300b](https://github.com/newjersey/navigator.business.nj.gov/commit/ade300b23bd7136cecabdee15fac0f4533b6c7de))
 
 # [2025.13.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.12.0...v2025.13.0) (2025-06-25)
 
-
 ### Bug Fixes
 
-* [AB[#0000](https://github.com/newjersey/navigator.business.nj.gov/issues/0000)] test fix for AnytimeActionTaxClearance ([89e1c96](https://github.com/newjersey/navigator.business.nj.gov/commit/89e1c96a490f40b47918b5bde21b84cbc2bdc718))
-* [AB[#114979](https://github.com/newjersey/navigator.business.nj.gov/issues/114979)] prevent 'details?.toJSON is not a function' error ([6562d53](https://github.com/newjersey/navigator.business.nj.gov/commit/6562d53155a61b54474c6a522052c12ac441804a))
-* [AB[#13777](https://github.com/newjersey/navigator.business.nj.gov/issues/13777)] Configure env for personalize my tasks tab ([15cc8c4](https://github.com/newjersey/navigator.business.nj.gov/commit/15cc8c4d8fe90dc7673d8a1e5c8995120ba964a1))
-* [AB[#13777](https://github.com/newjersey/navigator.business.nj.gov/issues/13777)] fix gradient in star icon ([3ab475f](https://github.com/newjersey/navigator.business.nj.gov/commit/3ab475fdd43d2aae0789c44e02ef58f44ba0f9b0))
-* [AB[#13777](https://github.com/newjersey/navigator.business.nj.gov/issues/13777)] pr fixes ([889e11c](https://github.com/newjersey/navigator.business.nj.gov/commit/889e11c9d12f0d09384ba326922b66719359962b))
-* [AB[#14467](https://github.com/newjersey/navigator.business.nj.gov/issues/14467)] Update ETP environment and validation ([e9c1816](https://github.com/newjersey/navigator.business.nj.gov/commit/e9c181601c197f8b19b0c78628f8d59f525d1700))
-* [AB[#14657](https://github.com/newjersey/navigator.business.nj.gov/issues/14657)] remove auth from tax clearance logs ([#10443](https://github.com/newjersey/navigator.business.nj.gov/issues/10443)) ([08b6797](https://github.com/newjersey/navigator.business.nj.gov/commit/08b67974f958fded8a512b841ba2229163aff08e))
-* [AB[#14736](https://github.com/newjersey/navigator.business.nj.gov/issues/14736)] Tax Clearance Alert positon ([78ad886](https://github.com/newjersey/navigator.business.nj.gov/commit/78ad8861a3887140c9ab8a96e5f61bb935b38603))
-* [AB[#14779](https://github.com/newjersey/navigator.business.nj.gov/issues/14779)] fix flaking test by hardcoding current time ([f527548](https://github.com/newjersey/navigator.business.nj.gov/commit/f527548235a4100323018faf794815b2d67b58c4))
-* [AB[#14795](https://github.com/newjersey/navigator.business.nj.gov/issues/14795)] fix test flaking due to invalid NJ zipcode ([eb02817](https://github.com/newjersey/navigator.business.nj.gov/commit/eb02817f38bb72806efdf3bbcf3bc386531ef1bf))
-* [AB[#14796](https://github.com/newjersey/navigator.business.nj.gov/issues/14796)] Change copy from Personalize My Tasks to Personalize My Experience ([a4de1d3](https://github.com/newjersey/navigator.business.nj.gov/commit/a4de1d31b2bffcc1ef903cc74e44fb825805209c))
-* [AB[#14796](https://github.com/newjersey/navigator.business.nj.gov/issues/14796)] Change to Personalize my experience ([d493079](https://github.com/newjersey/navigator.business.nj.gov/commit/d493079eae5280675cf2d313a60004829108e553))
-* [AB[#14891](https://github.com/newjersey/navigator.business.nj.gov/issues/14891)] callout icon bullets will show without needing body text ([a5c8c40](https://github.com/newjersey/navigator.business.nj.gov/commit/a5c8c408f33fd8c11e0d85d0ead07fe37c1b7973))
-* [AB[#14936](https://github.com/newjersey/navigator.business.nj.gov/issues/14936)] Limit ABC ETP permits to 4 days in the future ([c586a29](https://github.com/newjersey/navigator.business.nj.gov/commit/c586a29d1b2b067a125c71a12028dd7e33bb8df0))
-* [AB[#14936](https://github.com/newjersey/navigator.business.nj.gov/issues/14936)] Remove flaky timer based test ([8e47455](https://github.com/newjersey/navigator.business.nj.gov/commit/8e474555fdc466e5403eb39b8ee9272a55b67675))
-* [AB[#8375](https://github.com/newjersey/navigator.business.nj.gov/issues/8375)] xray config ([fb78633](https://github.com/newjersey/navigator.business.nj.gov/commit/fb78633a0f08ee5cb77cbc85adeceba06166dc65))
-* cspell merge error ([6166cbe](https://github.com/newjersey/navigator.business.nj.gov/commit/6166cbe49b469a086505fe71579f639fbf29bb3b))
-* **deps:** update nextjs monorepo to v15.3.3 ([d946f47](https://github.com/newjersey/navigator.business.nj.gov/commit/d946f47e131ceec598205be8df23528bf5cc9e19))
-* **deps:** update nextjs monorepo to v15.3.4 ([5682487](https://github.com/newjersey/navigator.business.nj.gov/commit/5682487d5285886136f0099d6de9cb440aec55ad))
-
+- [AB#0000](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000) test fix for AnytimeActionTaxClearance ([89e1c96](https://github.com/newjersey/navigator.business.nj.gov/commit/89e1c96a490f40b47918b5bde21b84cbc2bdc718))
+- [AB#114979](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/114979) prevent 'details?.toJSON is not a function' error ([6562d53](https://github.com/newjersey/navigator.business.nj.gov/commit/6562d53155a61b54474c6a522052c12ac441804a))
+- [AB#13777](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13777) Configure env for personalize my tasks tab ([15cc8c4](https://github.com/newjersey/navigator.business.nj.gov/commit/15cc8c4d8fe90dc7673d8a1e5c8995120ba964a1))
+- [AB#13777](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13777) fix gradient in star icon ([3ab475f](https://github.com/newjersey/navigator.business.nj.gov/commit/3ab475fdd43d2aae0789c44e02ef58f44ba0f9b0))
+- [AB#13777](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13777) pr fixes ([889e11c](https://github.com/newjersey/navigator.business.nj.gov/commit/889e11c9d12f0d09384ba326922b66719359962b))
+- [AB#14467](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14467) Update ETP environment and validation ([e9c1816](https://github.com/newjersey/navigator.business.nj.gov/commit/e9c181601c197f8b19b0c78628f8d59f525d1700))
+- [AB#14657](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14657) remove auth from tax clearance logs ([#10443](https://github.com/newjersey/navigator.business.nj.gov/issues/10443)) ([08b6797](https://github.com/newjersey/navigator.business.nj.gov/commit/08b67974f958fded8a512b841ba2229163aff08e))
+- [AB#14736](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14736) Tax Clearance Alert positon ([78ad886](https://github.com/newjersey/navigator.business.nj.gov/commit/78ad8861a3887140c9ab8a96e5f61bb935b38603))
+- [AB#14779](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14779) fix flaking test by hardcoding current time ([f527548](https://github.com/newjersey/navigator.business.nj.gov/commit/f527548235a4100323018faf794815b2d67b58c4))
+- [AB#14795](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14795) fix test flaking due to invalid NJ zipcode ([eb02817](https://github.com/newjersey/navigator.business.nj.gov/commit/eb02817f38bb72806efdf3bbcf3bc386531ef1bf))
+- [AB#14796](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14796) Change copy from Personalize My Tasks to Personalize My Experience ([a4de1d3](https://github.com/newjersey/navigator.business.nj.gov/commit/a4de1d31b2bffcc1ef903cc74e44fb825805209c))
+- [AB#14796](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14796) Change to Personalize my experience ([d493079](https://github.com/newjersey/navigator.business.nj.gov/commit/d493079eae5280675cf2d313a60004829108e553))
+- [AB#14891](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14891) callout icon bullets will show without needing body text ([a5c8c40](https://github.com/newjersey/navigator.business.nj.gov/commit/a5c8c408f33fd8c11e0d85d0ead07fe37c1b7973))
+- [AB#14936](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14936) Limit ABC ETP permits to 4 days in the future ([c586a29](https://github.com/newjersey/navigator.business.nj.gov/commit/c586a29d1b2b067a125c71a12028dd7e33bb8df0))
+- [AB#14936](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14936) Remove flaky timer based test ([8e47455](https://github.com/newjersey/navigator.business.nj.gov/commit/8e474555fdc466e5403eb39b8ee9272a55b67675))
+- [AB#8375](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8375) xray config ([fb78633](https://github.com/newjersey/navigator.business.nj.gov/commit/fb78633a0f08ee5cb77cbc85adeceba06166dc65))
+- cspell merge error ([6166cbe](https://github.com/newjersey/navigator.business.nj.gov/commit/6166cbe49b469a086505fe71579f639fbf29bb3b))
+- **deps:** update nextjs monorepo to v15.3.3 ([d946f47](https://github.com/newjersey/navigator.business.nj.gov/commit/d946f47e131ceec598205be8df23528bf5cc9e19))
+- **deps:** update nextjs monorepo to v15.3.4 ([5682487](https://github.com/newjersey/navigator.business.nj.gov/commit/5682487d5285886136f0099d6de9cb440aec55ad))
 
 ### Features
 
-* [AB[#13626](https://github.com/newjersey/navigator.business.nj.gov/issues/13626)] Lock Fields in Tax Clearance ([43e29e6](https://github.com/newjersey/navigator.business.nj.gov/commit/43e29e68b2cf96a6c6cd71da4a5325af2a865f3d))
-* [AB[#13777](https://github.com/newjersey/navigator.business.nj.gov/issues/13777)] Add profile accordions in personalize your tasks tab ([80c30fd](https://github.com/newjersey/navigator.business.nj.gov/commit/80c30fd28ae53ba1f87200665507d614638b4cc6))
-* [AB[#14385](https://github.com/newjersey/navigator.business.nj.gov/issues/14385)] Add location based information to profile accordion ([6e7bd1d](https://github.com/newjersey/navigator.business.nj.gov/commit/6e7bd1d644545943b006a3f680f4c4a78758838a))
-* [AB[#14385](https://github.com/newjersey/navigator.business.nj.gov/issues/14385)] Add location based information to profile accordion ([8b557d6](https://github.com/newjersey/navigator.business.nj.gov/commit/8b557d601ce8b09ee20286b9da9d6fdd3bcd31ff))
-* [AB[#14385](https://github.com/newjersey/navigator.business.nj.gov/issues/14385)] Add location based information to profile accordion ([1104783](https://github.com/newjersey/navigator.business.nj.gov/commit/11047832b01fab679726264924331b70309d7990))
-* [AB[#14385](https://github.com/newjersey/navigator.business.nj.gov/issues/14385)] Add location based information to profile accordion ([9b48bcf](https://github.com/newjersey/navigator.business.nj.gov/commit/9b48bcfa637f79199a576d3f0d8b99b6c2b03893))
-* [AB[#14386](https://github.com/newjersey/navigator.business.nj.gov/issues/14386)] added profile customize tab nonEssentialQuestion section content ([87543ed](https://github.com/newjersey/navigator.business.nj.gov/commit/87543ed3500bfc6d7775cf809bd5e73b541d3039))
-* [AB[#14386](https://github.com/newjersey/navigator.business.nj.gov/issues/14386)] eliminated personalize My Task Section for domestic employer industry ([83cd966](https://github.com/newjersey/navigator.business.nj.gov/commit/83cd96661f1ea03e9e62df86810f744e9878ce4e))
-* [AB[#14386](https://github.com/newjersey/navigator.business.nj.gov/issues/14386)] fixed lint issue on main ([869d60b](https://github.com/newjersey/navigator.business.nj.gov/commit/869d60b652b41aa6f20fc6109e4e914ae2a80112))
-* [AB[#14386](https://github.com/newjersey/navigator.business.nj.gov/issues/14386)] fixed testing issue for nonEssentailQuestionsSection ([00ecf6d](https://github.com/newjersey/navigator.business.nj.gov/commit/00ecf6de5b7a2da08ee01a0c9cb9fb56a6da1f61))
-* [AB[#14466](https://github.com/newjersey/navigator.business.nj.gov/issues/14466)] clear submission error after user updates tax clearance form ([0a1f058](https://github.com/newjersey/navigator.business.nj.gov/commit/0a1f05812b88bad794b96e14f5688f0e191abbc8))
-* [AB[#14471](https://github.com/newjersey/navigator.business.nj.gov/issues/14471)] update returnToLink when showing sign-in/register modal on tax clearance steps ([744cddd](https://github.com/newjersey/navigator.business.nj.gov/commit/744cdddb3bc7ba4d0556bbb0d69cc1085a0f9a51))
-* [AB[#14543](https://github.com/newjersey/navigator.business.nj.gov/issues/14543)] add post body to health check ([dad1bbe](https://github.com/newjersey/navigator.business.nj.gov/commit/dad1bbe1a897db68d85f22475c5bb3d236636b57))
-* [AB[#14643](https://github.com/newjersey/navigator.business.nj.gov/issues/14643)] making error anchor link switch back to check eligibility step ([ee72afc](https://github.com/newjersey/navigator.business.nj.gov/commit/ee72afc2e887ccf7acf048db146fc71dd59c87fd))
-* [AB[#8375](https://github.com/newjersey/navigator.business.nj.gov/issues/8375)] xray renewal event ([16e2d6f](https://github.com/newjersey/navigator.business.nj.gov/commit/16e2d6f7533962d360e636cf437981fbdae0a99f))
+- [AB#13626](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13626) Lock Fields in Tax Clearance ([43e29e6](https://github.com/newjersey/navigator.business.nj.gov/commit/43e29e68b2cf96a6c6cd71da4a5325af2a865f3d))
+- [AB#13777](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13777) Add profile accordions in personalize your tasks tab ([80c30fd](https://github.com/newjersey/navigator.business.nj.gov/commit/80c30fd28ae53ba1f87200665507d614638b4cc6))
+- [AB#14385](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14385) Add location based information to profile accordion ([6e7bd1d](https://github.com/newjersey/navigator.business.nj.gov/commit/6e7bd1d644545943b006a3f680f4c4a78758838a))
+- [AB#14385](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14385) Add location based information to profile accordion ([8b557d6](https://github.com/newjersey/navigator.business.nj.gov/commit/8b557d601ce8b09ee20286b9da9d6fdd3bcd31ff))
+- [AB#14385](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14385) Add location based information to profile accordion ([1104783](https://github.com/newjersey/navigator.business.nj.gov/commit/11047832b01fab679726264924331b70309d7990))
+- [AB#14385](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14385) Add location based information to profile accordion ([9b48bcf](https://github.com/newjersey/navigator.business.nj.gov/commit/9b48bcfa637f79199a576d3f0d8b99b6c2b03893))
+- [AB#14386](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14386) added profile customize tab nonEssentialQuestion section content ([87543ed](https://github.com/newjersey/navigator.business.nj.gov/commit/87543ed3500bfc6d7775cf809bd5e73b541d3039))
+- [AB#14386](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14386) eliminated personalize My Task Section for domestic employer industry ([83cd966](https://github.com/newjersey/navigator.business.nj.gov/commit/83cd96661f1ea03e9e62df86810f744e9878ce4e))
+- [AB#14386](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14386) fixed lint issue on main ([869d60b](https://github.com/newjersey/navigator.business.nj.gov/commit/869d60b652b41aa6f20fc6109e4e914ae2a80112))
+- [AB#14386](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14386) fixed testing issue for nonEssentailQuestionsSection ([00ecf6d](https://github.com/newjersey/navigator.business.nj.gov/commit/00ecf6de5b7a2da08ee01a0c9cb9fb56a6da1f61))
+- [AB#14466](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14466) clear submission error after user updates tax clearance form ([0a1f058](https://github.com/newjersey/navigator.business.nj.gov/commit/0a1f05812b88bad794b96e14f5688f0e191abbc8))
+- [AB#14471](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14471) update returnToLink when showing sign-in/register modal on tax clearance steps ([744cddd](https://github.com/newjersey/navigator.business.nj.gov/commit/744cdddb3bc7ba4d0556bbb0d69cc1085a0f9a51))
+- [AB#14543](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14543) add post body to health check ([dad1bbe](https://github.com/newjersey/navigator.business.nj.gov/commit/dad1bbe1a897db68d85f22475c5bb3d236636b57))
+- [AB#14643](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14643) making error anchor link switch back to check eligibility step ([ee72afc](https://github.com/newjersey/navigator.business.nj.gov/commit/ee72afc2e887ccf7acf048db146fc71dd59c87fd))
+- [AB#8375](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8375) xray renewal event ([16e2d6f](https://github.com/newjersey/navigator.business.nj.gov/commit/16e2d6f7533962d360e636cf437981fbdae0a99f))
 
 # [2025.12.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.11.0...v2025.12.0) (2025-06-09)
 
-
 ### Bug Fixes
 
-* [AB[#13171](https://github.com/newjersey/navigator.business.nj.gov/issues/13171)] updated yml files to match json configs ([2977b80](https://github.com/newjersey/navigator.business.nj.gov/commit/2977b80f35c83c84e2a7a9181b8cd84a407a4035))
-* [AB[#13891](https://github.com/newjersey/navigator.business.nj.gov/issues/13891)] change formContext onSubmit for custom onSubmit ([5b1575c](https://github.com/newjersey/navigator.business.nj.gov/commit/5b1575cdd3a00f9079df0154c4f89929a09de0ef))
-* [AB[#13891](https://github.com/newjersey/navigator.business.nj.gov/issues/13891)] handle tax clearance input errors on submit ([7c2c60a](https://github.com/newjersey/navigator.business.nj.gov/commit/7c2c60a7f34dfd5e5a8918420dfa4f8ba4db471e))
-* [AB[#14067](https://github.com/newjersey/navigator.business.nj.gov/issues/14067)] link label to select input and make it respond to click events ([5ec1775](https://github.com/newjersey/navigator.business.nj.gov/commit/5ec1775dc26022b395bbf6af536b00625c58e886))
-* [AB[#14382](https://github.com/newjersey/navigator.business.nj.gov/issues/14382)] remove domestic-employer as option for permits tests ([36becf6](https://github.com/newjersey/navigator.business.nj.gov/commit/36becf66fa85fbbb6c1e4e007dca9163375e0344))
-* [AB[#14467](https://github.com/newjersey/navigator.business.nj.gov/issues/14467)] move help button ([aa05c62](https://github.com/newjersey/navigator.business.nj.gov/commit/aa05c622f1560ef03d4a15a069fcee38d88b3734))
-* [AB[#14467](https://github.com/newjersey/navigator.business.nj.gov/issues/14467)] Update ETP stepper from ABC feedback ([597adfa](https://github.com/newjersey/navigator.business.nj.gov/commit/597adfa2e3967bcc8f8335103396bf6b547d2335))
-* [AB[#14528](https://github.com/newjersey/navigator.business.nj.gov/issues/14528)] change analytic event names ([e6f7d30](https://github.com/newjersey/navigator.business.nj.gov/commit/e6f7d3041ab0562be22d36e88d31e1df3d91c021))
-* [AB[#14658](https://github.com/newjersey/navigator.business.nj.gov/issues/14658)] more distinct ineligible tax clearance error ([e6455c8](https://github.com/newjersey/navigator.business.nj.gov/commit/e6455c82d5efbb693ea509cd8b098d256f42bc19))
-* [AB[#7327](https://github.com/newjersey/navigator.business.nj.gov/issues/7327)] fix agentAddressCity validation ([fe0a8d9](https://github.com/newjersey/navigator.business.nj.gov/commit/fe0a8d95bbc2f16127d40d28b4d2c414840e5fe7))
-* [AB[#7751](https://github.com/newjersey/navigator.business.nj.gov/issues/7751)] pr comments ([6e67336](https://github.com/newjersey/navigator.business.nj.gov/commit/6e673363dad77eb24b5e6229ef1ea915d99c98f9))
-* [AB[#7863](https://github.com/newjersey/navigator.business.nj.gov/issues/7863)] Allow requests to emergency trip permit api without auth ([3e4fc91](https://github.com/newjersey/navigator.business.nj.gov/commit/3e4fc910ce758f43e0b123de85f1ea3e382348f2))
-* [AB[#7863](https://github.com/newjersey/navigator.business.nj.gov/issues/7863)] Change routing for emergency trip permit ([70df618](https://github.com/newjersey/navigator.business.nj.gov/commit/70df618f07f04a58bce0c963b0b7f901443955aa))
-* [AB[#8150](https://github.com/newjersey/navigator.business.nj.gov/issues/8150)] information in the tax detail screen is not floating / wrapping correctly ([b7b2b70](https://github.com/newjersey/navigator.business.nj.gov/commit/b7b2b70391c6610588beb5c0b88a17ab9c3d0d9f))
-* address race condition in tax clearance tax id check ([6a72e82](https://github.com/newjersey/navigator.business.nj.gov/commit/6a72e829b2a28fad52570e325babb3b533d00e55))
-* **deps:** update aws-sdk ([25f9715](https://github.com/newjersey/navigator.business.nj.gov/commit/25f97152806915e247ec56051dd1c4f211fd2856))
-* Fix that summaryDescriptionMd was multi-line without an indent ([#10366](https://github.com/newjersey/navigator.business.nj.gov/issues/10366)) ([efb3e1d](https://github.com/newjersey/navigator.business.nj.gov/commit/efb3e1d2da03de2798bc4824e0060280fe0f3902))
-
+- [AB#13171](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13171) updated yml files to match json configs ([2977b80](https://github.com/newjersey/navigator.business.nj.gov/commit/2977b80f35c83c84e2a7a9181b8cd84a407a4035))
+- [AB#13891](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13891) change formContext onSubmit for custom onSubmit ([5b1575c](https://github.com/newjersey/navigator.business.nj.gov/commit/5b1575cdd3a00f9079df0154c4f89929a09de0ef))
+- [AB#13891](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13891) handle tax clearance input errors on submit ([7c2c60a](https://github.com/newjersey/navigator.business.nj.gov/commit/7c2c60a7f34dfd5e5a8918420dfa4f8ba4db471e))
+- [AB#14067](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14067) link label to select input and make it respond to click events ([5ec1775](https://github.com/newjersey/navigator.business.nj.gov/commit/5ec1775dc26022b395bbf6af536b00625c58e886))
+- [AB#14382](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14382) remove domestic-employer as option for permits tests ([36becf6](https://github.com/newjersey/navigator.business.nj.gov/commit/36becf66fa85fbbb6c1e4e007dca9163375e0344))
+- [AB#14467](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14467) move help button ([aa05c62](https://github.com/newjersey/navigator.business.nj.gov/commit/aa05c622f1560ef03d4a15a069fcee38d88b3734))
+- [AB#14467](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14467) Update ETP stepper from ABC feedback ([597adfa](https://github.com/newjersey/navigator.business.nj.gov/commit/597adfa2e3967bcc8f8335103396bf6b547d2335))
+- [AB#14528](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14528) change analytic event names ([e6f7d30](https://github.com/newjersey/navigator.business.nj.gov/commit/e6f7d3041ab0562be22d36e88d31e1df3d91c021))
+- [AB#14658](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14658) more distinct ineligible tax clearance error ([e6455c8](https://github.com/newjersey/navigator.business.nj.gov/commit/e6455c82d5efbb693ea509cd8b098d256f42bc19))
+- [AB#7327](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7327) fix agentAddressCity validation ([fe0a8d9](https://github.com/newjersey/navigator.business.nj.gov/commit/fe0a8d95bbc2f16127d40d28b4d2c414840e5fe7))
+- [AB#7751](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7751) pr comments ([6e67336](https://github.com/newjersey/navigator.business.nj.gov/commit/6e673363dad77eb24b5e6229ef1ea915d99c98f9))
+- [AB#7863](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7863) Allow requests to emergency trip permit api without auth ([3e4fc91](https://github.com/newjersey/navigator.business.nj.gov/commit/3e4fc910ce758f43e0b123de85f1ea3e382348f2))
+- [AB#7863](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7863) Change routing for emergency trip permit ([70df618](https://github.com/newjersey/navigator.business.nj.gov/commit/70df618f07f04a58bce0c963b0b7f901443955aa))
+- [AB#8150](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8150) information in the tax detail screen is not floating / wrapping correctly ([b7b2b70](https://github.com/newjersey/navigator.business.nj.gov/commit/b7b2b70391c6610588beb5c0b88a17ab9c3d0d9f))
+- address race condition in tax clearance tax id check ([6a72e82](https://github.com/newjersey/navigator.business.nj.gov/commit/6a72e829b2a28fad52570e325babb3b533d00e55))
+- **deps:** update aws-sdk ([25f9715](https://github.com/newjersey/navigator.business.nj.gov/commit/25f97152806915e247ec56051dd1c4f211fd2856))
+- Fix that summaryDescriptionMd was multi-line without an indent ([#10366](https://github.com/newjersey/navigator.business.nj.gov/issues/10366)) ([efb3e1d](https://github.com/newjersey/navigator.business.nj.gov/commit/efb3e1d2da03de2798bc4824e0060280fe0f3902))
 
 ### Features
 
-* [#AB7713] basic error validation and stepper success for tax clearance form ([0330ad1](https://github.com/newjersey/navigator.business.nj.gov/commit/0330ad1abc5b25fc7c3fddff82832cc99f88c1cf)), closes [#AB7713](https://github.com/newjersey/navigator.business.nj.gov/issues/AB7713)
-* [AB:13770] Add guest mode tax clearance access ([817a1ca](https://github.com/newjersey/navigator.business.nj.gov/commit/817a1ca07eca87e6a35ff574683f490d48d02e44))
-* [AB:14543] add tax clearance health check endpoint ([97ab892](https://github.com/newjersey/navigator.business.nj.gov/commit/97ab892e1cdc49c6dc524b8b6b9b85b024cb024e))
-* [AB[#12793](https://github.com/newjersey/navigator.business.nj.gov/issues/12793)] Encrypt Tax Clearance ID and PIN ([#10367](https://github.com/newjersey/navigator.business.nj.gov/issues/10367)) ([869713a](https://github.com/newjersey/navigator.business.nj.gov/commit/869713a5b852f9e9cf02263289f86aa66155c5c5))
-* [AB[#12793](https://github.com/newjersey/navigator.business.nj.gov/issues/12793)] Fix password view bug in tax task (separate from profile or tax clearance) ([c46dd77](https://github.com/newjersey/navigator.business.nj.gov/commit/c46dd77cd30391bae8a9326d0d33b1c34892f6ed)), closes [/github.com/newjersey/navigator.business.nj.gov/pull/10273#discussion_r2076164682](https://github.com//github.com/newjersey/navigator.business.nj.gov/pull/10273/issues/discussion_r2076164682)
-* [AB[#13778](https://github.com/newjersey/navigator.business.nj.gov/issues/13778)] Add synonyms for anytime action dropdown search ([0a46c64](https://github.com/newjersey/navigator.business.nj.gov/commit/0a46c646fc46668b45ba34aed7f561287875af69))
-* [AB[#13778](https://github.com/newjersey/navigator.business.nj.gov/issues/13778)] Add synonyms for anytime action dropdown search to relevant tasks ([c47fafb](https://github.com/newjersey/navigator.business.nj.gov/commit/c47fafb83bc374bacc99b90adf9671197f0aa987))
-* [AB[#13891](https://github.com/newjersey/navigator.business.nj.gov/issues/13891)] handle tax clearance input errors on submit ([3defdb9](https://github.com/newjersey/navigator.business.nj.gov/commit/3defdb960e99e9f852cc0073f45275949ee7581c))
-* [AB[#13918](https://github.com/newjersey/navigator.business.nj.gov/issues/13918)] update focus state color ([30235de](https://github.com/newjersey/navigator.business.nj.gov/commit/30235de9ab051ee9331a2fbff71bb380e2d60df2))
-* [AB[#14131](https://github.com/newjersey/navigator.business.nj.gov/issues/14131)] add quick reference callout ([e1b6260](https://github.com/newjersey/navigator.business.nj.gov/commit/e1b626077e6c000b516795565cf04b02fe874340))
-* [AB[#14239](https://github.com/newjersey/navigator.business.nj.gov/issues/14239)] Personalize My Tasks button ([ea524d5](https://github.com/newjersey/navigator.business.nj.gov/commit/ea524d55007dde7e11700877feb45e175ec3a029))
-* [AB[#14239](https://github.com/newjersey/navigator.business.nj.gov/issues/14239)] Personalize My Tasks button ([c49fc55](https://github.com/newjersey/navigator.business.nj.gov/commit/c49fc55539da86a416988dd688170c01c807bfc2))
-* [AB[#14311](https://github.com/newjersey/navigator.business.nj.gov/issues/14311)] add PII hashing service to use for tax ID hashing ([004c1d7](https://github.com/newjersey/navigator.business.nj.gov/commit/004c1d797812b831db2c605769be2b6ae6778490))
-* [AB[#14314](https://github.com/newjersey/navigator.business.nj.gov/issues/14314)] add logic to prevent business from requesting tax clearance if tax ID is in use ([5441ba6](https://github.com/newjersey/navigator.business.nj.gov/commit/5441ba6307285b653a41310f888fc202599cb7cd))
-* [AB[#14528](https://github.com/newjersey/navigator.business.nj.gov/issues/14528)] add analytic events for tax clearance ([4769d16](https://github.com/newjersey/navigator.business.nj.gov/commit/4769d1684b7262c44307955f4d69d7a20a41fad5))
-* [AB[#7714](https://github.com/newjersey/navigator.business.nj.gov/issues/7714)] Generic Taxation Api Error Message ([#10370](https://github.com/newjersey/navigator.business.nj.gov/issues/10370)) ([1858485](https://github.com/newjersey/navigator.business.nj.gov/commit/18584855b6939b5c1c22e27dc6a06e051165ea1b))
-* [AB[#7714](https://github.com/newjersey/navigator.business.nj.gov/issues/7714)] Handle 500 errors from tax clearance api ([46470f1](https://github.com/newjersey/navigator.business.nj.gov/commit/46470f15da087a154778385c3ffce1a3449b9d39))
-* [AB[#7751](https://github.com/newjersey/navigator.business.nj.gov/issues/7751)] tax clearance specific error messges ([cc1092b](https://github.com/newjersey/navigator.business.nj.gov/commit/cc1092b9580b76b034711c34433767999256f8ad))
-* [AB[#7782](https://github.com/newjersey/navigator.business.nj.gov/issues/7782)] Encrypt Profile Tax Pin ([#10273](https://github.com/newjersey/navigator.business.nj.gov/issues/10273)) ([70cb0de](https://github.com/newjersey/navigator.business.nj.gov/commit/70cb0de7de60ce2378de5d17ca3e34b9e3ebbea9))
-* [AB[#7782](https://github.com/newjersey/navigator.business.nj.gov/issues/7782)] Fix profile tax pin init view ([d43791b](https://github.com/newjersey/navigator.business.nj.gov/commit/d43791b59fdb90844b126c6d507099da07124b4a)), closes [#10367](https://github.com/newjersey/navigator.business.nj.gov/issues/10367)
-* [AB[#7782](https://github.com/newjersey/navigator.business.nj.gov/issues/7782)] Prefactor pass encryption client to migration functions ([c492bc0](https://github.com/newjersey/navigator.business.nj.gov/commit/c492bc07d9244decb67bc32a0fe820f8e2147bcb))
-* [AB[#7867](https://github.com/newjersey/navigator.business.nj.gov/issues/7867)] add migration to add hashed tax ID to userData structure ([2013bf7](https://github.com/newjersey/navigator.business.nj.gov/commit/2013bf7ae160ba5e7d6781f2138b4f2c1a0931f9))
-* [AB[#8142](https://github.com/newjersey/navigator.business.nj.gov/issues/8142)] content team can add anytime action categories via CMS, content in previous commit a6c7d20004b115867be42d024d75fe2f800eb1ae ([e8414f5](https://github.com/newjersey/navigator.business.nj.gov/commit/e8414f52cf79f5be00fc69fce960160c07e04ec5))
-* [AB[#8322](https://github.com/newjersey/navigator.business.nj.gov/issues/8322)] add transport waste question ([76b8bcb](https://github.com/newjersey/navigator.business.nj.gov/commit/76b8bcba3309f6cbac333da9f5f89c06c81cd69c))
-* [AB[#8605](https://github.com/newjersey/navigator.business.nj.gov/issues/8605)] add errLog for myNJSelf-Reg and test for fail path ([f856df8](https://github.com/newjersey/navigator.business.nj.gov/commit/f856df8007da8fba7c57fd2d1e5bda9147a7a318))
-
+- [#AB7713] basic error validation and stepper success for tax clearance form ([0330ad1](https://github.com/newjersey/navigator.business.nj.gov/commit/0330ad1abc5b25fc7c3fddff82832cc99f88c1cf)), closes [#AB7713](https://github.com/newjersey/navigator.business.nj.gov/issues/AB7713)
+- [AB:13770] Add guest mode tax clearance access ([817a1ca](https://github.com/newjersey/navigator.business.nj.gov/commit/817a1ca07eca87e6a35ff574683f490d48d02e44))
+- [AB:14543] add tax clearance health check endpoint ([97ab892](https://github.com/newjersey/navigator.business.nj.gov/commit/97ab892e1cdc49c6dc524b8b6b9b85b024cb024e))
+- [AB#12793](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12793) Encrypt Tax Clearance ID and PIN ([#10367](https://github.com/newjersey/navigator.business.nj.gov/issues/10367)) ([869713a](https://github.com/newjersey/navigator.business.nj.gov/commit/869713a5b852f9e9cf02263289f86aa66155c5c5))
+- [AB#12793](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12793) Fix password view bug in tax task (separate from profile or tax clearance) ([c46dd77](https://github.com/newjersey/navigator.business.nj.gov/commit/c46dd77cd30391bae8a9326d0d33b1c34892f6ed)), closes [/github.com/newjersey/navigator.business.nj.gov/pull/10273#discussion_r2076164682](https://github.com//github.com/newjersey/navigator.business.nj.gov/pull/10273/issues/discussion_r2076164682)
+- [AB#13778](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13778) Add synonyms for anytime action dropdown search ([0a46c64](https://github.com/newjersey/navigator.business.nj.gov/commit/0a46c646fc46668b45ba34aed7f561287875af69))
+- [AB#13778](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13778) Add synonyms for anytime action dropdown search to relevant tasks ([c47fafb](https://github.com/newjersey/navigator.business.nj.gov/commit/c47fafb83bc374bacc99b90adf9671197f0aa987))
+- [AB#13891](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13891) handle tax clearance input errors on submit ([3defdb9](https://github.com/newjersey/navigator.business.nj.gov/commit/3defdb960e99e9f852cc0073f45275949ee7581c))
+- [AB#13918](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13918) update focus state color ([30235de](https://github.com/newjersey/navigator.business.nj.gov/commit/30235de9ab051ee9331a2fbff71bb380e2d60df2))
+- [AB#14131](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14131) add quick reference callout ([e1b6260](https://github.com/newjersey/navigator.business.nj.gov/commit/e1b626077e6c000b516795565cf04b02fe874340))
+- [AB#14239](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14239) Personalize My Tasks button ([ea524d5](https://github.com/newjersey/navigator.business.nj.gov/commit/ea524d55007dde7e11700877feb45e175ec3a029))
+- [AB#14239](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14239) Personalize My Tasks button ([c49fc55](https://github.com/newjersey/navigator.business.nj.gov/commit/c49fc55539da86a416988dd688170c01c807bfc2))
+- [AB#14311](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14311) add PII hashing service to use for tax ID hashing ([004c1d7](https://github.com/newjersey/navigator.business.nj.gov/commit/004c1d797812b831db2c605769be2b6ae6778490))
+- [AB#14314](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14314) add logic to prevent business from requesting tax clearance if tax ID is in use ([5441ba6](https://github.com/newjersey/navigator.business.nj.gov/commit/5441ba6307285b653a41310f888fc202599cb7cd))
+- [AB#14528](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14528) add analytic events for tax clearance ([4769d16](https://github.com/newjersey/navigator.business.nj.gov/commit/4769d1684b7262c44307955f4d69d7a20a41fad5))
+- [AB#7714](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7714) Generic Taxation Api Error Message ([#10370](https://github.com/newjersey/navigator.business.nj.gov/issues/10370)) ([1858485](https://github.com/newjersey/navigator.business.nj.gov/commit/18584855b6939b5c1c22e27dc6a06e051165ea1b))
+- [AB#7714](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7714) Handle 500 errors from tax clearance api ([46470f1](https://github.com/newjersey/navigator.business.nj.gov/commit/46470f15da087a154778385c3ffce1a3449b9d39))
+- [AB#7751](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7751) tax clearance specific error messges ([cc1092b](https://github.com/newjersey/navigator.business.nj.gov/commit/cc1092b9580b76b034711c34433767999256f8ad))
+- [AB#7782](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7782) Encrypt Profile Tax Pin ([#10273](https://github.com/newjersey/navigator.business.nj.gov/issues/10273)) ([70cb0de](https://github.com/newjersey/navigator.business.nj.gov/commit/70cb0de7de60ce2378de5d17ca3e34b9e3ebbea9))
+- [AB#7782](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7782) Fix profile tax pin init view ([d43791b](https://github.com/newjersey/navigator.business.nj.gov/commit/d43791b59fdb90844b126c6d507099da07124b4a)), closes [#10367](https://github.com/newjersey/navigator.business.nj.gov/issues/10367)
+- [AB#7782](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7782) Prefactor pass encryption client to migration functions ([c492bc0](https://github.com/newjersey/navigator.business.nj.gov/commit/c492bc07d9244decb67bc32a0fe820f8e2147bcb))
+- [AB#7867](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7867) add migration to add hashed tax ID to userData structure ([2013bf7](https://github.com/newjersey/navigator.business.nj.gov/commit/2013bf7ae160ba5e7d6781f2138b4f2c1a0931f9))
+- [AB#8142](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8142) content team can add anytime action categories via CMS, content in previous commit a6c7d20004b115867be42d024d75fe2f800eb1ae ([e8414f5](https://github.com/newjersey/navigator.business.nj.gov/commit/e8414f52cf79f5be00fc69fce960160c07e04ec5))
+- [AB#8322](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8322) add transport waste question ([76b8bcb](https://github.com/newjersey/navigator.business.nj.gov/commit/76b8bcba3309f6cbac333da9f5f89c06c81cd69c))
+- [AB#8605](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8605) add errLog for myNJSelf-Reg and test for fail path ([f856df8](https://github.com/newjersey/navigator.business.nj.gov/commit/f856df8007da8fba7c57fd2d1e5bda9147a7a318))
 
 ### Reverts
 
-* Revert "chore: correct .prettierrc syntax and simplify Markdown formatting rules" ([4843b37](https://github.com/newjersey/navigator.business.nj.gov/commit/4843b37b85d299e9636791316b1860ad2de4adfc))
+- Revert "chore: correct .prettierrc syntax and simplify Markdown formatting rules" ([4843b37](https://github.com/newjersey/navigator.business.nj.gov/commit/4843b37b85d299e9636791316b1860ad2de4adfc))
 
 # [2025.11.0](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.10.1...v2025.11.0) (2025-05-12)
 
-
 ### Bug Fixes
 
-* [AB[#13890](https://github.com/newjersey/navigator.business.nj.gov/issues/13890)] fixed after hours test flakyness ([b467a3c](https://github.com/newjersey/navigator.business.nj.gov/commit/b467a3c4870dbb1e3d463620d292c8d817ea1d5e))
-* [AB[#13908](https://github.com/newjersey/navigator.business.nj.gov/issues/13908)] updates to accessibility for profileNav ([3f4ff55](https://github.com/newjersey/navigator.business.nj.gov/commit/3f4ff5518b955e5b579eb38adafbf768ae6a136d))
-* [AB[#14182](https://github.com/newjersey/navigator.business.nj.gov/issues/14182)] capitalization contextual info issue for content repo ([0a67c1a](https://github.com/newjersey/navigator.business.nj.gov/commit/0a67c1aec39cb614be3dddff0b8508aff0983f13))
-* [AB[#7017](https://github.com/newjersey/navigator.business.nj.gov/issues/7017)] x-ray registration review fixes ([32e9008](https://github.com/newjersey/navigator.business.nj.gov/commit/32e9008aa553c3c63e61e64464fb16edecce1379))
-* [AB[#7458](https://github.com/newjersey/navigator.business.nj.gov/issues/7458)] add query to get find userWithBusinessName ([08ced34](https://github.com/newjersey/navigator.business.nj.gov/commit/08ced347f883571f4b75fb1fdf0a78416c192e1d))
-* capitalization build issue for content repo ([e548d21](https://github.com/newjersey/navigator.business.nj.gov/commit/e548d219041670f8da0b32563c2f69692204f52d))
-* capitalization contextual info issue for content repo ([2e5f318](https://github.com/newjersey/navigator.business.nj.gov/commit/2e5f3181a370218c572c1a04344520eb7d0c64d5))
-* content-repo merge conflicts ([18a77c9](https://github.com/newjersey/navigator.business.nj.gov/commit/18a77c92f83b2f5f6d0edaafd58a21b0053cba64))
-* **deps:** update aws-sdk ([0b5b022](https://github.com/newjersey/navigator.business.nj.gov/commit/0b5b022044a7143937978750c9a32f08e275195f))
-* **deps:** update aws-sdk ([1352808](https://github.com/newjersey/navigator.business.nj.gov/commit/1352808123a198a157b0450620813628159460f4))
-* **deps:** update aws-sdk to v3.802.0 ([e7bcd57](https://github.com/newjersey/navigator.business.nj.gov/commit/e7bcd57d4b6c534081f734bc81798d797cc0e222))
-* **deps:** update cypress ([1015823](https://github.com/newjersey/navigator.business.nj.gov/commit/1015823ecee95e58e855d710eba8d863f8c2f147))
-* **deps:** update dependency @aws-crypto/client-node to v4.2.1 ([71f16aa](https://github.com/newjersey/navigator.business.nj.gov/commit/71f16aa93b8d1ede682e745b17b1198ba4168f87))
-* **deps:** update dependency aws-amplify to v6.14.2 ([26c6b43](https://github.com/newjersey/navigator.business.nj.gov/commit/26c6b43c822e2e7be4c84d19dc727916f87f5379))
-* **deps:** update dependency aws-amplify to v6.14.4 ([d79fd77](https://github.com/newjersey/navigator.business.nj.gov/commit/d79fd778a24c32fca98234380b817bc2194e9f55))
-* **deps:** update dependency axios to v1.8.4 ([b09addc](https://github.com/newjersey/navigator.business.nj.gov/commit/b09addc190125476192fc95ef4f19a52c9abcb5c))
-* **deps:** update dependency axios to v1.9.0 ([e5ae0fc](https://github.com/newjersey/navigator.business.nj.gov/commit/e5ae0fc2f433069e0ff4b4839a1e0bda6b9bdd83))
-* **deps:** update dependency dedent to v1.6.0 ([fef937e](https://github.com/newjersey/navigator.business.nj.gov/commit/fef937e12b9c953a5422d8fa05b2fd1cd9e66569))
-* **deps:** update dependency next to v15.2.4 [security] ([7ef7ec7](https://github.com/newjersey/navigator.business.nj.gov/commit/7ef7ec71e04b1bfa83aded68fdbc0c3813783e6c))
-* **deps:** update dependency remove-markdown to v0.6.2 ([3efac55](https://github.com/newjersey/navigator.business.nj.gov/commit/3efac55b51b4907834505d2f8f633c7cff0dafa6))
-* **deps:** update material-ui ([50c332a](https://github.com/newjersey/navigator.business.nj.gov/commit/50c332a9beb44e81eeb6680a224ee9219a42a7bb))
-* **deps:** update nextjs monorepo to v15.3.1 ([1a874b5](https://github.com/newjersey/navigator.business.nj.gov/commit/1a874b55c886d9390c495100c90bcddb7756d884))
-
+- [AB#13890](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13890) fixed after hours test flakyness ([b467a3c](https://github.com/newjersey/navigator.business.nj.gov/commit/b467a3c4870dbb1e3d463620d292c8d817ea1d5e))
+- [AB#13908](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13908) updates to accessibility for profileNav ([3f4ff55](https://github.com/newjersey/navigator.business.nj.gov/commit/3f4ff5518b955e5b579eb38adafbf768ae6a136d))
+- [AB#14182](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/14182) capitalization contextual info issue for content repo ([0a67c1a](https://github.com/newjersey/navigator.business.nj.gov/commit/0a67c1aec39cb614be3dddff0b8508aff0983f13))
+- [AB#7017](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7017) x-ray registration review fixes ([32e9008](https://github.com/newjersey/navigator.business.nj.gov/commit/32e9008aa553c3c63e61e64464fb16edecce1379))
+- [AB#7458](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7458) add query to get find userWithBusinessName ([08ced34](https://github.com/newjersey/navigator.business.nj.gov/commit/08ced347f883571f4b75fb1fdf0a78416c192e1d))
+- capitalization build issue for content repo ([e548d21](https://github.com/newjersey/navigator.business.nj.gov/commit/e548d219041670f8da0b32563c2f69692204f52d))
+- capitalization contextual info issue for content repo ([2e5f318](https://github.com/newjersey/navigator.business.nj.gov/commit/2e5f3181a370218c572c1a04344520eb7d0c64d5))
+- content-repo merge conflicts ([18a77c9](https://github.com/newjersey/navigator.business.nj.gov/commit/18a77c92f83b2f5f6d0edaafd58a21b0053cba64))
+- **deps:** update aws-sdk ([0b5b022](https://github.com/newjersey/navigator.business.nj.gov/commit/0b5b022044a7143937978750c9a32f08e275195f))
+- **deps:** update aws-sdk ([1352808](https://github.com/newjersey/navigator.business.nj.gov/commit/1352808123a198a157b0450620813628159460f4))
+- **deps:** update aws-sdk to v3.802.0 ([e7bcd57](https://github.com/newjersey/navigator.business.nj.gov/commit/e7bcd57d4b6c534081f734bc81798d797cc0e222))
+- **deps:** update cypress ([1015823](https://github.com/newjersey/navigator.business.nj.gov/commit/1015823ecee95e58e855d710eba8d863f8c2f147))
+- **deps:** update dependency @aws-crypto/client-node to v4.2.1 ([71f16aa](https://github.com/newjersey/navigator.business.nj.gov/commit/71f16aa93b8d1ede682e745b17b1198ba4168f87))
+- **deps:** update dependency aws-amplify to v6.14.2 ([26c6b43](https://github.com/newjersey/navigator.business.nj.gov/commit/26c6b43c822e2e7be4c84d19dc727916f87f5379))
+- **deps:** update dependency aws-amplify to v6.14.4 ([d79fd77](https://github.com/newjersey/navigator.business.nj.gov/commit/d79fd778a24c32fca98234380b817bc2194e9f55))
+- **deps:** update dependency axios to v1.8.4 ([b09addc](https://github.com/newjersey/navigator.business.nj.gov/commit/b09addc190125476192fc95ef4f19a52c9abcb5c))
+- **deps:** update dependency axios to v1.9.0 ([e5ae0fc](https://github.com/newjersey/navigator.business.nj.gov/commit/e5ae0fc2f433069e0ff4b4839a1e0bda6b9bdd83))
+- **deps:** update dependency dedent to v1.6.0 ([fef937e](https://github.com/newjersey/navigator.business.nj.gov/commit/fef937e12b9c953a5422d8fa05b2fd1cd9e66569))
+- **deps:** update dependency next to v15.2.4 [security] ([7ef7ec7](https://github.com/newjersey/navigator.business.nj.gov/commit/7ef7ec71e04b1bfa83aded68fdbc0c3813783e6c))
+- **deps:** update dependency remove-markdown to v0.6.2 ([3efac55](https://github.com/newjersey/navigator.business.nj.gov/commit/3efac55b51b4907834505d2f8f633c7cff0dafa6))
+- **deps:** update material-ui ([50c332a](https://github.com/newjersey/navigator.business.nj.gov/commit/50c332a9beb44e81eeb6680a224ee9219a42a7bb))
+- **deps:** update nextjs monorepo to v15.3.1 ([1a874b5](https://github.com/newjersey/navigator.business.nj.gov/commit/1a874b55c886d9390c495100c90bcddb7756d884))
 
 ### Features
 
-* [AB[#13315](https://github.com/newjersey/navigator.business.nj.gov/issues/13315)] Tax Clearance Certificate Download ([928d4f7](https://github.com/newjersey/navigator.business.nj.gov/commit/928d4f7ed332d39b8fe1b60c3356d85321dbdbb9))
-* [AB[#13315](https://github.com/newjersey/navigator.business.nj.gov/issues/13315)] Tax Clearance Download PR Feedback ([1deef13](https://github.com/newjersey/navigator.business.nj.gov/commit/1deef137a078c3f54ec09206bbb36a31b0535abb))
-* [AB[#13633](https://github.com/newjersey/navigator.business.nj.gov/issues/13633)] add anytime action category for vehicle related actions ([741c1c5](https://github.com/newjersey/navigator.business.nj.gov/commit/741c1c5ae51b3ee5a3813b6ad668775a6cdf66a0))
-* [AB[#13776](https://github.com/newjersey/navigator.business.nj.gov/issues/13776)] add Permits & Licenses Tab to Profile ([994fe3b](https://github.com/newjersey/navigator.business.nj.gov/commit/994fe3b72cf4f609289fa942b3acc104a256c347))
-* [AB[#6936](https://github.com/newjersey/navigator.business.nj.gov/issues/6936)] update content on Tax Calendar access ([7ed63ab](https://github.com/newjersey/navigator.business.nj.gov/commit/7ed63ab5bfa762451a567b58e46d982d14aef101))
-* [AB[#7071](https://github.com/newjersey/navigator.business.nj.gov/issues/7071)] xray registration status ([457de19](https://github.com/newjersey/navigator.business.nj.gov/commit/457de192af59f89ddca3d41963d3d5372c2b1d9c))
-* [AB[#7714](https://github.com/newjersey/navigator.business.nj.gov/issues/7714)] Tax Clearance rename SYSTEM_ERROR -> NATURAL_PROGRAM_ERROR. ([fba4cda](https://github.com/newjersey/navigator.business.nj.gov/commit/fba4cda9461b5b82b0fc365ccdf11fc59c7709b6))
-* [AB[#7752](https://github.com/newjersey/navigator.business.nj.gov/issues/7752)] successful tax clearance document response ([178deb3](https://github.com/newjersey/navigator.business.nj.gov/commit/178deb3528e9d1f0734f9b8f813773632cf327c8))
-* [AB[#7863](https://github.com/newjersey/navigator.business.nj.gov/issues/7863)] ABC ETP application connection ([c5b1cdd](https://github.com/newjersey/navigator.business.nj.gov/commit/c5b1cdd484f11210424ed3984b93bf13e0ae3c58))
+- [AB#13315](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13315) Tax Clearance Certificate Download ([928d4f7](https://github.com/newjersey/navigator.business.nj.gov/commit/928d4f7ed332d39b8fe1b60c3356d85321dbdbb9))
+- [AB#13315](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13315) Tax Clearance Download PR Feedback ([1deef13](https://github.com/newjersey/navigator.business.nj.gov/commit/1deef137a078c3f54ec09206bbb36a31b0535abb))
+- [AB#13633](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13633) add anytime action category for vehicle related actions ([741c1c5](https://github.com/newjersey/navigator.business.nj.gov/commit/741c1c5ae51b3ee5a3813b6ad668775a6cdf66a0))
+- [AB#13776](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13776) add Permits & Licenses Tab to Profile ([994fe3b](https://github.com/newjersey/navigator.business.nj.gov/commit/994fe3b72cf4f609289fa942b3acc104a256c347))
+- [AB#6936](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/6936) update content on Tax Calendar access ([7ed63ab](https://github.com/newjersey/navigator.business.nj.gov/commit/7ed63ab5bfa762451a567b58e46d982d14aef101))
+- [AB#7071](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7071) xray registration status ([457de19](https://github.com/newjersey/navigator.business.nj.gov/commit/457de192af59f89ddca3d41963d3d5372c2b1d9c))
+- [AB#7714](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7714) Tax Clearance rename SYSTEM_ERROR -> NATURAL_PROGRAM_ERROR. ([fba4cda](https://github.com/newjersey/navigator.business.nj.gov/commit/fba4cda9461b5b82b0fc365ccdf11fc59c7709b6))
+- [AB#7752](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7752) successful tax clearance document response ([178deb3](https://github.com/newjersey/navigator.business.nj.gov/commit/178deb3528e9d1f0734f9b8f813773632cf327c8))
+- [AB#7863](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7863) ABC ETP application connection ([c5b1cdd](https://github.com/newjersey/navigator.business.nj.gov/commit/c5b1cdd484f11210424ed3984b93bf13e0ae3c58))
 
 ## [2025.10.1](https://github.com/newjersey/navigator.business.nj.gov/compare/v2025.10.0...v2025.10.1) (2025-05-02)
 
@@ -663,13 +611,13 @@
 
 ### Bug Fixes
 
-- [AB[#13557](https://github.com/newjersey/navigator.business.nj.gov/issues/13557)] fix flaky
+- [AB#13557](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13557) fix flaky
   carnival test
   ([44bcea8](https://github.com/newjersey/navigator.business.nj.gov/commit/44bcea86b29a53133b3277085fa9355a41a94d03))
-- [AB[#13557](https://github.com/newjersey/navigator.business.nj.gov/issues/13557)] update case for
+- [AB#13557](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13557) update case for
   anytime action category
   ([a6b3193](https://github.com/newjersey/navigator.business.nj.gov/commit/a6b3193ce56a7804d692152141267fd48bc6ebbd))
-- [AB[#13673](https://github.com/newjersey/navigator.business.nj.gov/issues/13673)] forceRefresh
+- [AB#13673](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13673) forceRefresh
   auth fixes
   ([02d870b](https://github.com/newjersey/navigator.business.nj.gov/commit/02d870b1fa73f68643777b45cda1700cbb61c4e8))
 - special dental permit summaryDescriptioMd
@@ -677,7 +625,7 @@
 
 ### Features
 
-- [AB[#6768](https://github.com/newjersey/navigator.business.nj.gov/issues/6768)] add carnival
+- [AB#6768](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/6768) add carnival
   permits for up and running poppies
   ([db76164](https://github.com/newjersey/navigator.business.nj.gov/commit/db76164eece581c9da6e9590838bac68baa40645))
 
@@ -685,21 +633,21 @@
 
 ### Bug Fixes
 
-- [AB[#0000](https://github.com/newjersey/navigator.business.nj.gov/issues/0000)] fix conflict issue
+- [AB#0000](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000) fix conflict issue
   with pharmacy
   ([984f855](https://github.com/newjersey/navigator.business.nj.gov/commit/984f855085708a3f4dafb564df50ba59632474f6))
-- [AB[#12799](https://github.com/newjersey/navigator.business.nj.gov/issues/12799)] update
+- [AB#12799](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12799) update
   invocation freq in prod for migrateusersVersion
   ([6b0e18f](https://github.com/newjersey/navigator.business.nj.gov/commit/6b0e18f39e51a24cfc80f4480b7d574b172c5820))
-- [AB[#12799](https://github.com/newjersey/navigator.business.nj.gov/issues/12799)] update
+- [AB#12799](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12799) update
   invocation freq in prod for migrateusersVersion
   ([31cafb3](https://github.com/newjersey/navigator.business.nj.gov/commit/31cafb3bbdcb12e555b16d3962fa3739c9f90dd5))
-- [AB[#13172](https://github.com/newjersey/navigator.business.nj.gov/issues/13172)] skip flaky tests
+- [AB#13172](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13172) skip flaky tests
   ([6e3a2d1](https://github.com/newjersey/navigator.business.nj.gov/commit/6e3a2d11d057129b76d1dcda3ec382cba88e21f7))
-- [AB[#13227](https://github.com/newjersey/navigator.business.nj.gov/issues/13227)] update header
+- [AB#13227](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13227) update header
   copy and ability to update copy in cms
   ([c54bcc1](https://github.com/newjersey/navigator.business.nj.gov/commit/c54bcc12fce87d94333dd5fab2bd2b229abd5ea4))
-- [AB[#13427](https://github.com/newjersey/navigator.business.nj.gov/issues/13427)] update routing
+- [AB#13427](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13427) update routing
   from login to account-setup when onboarding is complete
   ([42ef18c](https://github.com/newjersey/navigator.business.nj.gov/commit/42ef18c7291103a0b54628e758f933e20087de85))
 - **deps:** update dependency axios to v1.8.3
@@ -710,25 +658,25 @@
 ### Features
 
 - [[#187531990](https://github.com/newjersey/navigator.business.nj.gov/issues/187531990) |
-  AB[#4988](https://github.com/newjersey/navigator.business.nj.gov/issues/4988)] enable status check
+  [AB#4988](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/4988) enable status check
   for public movers license
   ([#9925](https://github.com/newjersey/navigator.business.nj.gov/issues/9925))
   ([fa6e2ee](https://github.com/newjersey/navigator.business.nj.gov/commit/fa6e2eeedc65cda35c85249592249fc66b3909b6))
-- [AB[#12716](https://github.com/newjersey/navigator.business.nj.gov/issues/12716)] Enable
+- [AB#12716](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12716) Enable
   reproducing test randomness in `api/`
   ([1f5da6d](https://github.com/newjersey/navigator.business.nj.gov/commit/1f5da6d4300076cdb867b28d5b5907a6b5412636)),
   closes
   [/github.com/jestjs/jest/issues/7421#issuecomment-442438684](https://github.com//github.com/jestjs/jest/issues/7421/issues/issuecomment-442438684)
-- [AB[#12716](https://github.com/newjersey/navigator.business.nj.gov/issues/12716)] Enable
+- [AB#12716](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12716) Enable
   reproducing test randomness in `web/`
   ([0963278](https://github.com/newjersey/navigator.business.nj.gov/commit/09632785dbd01fa02cf6a305500821e76eac52d5))
-- [AB[#12716](https://github.com/newjersey/navigator.business.nj.gov/issues/12716)] Enable
+- [AB#12716](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12716) Enable
   reproducing test randomness in Cypress
   ([45a6e5b](https://github.com/newjersey/navigator.business.nj.gov/commit/45a6e5bcab045085144dfbb1b83b3057875da1d0))
-- [AB[#13166](https://github.com/newjersey/navigator.business.nj.gov/issues/13166)] add alert when
+- [AB#13166](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13166) add alert when
   no fundings are applicable on njeda fundings page
   ([9c4e313](https://github.com/newjersey/navigator.business.nj.gov/commit/9c4e313436400ae864447120e60f47f60d10a4bd))
-- [AB[#7865](https://github.com/newjersey/navigator.business.nj.gov/issues/7865)] implement anytime
+- [AB#7865](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/7865) implement anytime
   action descriptions
   ([fdf09e0](https://github.com/newjersey/navigator.business.nj.gov/commit/fdf09e04cdfe9d2dd51a476f0d0d47b2ab2c715b))
 
@@ -744,30 +692,30 @@
 ### Bug Fixes
 
 - [[#0](https://github.com/newjersey/navigator.business.nj.gov/issues/0) |
-  AB[#0](https://github.com/newjersey/navigator.business.nj.gov/issues/0)] disable flaky test
+  [AB#0](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0) disable flaky test
   ([f293d57](https://github.com/newjersey/navigator.business.nj.gov/commit/f293d57ed4faefb54cc6541f7c0f060f02f97fd1))
 - [[#188887754](https://github.com/newjersey/navigator.business.nj.gov/issues/188887754) |
-  AB[#8670](https://github.com/newjersey/navigator.business.nj.gov/issues/8670)] Fix Anytime Actions
+  [AB#8670](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8670) Fix Anytime Actions
   Category Spelling
   ([08e6467](https://github.com/newjersey/navigator.business.nj.gov/commit/08e6467984f7466435e1c474c77a52190f61d831))
 - [[#188908973](https://github.com/newjersey/navigator.business.nj.gov/issues/188908973) |
-  AB[#12673](https://github.com/newjersey/navigator.business.nj.gov/issues/12673)] convert email to
+  [AB#12673](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12673) convert email to
   lowercase for /self-reg and /users/emailCheck
   ([93770ce](https://github.com/newjersey/navigator.business.nj.gov/commit/93770ce961d67030731f4cf38fa353a3d48780cb))
 - [[#188924007](https://github.com/newjersey/navigator.business.nj.gov/issues/188924007) |
-  AB[#12737](https://github.com/newjersey/navigator.business.nj.gov/issues/12737)] add space in
+  [AB#12737](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12737) add space in
   Additional Provisions header
   ([9b41edb](https://github.com/newjersey/navigator.business.nj.gov/commit/9b41edbdfaf8a747580fabc71be12f1bc6b4f258))
-- [AB[#12799](https://github.com/newjersey/navigator.business.nj.gov/issues/12799)] fix user data
+- [AB#12799](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12799) fix user data
   migration
   ([aa01679](https://github.com/newjersey/navigator.business.nj.gov/commit/aa01679f1c2271d192b238f24c3da7adaf1195ee))
-- [AB[#13172](https://github.com/newjersey/navigator.business.nj.gov/issues/13172)] skip or update
+- [AB#13172](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13172) skip or update
   all flaky tests in CircleCI Insights
   ([275003f](https://github.com/newjersey/navigator.business.nj.gov/commit/275003f4a2fb1748d9c071fd5acefb2ac6c0bdd3))
-- [AB[#13379](https://github.com/newjersey/navigator.business.nj.gov/issues/13379)] resolve
+- [AB#13379](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13379) resolve
   requestException in fetchAuthSession
   ([f475f19](https://github.com/newjersey/navigator.business.nj.gov/commit/f475f19f152688564b981daae4c3e67eb71c611a))
-- [AB[#4703](https://github.com/newjersey/navigator.business.nj.gov/issues/4703)] PR review comments
+- [AB#4703](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/4703) PR review comments
   fix
   ([eac4229](https://github.com/newjersey/navigator.business.nj.gov/commit/eac4229905babba1149ea0166fe53abc513c67fa))
 - **deps:** update dependency axios to v1.8.2 [security]
@@ -778,7 +726,7 @@
 ### Features
 
 - [[#188595636](https://github.com/newjersey/navigator.business.nj.gov/issues/188595636) |
-  AB[#4703](https://github.com/newjersey/navigator.business.nj.gov/issues/4703)] add tax clearance
+  [AB#4703](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/4703) add tax clearance
   certificate screens
   ([be2dc99](https://github.com/newjersey/navigator.business.nj.gov/commit/be2dc999a5377804e741633e472f741d385fbb45))
 - [[#188887754](https://github.com/newjersey/navigator.business.nj.gov/issues/188887754) #AB8670]
@@ -786,14 +734,14 @@
   ([2b544e2](https://github.com/newjersey/navigator.business.nj.gov/commit/2b544e2dd4c4a29feed43ecca01810dfd4530d7b)),
   closes [#AB8670](https://github.com/newjersey/navigator.business.nj.gov/issues/AB8670)
 - [[#188887754](https://github.com/newjersey/navigator.business.nj.gov/issues/188887754) |
-  AB[#8670](https://github.com/newjersey/navigator.business.nj.gov/issues/8670)] Alphabetize anytime
+  [AB#8670](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8670) Alphabetize anytime
   actions dropdown category order
   ([7be461c](https://github.com/newjersey/navigator.business.nj.gov/commit/7be461c2cb91ee279cf23458fc350d4fe4330ad9))
 - [[#188887754](https://github.com/newjersey/navigator.business.nj.gov/issues/188887754) |
-  AB[#8670](https://github.com/newjersey/navigator.business.nj.gov/issues/8670)] Remove duplicate
+  [AB#8670](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8670) Remove duplicate
   close business task and the anytime action link category
   ([d56aa98](https://github.com/newjersey/navigator.business.nj.gov/commit/d56aa98d8ed6f07c17ca128ee2407167a849ec22))
-- [AB[#8670](https://github.com/newjersey/navigator.business.nj.gov/issues/8670)] Fix anytime
+- [AB#8670](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/8670) Fix anytime
   actions that were not moved over
   ([e494375](https://github.com/newjersey/navigator.business.nj.gov/commit/e494375d06f18d1eb342e5635e686359549f8bfa))
 
@@ -807,7 +755,7 @@
 ### Features
 
 - [[#188960391](https://github.com/newjersey/navigator.business.nj.gov/issues/188960391) |
-  AB[#13170](https://github.com/newjersey/navigator.business.nj.gov/issues/13170)] add survey link
+  [AB#13170](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/13170) add survey link
   behind a feature flag on formation success
   ([edf4d10](https://github.com/newjersey/navigator.business.nj.gov/commit/edf4d10d4304c4172b9d22fde292019e4768ecb3))
 
@@ -815,7 +763,7 @@
 
 ### Bug Fixes
 
-- [AB[#12799](https://github.com/newjersey/navigator.business.nj.gov/issues/12799)] update query to
+- [AB#12799](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/12799) update query to
   use current version dynamically
   ([b3b3c51](https://github.com/newjersey/navigator.business.nj.gov/commit/b3b3c516af6dfd9eba901a74d4cd8964b6280679))
 - add retry to first cypress test as workaround to race condition causing a failure

--- a/api/cdk/package.json
+++ b/api/cdk/package.json
@@ -13,14 +13,14 @@
     "prettier:check": "prettier . --check --ignore-path=./.eslintignore"
   },
   "devDependencies": {
-    "@jest/globals": "^30.1.2",
+    "@jest/globals": "30.1.2",
     "@types/jest": "29.5.14",
     "@types/node": "24.1.0",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/parser": "7.18.0",
     "aws-cdk": "2.1033.0",
-    "aws-cdk-lib": "^2.215.0",
-    "esbuild": "^0.27.0",
+    "aws-cdk-lib": "2.215.0",
+    "esbuild": "0.27.0",
     "eslint": "8.57.1",
     "eslint-config-prettier": "9.1.2",
     "eslint-plugin-jest": "27.9.0",
@@ -34,6 +34,6 @@
     "typescript": "5.9.3"
   },
   "dependencies": {
-    "constructs": "^10.0.0"
+    "constructs": "10.0.0"
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -61,7 +61,7 @@
     "zod": "4.3.5"
   },
   "devDependencies": {
-    "@aws-sdk/client-cognito-identity-provider": "^3.777.0",
+    "@aws-sdk/client-cognito-identity-provider": "3.777.0",
     "@businessnjgovnavigator/shared": "*",
     "@jest/types": "29.6.3",
     "@types/cors": "2.8.19",
@@ -76,11 +76,11 @@
     "@types/xml2js": "0.4.14",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/parser": "7.18.0",
-    "concurrently": "^9.2.1",
+    "concurrently": "9.2.1",
     "cross-env": "10.1.0",
     "dependency-cruiser": "17.3.1",
     "dotenv": "17.2.3",
-    "esbuild": "^0.27.0",
+    "esbuild": "0.27.0",
     "eslint": "8.57.1",
     "eslint-config-prettier": "9.1.2",
     "eslint-plugin-jest": "27.9.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "babel-jest": "29.7.0",
     "body-parser": "1.20.3",
     "broken-link-checker": "0.7.8",
-    "constructs": "^10.0.0",
+    "constructs": "10.0.0",
     "cors": "2.8.5",
     "cypress-axe": "1.7.0",
     "dayjs": "1.11.19",
@@ -120,13 +120,13 @@
     "zod": "4.3.5"
   },
   "devDependencies": {
-    "@aws-sdk/client-cognito-identity-provider": "^3.777.0",
+    "@aws-sdk/client-cognito-identity-provider": "3.777.0",
     "@aws-sdk/types": "3.893.0",
     "@babel/core": "7.28.5",
     "@businessnjgovnavigator/shared": "*",
     "@cypress-audit/lighthouse": "1.4.2",
     "@cypress-audit/pa11y": "1.4.2",
-    "@jest/globals": "^30.1.2",
+    "@jest/globals": "30.1.2",
     "@jest/types": "29.6.3",
     "@mui/system": "5.18.0",
     "@next/bundle-analyzer": "16.1.1",
@@ -156,6 +156,8 @@
     "@testing-library/react": "16.3.0",
     "@testing-library/user-event": "14.6.1",
     "@types/broken-link-checker": "0.7.3",
+    "@types/conventional-changelog-writer": "4.0.11",
+    "@types/conventional-commits-parser": "5.0.2",
     "@types/cors": "2.8.19",
     "@types/cypress-dotenv": "2.0.3",
     "@types/dedent": "0.7.2",
@@ -171,7 +173,7 @@
     "@types/react-swipeable-views": "0.13.6",
     "@types/react-transition-group": "4.4.12",
     "@types/remove-markdown": "0.3.4",
-    "@types/seedrandom": "^3.0.8",
+    "@types/seedrandom": "3.0.8",
     "@types/simple-oauth2": "5.0.7",
     "@types/supertest": "6.0.3",
     "@types/testing-library__jest-dom": "5.14.9",
@@ -181,12 +183,12 @@
     "@typescript-eslint/parser": "7.18.0",
     "@vitest/coverage-v8": "2.1.8",
     "aws-cdk": "2.1033.0",
-    "aws-cdk-lib": "^2.215.0",
+    "aws-cdk-lib": "2.215.0",
     "babel-loader": "10.0.0",
     "cat": "0.2.0",
     "check-node-version": "4.2.1",
     "clean-webpack-plugin": "4.0.0",
-    "concurrently": "^9.2.1",
+    "concurrently": "9.2.1",
     "copy-webpack-plugin": "13.0.1",
     "cross-env": "10.1.0",
     "cspell": "9.3.2",
@@ -196,7 +198,7 @@
     "dependency-cruiser": "17.3.1",
     "dotenv": "17.2.3",
     "dynamodb-admin": "5.1.3",
-    "esbuild": "^0.27.0",
+    "esbuild": "0.27.0",
     "eslint": "8.57.1",
     "eslint-config-next": "15.5.6",
     "eslint-config-prettier": "9.1.2",
@@ -229,7 +231,7 @@
     "rimraf": "6.1.2",
     "sass": "1.94.2",
     "sass-loader": "16.0.6",
-    "seedrandom": "^3.0.5",
+    "seedrandom": "3.0.5",
     "semantic-release": "19.0.5",
     "storybook": "7.6.21",
     "style-loader": "4.0.0",
@@ -237,7 +239,7 @@
     "ts-jest": "29.4.5",
     "ts-loader": "9.5.4",
     "ts-node": "10.9.2",
-    "ts-node-dev": "^2.0.0",
+    "ts-node-dev": "2.0.0",
     "tsconfig-paths": "4.2.0",
     "tsx": "4.21.0",
     "typescript": "5.9.3",
@@ -275,38 +277,6 @@
       "prettier --write"
     ],
     "*.{css,md,scss,yml,yaml}": "prettier --write"
-  },
-  "release": {
-    "baseBranch": "main",
-    "plugins": [
-      [
-        "@semantic-release/commit-analyzer",
-        {
-          "preset": "angular",
-          "parserOpts": {
-            "noteKeywords": [
-              "BREAKING CHANGE",
-              "BREAKING CHANGES"
-            ]
-          }
-        }
-      ],
-      [
-        "@semantic-release/release-notes-generator",
-        {
-          "preset": "angular"
-        }
-      ],
-      "@semantic-release/npm",
-      "@semantic-release/changelog",
-      [
-        "@semantic-release/github",
-        {
-          "successComment": false
-        }
-      ],
-      "@semantic-release/git"
-    ]
   },
   "packageManager": "yarn@4.9.4",
   "resolutions": {

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,0 +1,155 @@
+// ---------------------------------------------------------------------------
+// JSDoc types
+// ---------------------------------------------------------------------------
+
+/** @typedef {import('conventional-commits-parser').Commit} Commit */
+/** @typedef {import('conventional-changelog-writer').Context} WriterContext */
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ADO_BASE = "https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit";
+
+// ---------------------------------------------------------------------------
+// Pure helper functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if the commit should be omitted from the changelog.
+ * Commits with breaking-change notes are always kept; otherwise only
+ * feat / fix / perf / revert are included.
+ *
+ * @param {Commit} commit
+ * @returns {boolean}
+ */
+const shouldDiscard = (commit) => {
+  if (commit.notes.length > 0) return false;
+  const releasable = ["feat", "fix", "perf", "revert"];
+  return !releasable.includes(commit.type) && !commit.revert;
+};
+
+/**
+ * Maps a conventional-commit type token to its changelog section label.
+ * Preserves the original Angular preset's if-else order so that the
+ * `revert || commit.revert` edge case is handled identically.
+ *
+ * @param {Commit} commit
+ * @returns {string | null}
+ */
+const resolveType = (commit) => {
+  if (commit.type === "feat") return "Features";
+  if (commit.type === "fix") return "Bug Fixes";
+  if (commit.type === "perf") return "Performance Improvements";
+  if (commit.type === "revert" || commit.revert) return "Reverts";
+  if (commit.type === "docs") return "Documentation";
+  if (commit.type === "style") return "Styles";
+  if (commit.type === "refactor") return "Code Refactoring";
+  if (commit.type === "test") return "Tests";
+  if (commit.type === "build") return "Build System";
+  if (commit.type === "ci") return "Continuous Integration";
+  return commit.type;
+};
+
+/**
+ * Replaces `[AB#N]` with an Azure DevOps work-item link and bare `#N` with a
+ * GitHub issue link in a single regex pass (preventing the ADO-embedded `#N`
+ * from being re-matched by the GitHub branch of the alternation).
+ *
+ * @param {string} subject
+ * @param {string | undefined} repoBase  e.g. "https://github.com/org/repo"
+ * @returns {{ subject: string, issues: string[] }}
+ */
+const linkifyIssues = (subject, repoBase) => {
+  const issues = [];
+  const result = subject.replace(/\[AB#(\d+)\]|#([0-9]+)/g, (match, adoIssue, ghIssue) => {
+    if (adoIssue !== undefined) {
+      issues.push(adoIssue);
+      return `[AB#${adoIssue}](${ADO_BASE}/${adoIssue})`;
+    }
+    if (ghIssue !== undefined && repoBase) {
+      issues.push(ghIssue);
+      return `[#${ghIssue}](${repoBase}/issues/${ghIssue})`;
+    }
+    return match;
+  });
+  return { subject: result, issues };
+};
+
+/**
+ * Replaces `@username` mentions with Markdown profile links.
+ * Org-scoped handles (`@org/team`) are left as plain text.
+ *
+ * @param {string} subject
+ * @param {string} host  e.g. "https://github.com"
+ * @returns {string}
+ */
+const linkifyMentions = (subject, host) =>
+  subject.replace(/\B@([a-z0-9](?:-?[a-z0-9/]){0,38})/g, (_, username) =>
+    username.includes("/") ? `@${username}` : `[@${username}](${host}/${username})`,
+  );
+
+// ---------------------------------------------------------------------------
+// Transform
+// ---------------------------------------------------------------------------
+
+/**
+ * Transform function for `conventional-changelog-writer`.
+ * Replicates the Angular preset's transform with ADO work-item links
+ * replacing GitHub issue links for `[AB#N]` references.
+ *
+ * @param {Commit} commit
+ * @param {WriterContext} context
+ * @returns {Commit | undefined}
+ */
+const adoTransform = (commit, context) => {
+  commit.notes.forEach((note) => {
+    note.title = "BREAKING CHANGES";
+  });
+
+  if (shouldDiscard(commit)) return;
+
+  commit.type = resolveType(commit);
+  if (commit.scope === "*") commit.scope = "";
+  if (typeof commit.hash === "string") commit.shortHash = commit.hash.substring(0, 7);
+
+  if (typeof commit.subject === "string") {
+    const repoBase = context.repository
+      ? `${context.host}/${context.owner}/${context.repository}`
+      : context.repoUrl;
+
+    const { subject, issues } = linkifyIssues(commit.subject, repoBase);
+    commit.subject = context.host ? linkifyMentions(subject, context.host) : subject;
+    commit.references = commit.references.filter((ref) => !issues.includes(ref.issue));
+  }
+
+  return commit;
+};
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+module.exports = {
+  branches: ["main"],
+  plugins: [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        preset: "angular",
+        parserOpts: { noteKeywords: ["BREAKING CHANGE", "BREAKING CHANGES"] },
+      },
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        preset: "angular",
+        writerOpts: { transform: adoTransform },
+      },
+    ],
+    "@semantic-release/npm",
+    "@semantic-release/changelog",
+    ["@semantic-release/github", { successComment: false }],
+    "@semantic-release/git",
+  ],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -596,50 +596,50 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-cognito-identity-provider@npm:^3.777.0":
-  version: 3.936.0
-  resolution: "@aws-sdk/client-cognito-identity-provider@npm:3.936.0"
+"@aws-sdk/client-cognito-identity-provider@npm:3.777.0":
+  version: 3.777.0
+  resolution: "@aws-sdk/client-cognito-identity-provider@npm:3.777.0"
   dependencies:
     "@aws-crypto/sha256-browser": 5.2.0
     "@aws-crypto/sha256-js": 5.2.0
-    "@aws-sdk/core": 3.936.0
-    "@aws-sdk/credential-provider-node": 3.936.0
-    "@aws-sdk/middleware-host-header": 3.936.0
-    "@aws-sdk/middleware-logger": 3.936.0
-    "@aws-sdk/middleware-recursion-detection": 3.936.0
-    "@aws-sdk/middleware-user-agent": 3.936.0
-    "@aws-sdk/region-config-resolver": 3.936.0
-    "@aws-sdk/types": 3.936.0
-    "@aws-sdk/util-endpoints": 3.936.0
-    "@aws-sdk/util-user-agent-browser": 3.936.0
-    "@aws-sdk/util-user-agent-node": 3.936.0
-    "@smithy/config-resolver": ^4.4.3
-    "@smithy/core": ^3.18.5
-    "@smithy/fetch-http-handler": ^5.3.6
-    "@smithy/hash-node": ^4.2.5
-    "@smithy/invalid-dependency": ^4.2.5
-    "@smithy/middleware-content-length": ^4.2.5
-    "@smithy/middleware-endpoint": ^4.3.12
-    "@smithy/middleware-retry": ^4.4.12
-    "@smithy/middleware-serde": ^4.2.6
-    "@smithy/middleware-stack": ^4.2.5
-    "@smithy/node-config-provider": ^4.3.5
-    "@smithy/node-http-handler": ^4.4.5
-    "@smithy/protocol-http": ^5.3.5
-    "@smithy/smithy-client": ^4.9.8
-    "@smithy/types": ^4.9.0
-    "@smithy/url-parser": ^4.2.5
-    "@smithy/util-base64": ^4.3.0
-    "@smithy/util-body-length-browser": ^4.2.0
-    "@smithy/util-body-length-node": ^4.2.1
-    "@smithy/util-defaults-mode-browser": ^4.3.11
-    "@smithy/util-defaults-mode-node": ^4.2.14
-    "@smithy/util-endpoints": ^3.2.5
-    "@smithy/util-middleware": ^4.2.5
-    "@smithy/util-retry": ^4.2.5
-    "@smithy/util-utf8": ^4.2.0
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/credential-provider-node": 3.777.0
+    "@aws-sdk/middleware-host-header": 3.775.0
+    "@aws-sdk/middleware-logger": 3.775.0
+    "@aws-sdk/middleware-recursion-detection": 3.775.0
+    "@aws-sdk/middleware-user-agent": 3.775.0
+    "@aws-sdk/region-config-resolver": 3.775.0
+    "@aws-sdk/types": 3.775.0
+    "@aws-sdk/util-endpoints": 3.775.0
+    "@aws-sdk/util-user-agent-browser": 3.775.0
+    "@aws-sdk/util-user-agent-node": 3.775.0
+    "@smithy/config-resolver": ^4.1.0
+    "@smithy/core": ^3.2.0
+    "@smithy/fetch-http-handler": ^5.0.2
+    "@smithy/hash-node": ^4.0.2
+    "@smithy/invalid-dependency": ^4.0.2
+    "@smithy/middleware-content-length": ^4.0.2
+    "@smithy/middleware-endpoint": ^4.1.0
+    "@smithy/middleware-retry": ^4.1.0
+    "@smithy/middleware-serde": ^4.0.3
+    "@smithy/middleware-stack": ^4.0.2
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/node-http-handler": ^4.0.4
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/smithy-client": ^4.2.0
+    "@smithy/types": ^4.2.0
+    "@smithy/url-parser": ^4.0.2
+    "@smithy/util-base64": ^4.0.0
+    "@smithy/util-body-length-browser": ^4.0.0
+    "@smithy/util-body-length-node": ^4.0.0
+    "@smithy/util-defaults-mode-browser": ^4.0.8
+    "@smithy/util-defaults-mode-node": ^4.0.8
+    "@smithy/util-endpoints": ^3.0.2
+    "@smithy/util-middleware": ^4.0.2
+    "@smithy/util-retry": ^4.0.2
+    "@smithy/util-utf8": ^4.0.0
     tslib: ^2.6.2
-  checksum: 8b0e15c0039dc130f1e239fd6e3611629154ba53d4986aa3d8e2de6891cccb7a1e1631da6307cafdbf9e889f7ac0dac0aaf31311e69bb6a12bc4852b11315612
+  checksum: 6d8be278482f34243ef08125e47551df7d01fab1b5894ccb2c688e1689f0593c2561171ff539a22e77830471606a9daf379d15fc7af7589528cba72dd2a0192b
   languageName: node
   linkType: hard
 
@@ -1296,6 +1296,52 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/client-sso@npm:3.777.0":
+  version: 3.777.0
+  resolution: "@aws-sdk/client-sso@npm:3.777.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/middleware-host-header": 3.775.0
+    "@aws-sdk/middleware-logger": 3.775.0
+    "@aws-sdk/middleware-recursion-detection": 3.775.0
+    "@aws-sdk/middleware-user-agent": 3.775.0
+    "@aws-sdk/region-config-resolver": 3.775.0
+    "@aws-sdk/types": 3.775.0
+    "@aws-sdk/util-endpoints": 3.775.0
+    "@aws-sdk/util-user-agent-browser": 3.775.0
+    "@aws-sdk/util-user-agent-node": 3.775.0
+    "@smithy/config-resolver": ^4.1.0
+    "@smithy/core": ^3.2.0
+    "@smithy/fetch-http-handler": ^5.0.2
+    "@smithy/hash-node": ^4.0.2
+    "@smithy/invalid-dependency": ^4.0.2
+    "@smithy/middleware-content-length": ^4.0.2
+    "@smithy/middleware-endpoint": ^4.1.0
+    "@smithy/middleware-retry": ^4.1.0
+    "@smithy/middleware-serde": ^4.0.3
+    "@smithy/middleware-stack": ^4.0.2
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/node-http-handler": ^4.0.4
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/smithy-client": ^4.2.0
+    "@smithy/types": ^4.2.0
+    "@smithy/url-parser": ^4.0.2
+    "@smithy/util-base64": ^4.0.0
+    "@smithy/util-body-length-browser": ^4.0.0
+    "@smithy/util-body-length-node": ^4.0.0
+    "@smithy/util-defaults-mode-browser": ^4.0.8
+    "@smithy/util-defaults-mode-node": ^4.0.8
+    "@smithy/util-endpoints": ^3.0.2
+    "@smithy/util-middleware": ^4.0.2
+    "@smithy/util-retry": ^4.0.2
+    "@smithy/util-utf8": ^4.0.0
+    tslib: ^2.6.2
+  checksum: fe6f999e2beee83d32f07e48731e478532dfc07f94aec6291fb1c25513e68e5482f9ec91146ffdb736074cd035342599482105c082e02498485b004abde44af6
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/client-sso@npm:3.896.0":
   version: 3.896.0
   resolution: "@aws-sdk/client-sso@npm:3.896.0"
@@ -1499,6 +1545,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/core@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/core@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/types": 3.775.0
+    "@smithy/core": ^3.2.0
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/signature-v4": ^5.0.2
+    "@smithy/smithy-client": ^4.2.0
+    "@smithy/types": ^4.2.0
+    "@smithy/util-middleware": ^4.0.2
+    fast-xml-parser: 4.4.1
+    tslib: ^2.6.2
+  checksum: 0968548015ad59fe8542c2c52c5651029ce962d7303c6b0203097142dbc6c0a5990d32aeefe032288e09bbfae60734a774a89c0cf5f4b9e8445111a11e23fece
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/core@npm:3.896.0":
   version: 3.896.0
   resolution: "@aws-sdk/core@npm:3.896.0"
@@ -1574,6 +1639,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-env@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: cc74c1775f99d6416118c3f05681a9b342db8056dde28f0c0ce1bf72e6547da6ef248837674970f6bb829d7b2125533e22a4694b81ab05e1a483e058e0d4a645
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-env@npm:3.896.0":
   version: 3.896.0
   resolution: "@aws-sdk/credential-provider-env@npm:3.896.0"
@@ -1627,6 +1705,24 @@ __metadata:
     "@smithy/util-stream": ^3.1.3
     tslib: ^2.6.2
   checksum: bc45dfe7d0a6868978d71fa73731784af1839f822c09ef13b5a08ad74fa57c008dd874dd1765317df61ab022f9470bf509df38a70dd0aa5262d1d2234cc5eda2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-http@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/credential-provider-http@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/fetch-http-handler": ^5.0.2
+    "@smithy/node-http-handler": ^4.0.4
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/smithy-client": ^4.2.0
+    "@smithy/types": ^4.2.0
+    "@smithy/util-stream": ^4.2.0
+    tslib: ^2.6.2
+  checksum: f57ad694f93f381eab96ddd6822690dd02ba18bc3533fa4e9eb4b623ff8b9990c23c06c7f2fe59e4d78d175aa065a641994259f1cbcf9e1e0ae10436eda84280
   languageName: node
   linkType: hard
 
@@ -1702,6 +1798,27 @@ __metadata:
   peerDependencies:
     "@aws-sdk/client-sts": ^3.621.0
   checksum: a3db43adfbdb2ea1d6d80b1ca6789e48b729fce2499039f99721f504322cba325e4b48ed842bd26ae6f49ca771e5817016b75cda31cf247fd3e2bd0ac235b332
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-ini@npm:3.777.0":
+  version: 3.777.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.777.0"
+  dependencies:
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/credential-provider-env": 3.775.0
+    "@aws-sdk/credential-provider-http": 3.775.0
+    "@aws-sdk/credential-provider-process": 3.775.0
+    "@aws-sdk/credential-provider-sso": 3.777.0
+    "@aws-sdk/credential-provider-web-identity": 3.777.0
+    "@aws-sdk/nested-clients": 3.777.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/credential-provider-imds": ^4.0.2
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/shared-ini-file-loader": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 87058aae710c31a5e21a3d9eec720bea8b64d0a007316308272c79e47eabfe6d4ef99e8e110addcf7952e3a1a0012ed00667d2bade18684f9a88757049334c19
   languageName: node
   linkType: hard
 
@@ -1805,6 +1922,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-node@npm:3.777.0":
+  version: 3.777.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.777.0"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.775.0
+    "@aws-sdk/credential-provider-http": 3.775.0
+    "@aws-sdk/credential-provider-ini": 3.777.0
+    "@aws-sdk/credential-provider-process": 3.775.0
+    "@aws-sdk/credential-provider-sso": 3.777.0
+    "@aws-sdk/credential-provider-web-identity": 3.777.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/credential-provider-imds": ^4.0.2
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/shared-ini-file-loader": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 7e2f3eb6c7d5bdff2a0978df6d03e09fd1edd63587de0281434b48d62836137128c7eda7bb2ad3c4ace2ef232ff60c6f37bbb22c42c77db283d0f1fc093c3aca
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-node@npm:3.896.0":
   version: 3.896.0
   resolution: "@aws-sdk/credential-provider-node@npm:3.896.0"
@@ -1878,6 +2015,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-process@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/shared-ini-file-loader": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 80080da427c95a01c3a44c9cf6cd237b93a41fa54646bbe1b924e239bcf78a662efcb1f1bb48ba3c530919c31b11c3030baf64fbda3ef75dbab18309066a882f
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-process@npm:3.896.0":
   version: 3.896.0
   resolution: "@aws-sdk/credential-provider-process@npm:3.896.0"
@@ -1932,6 +2083,22 @@ __metadata:
     "@smithy/types": ^3.3.0
     tslib: ^2.6.2
   checksum: 4602308a0bf74bda9dd7b92caf02868b855935deb703a8894d052c81864ef9c9359408ec84569f71527c1b204577940ebe1a9f6cbba8de677471eb590d91c3ba
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-sso@npm:3.777.0":
+  version: 3.777.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.777.0"
+  dependencies:
+    "@aws-sdk/client-sso": 3.777.0
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/token-providers": 3.777.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/shared-ini-file-loader": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 4d16e1ab9b0c8c730b66a9e50e89a9109a2f243ab9a2a2b5cccd2df307f75f69f58ac0a88689482d22b007153fba14714796e5cf2b6a1927295aadab43dd1b49
   languageName: node
   linkType: hard
 
@@ -1994,6 +2161,20 @@ __metadata:
   peerDependencies:
     "@aws-sdk/client-sts": ^3.621.0
   checksum: b1157e83b81c21f384ad95d29c646149124136c38e6395265ff8d9f5f6afec1e3e2b70c1f0be165c440058802c3871f3766c5e7ba44705ced447de221f4d04df
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:3.777.0":
+  version: 3.777.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.777.0"
+  dependencies:
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/nested-clients": 3.777.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 15bcfe2872ada16667be2dcc015028901b19c128a6dc44ed5e79979857771f81822cee2bfb9178a441c1ab207779e6ae84c8c2423e4c4ec7b32ae74fdbb39091
   languageName: node
   linkType: hard
 
@@ -2181,6 +2362,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-host-header@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/types": 3.775.0
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 2a1f7caa4c4567e8f0349d456ec047e5c20b8e583d11d41ba4a669f82c769b6d2d4a359ac40587f95043350126b70fd7957cdacb6251f984192819d2f873008d
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-host-header@npm:3.893.0":
   version: 3.893.0
   resolution: "@aws-sdk/middleware-host-header@npm:3.893.0"
@@ -2239,6 +2432,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-logger@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/types": 3.775.0
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 8a19f4227378802afd358884ddb8b76e3fbfd8c071b8a398744936f469207bf9bda71e451b53845fb76cd82d4de5057ac949e0eccdc8394cdf35da1a40afcbb3
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-logger@npm:3.893.0":
   version: 3.893.0
   resolution: "@aws-sdk/middleware-logger@npm:3.893.0"
@@ -2281,6 +2485,18 @@ __metadata:
     "@smithy/types": ^3.3.0
     tslib: ^2.6.2
   checksum: 1dedbbab2f79d4c0b214ca183a45daf89e98f9a33b2a08dcd7d30e059c1bcc04a74499b49870300d5f0b827d660512582f96f857624d3feaaf194a7a92703cea
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-recursion-detection@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/types": 3.775.0
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 6004dd149eb485f04d9d2bc96af51176fe70a6e1679d10c395f7af274e4b3948443de7b219f02b0314a3f66d54b36927fee6643b0ebd6aa55fba1b1e7e3422dd
   languageName: node
   linkType: hard
 
@@ -2369,6 +2585,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-user-agent@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/types": 3.775.0
+    "@aws-sdk/util-endpoints": 3.775.0
+    "@smithy/core": ^3.2.0
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: ba641eba1ee11e05bf59019de0826540fc8faa0c5eea3c6a7cc66fb85898db01c68fb1086fb66183de46bded72a8cb991789f39527f93add178375303a18444a
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-user-agent@npm:3.896.0":
   version: 3.896.0
   resolution: "@aws-sdk/middleware-user-agent@npm:3.896.0"
@@ -2411,6 +2642,52 @@ __metadata:
     "@smithy/types": ^4.9.0
     tslib: ^2.6.2
   checksum: 850fce494ba53f06bca2be7cfdbe04ab5df68818ce5436969231f8dc9e2297c56eafd4003f86e33c8dcb22147708c97d9375459f0f0763dd94a1fe703179cd41
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/nested-clients@npm:3.777.0":
+  version: 3.777.0
+  resolution: "@aws-sdk/nested-clients@npm:3.777.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/middleware-host-header": 3.775.0
+    "@aws-sdk/middleware-logger": 3.775.0
+    "@aws-sdk/middleware-recursion-detection": 3.775.0
+    "@aws-sdk/middleware-user-agent": 3.775.0
+    "@aws-sdk/region-config-resolver": 3.775.0
+    "@aws-sdk/types": 3.775.0
+    "@aws-sdk/util-endpoints": 3.775.0
+    "@aws-sdk/util-user-agent-browser": 3.775.0
+    "@aws-sdk/util-user-agent-node": 3.775.0
+    "@smithy/config-resolver": ^4.1.0
+    "@smithy/core": ^3.2.0
+    "@smithy/fetch-http-handler": ^5.0.2
+    "@smithy/hash-node": ^4.0.2
+    "@smithy/invalid-dependency": ^4.0.2
+    "@smithy/middleware-content-length": ^4.0.2
+    "@smithy/middleware-endpoint": ^4.1.0
+    "@smithy/middleware-retry": ^4.1.0
+    "@smithy/middleware-serde": ^4.0.3
+    "@smithy/middleware-stack": ^4.0.2
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/node-http-handler": ^4.0.4
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/smithy-client": ^4.2.0
+    "@smithy/types": ^4.2.0
+    "@smithy/url-parser": ^4.0.2
+    "@smithy/util-base64": ^4.0.0
+    "@smithy/util-body-length-browser": ^4.0.0
+    "@smithy/util-body-length-node": ^4.0.0
+    "@smithy/util-defaults-mode-browser": ^4.0.8
+    "@smithy/util-defaults-mode-node": ^4.0.8
+    "@smithy/util-endpoints": ^3.0.2
+    "@smithy/util-middleware": ^4.0.2
+    "@smithy/util-retry": ^4.0.2
+    "@smithy/util-utf8": ^4.0.0
+    tslib: ^2.6.2
+  checksum: 0633874d2f044047336c161f6db3e9e0ea1bf2cabb107b94e86983da779c98c7df4de73024cfdb7f2839ded02f6e536547f9aa5c4d74527cc10f64a4a57767b1
   languageName: node
   linkType: hard
 
@@ -2576,6 +2853,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/region-config-resolver@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/region-config-resolver@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/types": 3.775.0
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/types": ^4.2.0
+    "@smithy/util-config-provider": ^4.0.0
+    "@smithy/util-middleware": ^4.0.2
+    tslib: ^2.6.2
+  checksum: 14a943b75a873762c6d2b052a99445a97c9e0a67e379d161974f8515bc5e73b45c2f594d0736e5a5cff388eaa574460760bf8c1e3f938828725e08bc393e7d6e
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/region-config-resolver@npm:3.893.0":
   version: 3.893.0
   resolution: "@aws-sdk/region-config-resolver@npm:3.893.0"
@@ -2671,6 +2962,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/token-providers@npm:3.777.0":
+  version: 3.777.0
+  resolution: "@aws-sdk/token-providers@npm:3.777.0"
+  dependencies:
+    "@aws-sdk/nested-clients": 3.777.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/shared-ini-file-loader": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 6103febadbaf4068b348368b2524d4b8e9f9f13a7e3a39bfc7a926722250f53c31d8dfd7fda4e069952389d042e08fed965bfe133652ab3583558052b2bb8b6f
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/token-providers@npm:3.896.0":
   version: 3.896.0
   resolution: "@aws-sdk/token-providers@npm:3.896.0"
@@ -2743,6 +3048,16 @@ __metadata:
     "@smithy/types": ^3.3.0
     tslib: ^2.6.2
   checksum: 522768d08f104065b0ff6a37eddaa7803186014acee1c0011b3dbd3ef841e47ae694e58f608aeec8a39d22d644d759ade996fe51d18b880617778dc2dbbe1ede
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/types@npm:3.775.0"
+  dependencies:
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 2380a8b68a9772297ca1f70cf4d50bca36929d5d67aad1d45194814d2a90c490fb591192e09f43a82ccc9761d25585e0396563bc8227238a2a0101e9a72e5813
   languageName: node
   linkType: hard
 
@@ -2849,6 +3164,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/util-endpoints@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/types": 3.775.0
+    "@smithy/types": ^4.2.0
+    "@smithy/util-endpoints": ^3.0.2
+    tslib: ^2.6.2
+  checksum: c179bab95ca2f848a798a5f4c17829e7831d6429fc5ae061c58478c99d00d45335e778e30fdf42fa0a58964e554dfd27fed702596d688dca01313e4e83480c40
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-endpoints@npm:3.895.0":
   version: 3.895.0
   resolution: "@aws-sdk/util-endpoints@npm:3.895.0"
@@ -2921,6 +3248,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/util-user-agent-browser@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/types": 3.775.0
+    "@smithy/types": ^4.2.0
+    bowser: ^2.11.0
+    tslib: ^2.6.2
+  checksum: 8df00a8280492335a34f91a403830ab2cafef12216724b9442cf4436a4ba718221de35eb7b2e0d3135f8631e2ab5422813f8438ce765746c89c22264b76d7ac2
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-user-agent-browser@npm:3.893.0":
   version: 3.893.0
   resolution: "@aws-sdk/util-user-agent-browser@npm:3.893.0"
@@ -2971,6 +3310,24 @@ __metadata:
     aws-crt:
       optional: true
   checksum: 1f010080c2301fd836908963a235ef39e597d959e27461d15d4958fa582ab20795022f8cb7429c183c386f558a5c125cb254a0c4e844dbc6422169f4884be34a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-node@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/middleware-user-agent": 3.775.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  peerDependencies:
+    aws-crt: ">=1.0.0"
+  peerDependenciesMeta:
+    aws-crt:
+      optional: true
+  checksum: 945cd95c863376004635d86ee4c25ead079d0318e5dd820f921ceb2e0cfc0f817f6c5d7d08ea220e21c4b3887f9188430531b2da82ad02213915c8e718bfd8e5
   languageName: node
   linkType: hard
 
@@ -4572,15 +4929,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@businessnjgovnavigator/api-cdk@workspace:api/cdk"
   dependencies:
-    "@jest/globals": ^30.1.2
+    "@jest/globals": 30.1.2
     "@types/jest": 29.5.14
     "@types/node": 24.1.0
     "@typescript-eslint/eslint-plugin": 7.18.0
     "@typescript-eslint/parser": 7.18.0
     aws-cdk: 2.1033.0
-    aws-cdk-lib: ^2.215.0
-    constructs: ^10.0.0
-    esbuild: ^0.27.0
+    aws-cdk-lib: 2.215.0
+    constructs: 10.0.0
+    esbuild: 0.27.0
     eslint: 8.57.1
     eslint-config-prettier: 9.1.2
     eslint-plugin-jest: 27.9.0
@@ -4602,7 +4959,7 @@ __metadata:
     "@aws-crypto/client-node": 4.2.1
     "@aws-sdk/client-cloudwatch": 3.896.0
     "@aws-sdk/client-cloudwatch-logs": 3.896.0
-    "@aws-sdk/client-cognito-identity-provider": ^3.777.0
+    "@aws-sdk/client-cognito-identity-provider": 3.777.0
     "@aws-sdk/client-dynamodb": 3.896.0
     "@aws-sdk/client-lambda": 3.896.0
     "@aws-sdk/client-s3": 3.896.0
@@ -4632,14 +4989,14 @@ __metadata:
     airtable: 0.12.2
     axios: 1.13.5
     body-parser: 1.20.3
-    concurrently: ^9.2.1
+    concurrently: 9.2.1
     cors: 2.8.5
     cross-env: 10.1.0
     dayjs: 1.11.19
     dedent: 1.7.0
     dependency-cruiser: 17.3.1
     dotenv: 17.2.3
-    esbuild: ^0.27.0
+    esbuild: 0.27.0
     eslint: 8.57.1
     eslint-config-prettier: 9.1.2
     eslint-plugin-jest: 27.9.0
@@ -4714,7 +5071,7 @@ __metadata:
     "@aws-crypto/sha256-browser": 5.2.0
     "@aws-sdk/client-cloudwatch": 3.896.0
     "@aws-sdk/client-cloudwatch-logs": 3.896.0
-    "@aws-sdk/client-cognito-identity-provider": ^3.777.0
+    "@aws-sdk/client-cognito-identity-provider": 3.777.0
     "@aws-sdk/client-dynamodb": 3.896.0
     "@aws-sdk/client-lambda": 3.896.0
     "@aws-sdk/client-s3": 3.896.0
@@ -4737,7 +5094,7 @@ __metadata:
     "@cypress-audit/pa11y": 1.4.2
     "@emotion/react": 11.14.0
     "@emotion/styled": 11.14.1
-    "@jest/globals": ^30.1.2
+    "@jest/globals": 30.1.2
     "@jest/types": 29.6.3
     "@mui/icons-material": 5.18.0
     "@mui/lab": 5.0.0-alpha.177
@@ -4777,6 +5134,8 @@ __metadata:
     "@testing-library/react": 16.3.0
     "@testing-library/user-event": 14.6.1
     "@types/broken-link-checker": 0.7.3
+    "@types/conventional-changelog-writer": 4.0.11
+    "@types/conventional-commits-parser": 5.0.2
     "@types/cors": 2.8.19
     "@types/cypress-dotenv": 2.0.3
     "@types/dedent": 0.7.2
@@ -4793,7 +5152,7 @@ __metadata:
     "@types/react-swipeable-views": 0.13.6
     "@types/react-transition-group": 4.4.12
     "@types/remove-markdown": 0.3.4
-    "@types/seedrandom": ^3.0.8
+    "@types/seedrandom": 3.0.8
     "@types/simple-oauth2": 5.0.7
     "@types/supertest": 6.0.3
     "@types/testing-library__jest-dom": 5.14.9
@@ -4805,7 +5164,7 @@ __metadata:
     airtable: 0.12.2
     aws-amplify: 6.15.8
     aws-cdk: 2.1033.0
-    aws-cdk-lib: ^2.215.0
+    aws-cdk-lib: 2.215.0
     axios: 1.13.5
     babel-jest: 29.7.0
     babel-loader: 10.0.0
@@ -4814,8 +5173,8 @@ __metadata:
     cat: 0.2.0
     check-node-version: 4.2.1
     clean-webpack-plugin: 4.0.0
-    concurrently: ^9.2.1
-    constructs: ^10.0.0
+    concurrently: 9.2.1
+    constructs: 10.0.0
     copy-webpack-plugin: 13.0.1
     cors: 2.8.5
     cross-env: 10.1.0
@@ -4830,7 +5189,7 @@ __metadata:
     dependency-cruiser: 17.3.1
     dotenv: 17.2.3
     dynamodb-admin: 5.1.3
-    esbuild: ^0.27.0
+    esbuild: 0.27.0
     eslint: 8.57.1
     eslint-config-next: 15.5.6
     eslint-config-prettier: 9.1.2
@@ -4888,7 +5247,7 @@ __metadata:
     rimraf: 6.1.2
     sass: 1.94.2
     sass-loader: 16.0.6
-    seedrandom: ^3.0.5
+    seedrandom: 3.0.5
     semantic-release: 19.0.5
     serverless-http: 3.2.0
     simple-oauth2: 5.1.0
@@ -4900,7 +5259,7 @@ __metadata:
     ts-jest: 29.4.5
     ts-loader: 9.5.4
     ts-node: 10.9.2
-    ts-node-dev: ^2.0.0
+    ts-node-dev: 2.0.0
     tsconfig-paths: 4.2.0
     tsx: 4.21.0
     typescript: 5.9.3
@@ -6065,6 +6424,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/aix-ppc64@npm:0.27.0"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/aix-ppc64@npm:0.27.1"
@@ -6089,6 +6455,13 @@ __metadata:
 "@esbuild/android-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/android-arm64@npm:0.25.12"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/android-arm64@npm:0.27.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -6121,6 +6494,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/android-arm@npm:0.27.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/android-arm@npm:0.27.1"
@@ -6145,6 +6525,13 @@ __metadata:
 "@esbuild/android-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/android-x64@npm:0.25.12"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/android-x64@npm:0.27.0"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -6177,6 +6564,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/darwin-arm64@npm:0.27.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-arm64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/darwin-arm64@npm:0.27.1"
@@ -6201,6 +6595,13 @@ __metadata:
 "@esbuild/darwin-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/darwin-x64@npm:0.25.12"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/darwin-x64@npm:0.27.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -6233,6 +6634,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/freebsd-arm64@npm:0.27.0"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-arm64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/freebsd-arm64@npm:0.27.1"
@@ -6257,6 +6665,13 @@ __metadata:
 "@esbuild/freebsd-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/freebsd-x64@npm:0.25.12"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/freebsd-x64@npm:0.27.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -6289,6 +6704,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-arm64@npm:0.27.0"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/linux-arm64@npm:0.27.1"
@@ -6313,6 +6735,13 @@ __metadata:
 "@esbuild/linux-arm@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-arm@npm:0.25.12"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-arm@npm:0.27.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -6345,6 +6774,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-ia32@npm:0.27.0"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ia32@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/linux-ia32@npm:0.27.1"
@@ -6369,6 +6805,13 @@ __metadata:
 "@esbuild/linux-loong64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-loong64@npm:0.25.12"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-loong64@npm:0.27.0"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -6401,6 +6844,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-mips64el@npm:0.27.0"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-mips64el@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/linux-mips64el@npm:0.27.1"
@@ -6425,6 +6875,13 @@ __metadata:
 "@esbuild/linux-ppc64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-ppc64@npm:0.25.12"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-ppc64@npm:0.27.0"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -6457,6 +6914,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-riscv64@npm:0.27.0"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-riscv64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/linux-riscv64@npm:0.27.1"
@@ -6481,6 +6945,13 @@ __metadata:
 "@esbuild/linux-s390x@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-s390x@npm:0.25.12"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-s390x@npm:0.27.0"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -6513,6 +6984,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-x64@npm:0.27.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-x64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/linux-x64@npm:0.27.1"
@@ -6523,6 +7001,13 @@ __metadata:
 "@esbuild/netbsd-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/netbsd-arm64@npm:0.25.12"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/netbsd-arm64@npm:0.27.0"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -6555,6 +7040,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/netbsd-x64@npm:0.27.0"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-x64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/netbsd-x64@npm:0.27.1"
@@ -6565,6 +7057,13 @@ __metadata:
 "@esbuild/openbsd-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/openbsd-arm64@npm:0.25.12"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/openbsd-arm64@npm:0.27.0"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -6597,6 +7096,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/openbsd-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/openbsd-x64@npm:0.27.0"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-x64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/openbsd-x64@npm:0.27.1"
@@ -6607,6 +7113,13 @@ __metadata:
 "@esbuild/openharmony-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/openharmony-arm64@npm:0.25.12"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/openharmony-arm64@npm:0.27.0"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -6639,6 +7152,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/sunos-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/sunos-x64@npm:0.27.0"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/sunos-x64@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/sunos-x64@npm:0.27.1"
@@ -6663,6 +7183,13 @@ __metadata:
 "@esbuild/win32-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/win32-arm64@npm:0.25.12"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/win32-arm64@npm:0.27.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -6695,6 +7222,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/win32-ia32@npm:0.27.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-ia32@npm:0.27.1":
   version: 0.27.1
   resolution: "@esbuild/win32-ia32@npm:0.27.1"
@@ -6719,6 +7253,13 @@ __metadata:
 "@esbuild/win32-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/win32-x64@npm:0.25.12"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/win32-x64@npm:0.27.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7300,15 +7841,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/environment@npm:30.2.0":
-  version: 30.2.0
-  resolution: "@jest/environment@npm:30.2.0"
+"@jest/environment@npm:30.1.2":
+  version: 30.1.2
+  resolution: "@jest/environment@npm:30.1.2"
   dependencies:
-    "@jest/fake-timers": 30.2.0
-    "@jest/types": 30.2.0
+    "@jest/fake-timers": 30.1.2
+    "@jest/types": 30.0.5
     "@types/node": "*"
-    jest-mock: 30.2.0
-  checksum: 70df0ff33fd75552c7c23c6126a57f6658ca28d507405f2dd4f9399ffc62c646c1173cbdb045b2de22d739a0f467d68ff57b88897adbe6510988ead3ea8dedae
+    jest-mock: 30.0.5
+  checksum: cc14648ec0ec7fd1b2a0f0e261bb70c4fd320cdf00962a27eb2bff5158b1302665e58aa91c0fcda7d465e952df6b4e55eb6be87e5325253ba0379d076ed88e89
   languageName: node
   linkType: hard
 
@@ -7321,6 +7862,15 @@ __metadata:
     "@types/node": "*"
     jest-mock: ^29.7.0
   checksum: 6fb398143b2543d4b9b8d1c6dbce83fa5247f84f550330604be744e24c2bd2178bb893657d62d1b97cf2f24baf85c450223f8237cccb71192c36a38ea2272934
+  languageName: node
+  linkType: hard
+
+"@jest/expect-utils@npm:30.1.2":
+  version: 30.1.2
+  resolution: "@jest/expect-utils@npm:30.1.2"
+  dependencies:
+    "@jest/get-type": 30.1.0
+  checksum: 739b7a06859cc083d85838e2e0dbda8208f4cdca25a8221ae0bc528ed8e84adfa402760e677a7305637a57db952f3838f260e13827ac9841bc231e0b0f202942
   languageName: node
   linkType: hard
 
@@ -7342,13 +7892,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/expect@npm:30.2.0":
-  version: 30.2.0
-  resolution: "@jest/expect@npm:30.2.0"
+"@jest/expect@npm:30.1.2":
+  version: 30.1.2
+  resolution: "@jest/expect@npm:30.1.2"
   dependencies:
-    expect: 30.2.0
-    jest-snapshot: 30.2.0
-  checksum: f75e6753abd9aeef56ff01025a79d9ca7faf07c9e68da0b89b2317b8c552589316dd07cd61722d148d73d741f3d84121ea031737971cdac36559b1805fc50748
+    expect: 30.1.2
+    jest-snapshot: 30.1.2
+  checksum: c75447bd8da3edb8511578848114dd0a2815679410d63528797612e70b98c2d1dc8956473063a6095f622a3050bb95ad293dc0ebe4aaf00469ed6c50bd726eca
   languageName: node
   linkType: hard
 
@@ -7362,17 +7912,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/fake-timers@npm:30.2.0":
-  version: 30.2.0
-  resolution: "@jest/fake-timers@npm:30.2.0"
+"@jest/fake-timers@npm:30.1.2":
+  version: 30.1.2
+  resolution: "@jest/fake-timers@npm:30.1.2"
   dependencies:
-    "@jest/types": 30.2.0
+    "@jest/types": 30.0.5
     "@sinonjs/fake-timers": ^13.0.0
     "@types/node": "*"
-    jest-message-util: 30.2.0
-    jest-mock: 30.2.0
-    jest-util: 30.2.0
-  checksum: eae3b366f4973ef2d18ac54d4a89e8fb4b119994c8f10f153663bf9b5558b946c5bbe338a1e09a23ab7184cb619423dff51f4b4a98cd3b0987aef53cbb6a4ef3
+    jest-message-util: 30.1.0
+    jest-mock: 30.0.5
+    jest-util: 30.0.5
+  checksum: 12077a48c2ae11519be1d9e0366ff23501d3119057b560deab3139af47c0234c927cf14ec1ba686f6c624c4c39454dc7b30fd7e8c40ae1a6275538281fb603c0
   languageName: node
   linkType: hard
 
@@ -7397,6 +7947,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/globals@npm:30.1.2":
+  version: 30.1.2
+  resolution: "@jest/globals@npm:30.1.2"
+  dependencies:
+    "@jest/environment": 30.1.2
+    "@jest/expect": 30.1.2
+    "@jest/types": 30.0.5
+    jest-mock: 30.0.5
+  checksum: 5896b0f85d3735199af8ba47d9adaddc290d2f0fdb99afd23893a0d4a9e6855514b2555ed3f379bd13d84e026be05132dbb90af8bc2393e97c3847efa6d25ee5
+  languageName: node
+  linkType: hard
+
 "@jest/globals@npm:^29.7.0":
   version: 29.7.0
   resolution: "@jest/globals@npm:29.7.0"
@@ -7406,18 +7968,6 @@ __metadata:
     "@jest/types": ^29.6.3
     jest-mock: ^29.7.0
   checksum: 97dbb9459135693ad3a422e65ca1c250f03d82b2a77f6207e7fa0edd2c9d2015fbe4346f3dc9ebff1678b9d8da74754d4d440b7837497f8927059c0642a22123
-  languageName: node
-  linkType: hard
-
-"@jest/globals@npm:^30.1.2":
-  version: 30.2.0
-  resolution: "@jest/globals@npm:30.2.0"
-  dependencies:
-    "@jest/environment": 30.2.0
-    "@jest/expect": 30.2.0
-    "@jest/types": 30.2.0
-    jest-mock: 30.2.0
-  checksum: d4a331d3847cebb3acefe120350d8a6bb5517c1403de7cd2b4dc67be425f37ba0511beee77d6837b4da2d93a25a06d6f829ad7837da365fae45e1da57523525c
   languageName: node
   linkType: hard
 
@@ -7486,15 +8036,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/snapshot-utils@npm:30.2.0":
-  version: 30.2.0
-  resolution: "@jest/snapshot-utils@npm:30.2.0"
+"@jest/snapshot-utils@npm:30.1.2":
+  version: 30.1.2
+  resolution: "@jest/snapshot-utils@npm:30.1.2"
   dependencies:
-    "@jest/types": 30.2.0
+    "@jest/types": 30.0.5
     chalk: ^4.1.2
     graceful-fs: ^4.2.11
     natural-compare: ^1.4.0
-  checksum: 92a3edfb30850e163477fa0ac54543ffc68e0c45515504a7f213258a21f6dbb40b9aaff53edd6abf878253f1a5d7fb72c44dbccf687837960de02c1f062d3c33
+  checksum: add8c117f889d98e29a0614400a0f9d33c248551e1565ada69ebee9ce286dc0e03ffe775bddf8277f4e62a177fb86ba1427cb75d1e92f864769f8f19a62cc702
   languageName: node
   linkType: hard
 
@@ -7533,26 +8083,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/transform@npm:30.2.0":
-  version: 30.2.0
-  resolution: "@jest/transform@npm:30.2.0"
+"@jest/transform@npm:30.1.2":
+  version: 30.1.2
+  resolution: "@jest/transform@npm:30.1.2"
   dependencies:
     "@babel/core": ^7.27.4
-    "@jest/types": 30.2.0
+    "@jest/types": 30.0.5
     "@jridgewell/trace-mapping": ^0.3.25
-    babel-plugin-istanbul: ^7.0.1
+    babel-plugin-istanbul: ^7.0.0
     chalk: ^4.1.2
     convert-source-map: ^2.0.0
     fast-json-stable-stringify: ^2.1.0
     graceful-fs: ^4.2.11
-    jest-haste-map: 30.2.0
+    jest-haste-map: 30.1.0
     jest-regex-util: 30.0.1
-    jest-util: 30.2.0
+    jest-util: 30.0.5
     micromatch: ^4.0.8
     pirates: ^4.0.7
     slash: ^3.0.0
     write-file-atomic: ^5.0.1
-  checksum: af2174b218605d089b0dee044fe9872e8aec42aa00e033e7e0446a2f43c94b8541a4eda2f4d3cb4fcae86944147d4e1923d997acc1f1d734974c70c9df393060
+  checksum: bed6c313ef067020428542f1f05dd8ff0c030567a4d2d02f001738c0e3c872c01f0b03839b972075e17ab1731a831c1db4ea30eacf78ab5ac2def23f2eceabe0
   languageName: node
   linkType: hard
 
@@ -7590,6 +8140,21 @@ __metadata:
     "@types/yargs": ^17.0.8
     chalk: ^4.0.0
   checksum: a0bcf15dbb0eca6bdd8ce61a3fb055349d40268622a7670a3b2eb3c3dbafe9eb26af59938366d520b86907b9505b0f9b29b85cec11579a9e580694b87cd90fcc
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:30.0.5":
+  version: 30.0.5
+  resolution: "@jest/types@npm:30.0.5"
+  dependencies:
+    "@jest/pattern": 30.0.1
+    "@jest/schemas": 30.0.5
+    "@types/istanbul-lib-coverage": ^2.0.6
+    "@types/istanbul-reports": ^3.0.4
+    "@types/node": "*"
+    "@types/yargs": ^17.0.33
+    chalk: ^4.1.2
+  checksum: 59a7ad26a5ca4f0480961b4a9bde05c954c4b00b267231f05e33fd05ed786abdebc0a3cdcb813df4bf05b3513b0a29c77db79e97b246ac4ab31285e4253e8335
   languageName: node
   linkType: hard
 
@@ -10444,6 +11009,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/config-resolver@npm:^4.1.0, @smithy/config-resolver@npm:^4.4.6":
+  version: 4.4.6
+  resolution: "@smithy/config-resolver@npm:4.4.6"
+  dependencies:
+    "@smithy/node-config-provider": ^4.3.8
+    "@smithy/types": ^4.12.0
+    "@smithy/util-config-provider": ^4.2.0
+    "@smithy/util-endpoints": ^3.2.8
+    "@smithy/util-middleware": ^4.2.8
+    tslib: ^2.6.2
+  checksum: ffb98899d0343a16692e0bab514719b88d3f97a696489eabaa1c7e52d534083dac440e51dbf8cadf7193e9fabddd7244e77e32d03f905a1469c3d8113fa02a6c
+  languageName: node
+  linkType: hard
+
 "@smithy/config-resolver@npm:^4.2.2, @smithy/config-resolver@npm:^4.4.1, @smithy/config-resolver@npm:^4.4.3":
   version: 4.4.3
   resolution: "@smithy/config-resolver@npm:4.4.3"
@@ -10492,6 +11071,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/core@npm:^3.2.0, @smithy/core@npm:^3.23.2":
+  version: 3.23.2
+  resolution: "@smithy/core@npm:3.23.2"
+  dependencies:
+    "@smithy/middleware-serde": ^4.2.9
+    "@smithy/protocol-http": ^5.3.8
+    "@smithy/types": ^4.12.0
+    "@smithy/util-base64": ^4.3.0
+    "@smithy/util-body-length-browser": ^4.2.0
+    "@smithy/util-middleware": ^4.2.8
+    "@smithy/util-stream": ^4.5.12
+    "@smithy/util-utf8": ^4.2.0
+    "@smithy/uuid": ^1.1.0
+    tslib: ^2.6.2
+  checksum: f85e8b7f15b9d0e9c1172c071e5189f7551e4b85154acdd9cc4b10884d9ba5cecc6533aa365bb04161b734668cac970402c538bbc43c0544e13e0909a9d60d3b
+  languageName: node
+  linkType: hard
+
 "@smithy/credential-provider-imds@npm:^3.2.0, @smithy/credential-provider-imds@npm:^3.2.8":
   version: 3.2.8
   resolution: "@smithy/credential-provider-imds@npm:3.2.8"
@@ -10502,6 +11099,19 @@ __metadata:
     "@smithy/url-parser": ^3.0.11
     tslib: ^2.6.2
   checksum: b6292a5525b3c6bc0d502688e4f02720b7085b51a069fda1cb64d6b4c50a1eb945310e467a4c0a050a3b5477cec26f8f95ae0a8e9b9052477a357b4fbf04ac63
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^4.0.2, @smithy/credential-provider-imds@npm:^4.2.8":
+  version: 4.2.8
+  resolution: "@smithy/credential-provider-imds@npm:4.2.8"
+  dependencies:
+    "@smithy/node-config-provider": ^4.3.8
+    "@smithy/property-provider": ^4.2.8
+    "@smithy/types": ^4.12.0
+    "@smithy/url-parser": ^4.2.8
+    tslib: ^2.6.2
+  checksum: 954bb2abdfda69b6b17386bf0270a8b7730d0d9fc3699cd2574b65bf17ad112b9be6711177d2fcad9fd694bd790b97541298210c7d9dba4736d9fa56fe75f167
   languageName: node
   linkType: hard
 
@@ -10667,6 +11277,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/fetch-http-handler@npm:^5.0.2, @smithy/fetch-http-handler@npm:^5.3.9":
+  version: 5.3.9
+  resolution: "@smithy/fetch-http-handler@npm:5.3.9"
+  dependencies:
+    "@smithy/protocol-http": ^5.3.8
+    "@smithy/querystring-builder": ^4.2.8
+    "@smithy/types": ^4.12.0
+    "@smithy/util-base64": ^4.3.0
+    tslib: ^2.6.2
+  checksum: de73fa72fb059a1b52771b8b4ab1ed541c1164f5e4ee6e7a6e6110c08081949e81236108698b2c91d61a8bbd5104bc0d05a93624a44d411f313c6342f0d01b74
+  languageName: node
+  linkType: hard
+
 "@smithy/fetch-http-handler@npm:^5.2.1, @smithy/fetch-http-handler@npm:^5.3.5, @smithy/fetch-http-handler@npm:^5.3.6":
   version: 5.3.6
   resolution: "@smithy/fetch-http-handler@npm:5.3.6"
@@ -10704,6 +11327,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/hash-node@npm:^4.0.2":
+  version: 4.2.8
+  resolution: "@smithy/hash-node@npm:4.2.8"
+  dependencies:
+    "@smithy/types": ^4.12.0
+    "@smithy/util-buffer-from": ^4.2.0
+    "@smithy/util-utf8": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 93916922b88e19c98b75b6c75b639e53c63ff62fb302f578d6b07fa9c1feb091b892949c3590600f708e2277395bff9d97386527990fbf74ec37056d035d3880
+  languageName: node
+  linkType: hard
+
 "@smithy/hash-node@npm:^4.1.1, @smithy/hash-node@npm:^4.2.4, @smithy/hash-node@npm:^4.2.5":
   version: 4.2.5
   resolution: "@smithy/hash-node@npm:4.2.5"
@@ -10734,6 +11369,16 @@ __metadata:
     "@smithy/types": ^3.7.2
     tslib: ^2.6.2
   checksum: 3f4d6114fb0ace339b97ce1e17df126a2a0d058a7ea32753ef16ab82da4f481b1a4a3b2655027e983a5569167ccb48f0471bf5ca4ab3e8f5f6193e52c07caeb8
+  languageName: node
+  linkType: hard
+
+"@smithy/invalid-dependency@npm:^4.0.2":
+  version: 4.2.8
+  resolution: "@smithy/invalid-dependency@npm:4.2.8"
+  dependencies:
+    "@smithy/types": ^4.12.0
+    tslib: ^2.6.2
+  checksum: 966e4b7fb233db2db150087f552230cb3b2b3169632eaff9bf57b7f3221505d46ad20c7568172e4d76c04bc0c8f89ecf099875a1547e861426236ce2be6a90ea
   languageName: node
   linkType: hard
 
@@ -10834,6 +11479,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-content-length@npm:^4.0.2":
+  version: 4.2.8
+  resolution: "@smithy/middleware-content-length@npm:4.2.8"
+  dependencies:
+    "@smithy/protocol-http": ^5.3.8
+    "@smithy/types": ^4.12.0
+    tslib: ^2.6.2
+  checksum: cda46f45ba40d70ac46a75822b33ca23c25973735e7d2e7cd932366c8227be1d2ce348582562a10293ea287d75b094305ae89afc1fa540d1b0e4c03a116e901d
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-content-length@npm:^4.1.1, @smithy/middleware-content-length@npm:^4.2.4, @smithy/middleware-content-length@npm:^4.2.5":
   version: 4.2.5
   resolution: "@smithy/middleware-content-length@npm:4.2.5"
@@ -10858,6 +11514,22 @@ __metadata:
     "@smithy/util-middleware": ^3.0.11
     tslib: ^2.6.2
   checksum: 6ca10e433e7bb10ad5b33c31b08abfbec4aaefce22c8c82f6742a6254b93b8b0dbddd5d4b9b4bea4d938a2ff890351f93c06801ddf2288829ede3e92ef6a2cb5
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-endpoint@npm:^4.1.0, @smithy/middleware-endpoint@npm:^4.4.16":
+  version: 4.4.16
+  resolution: "@smithy/middleware-endpoint@npm:4.4.16"
+  dependencies:
+    "@smithy/core": ^3.23.2
+    "@smithy/middleware-serde": ^4.2.9
+    "@smithy/node-config-provider": ^4.3.8
+    "@smithy/shared-ini-file-loader": ^4.4.3
+    "@smithy/types": ^4.12.0
+    "@smithy/url-parser": ^4.2.8
+    "@smithy/util-middleware": ^4.2.8
+    tslib: ^2.6.2
+  checksum: f1ddbba2a190a2135ff18f244c0f44d00971bab2cfcb13a60095160c8bd8924376952399369a3c2e3bc66c54838b233e1bce358035c320faa5c92a1639009644
   languageName: node
   linkType: hard
 
@@ -10894,6 +11566,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-retry@npm:^4.1.0":
+  version: 4.4.33
+  resolution: "@smithy/middleware-retry@npm:4.4.33"
+  dependencies:
+    "@smithy/node-config-provider": ^4.3.8
+    "@smithy/protocol-http": ^5.3.8
+    "@smithy/service-error-classification": ^4.2.8
+    "@smithy/smithy-client": ^4.11.5
+    "@smithy/types": ^4.12.0
+    "@smithy/util-middleware": ^4.2.8
+    "@smithy/util-retry": ^4.2.8
+    "@smithy/uuid": ^1.1.0
+    tslib: ^2.6.2
+  checksum: d7ed43036a03a94f6ca53a312484230dd1a66d52dc2839cbd26607fb78d08d7b924c5f622d277f970ca1da6fae680388dca1a0e38b4d169d106aa852e1cdd9da
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-retry@npm:^4.3.0, @smithy/middleware-retry@npm:^4.4.12, @smithy/middleware-retry@npm:^4.4.6":
   version: 4.4.12
   resolution: "@smithy/middleware-retry@npm:4.4.12"
@@ -10918,6 +11607,17 @@ __metadata:
     "@smithy/types": ^3.7.2
     tslib: ^2.6.2
   checksum: dbc180567a7bab74a645853abdc911fc03d1adedea0dcdfbf9259fef274fdc0a9ad3548479537d58176e1eeadcab7d30582a920731bd201dfc29f067265718ec
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-serde@npm:^4.0.3, @smithy/middleware-serde@npm:^4.2.9":
+  version: 4.2.9
+  resolution: "@smithy/middleware-serde@npm:4.2.9"
+  dependencies:
+    "@smithy/protocol-http": ^5.3.8
+    "@smithy/types": ^4.12.0
+    tslib: ^2.6.2
+  checksum: 85217b475e95446d9b448ea89b8ed0ddce3ccc3275dffb723dfd667edcaf461b250b7051d8bcee7a446b8924ab4b4d03d043d35bd48f39b5a78bc516bd9dd646
   languageName: node
   linkType: hard
 
@@ -10951,6 +11651,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-stack@npm:^4.0.2, @smithy/middleware-stack@npm:^4.2.8":
+  version: 4.2.8
+  resolution: "@smithy/middleware-stack@npm:4.2.8"
+  dependencies:
+    "@smithy/types": ^4.12.0
+    tslib: ^2.6.2
+  checksum: 45de485d2f5234a0eb6b84ecd7b961bbd4c1952626a750611fc237be87855f30f8a883f8d26ca2c84ff3adf8a81f53bf8b10a014ffa050ae06ac6bae9d6317c7
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-stack@npm:^4.1.1, @smithy/middleware-stack@npm:^4.2.4, @smithy/middleware-stack@npm:^4.2.5":
   version: 4.2.5
   resolution: "@smithy/middleware-stack@npm:4.2.5"
@@ -10970,6 +11680,18 @@ __metadata:
     "@smithy/types": ^3.7.2
     tslib: ^2.6.2
   checksum: 42b61e2286387046f55130f2e0c11048c41310789441fee708bc498bb2a3b44c75d4b4e1a6fcca5c3ac593b73d1b73c082e556f0d4eab3966561eae52513db2e
+  languageName: node
+  linkType: hard
+
+"@smithy/node-config-provider@npm:^4.0.2, @smithy/node-config-provider@npm:^4.3.8":
+  version: 4.3.8
+  resolution: "@smithy/node-config-provider@npm:4.3.8"
+  dependencies:
+    "@smithy/property-provider": ^4.2.8
+    "@smithy/shared-ini-file-loader": ^4.4.3
+    "@smithy/types": ^4.12.0
+    tslib: ^2.6.2
+  checksum: 98682d2c0235f041e7545ab7c5e9432a0d6307461042c21aa5cff2be5cebe5402a35de6a559c1a5a3b884c940d5d52679618552b422e393953ba2dc8a00e0fbb
   languageName: node
   linkType: hard
 
@@ -11024,6 +11746,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/node-http-handler@npm:^4.0.4, @smithy/node-http-handler@npm:^4.4.10":
+  version: 4.4.10
+  resolution: "@smithy/node-http-handler@npm:4.4.10"
+  dependencies:
+    "@smithy/abort-controller": ^4.2.8
+    "@smithy/protocol-http": ^5.3.8
+    "@smithy/querystring-builder": ^4.2.8
+    "@smithy/types": ^4.12.0
+    tslib: ^2.6.2
+  checksum: 1e9f0a2de1bc1a4546471ac98b82c9003ee9cf6c993b85e68bcbd5cd5bfce4dc480ce51c619238cb8a821d75825b098086af52d5c5cf5f5fca07e4f89b231990
+  languageName: node
+  linkType: hard
+
 "@smithy/property-provider@npm:^3.1.11, @smithy/property-provider@npm:^3.1.3":
   version: 3.1.11
   resolution: "@smithy/property-provider@npm:3.1.11"
@@ -11031,6 +11766,16 @@ __metadata:
     "@smithy/types": ^3.7.2
     tslib: ^2.6.2
   checksum: c6f4d4bb241381254083df95c36e8632fb7e54437ab5ad56cb6b1bf6c6b81072f396fa958a700037b1ab3efb6c25fb1f7aeb92560366f35fa14055c34077ea30
+  languageName: node
+  linkType: hard
+
+"@smithy/property-provider@npm:^4.0.2, @smithy/property-provider@npm:^4.2.8":
+  version: 4.2.8
+  resolution: "@smithy/property-provider@npm:4.2.8"
+  dependencies:
+    "@smithy/types": ^4.12.0
+    tslib: ^2.6.2
+  checksum: 6a19b5e44ceb37a85999796dfa73ce7d82653c1db0cfe332786e202b7333f988dc5e65902c0492dc37d48f4c48ccf35fc4fa92cdf1ca9e8f24d2d1d6206e3dd5
   languageName: node
   linkType: hard
 
@@ -11064,7 +11809,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/protocol-http@npm:^5.2.1, @smithy/protocol-http@npm:^5.3.4, @smithy/protocol-http@npm:^5.3.5, @smithy/protocol-http@npm:^5.3.8":
+"@smithy/protocol-http@npm:^5.1.0, @smithy/protocol-http@npm:^5.2.1, @smithy/protocol-http@npm:^5.3.4, @smithy/protocol-http@npm:^5.3.5, @smithy/protocol-http@npm:^5.3.8":
   version: 5.3.8
   resolution: "@smithy/protocol-http@npm:5.3.8"
   dependencies:
@@ -11137,6 +11882,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/querystring-parser@npm:^4.2.8":
+  version: 4.2.8
+  resolution: "@smithy/querystring-parser@npm:4.2.8"
+  dependencies:
+    "@smithy/types": ^4.12.0
+    tslib: ^2.6.2
+  checksum: a7c89eb63321fc8c4ed5a4b1bbb88f1254e128ab86e7d5aa666a2a2b7889489ccbc3efb7f73c34567b6dad8356b5cecb2a512ff0fd5a19266eb187ffe9868d86
+  languageName: node
+  linkType: hard
+
 "@smithy/service-error-classification@npm:^3.0.11":
   version: 3.0.11
   resolution: "@smithy/service-error-classification@npm:3.0.11"
@@ -11155,6 +11910,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/service-error-classification@npm:^4.2.8":
+  version: 4.2.8
+  resolution: "@smithy/service-error-classification@npm:4.2.8"
+  dependencies:
+    "@smithy/types": ^4.12.0
+  checksum: bf7dc438050d6fd9f563e4479a680fa284df6d2acddd305c27f5c0cb5dd94aa17b5ede42074100072be97f6cd04bda7e3ffb1e9535ececac7ebb9a11aa982c46
+  languageName: node
+  linkType: hard
+
 "@smithy/shared-ini-file-loader@npm:^3.1.12, @smithy/shared-ini-file-loader@npm:^3.1.4":
   version: 3.1.12
   resolution: "@smithy/shared-ini-file-loader@npm:3.1.12"
@@ -11162,6 +11926,16 @@ __metadata:
     "@smithy/types": ^3.7.2
     tslib: ^2.6.2
   checksum: f726604f0f176d8f05eb0adc0878474a04ebefc2796ad72ca7c40d83f8bac65ef1239c9b1f8faa25838787a9aa3f83f28c50f150db76000b900bf220934d4bc7
+  languageName: node
+  linkType: hard
+
+"@smithy/shared-ini-file-loader@npm:^4.0.2, @smithy/shared-ini-file-loader@npm:^4.4.3":
+  version: 4.4.3
+  resolution: "@smithy/shared-ini-file-loader@npm:4.4.3"
+  dependencies:
+    "@smithy/types": ^4.12.0
+    tslib: ^2.6.2
+  checksum: bda50324b855b8994029a47d256a70bb25f886759d5826e88479bb169f17d8d6c44570b762ea15b38fb29818ea6294fddc15027552efd9e2ef81c5465430afd2
   languageName: node
   linkType: hard
 
@@ -11188,6 +11962,22 @@ __metadata:
     "@smithy/util-utf8": ^3.0.0
     tslib: ^2.6.2
   checksum: 72b093212be97d3d6b19f7e5dc1185a31921f64417a3627dac6fe336a64f7413eadbc7afd4f6b7fd866eb249261216a63d526b46c15b3c542a3163d1e3ca62aa
+  languageName: node
+  linkType: hard
+
+"@smithy/signature-v4@npm:^5.0.2":
+  version: 5.3.8
+  resolution: "@smithy/signature-v4@npm:5.3.8"
+  dependencies:
+    "@smithy/is-array-buffer": ^4.2.0
+    "@smithy/protocol-http": ^5.3.8
+    "@smithy/types": ^4.12.0
+    "@smithy/util-hex-encoding": ^4.2.0
+    "@smithy/util-middleware": ^4.2.8
+    "@smithy/util-uri-escape": ^4.2.0
+    "@smithy/util-utf8": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 651073b25020d314a2dcca81fbfe2baa6522ec5be7bf930c1cfea1e24a1b7babe6da6dcf37c3faa0e69c1b994d3f3fb9d501e1dba787ed4e098f8cebf8b9809d
   languageName: node
   linkType: hard
 
@@ -11234,6 +12024,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/smithy-client@npm:^4.11.5, @smithy/smithy-client@npm:^4.2.0":
+  version: 4.11.5
+  resolution: "@smithy/smithy-client@npm:4.11.5"
+  dependencies:
+    "@smithy/core": ^3.23.2
+    "@smithy/middleware-endpoint": ^4.4.16
+    "@smithy/middleware-stack": ^4.2.8
+    "@smithy/protocol-http": ^5.3.8
+    "@smithy/types": ^4.12.0
+    "@smithy/util-stream": ^4.5.12
+    tslib: ^2.6.2
+  checksum: 33f78125828ba4f2d45c3e79f9fb0f826e58edb656b99589fbad711935a50fd29b86e08952c8795684ead4a5eeaf8e1d21ef33b8d6a170965eb922addf8dee98
+  languageName: node
+  linkType: hard
+
 "@smithy/smithy-client@npm:^4.6.4, @smithy/smithy-client@npm:^4.9.2, @smithy/smithy-client@npm:^4.9.8":
   version: 4.9.8
   resolution: "@smithy/smithy-client@npm:4.9.8"
@@ -11276,7 +12081,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/types@npm:^4.12.0, @smithy/types@npm:^4.5.0, @smithy/types@npm:^4.8.1, @smithy/types@npm:^4.9.0":
+"@smithy/types@npm:^4.12.0, @smithy/types@npm:^4.2.0, @smithy/types@npm:^4.5.0, @smithy/types@npm:^4.8.1, @smithy/types@npm:^4.9.0":
   version: 4.12.0
   resolution: "@smithy/types@npm:4.12.0"
   dependencies:
@@ -11304,6 +12109,17 @@ __metadata:
     "@smithy/types": ^3.7.2
     tslib: ^2.6.2
   checksum: 1af2edc53b969255c231028b034115f8d21807fd4ffa052ae4a03f9c47b28f8679a7c709626f9d549d537a7d63d20596c89515e229fc84114122fc9b51bb4519
+  languageName: node
+  linkType: hard
+
+"@smithy/url-parser@npm:^4.0.2, @smithy/url-parser@npm:^4.2.8":
+  version: 4.2.8
+  resolution: "@smithy/url-parser@npm:4.2.8"
+  dependencies:
+    "@smithy/querystring-parser": ^4.2.8
+    "@smithy/types": ^4.12.0
+    tslib: ^2.6.2
+  checksum: f354e69cc629084bbb7ed1759f2970d96e2c462d2849402057e86aeaa18b32d13f7e24b5244ecddac398b6504fe3705b8ee2696a68df662a556ae20566d68f38
   languageName: node
   linkType: hard
 
@@ -11339,7 +12155,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-base64@npm:^4.1.0, @smithy/util-base64@npm:^4.3.0":
+"@smithy/util-base64@npm:^4.0.0, @smithy/util-base64@npm:^4.1.0, @smithy/util-base64@npm:^4.3.0":
   version: 4.3.0
   resolution: "@smithy/util-base64@npm:4.3.0"
   dependencies:
@@ -11359,7 +12175,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-body-length-browser@npm:^4.1.0, @smithy/util-body-length-browser@npm:^4.2.0":
+"@smithy/util-body-length-browser@npm:^4.0.0, @smithy/util-body-length-browser@npm:^4.1.0, @smithy/util-body-length-browser@npm:^4.2.0":
   version: 4.2.0
   resolution: "@smithy/util-body-length-browser@npm:4.2.0"
   dependencies:
@@ -11377,7 +12193,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-body-length-node@npm:^4.1.0, @smithy/util-body-length-node@npm:^4.2.1":
+"@smithy/util-body-length-node@npm:^4.0.0, @smithy/util-body-length-node@npm:^4.1.0, @smithy/util-body-length-node@npm:^4.2.1":
   version: 4.2.1
   resolution: "@smithy/util-body-length-node@npm:4.2.1"
   dependencies:
@@ -11435,7 +12251,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-config-provider@npm:^4.1.0, @smithy/util-config-provider@npm:^4.2.0":
+"@smithy/util-config-provider@npm:^4.0.0, @smithy/util-config-provider@npm:^4.1.0, @smithy/util-config-provider@npm:^4.2.0":
   version: 4.2.0
   resolution: "@smithy/util-config-provider@npm:4.2.0"
   dependencies:
@@ -11454,6 +12270,18 @@ __metadata:
     bowser: ^2.11.0
     tslib: ^2.6.2
   checksum: 5fa366a9a87bd3272b8955b0e739ac737b11349cf031bbc7f22e3af9c0ac38d2a9fcf326165304e3aca4fa986dc0c06a8430e43bfca508fb5dca307c90750d12
+  languageName: node
+  linkType: hard
+
+"@smithy/util-defaults-mode-browser@npm:^4.0.8":
+  version: 4.3.32
+  resolution: "@smithy/util-defaults-mode-browser@npm:4.3.32"
+  dependencies:
+    "@smithy/property-provider": ^4.2.8
+    "@smithy/smithy-client": ^4.11.5
+    "@smithy/types": ^4.12.0
+    tslib: ^2.6.2
+  checksum: 9931577129f0afa0a197fd093cbafc49ed255bd27dae365902cbe5dd422299fb41e6af40c1527840a7adc75e299d356bc763f9fb70be066f131d58a9cad94ccf
   languageName: node
   linkType: hard
 
@@ -11484,6 +12312,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-defaults-mode-node@npm:^4.0.8":
+  version: 4.2.35
+  resolution: "@smithy/util-defaults-mode-node@npm:4.2.35"
+  dependencies:
+    "@smithy/config-resolver": ^4.4.6
+    "@smithy/credential-provider-imds": ^4.2.8
+    "@smithy/node-config-provider": ^4.3.8
+    "@smithy/property-provider": ^4.2.8
+    "@smithy/smithy-client": ^4.11.5
+    "@smithy/types": ^4.12.0
+    tslib: ^2.6.2
+  checksum: 5daf1b0fc77e44de212bf3b254450e44f069b7cae71f500c069b71765db292ffeb9e2229fa913af6ef554306156b082d0d4944d003458fb6895e81ca170b7465
+  languageName: node
+  linkType: hard
+
 "@smithy/util-defaults-mode-node@npm:^4.1.4, @smithy/util-defaults-mode-node@npm:^4.2.14, @smithy/util-defaults-mode-node@npm:^4.2.7":
   version: 4.2.14
   resolution: "@smithy/util-defaults-mode-node@npm:4.2.14"
@@ -11507,6 +12350,17 @@ __metadata:
     "@smithy/types": ^3.7.2
     tslib: ^2.6.2
   checksum: 6917604d6f7b7b78f8501152fc25795dabb22e10b6d004eb2234ac519cc0c8e8882b4919419626d29adf39cde41dc0874aa9fe3bb2fa3e655bbb89e191c2aa50
+  languageName: node
+  linkType: hard
+
+"@smithy/util-endpoints@npm:^3.0.2, @smithy/util-endpoints@npm:^3.2.8":
+  version: 3.2.8
+  resolution: "@smithy/util-endpoints@npm:3.2.8"
+  dependencies:
+    "@smithy/node-config-provider": ^4.3.8
+    "@smithy/types": ^4.12.0
+    tslib: ^2.6.2
+  checksum: d50a189c86b18737e513fa20ce46e3c472d87518e377a04683d7997059270f57c8dec80d5e4e0acb0251cd4b3c9a8d8ed1b9cbdd2ed25ada86ffb59a9cadff5b
   languageName: node
   linkType: hard
 
@@ -11567,6 +12421,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-middleware@npm:^4.0.2, @smithy/util-middleware@npm:^4.2.8":
+  version: 4.2.8
+  resolution: "@smithy/util-middleware@npm:4.2.8"
+  dependencies:
+    "@smithy/types": ^4.12.0
+    tslib: ^2.6.2
+  checksum: bc6b1f549d5e6faced387b2158c56f8b59937853987dbddd0b49da82cc2e97630d718b30c426fd77ecf882ff151c330428e25e2780407aeefbfcfd3c5e2c9a71
+  languageName: node
+  linkType: hard
+
 "@smithy/util-middleware@npm:^4.1.1, @smithy/util-middleware@npm:^4.2.4, @smithy/util-middleware@npm:^4.2.5":
   version: 4.2.5
   resolution: "@smithy/util-middleware@npm:4.2.5"
@@ -11585,6 +12449,17 @@ __metadata:
     "@smithy/types": ^3.7.2
     tslib: ^2.6.2
   checksum: b6e9a891944a2b77105e51ab854a5a0709cfdf9d60293b61782c9caa8ca06625f1dc812b10ee7c254519a40329a9ab4fd21f55bae2dfc9a879db0f06878d0337
+  languageName: node
+  linkType: hard
+
+"@smithy/util-retry@npm:^4.0.2, @smithy/util-retry@npm:^4.2.8":
+  version: 4.2.8
+  resolution: "@smithy/util-retry@npm:4.2.8"
+  dependencies:
+    "@smithy/service-error-classification": ^4.2.8
+    "@smithy/types": ^4.12.0
+    tslib: ^2.6.2
+  checksum: a3c84a496c169c5b3a002c9d98bb53cbd8401a81e17fdb6aaf1d2076ce849901c191dc98d62b3bb7bce8529075505ff6d2fd1fa39b1d1967dd24874a1d67920d
   languageName: node
   linkType: hard
 
@@ -11628,6 +12503,22 @@ __metadata:
     "@smithy/util-utf8": ^3.0.0
     tslib: ^2.6.2
   checksum: ac57b50f5072004471c97ecbdc33e649b221dced6754851eab77964e35c8d08866f477da3c4d28735054400984f1a68070019063fb592d780d9910325547ed02
+  languageName: node
+  linkType: hard
+
+"@smithy/util-stream@npm:^4.2.0, @smithy/util-stream@npm:^4.5.12":
+  version: 4.5.12
+  resolution: "@smithy/util-stream@npm:4.5.12"
+  dependencies:
+    "@smithy/fetch-http-handler": ^5.3.9
+    "@smithy/node-http-handler": ^4.4.10
+    "@smithy/types": ^4.12.0
+    "@smithy/util-base64": ^4.3.0
+    "@smithy/util-buffer-from": ^4.2.0
+    "@smithy/util-hex-encoding": ^4.2.0
+    "@smithy/util-utf8": ^4.2.0
+    tslib: ^2.6.2
+  checksum: a975bf9e90b91a41e690b248a21d4a909e11f6780753f69c322e9501649c8e9ed84120177884a60bbf95f326fbc8b8766c0dccfe7318ed3552df102b47d987af
   languageName: node
   linkType: hard
 
@@ -11714,7 +12605,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-utf8@npm:^4.1.0, @smithy/util-utf8@npm:^4.2.0":
+"@smithy/util-utf8@npm:^4.0.0, @smithy/util-utf8@npm:^4.1.0, @smithy/util-utf8@npm:^4.2.0":
   version: 4.2.0
   resolution: "@smithy/util-utf8@npm:4.2.0"
   dependencies:
@@ -13396,6 +14287,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/conventional-changelog-writer@npm:4.0.11":
+  version: 4.0.11
+  resolution: "@types/conventional-changelog-writer@npm:4.0.11"
+  dependencies:
+    "@types/conventional-commits-parser": "*"
+    "@types/node": "*"
+  checksum: 909fc8c8525006a29b349e89fb3f1bfc1452af379cee2c44d7aa533ab7d0c187200f888b9f7ec0f5b5dda675f9c39af1737cf4d1d6b3b38bcda12cefd0996850
+  languageName: node
+  linkType: hard
+
+"@types/conventional-commits-parser@npm:*, @types/conventional-commits-parser@npm:5.0.2":
+  version: 5.0.2
+  resolution: "@types/conventional-commits-parser@npm:5.0.2"
+  dependencies:
+    "@types/node": "*"
+  checksum: bd05e0f0619737c6bb7e663e6274adf41f7c7d5742ec297b4b6095b3dcf328f81dab60668ba38cf51aff83c6e8135666b418e533ce4a2724053f40b82a5d4ca9
+  languageName: node
+  linkType: hard
+
 "@types/cookiejar@npm:^2.1.5":
   version: 2.1.5
   resolution: "@types/cookiejar@npm:2.1.5"
@@ -13989,7 +14899,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/seedrandom@npm:^3.0.8":
+"@types/seedrandom@npm:3.0.8":
   version: 3.0.8
   resolution: "@types/seedrandom@npm:3.0.8"
   checksum: 9651de4ecb5ad060053678d6a42403dd78222bcca80016417c23b58b4f739e544b7197a78b97d6862cf417ea80fd2df612cc50ca0fa387fbe794e326a382ab0b
@@ -16014,9 +16924,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-cdk-lib@npm:^2.215.0":
-  version: 2.227.0
-  resolution: "aws-cdk-lib@npm:2.227.0"
+"aws-cdk-lib@npm:2.215.0":
+  version: 2.215.0
+  resolution: "aws-cdk-lib@npm:2.215.0"
   dependencies:
     "@aws-cdk/asset-awscli-v1": 2.2.242
     "@aws-cdk/asset-node-proxy-agent-v6": ^2.1.0
@@ -16034,7 +16944,7 @@ __metadata:
     yaml: 1.10.2
   peerDependencies:
     constructs: ^10.0.0
-  checksum: b1831ee1e71083fde34eb0208ad646cd41e0e35194f1f726600c1ae617b73ce4b783975b1f2232c9d793b80233738361967c09de3e7440b62b09c887f2869c6a
+  checksum: 9f0d8b339d4606a62c0bb81874cb3c7413840460d31459c2abb1d73ee04a587270caddd752c9d1fa8ba785c89b417c4f1461d5c068dbb5d0c01aaf2e30f7b82f
   languageName: node
   linkType: hard
 
@@ -16188,7 +17098,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-istanbul@npm:^7.0.1":
+"babel-plugin-istanbul@npm:^7.0.0":
   version: 7.0.1
   resolution: "babel-plugin-istanbul@npm:7.0.1"
   dependencies:
@@ -16260,7 +17170,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-preset-current-node-syntax@npm:^1.0.0, babel-preset-current-node-syntax@npm:^1.2.0":
+"babel-preset-current-node-syntax@npm:^1.0.0, babel-preset-current-node-syntax@npm:^1.1.0":
   version: 1.2.0
   resolution: "babel-preset-current-node-syntax@npm:1.2.0"
   dependencies:
@@ -18053,7 +18963,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"concurrently@npm:^9.2.1":
+"concurrently@npm:9.2.1":
   version: 9.2.1
   resolution: "concurrently@npm:9.2.1"
   dependencies:
@@ -18167,10 +19077,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"constructs@npm:^10.0.0":
-  version: 10.4.3
-  resolution: "constructs@npm:10.4.3"
-  checksum: ed1f589f27b72503aebd530c3465c78481617d8dc3fdd52efb2d0a9c0a27e9e30a44abfbeca2d608f9f123b7d079b7ae8de9e937a73bab8264f3d8741a481c3e
+"constructs@npm:10.0.0":
+  version: 10.0.0
+  resolution: "constructs@npm:10.0.0"
+  checksum: f1891ac12f4e7dbfcaae370e6d2c8de3ec41845164706ec140c5c29e67c490f2f8490716ad3cc215cb4871929d18b8a7b476e49e20ccc00a9b6a23d968a38ec9
   languageName: node
   linkType: hard
 
@@ -21110,6 +22020,95 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild@npm:0.27.0":
+  version: 0.27.0
+  resolution: "esbuild@npm:0.27.0"
+  dependencies:
+    "@esbuild/aix-ppc64": 0.27.0
+    "@esbuild/android-arm": 0.27.0
+    "@esbuild/android-arm64": 0.27.0
+    "@esbuild/android-x64": 0.27.0
+    "@esbuild/darwin-arm64": 0.27.0
+    "@esbuild/darwin-x64": 0.27.0
+    "@esbuild/freebsd-arm64": 0.27.0
+    "@esbuild/freebsd-x64": 0.27.0
+    "@esbuild/linux-arm": 0.27.0
+    "@esbuild/linux-arm64": 0.27.0
+    "@esbuild/linux-ia32": 0.27.0
+    "@esbuild/linux-loong64": 0.27.0
+    "@esbuild/linux-mips64el": 0.27.0
+    "@esbuild/linux-ppc64": 0.27.0
+    "@esbuild/linux-riscv64": 0.27.0
+    "@esbuild/linux-s390x": 0.27.0
+    "@esbuild/linux-x64": 0.27.0
+    "@esbuild/netbsd-arm64": 0.27.0
+    "@esbuild/netbsd-x64": 0.27.0
+    "@esbuild/openbsd-arm64": 0.27.0
+    "@esbuild/openbsd-x64": 0.27.0
+    "@esbuild/openharmony-arm64": 0.27.0
+    "@esbuild/sunos-x64": 0.27.0
+    "@esbuild/win32-arm64": 0.27.0
+    "@esbuild/win32-ia32": 0.27.0
+    "@esbuild/win32-x64": 0.27.0
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: db33b01d8f9234843e411c87527587f646b5ac082e3759fe796a71878dcb1180da0d4f8b33525c492d918c0262befe0e724c2d5d8a2c4b611c2c75549a3dbf91
+  languageName: node
+  linkType: hard
+
 "esbuild@npm:^0.18.0":
   version: 0.18.20
   resolution: "esbuild@npm:0.18.20"
@@ -21356,7 +22355,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.27.0, esbuild@npm:~0.27.0":
+"esbuild@npm:~0.27.0":
   version: 0.27.1
   resolution: "esbuild@npm:0.27.1"
   dependencies:
@@ -22090,17 +23089,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:30.2.0, expect@npm:^30.0.0":
-  version: 30.2.0
-  resolution: "expect@npm:30.2.0"
+"expect@npm:30.1.2":
+  version: 30.1.2
+  resolution: "expect@npm:30.1.2"
   dependencies:
-    "@jest/expect-utils": 30.2.0
+    "@jest/expect-utils": 30.1.2
     "@jest/get-type": 30.1.0
-    jest-matcher-utils: 30.2.0
-    jest-message-util: 30.2.0
-    jest-mock: 30.2.0
-    jest-util: 30.2.0
-  checksum: c798f5c82afec21669189245017f83b05d94d120daad6dd37794e85f4aee4fe54bb90cc356f0a7e48a973db132795aa5eb91ac5bc439c16aa96797392a694ca3
+    jest-matcher-utils: 30.1.2
+    jest-message-util: 30.1.0
+    jest-mock: 30.0.5
+    jest-util: 30.0.5
+  checksum: bdf2eb85e5f532d54a123a94c9c03e0ee3820bbba569b6666a9a20e2c2373cdea710598ec00f60425eece5a8b891197731fb1ccba09f28de17ae539c5e5116e5
   languageName: node
   linkType: hard
 
@@ -22114,6 +23113,20 @@ __metadata:
     jest-message-util: ^29.7.0
     jest-util: ^29.7.0
   checksum: 9257f10288e149b81254a0fda8ffe8d54a7061cd61d7515779998b012579d2b8c22354b0eb901daf0145f347403da582f75f359f4810c007182ad3fb318b5c0c
+  languageName: node
+  linkType: hard
+
+"expect@npm:^30.0.0":
+  version: 30.2.0
+  resolution: "expect@npm:30.2.0"
+  dependencies:
+    "@jest/expect-utils": 30.2.0
+    "@jest/get-type": 30.1.0
+    jest-matcher-utils: 30.2.0
+    jest-message-util: 30.2.0
+    jest-mock: 30.2.0
+    jest-util: 30.2.0
+  checksum: c798f5c82afec21669189245017f83b05d94d120daad6dd37794e85f4aee4fe54bb90cc356f0a7e48a973db132795aa5eb91ac5bc439c16aa96797392a694ca3
   languageName: node
   linkType: hard
 
@@ -25890,6 +26903,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:30.1.2":
+  version: 30.1.2
+  resolution: "jest-diff@npm:30.1.2"
+  dependencies:
+    "@jest/diff-sequences": 30.0.1
+    "@jest/get-type": 30.1.0
+    chalk: ^4.1.2
+    pretty-format: 30.0.5
+  checksum: 15f350b664f5fe00190cbd36dbe2fd477010bf471b9fb3b2b0b1a40ce4241b10595a05203fcb86aea7720d2be225419efc3d1afa921966b0371d33120c563eec
+  languageName: node
+  linkType: hard
+
 "jest-diff@npm:30.2.0":
   version: 30.2.0
   resolution: "jest-diff@npm:30.2.0"
@@ -25998,25 +27023,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-haste-map@npm:30.2.0":
-  version: 30.2.0
-  resolution: "jest-haste-map@npm:30.2.0"
+"jest-haste-map@npm:30.1.0":
+  version: 30.1.0
+  resolution: "jest-haste-map@npm:30.1.0"
   dependencies:
-    "@jest/types": 30.2.0
+    "@jest/types": 30.0.5
     "@types/node": "*"
     anymatch: ^3.1.3
     fb-watchman: ^2.0.2
     fsevents: ^2.3.3
     graceful-fs: ^4.2.11
     jest-regex-util: 30.0.1
-    jest-util: 30.2.0
-    jest-worker: 30.2.0
+    jest-util: 30.0.5
+    jest-worker: 30.1.0
     micromatch: ^4.0.8
     walker: ^1.0.8
   dependenciesMeta:
     fsevents:
       optional: true
-  checksum: b0514f8fc3463307247b81ca2a9db94e2dabd5ab7f890f0acdf3ffd98fa3d886aa186f6cbbc6ef09271c3f23d8a16c239b8ee20e61414c6abbb131d63b3ce0eb
+  checksum: 8619c258ccbb68317627dacff815d1fa7e446412ec0680a915519d5c157238c35c305cff7b8b9c572c3d7a25e03e822e53fec70611765466e4f5e9b1e54f9584
   languageName: node
   linkType: hard
 
@@ -26065,6 +27090,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-matcher-utils@npm:30.1.2":
+  version: 30.1.2
+  resolution: "jest-matcher-utils@npm:30.1.2"
+  dependencies:
+    "@jest/get-type": 30.1.0
+    chalk: ^4.1.2
+    jest-diff: 30.1.2
+    pretty-format: 30.0.5
+  checksum: 51735e221cdfcfbfe88ad8149b06f861356c3cf2e6713368f23216c9951768634082bfc821eb47acc09cafde8be8cbea01308d74f24c9b6075ea31492b77448a
+  languageName: node
+  linkType: hard
+
 "jest-matcher-utils@npm:30.2.0":
   version: 30.2.0
   resolution: "jest-matcher-utils@npm:30.2.0"
@@ -26086,6 +27123,23 @@ __metadata:
     jest-get-type: ^29.6.3
     pretty-format: ^29.7.0
   checksum: d7259e5f995d915e8a37a8fd494cb7d6af24cd2a287b200f831717ba0d015190375f9f5dc35393b8ba2aae9b2ebd60984635269c7f8cff7d85b077543b7744cd
+  languageName: node
+  linkType: hard
+
+"jest-message-util@npm:30.1.0":
+  version: 30.1.0
+  resolution: "jest-message-util@npm:30.1.0"
+  dependencies:
+    "@babel/code-frame": ^7.27.1
+    "@jest/types": 30.0.5
+    "@types/stack-utils": ^2.0.3
+    chalk: ^4.1.2
+    graceful-fs: ^4.2.11
+    micromatch: ^4.0.8
+    pretty-format: 30.0.5
+    slash: ^3.0.0
+    stack-utils: ^2.0.6
+  checksum: 89e01ee89cbc7412d905fe56a154ec9f4389be40cd1fd705567c3caaeb969287056d713d17b40be12282c9a52cd22b229668c7a4b543182847616d80be9d2916
   languageName: node
   linkType: hard
 
@@ -26120,6 +27174,17 @@ __metadata:
     slash: ^3.0.0
     stack-utils: ^2.0.3
   checksum: a9d025b1c6726a2ff17d54cc694de088b0489456c69106be6b615db7a51b7beb66788bea7a59991a019d924fbf20f67d085a445aedb9a4d6760363f4d7d09930
+  languageName: node
+  linkType: hard
+
+"jest-mock@npm:30.0.5":
+  version: 30.0.5
+  resolution: "jest-mock@npm:30.0.5"
+  dependencies:
+    "@jest/types": 30.0.5
+    "@types/node": "*"
+    jest-util: 30.0.5
+  checksum: 144077119e76dd28c2197169dc2bd6ec4c6980a50f32d9e24c79a6adf74e0d3b8bac72c02f6effc5aa27f520d3af7be12b3a06372d5296047f5e7b60fd26814b
   languageName: node
   linkType: hard
 
@@ -26267,32 +27332,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-snapshot@npm:30.2.0":
-  version: 30.2.0
-  resolution: "jest-snapshot@npm:30.2.0"
+"jest-snapshot@npm:30.1.2":
+  version: 30.1.2
+  resolution: "jest-snapshot@npm:30.1.2"
   dependencies:
     "@babel/core": ^7.27.4
     "@babel/generator": ^7.27.5
     "@babel/plugin-syntax-jsx": ^7.27.1
     "@babel/plugin-syntax-typescript": ^7.27.1
     "@babel/types": ^7.27.3
-    "@jest/expect-utils": 30.2.0
+    "@jest/expect-utils": 30.1.2
     "@jest/get-type": 30.1.0
-    "@jest/snapshot-utils": 30.2.0
-    "@jest/transform": 30.2.0
-    "@jest/types": 30.2.0
-    babel-preset-current-node-syntax: ^1.2.0
+    "@jest/snapshot-utils": 30.1.2
+    "@jest/transform": 30.1.2
+    "@jest/types": 30.0.5
+    babel-preset-current-node-syntax: ^1.1.0
     chalk: ^4.1.2
-    expect: 30.2.0
+    expect: 30.1.2
     graceful-fs: ^4.2.11
-    jest-diff: 30.2.0
-    jest-matcher-utils: 30.2.0
-    jest-message-util: 30.2.0
-    jest-util: 30.2.0
-    pretty-format: 30.2.0
+    jest-diff: 30.1.2
+    jest-matcher-utils: 30.1.2
+    jest-message-util: 30.1.0
+    jest-util: 30.0.5
+    pretty-format: 30.0.5
     semver: ^7.7.2
     synckit: ^0.11.8
-  checksum: e2277d5894aa45496de5ce2918cb07d1f7b568949e36835be462cec7f79868e567299c4ced2573ab3e61b848f4159ab3c3d657f2942aaff2a5496210c56110f2
+  checksum: ac5cf5862ec7c85f95dbe27931ba4b7ea3a9a17838e7a5633a49a4894a4efcf8f3fbf13d2c59ab623f70f858dc06a8030a9a3ee2e1ae6df02a76acbf4eee7b14
   languageName: node
   linkType: hard
 
@@ -26321,6 +27386,20 @@ __metadata:
     pretty-format: ^29.7.0
     semver: ^7.5.3
   checksum: 86821c3ad0b6899521ce75ee1ae7b01b17e6dfeff9166f2cf17f012e0c5d8c798f30f9e4f8f7f5bed01ea7b55a6bc159f5eda778311162cbfa48785447c237ad
+  languageName: node
+  linkType: hard
+
+"jest-util@npm:30.0.5":
+  version: 30.0.5
+  resolution: "jest-util@npm:30.0.5"
+  dependencies:
+    "@jest/types": 30.0.5
+    "@types/node": "*"
+    chalk: ^4.1.2
+    ci-info: ^4.2.0
+    graceful-fs: ^4.2.11
+    picomatch: ^4.0.2
+  checksum: 16e059b849e8ac9a6eb0a62db18aa88cb8e9566d26fe7a4f2da1d166b322b937a4d4ee2e4881764cc270d3947d1734d319d444df75fb6964dbe2b99081f4e00a
   languageName: node
   linkType: hard
 
@@ -26382,16 +27461,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-worker@npm:30.2.0":
-  version: 30.2.0
-  resolution: "jest-worker@npm:30.2.0"
+"jest-worker@npm:30.1.0":
+  version: 30.1.0
+  resolution: "jest-worker@npm:30.1.0"
   dependencies:
     "@types/node": "*"
     "@ungap/structured-clone": ^1.3.0
-    jest-util: 30.2.0
+    jest-util: 30.0.5
     merge-stream: ^2.0.0
     supports-color: ^8.1.1
-  checksum: c3d01041fcee8aa87186d18ae5fcd4c56bc82dff3bc39998b1af6c0d6c4792660f750e183f3b25e7fbfd24a48297835809d4516c5e10472d6b556277fb2206ef
+  checksum: 6335d0865039a8853ea9858a6953c5bf86719ba3e31ef8315cd23f2218a23bb25aaa284eec1aaf02f92798f40845b1793f0b8e4eb289d91775a3c276e5372356
   languageName: node
   linkType: hard
 
@@ -31827,6 +32906,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:30.0.5":
+  version: 30.0.5
+  resolution: "pretty-format@npm:30.0.5"
+  dependencies:
+    "@jest/schemas": 30.0.5
+    ansi-styles: ^5.2.0
+    react-is: ^18.3.1
+  checksum: 0772b7432ff4083483dc12b5b9a1904a1a8f2654936af2a5fa3ba5dfa994a4c7ef843f132152894fd96203a09e0ef80dab2e99dabebd510da86948ed91238fed
+  languageName: node
+  linkType: hard
+
 "pretty-format@npm:30.2.0, pretty-format@npm:^30.0.0":
   version: 30.2.0
   resolution: "pretty-format@npm:30.2.0"
@@ -34388,7 +35478,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"seedrandom@npm:^3.0.5":
+"seedrandom@npm:3.0.5":
   version: 3.0.5
   resolution: "seedrandom@npm:3.0.5"
   checksum: 728b56bc3bc1b9ddeabd381e449b51cb31bdc0aa86e27fcd0190cea8c44613d5bcb2f6bb63ed79f78180cbe791c20b8ec31a9627f7b7fc7f476fd2bdb7e2da9f
@@ -36857,7 +37947,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-node-dev@npm:^2.0.0":
+"ts-node-dev@npm:2.0.0":
   version: 2.0.0
   resolution: "ts-node-dev@npm:2.0.0"
   dependencies:


### PR DESCRIPTION

<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

Moves the semantic-release configuration out of `package.json` and into a dedicated `release.config.js` file. The new config introduces a custom `adoTransform` function for `conventional-changelog-writer` that converts `[AB#(\d+)]` commit message references into clickable Azure DevOps work-item links in generated changelogs, rather than treating them as GitHub issues.

Also adds `@types/conventional-changelog-writer` and `@types/conventional-commits-parser` as dev dependencies to support the typed JSDoc annotations in the new config file.

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

Two new dev dependencies are added:

- `@types/conventional-changelog-writer@4.0.11`
- `@types/conventional-commits-parser@5.0.2`

Run `yarn install` after pulling this branch. No migrations or infrastructure changes are required. The semantic-release behavior at runtime is unchanged except for the ADO link format in generated changelog entries.

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

No user-facing changes requiring manual testing. To verify the release config is valid:

1. Run `node -e "require('./release.config.js')"` — should print nothing and exit cleanly.
2. Confirm the `release` block is no longer present in `package.json`.
3. Optionally run a dry-run release (`npx semantic-release --dry-run`) and inspect changelog output to confirm `[AB#XXXXX]` references render as ADO links.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

- The `adoTransform` replicates the Angular preset's transform logic verbatim, with the ADO linkification layered in via a single regex alternation (`/\[AB#(\d+)\]|#([0-9]+)/g`). The ADO branch is matched first to prevent the embedded `#N` from being re-captured by the GitHub branch.
- `@username` mention linkification is preserved from the original Angular preset.
- Org-scoped handles (`@org/team`) are intentionally left as plain text to avoid broken profile links.
- Future: if the team moves to a monorepo or multi-package setup, the `branches` array in `release.config.js` may need updating alongside any package-specific plugin config.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `request-reviewer` tag on github to request reviews