### PR TITLE
feat: [AB#17402] upload intercom macros to s3

### DIFF
--- a/.github/workflows/deploy-dev-environment.yml
+++ b/.github/workflows/deploy-dev-environment.yml
@@ -109,6 +109,9 @@ jobs:
       TAX_CLEARANCE_CERTIFICATE_USER_NAME: ${{ secrets.TAX_CLEARANCE_CERTIFICATE_USER_NAME_DEV }}
       TAX_CLEARANCE_CERTIFICATE_URL: ${{ vars.TAX_CLEARANCE_CERTIFICATE_URL_DEV }}
 
+      INTERCOM_MACROS_BASE_URL: ${{ vars.INTERCOM_MACROS_BASE_URL }}
+      INTERCOM_TOKEN: ${{ secrets.INTERCOM_TOKEN }}
+
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/api/cdk/bin/app.ts
+++ b/api/cdk/bin/app.ts
@@ -36,6 +36,7 @@ const lambdaStack = new LambdaStack(app, `LambdaStack-${stage}`, {
   stage: stage,
   lambdaRole: iamStack.role,
   messagesBucket: storageStack.messagesBucket,
+  intercomMacrosBucket: storageStack.intercomMacrosBucket,
   env,
 });
 

--- a/api/cdk/lib/lambdaStack.ts
+++ b/api/cdk/lib/lambdaStack.ts
@@ -25,6 +25,7 @@ export interface LambdaStackProps extends StackProps {
   stage: string;
   lambdaRole: iam.Role;
   messagesBucket: IBucket;
+  intercomMacrosBucket: IBucket;
 }
 
 export class LambdaStack extends Stack {
@@ -127,6 +128,9 @@ export class LambdaStack extends Stack {
 
     const skipSaveDocumentsToS3 = process.env.SKIP_SAVE_DOCUMENTS_TO_S3 || "";
     const useFakeSelfReg = process.env.USE_FAKE_SELF_REG || "";
+
+    const intercomMacrosUrl = process.env.INTERCOM_MACROS_BASE_URL || "";
+    const intercomToken = process.env.INTERCOM_TOKEN || "";
 
     /**
      * Environment Variables for Github Oauth2 lambda
@@ -250,6 +254,45 @@ export class LambdaStack extends Stack {
           CMS_OAUTH_CLIENT_SECRET: cmsoAuthClientSecret,
         },
       });
+
+      this.lambdas.updateKbWithIntercomMacros = createLambda(this, {
+        role: props.lambdaRole,
+        id: `${this.serviceName}-${props.stage}-updateKbWithIntercomMacros`,
+        stage: props.stage,
+        functionName: `${this.serviceName}-${props.stage}-updateKbWithIntercomMacros`,
+        entry: path.join(__dirname, "../../src/functions/updateKbWithIntercomMacros/app.ts"),
+        handler: "handler",
+        runtime: Runtime.NODEJS_22_X,
+        timeout: Duration.seconds(30),
+        memorySize: 1024,
+        ephemeralStorageSize: Size.mebibytes(512),
+        ...vpcProps,
+        environment: {
+          API_BASE_URL: apiBaseUrl,
+          INTERCOM_TOKEN: intercomToken,
+          INTERCOM_MACROS_BASE_URL: intercomMacrosUrl,
+          INTERCOM_MACROS_BUCKET: props.intercomMacrosBucket.bucketName,
+        },
+      });
+
+      const updateKbWithIntercomMacrosRule = new events.Rule(
+        this,
+        "UpdateKbWithIntercomMacrosSchedule",
+        {
+          schedule: events.Schedule.cron({
+            minute: "0",
+            hour: "13", // 1 PM UTC
+            weekDay: "FRI", // Friday
+          }),
+          description:
+            "Scheduled rule for updateKbWithIntercomMacros Lambda - runs weekly on Fridays at 1:00 PM UTC (8:00 AM EST/EDT)",
+        },
+      );
+      updateKbWithIntercomMacrosRule.addTarget(
+        new targets.LambdaFunction(this.lambdas.updateKbWithIntercomMacros),
+      );
+
+      props.intercomMacrosBucket.grantWrite(this.lambdas.updateKbWithIntercomMacros);
     }
 
     if (props.stage !== CONTENT_STAGE && props.stage !== TESTING_STAGE) {
@@ -384,7 +427,6 @@ export class LambdaStack extends Stack {
         MESSAGES_BUCKET: props.messagesBucket.bucketName,
       },
     });
-
     props.messagesBucket.grantWrite(this.lambdas.messagingService);
 
     const topic = sns.Topic.fromTopicArn(

--- a/api/cdk/lib/storageStack.ts
+++ b/api/cdk/lib/storageStack.ts
@@ -9,6 +9,7 @@ export interface StorageStackProps extends StackProps {
 
 export class StorageStack extends Stack {
   public readonly messagesBucket: s3.Bucket;
+  public readonly intercomMacrosBucket: s3.Bucket;
 
   constructor(scope: Construct, id: string, props: StorageStackProps) {
     super(scope, id, props);
@@ -20,6 +21,15 @@ export class StorageStack extends Stack {
       bucketName: `nj-bfs-user-messages-${props.stage}`,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       removalPolicy: removalPolicy,
+      autoDeleteObjects: false,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      versioned: false,
+    });
+
+    this.intercomMacrosBucket = new s3.Bucket(this, "IntercomMacrosBucket", {
+      bucketName: `nj-bfs-intercom-macros-${props.stage}`,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: RemovalPolicy.RETAIN,
       autoDeleteObjects: false,
       encryption: s3.BucketEncryption.S3_MANAGED,
       versioned: false,

--- a/api/cdk/test/lambdaStack.test.ts
+++ b/api/cdk/test/lambdaStack.test.ts
@@ -20,6 +20,10 @@ describe("LambdaStack", () => {
         bucketName: "messages-bucket-local",
         grantWrite: () => {},
       } as unknown as IBucket,
+      intercomMacrosBucket: {
+        bucketName: "intercom-macros-bucket-local",
+        grantWrite: () => {},
+      } as unknown as IBucket,
     };
 
     stack = new LambdaStack(app, "TestLambdaStack", defaultProps);

--- a/api/src/functions/updateKbWithIntercomMacros/app.ts
+++ b/api/src/functions/updateKbWithIntercomMacros/app.ts
@@ -1,0 +1,149 @@
+import { PutObjectCommand, S3Client, S3ServiceException } from "@aws-sdk/client-s3";
+import { STAGE } from "@functions/config";
+import { LogWriter, LogWriterType } from "@libs/logWriter";
+
+export const handler = async (): Promise<void> => {
+  const logger = LogWriter(`NavigatorWebService/${STAGE}`, "ApiLogs");
+  const intercomMacrosBucketName = process.env.INTERCOM_MACROS_BUCKET;
+
+  const intercomMacros = await createIntercomMacrosObj(logger);
+  const client = new S3Client({});
+  await uploadToS3(logger, client, intercomMacros, intercomMacrosBucketName);
+};
+
+interface IntercomMacro {
+  type: string;
+  id: string;
+  name: string;
+  body: string;
+  body_text: string;
+  created_at: string;
+  updated_at: string;
+  visible_to: string;
+  visible_to_team_ids: string[];
+  available_on: string[];
+}
+
+interface Pages {
+  type: string;
+  per_page: number;
+  next: {
+    starting_after: string;
+  };
+}
+
+interface IntercomMacrosListResponse {
+  type: string;
+  data: IntercomMacro[];
+  pages: Pages;
+}
+
+const removeNewLines = (text: string): string => {
+  return text.replaceAll("\n", "");
+};
+
+const removeNonAsciiCharacters = (text: string): string => {
+  return text.replaceAll(/[^\u0020-\u007E]/g, "");
+};
+
+const sanitizeText = (text: string): string => {
+  text = removeNewLines(text);
+  text = removeNonAsciiCharacters(text);
+  return text;
+};
+
+const containsDynamicPhrase = (text: string): boolean => {
+  const regex = /{{[^}]+}}/;
+  return regex.test(text);
+};
+
+const containsSpanishMarker = (text: string): boolean => {
+  return text.includes("- Spanish") || text.includes("SP: ");
+};
+
+const formatMacrosIntoJson = (intercomObjs: IntercomMacro[]): Record<string, string> => {
+  const macrosMap: Record<string, string> = {};
+  for (const macro of intercomObjs) {
+    if (!containsDynamicPhrase(macro.body_text) && !containsSpanishMarker(macro.name))
+      macrosMap[sanitizeText(macro.name)] = sanitizeText(macro.body_text);
+  }
+  return macrosMap;
+};
+
+const fetchMarcosListFromIntercom = async (
+  startAfterCursor: string,
+): Promise<{
+  intercomObjs: Record<string, string>;
+  startAfterCursor?: string;
+}> => {
+  const startingTime = "1577865600"; // January 1, 2020
+  const response = await fetch(
+    `${process.env.INTERCOM_MACROS_BASE_URL}?per_page=50&starting_after=${startAfterCursor}&updated_since=${startingTime}`,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${process.env.INTERCOM_TOKEN}`,
+        Accept: "application/json",
+        "Intercom-Version": "Unstable",
+      },
+    },
+  );
+  const data = (await response.json()) as IntercomMacrosListResponse;
+  return {
+    intercomObjs: formatMacrosIntoJson(data.data),
+    startAfterCursor: data.pages?.next?.starting_after,
+  };
+};
+
+const createIntercomMacrosObj = async (logger: LogWriterType): Promise<Record<string, string>> => {
+  try {
+    let macrosObject: Record<string, string> = {};
+
+    const initialResponse = await fetchMarcosListFromIntercom("");
+    macrosObject = { ...macrosObject, ...initialResponse.intercomObjs };
+    let startAfterCursor = initialResponse.startAfterCursor;
+
+    while (startAfterCursor) {
+      const result = await fetchMarcosListFromIntercom(startAfterCursor);
+      startAfterCursor = result.startAfterCursor;
+      macrosObject = { ...macrosObject, ...result.intercomObjs };
+    }
+
+    logger.LogInfo(`Successfully fetched data ${Object.keys(macrosObject).length} macros`);
+    return macrosObject;
+  } catch (error) {
+    logger.LogError(`Failed to fetch from Intercom: ${error}`);
+    throw error;
+  }
+};
+
+const uploadToS3 = async (
+  logger: LogWriterType,
+  client: S3Client,
+  intercomMacros: Record<string, string>,
+  bucketName: string | undefined,
+): Promise<void> => {
+  try {
+    await client.send(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "intercom-macros-json",
+        Body: JSON.stringify(intercomMacros),
+      }),
+    );
+    logger.LogInfo("Successfully uploaded macros to S3");
+  } catch (error) {
+    if (error instanceof S3ServiceException && error.name === "EntityTooLarge") {
+      logger.LogError(
+        `Error from S3 while uploading object to ${bucketName}. The object was too large.`,
+      );
+    } else if (error instanceof S3ServiceException) {
+      logger.LogError(
+        `Error from S3 while uploading object to ${bucketName}.  ${error.name}: ${error.message}`,
+      );
+    } else {
+      logger.LogError(`Unexpected error occurred: ${error}`);
+      throw error;
+    }
+  }
+};


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [AB#17402](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17402).

### Approach
I created a lambda function that runs once a week at 8 am EST. It does the following:
1) Retrieve all the stored macros within our intercom workspace 
2) Sanitizes the text, removes new line characters, non ASCII characters, and removes non english macros for now.
3) Creates a JSON object with the sanitized text, `{MACRO_NAME: MACROS_BODY_TEXT}`
and uploads them into a S3 bucket so we can point our BAC knowledge base towards it.

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
I tested it thoroughly in the testing environment. If you wanted to test it as well, you would have to pass in the env variables into `testing-dev-environment.yml` (similar to `deploy-dev-environment.yml`) and move the lambda creation logic outside of `if dev` in `lambdaStack.ts`

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `request-reviewer` tag on github to request reviews
