### PR TITLE
chore: add PR Show GitHub Actions workflow

### DIFF
--- a/.github/workflows/pr-show.yml
+++ b/.github/workflows/pr-show.yml
@@ -1,0 +1,47 @@
+name: PR Show
+
+on:
+  pull_request:
+    types: ["labeled"]
+
+jobs:
+  post-slack-message:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: contains(github.event.pull_request.labels.*.name, 'pr-show')
+    steps:
+      - uses: actions/checkout@v6
+      - name: "Look up PR author in Slack"
+        id: lookup-pr-author
+        uses: newjersey/innovation-shared-actions/.github/actions/lookup-slack-users@main
+        with:
+          github_usernames: ${{ github.event.pull_request.user.login }}
+          github_slack_mapping: ${{ vars.GH_SLACK_USER_MAP }}
+      - name: Build author mention
+        id: build-author-mention
+        shell: bash
+        run: |
+          PR_AUTHOR_SLACK='${{ steps.lookup-pr-author.outputs.slack_users }}'
+          PR_AUTHOR_GITHUB='${{ steps.lookup-pr-author.outputs.github_users }}'
+
+          AUTHOR_MENTION=$(printf '%s %s' "$PR_AUTHOR_SLACK" "$PR_AUTHOR_GITHUB" | jq -r -s '
+            (.[0] | map("<@" + . + ">")) + (.[1] | map("@" + .)) | .[0]
+          ')
+
+          echo "author-mention=$AUTHOR_MENTION" >> $GITHUB_OUTPUT
+      - name: Build ADO connection
+        id: build-ado-connection
+        shell: bash
+        run: |
+          python3 scripts/generate_ado_link.py "${{ github.event.pull_request.title }}"
+      - name: Send Slack message
+        uses: newjersey/innovation-shared-actions/.github/actions/slack-message@main
+        with:
+          channel_id: ${{ secrets.SLACK_BIZX_ENG_CHANNEL_ID }}
+          message:
+            "[ <${{ github.event.pull_request.html_url }}|PR Show> ] ${{
+            github.event.repository.full_name}} - #${{ github.event.pull_request.number }} by ${{
+            steps.build-author-mention.outputs.author-mention }}:\n\n*${{
+            steps.build-ado-connection.outputs.pr_title }}*"
+          token: ${{ secrets.SLACK_OAUTH_TOKEN }}


### PR DESCRIPTION
## Description

Adds a new GitHub Actions workflow that posts a Slack announcement when the `pr-show` label is applied to a PR. This mirrors the existing `request-reviewers.yml` but without any reviewer assignment logic — just a single formatted message to the eng channel.

### Approach

Adds `.github/workflows/pr-show.yml`. When the `pr-show` label is applied, it looks up the PR author in Slack, formats an ADO-linked title, and posts a single message in the format `[ PR Show ] repo - #NUM by @author: *title*` — no reviewer lookup, no thread reply.

### Steps to Test

1. Apply the `pr-show` label to any open PR
2. Check the GitHub Actions tab — the "PR Show" workflow should trigger and complete successfully
3. Verify the Slack message appears in the eng channel with `[ PR Show ]` as a clickable link to the PR and no thread reply

### Notes

Reuses the same secrets/vars as `request-reviewers.yml` (`SLACK_OAUTH_TOKEN`, `SLACK_BIZX_ENG_CHANNEL_ID`, `GH_SLACK_USER_MAP`) — no new configuration needed.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `request-reviewer` tag on GitHub to request reviews