### PR TITLE
chore: [AB#17687] run the Webflow sync scripts when synced content is modified

### DIFF
--- a/.github/workflows/deploy-content-environment.yml
+++ b/.github/workflows/deploy-content-environment.yml
@@ -104,11 +104,64 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for Webflow Content Changes
+        id: check-changes
+        shell: bash
+        run: |
+          # Check if any files in the Webflow-synced directories have changed
+          if git diff --name-only origin/main HEAD | grep -qE '^content/src/(roadmaps/industries|licenses|fundings)/'; then
+            echo "webflow_changes=true" >> $GITHUB_OUTPUT
+            echo "Changes detected in Webflow-synced content directories"
+          else
+            echo "webflow_changes=false" >> $GITHUB_OUTPUT
+            echo "No changes in Webflow-synced content directories"
+          fi
 
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: yarn
+
+      - uses: actions/cache@v5
+        with:
+          path: .yarn/cache
+          key: yarn-cache-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-cache-
+
+      - name: Install Dependencies
+        shell: bash
+        run: yarn install --immutable
+
+      - name: Build
+        shell: bash
+        run: yarn build
+
+      - name: Sync Webflow Content
+        if: steps.check-changes.outputs.webflow_changes == 'true'
+        working-directory: web
+        shell: bash
+        env:
+          WEBFLOW_API_TOKEN: ${{ secrets.WEBFLOW_API_TOKEN }}
+        run: yarn workspace @businessnjgovnavigator/web webflow:run-sync
+
+      - name: Commit and Push Changes
+        if: steps.check-changes.outputs.webflow_changes == 'true'
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if [[ -n $(git status --porcelain) ]]; then
+            git add .
+            git commit -m "chore: sync Webflow content and store webflowIds [skip ci]"
+            git push
+          else
+            echo "No changes to commit"
+          fi
 
       - uses: ./.github/actions/deploy
         with:

--- a/web/package.json
+++ b/web/package.json
@@ -31,10 +31,11 @@
     "test": "cross-env-shell DEBUG_PRINT_LIMIT=50000 jest",
     "typecheck": "tsc --noemit",
     "typecheck:cypress": "tsc --noemit --project cypress/tsconfig.json",
+    "webflow:run-sync": "yarn webflow:fundings-sync && yarn webflow:industries-sync && yarn webflow:licenses-sync",
+    "webflow:faq-sync": "tsx ./src/scripts/webflow/faqSync.ts",
     "webflow:fundings-sync": "tsx ./src/scripts/webflow/fundingSync.ts",
     "webflow:industries-sync": "tsx ./src/scripts/webflow/industrySync.ts",
-    "webflow:licenses-sync": "tsx ./src/scripts/webflow/licenseSync.ts",
-    "webflow:faq-sync": "tsx ./src/scripts/webflow/faqSync.ts"
+    "webflow:licenses-sync": "tsx ./src/scripts/webflow/licenseSync.ts"
   },
   "dependencies": {
     "@aws-crypto/sha256-browser": "5.2.0",


### PR DESCRIPTION
## Description

Runs the Webflow sync scripts automatically when content synced to Webflow is updated.

### Ticket

This pull request resolves [#17687](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17687).

### Approach

- Created a new script `webflow:run-sync` in `web/package.json` that will run all sync scripts in sequence
- Added a new step to the content deployment workflow which invokes this script
- At the end, the workflow will conditionally commit any changes against the `content-repo` branch
  - Commit message includes `[skip ci]` to avoid re-triggering the GitHub Action

### Steps to Test

Run the workflow, check if the Webflow sync runs in GHA.

Additionally, add a new content item to one of the synced collections. That item should get a new `webflowId` and that change should be reflected in the file in a new commit.

### Notes

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [X] I have added the `request-reviewer` tag on github to request reviews
