### PR TITLE
chore: improve generate-new-migration.sh quality and coverage

### DIFF
--- a/scripts/generate-new-migration.sh
+++ b/scripts/generate-new-migration.sh
@@ -1,82 +1,87 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+# Portable in-place sed using mktemp — avoids BSD/GNU sed compatibility issues
+sedi() {
+  local script="$1" file tmp
+  shift
+  for file in "$@"; do
+    tmp=$(mktemp)
+    sed "$script" "$file" > "$tmp" && mv "$tmp" "$file"
+  done
+}
 
 echo "What is the name of the migration file you want to create (excluding version number)?"
+read -r NEW_FILENAME
 
-read NEW_FILENAME
+# Normalize to snake_case: lowercase, replace non-alphanumeric runs with underscores, strip leading/trailing underscores
+NEW_FILENAME=$(echo "$NEW_FILENAME" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '_' | sed 's/^_*//;s/_*$//')
 
-if ! [[ $NEW_FILENAME =~ ^[a-z]+(_[a-z]+)*$ ]]; then
-    echo "Error: Filename must be in snake_case (lowercase letters separated by underscores)"
-    exit 1
+if [[ -z "$NEW_FILENAME" ]]; then
+  echo "Error: Could not derive a valid filename from input"
+  exit 1
 fi
 
-## Get most recent version number
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-cd "$PROJECT_ROOT/api/src/db/migrations/"
+MIGRATIONS_DIR="$PROJECT_ROOT/api/src/db/migrations"
 
-MOST_RECENT_FILENAME=$(ls -1v $(pwd) | sort -V | tail -n 1)
+cd "$MIGRATIONS_DIR" || exit
 
-MOST_RECENT_FILENAME_WITHOUT_FILETYPE=$(echo $MOST_RECENT_FILENAME | cut -d "." -f 1)
+# Derive version info from the most recent migration file
+MOST_RECENT_FILENAME=$(find . -maxdepth 1 -name "v*.ts" ! -name "*.test.ts" | sort -V | tail -n 1)
+MOST_RECENT_FILENAME="${MOST_RECENT_FILENAME#./}"
+MOST_RECENT_FILENAME_NO_EXT="${MOST_RECENT_FILENAME%.ts}"
+MOST_RECENT_VERSION_NUMBER="${MOST_RECENT_FILENAME%%_*}"
+MOST_RECENT_VERSION_NUMBER="${MOST_RECENT_VERSION_NUMBER#v}"
 
-MOST_RECENT_FILE_VERSION=$(echo $MOST_RECENT_FILENAME | cut -d "_" -f 1)
-
-MOST_RECENT_VERSION_NUMBER=$(echo $MOST_RECENT_FILE_VERSION | cut -d "v" -f 2)
-
-NEW_VERSION_NUMBER=$(($MOST_RECENT_VERSION_NUMBER + 1))
-
+PREV_VERSION_NUMBER=$((MOST_RECENT_VERSION_NUMBER - 1))
+NEW_VERSION_NUMBER=$((MOST_RECENT_VERSION_NUMBER + 1))
 NEW_FILENAME_COMPLETE="v${NEW_VERSION_NUMBER}_${NEW_FILENAME}.ts"
 
-## Create new file
+# Create new migration file from the previous one
 cp "$MOST_RECENT_FILENAME" "$NEW_FILENAME_COMPLETE"
 echo "New migration created at: api/src/db/migrations/$NEW_FILENAME_COMPLETE"
 
-# Replace version numbers
-sed -i.bak "s/$MOST_RECENT_VERSION_NUMBER/$NEW_VERSION_NUMBER/g" "$NEW_FILENAME_COMPLETE"
+# Update version numbers inside the new file
+sedi "s/$MOST_RECENT_VERSION_NUMBER/$NEW_VERSION_NUMBER/g" "$NEW_FILENAME_COMPLETE"
+sedi "s/$PREV_VERSION_NUMBER/$MOST_RECENT_VERSION_NUMBER/g" "$NEW_FILENAME_COMPLETE"
 
-sed -i.bak "s/$((MOST_RECENT_VERSION_NUMBER - 1))/$MOST_RECENT_VERSION_NUMBER/g" "$NEW_FILENAME_COMPLETE"
+# Fix the import to point to the previous migration file
+sedi "s|@db/migrations/.*|@db/migrations/$MOST_RECENT_FILENAME_NO_EXT\"|g" "$NEW_FILENAME_COMPLETE"
 
-## Adjust import in new file
-MOST_RECENT_FILENAME_NO_EXT=${MOST_RECENT_FILENAME%.ts}
-sed -i.bak "s|@db/migrations/.*|@db/migrations/$MOST_RECENT_FILENAME_NO_EXT\"|g" "$NEW_FILENAME_COMPLETE"
+# Update CURRENT_VERSION in userData.ts
+sedi "s/$MOST_RECENT_VERSION_NUMBER/$NEW_VERSION_NUMBER/g" "$PROJECT_ROOT/shared/src/userData.ts"
 
-## Update current version variable in UserData.ts
-sed -i.bak "s/$MOST_RECENT_VERSION_NUMBER/$NEW_VERSION_NUMBER/g" "../../../../shared/src/userData.ts"
-
-## Add migration function to migration.ts collection
-MIGRATE_FUNCTION_LAST_LINE_NUMBER=$(grep -n "migrate_v$(($MOST_RECENT_VERSION_NUMBER - 1))_to_v$MOST_RECENT_VERSION_NUMBER," "migrations.ts" | cut -d ":" -f 1)
-MIGRATE_FUNCTION_NEXT_LINE_NUMBER=$((${MIGRATE_FUNCTION_LAST_LINE_NUMBER} + 1))
-sed -i.bak "${MIGRATE_FUNCTION_NEXT_LINE_NUMBER}i\\
+# Add new migration function to migrations.ts
+PREV_MIGRATE_LINE=$(grep -n "migrate_v${PREV_VERSION_NUMBER}_to_v${MOST_RECENT_VERSION_NUMBER}," migrations.ts | cut -d ":" -f 1)
+sedi "$((PREV_MIGRATE_LINE + 1))i\\
   migrate_v${MOST_RECENT_VERSION_NUMBER}_to_v${NEW_VERSION_NUMBER},
-" "migrations.ts"
+" migrations.ts
 
-## Add new migration function import
-MIGRATE_FUNCTION_IMPORT_LAST_LINE_NUMBER=$(grep -n "import { migrate_v$(($MOST_RECENT_VERSION_NUMBER - 1))_to_v$MOST_RECENT_VERSION_NUMBER }" "migrations.ts" | cut -d ":" -f 1)
-MIGRATE_FUNCTION_IMPORT_NEW_LINE_NUMBER=$((${MIGRATE_FUNCTION_IMPORT_LAST_LINE_NUMBER} + 1))
-sed -i.bak "${MIGRATE_FUNCTION_IMPORT_NEW_LINE_NUMBER}i\\
+# Add new import to migrations.ts
+PREV_IMPORT_LINE=$(grep -n "import { migrate_v${PREV_VERSION_NUMBER}_to_v${MOST_RECENT_VERSION_NUMBER} }" migrations.ts | cut -d ":" -f 1)
+sedi "$((PREV_IMPORT_LINE + 1))i\\
 import { migrate_v${MOST_RECENT_VERSION_NUMBER}_to_v${NEW_VERSION_NUMBER} } from \"@db/migrations/v${NEW_VERSION_NUMBER}_${NEW_FILENAME}\";
-" "migrations.ts"
+" migrations.ts
 
-## Update generator function in migrations.ts
-sed -i.bak "s|v${MOST_RECENT_VERSION_NUMBER}UserData as CURRENT_GENERATOR } from \"@db/migrations/${MOST_RECENT_FILENAME_WITHOUT_FILETYPE}\"|v${NEW_VERSION_NUMBER}UserData as CURRENT_GENERATOR } from \"@db/migrations/v${NEW_VERSION_NUMBER}_${NEW_FILENAME}\"|g" "migrations.ts"
+# Update CURRENT_GENERATOR export in migrations.ts
+sedi "s|v${MOST_RECENT_VERSION_NUMBER}UserData as CURRENT_GENERATOR } from \"@db/migrations/${MOST_RECENT_FILENAME_NO_EXT}\"|v${NEW_VERSION_NUMBER}UserData as CURRENT_GENERATOR } from \"@db/migrations/v${NEW_VERSION_NUMBER}_${NEW_FILENAME}\"|g" migrations.ts
 
-# Update ZodSchema files
-cd "$PROJECT_ROOT/api/src/db/zodSchema/"
+# Update Zod schema files and the print-schema script
 ZOD_SCHEMA_FILE="$PROJECT_ROOT/api/src/db/zodSchema/zodSchemas.ts"
 ZOD_SCHEMA_TEST_FILE="$PROJECT_ROOT/api/src/db/zodSchema/zodSchemas.test.ts"
+PRINT_USER_SCHEMA_FILE="$PROJECT_ROOT/api/scripts/printUserZodSchema.ts"
 
 echo "Updating Zod schema imports and schema version numbers"
-# Replace filename references
-sed -i.bak "s/${MOST_RECENT_FILENAME_WITHOUT_FILETYPE}/v${NEW_VERSION_NUMBER}_${NEW_FILENAME}/g" \
+sedi "s/${MOST_RECENT_FILENAME_NO_EXT}/v${NEW_VERSION_NUMBER}_${NEW_FILENAME}/g" \
   "$ZOD_SCHEMA_FILE" \
-  "$ZOD_SCHEMA_TEST_FILE"
+  "$ZOD_SCHEMA_TEST_FILE" \
+  "$PRINT_USER_SCHEMA_FILE"
 
-# Replace version references
-sed -i.bak "s/${MOST_RECENT_VERSION_NUMBER}/${NEW_VERSION_NUMBER}/g" \
+sedi "s/${MOST_RECENT_VERSION_NUMBER}/${NEW_VERSION_NUMBER}/g" \
   "$ZOD_SCHEMA_FILE" \
-  "$ZOD_SCHEMA_TEST_FILE"
-
-echo "Cleaning up backup files..."
-cd "$PROJECT_ROOT"
-find . -not -path "*/node_modules/*" -name "*.bak" -delete
+  "$ZOD_SCHEMA_TEST_FILE" \
+  "$PRINT_USER_SCHEMA_FILE"
 
 echo ""
 echo "------------------------------------"


### PR DESCRIPTION
## Description

Fixes all shellcheck violations in `generate-new-migration.sh`, improves readability throughout, and extends the script to also update `api/scripts/printUserZodSchema.ts` when a new migration is created (it hardcodes the migration filename and version number but was previously excluded from the automated replacements).

### Approach

- Added `set -euo pipefail` for safer script execution
- Replaced `ls` with `find` to satisfy SC2012/SC2046 (non-alphanumeric filenames, unquoted command substitution)
- Added `read -r` (SC2162), `|| exit` on `cd` calls (SC2164), quoted variables in command substitutions (SC2086), removed unnecessary `${}` in arithmetic expressions (SC2004)
- Replaced `echo ... | cut` chains with bash parameter expansion
- Deduped `MOST_RECENT_FILENAME_NO_EXT` / `MOST_RECENT_FILENAME_WITHOUT_FILETYPE` (same value, defined twice)
- Introduced `PREV_VERSION_NUMBER` to avoid recomputing `$((N - 1))` inline in two places
- Inlined `+1` arithmetic directly into `sed` calls, eliminating one-off `*_NEXT_LINE_NUMBER` variables
- Removed unnecessary `cd` into the zodSchema directory (all paths there are already absolute)
- Replaced `sed -i.bak` + cleanup step with a `sedi()` helper that uses `mktemp` for portable in-place editing — no backup files created, works on both macOS (BSD sed) and Linux (GNU sed)
- Input is now normalized to snake_case automatically (lowercased, non-alphanumeric runs replaced with underscores) instead of rejecting non-snake_case input with an error

### Steps to Test

1. Run `bash scripts/generate-new-migration.sh` with inputs of varying cases and spacing (e.g. `"Add New Field"`, `"remove  hidden  fundings"`) and verify they are normalized correctly
2. Verify the new migration file is created in `api/src/db/migrations/`
3. Verify `shared/src/userData.ts`, `migrations.ts`, `zodSchemas.ts`, `zodSchemas.test.ts`, and `api/scripts/printUserZodSchema.ts` are all updated with the new version number
4. Run `shellcheck scripts/generate-new-migration.sh` and confirm it exits cleanly
5. Verify no `.bak` files are left behind after the script runs

### Notes

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `request-reviewer` tag on github to request reviews