### PR TITLE
chore: [AB#17524] - Manage IAM configuration with CDK

### DIFF
--- a/.github/actions/deploy-cdk/action.yml
+++ b/.github/actions/deploy-cdk/action.yml
@@ -31,6 +31,17 @@ runs:
           --region us-east-1 \
           --require-approval never
 
+    - name: Import IAM resources in CDK IamStack
+      shell: bash
+      run: |
+        echo "Importing IAM resources for stage: $STAGE"
+        yarn workspace @businessnjgovnavigator/api-cdk cdk deploy IamStack-${{ env.STAGE }} \
+          --import-existing-resources \
+          --qualifier biz-nj \
+          --verbose \
+          --region us-east-1 \
+          --require-approval never
+
     - name: Deploy CDK
       shell: bash
       run: |

--- a/.github/workflows/deploy-dev-environment.yml
+++ b/.github/workflows/deploy-dev-environment.yml
@@ -117,6 +117,10 @@ jobs:
 
       CMS_OAUTH_CLIENT_ID: ${{vars.CMS_OAUTH_CLIENT_ID}}
       CMS_OAUTH_CLIENT_SECRET: ${{secrets.CMS_OAUTH_CLIENT_SECRET}}
+
+      SHARED_IDENTITY_POOL_IDS:
+        "${{ secrets.COGNITO_IDENTITY_POOL_ID_DEV }},${{ secrets.COGNITO_IDENTITY_POOL_ID_TESTING
+        }},${{ secrets.COGNITO_IDENTITY_POOL_ID_CONTENT }}"
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/api/cdk/.eslintrc.json
+++ b/api/cdk/.eslintrc.json
@@ -17,7 +17,8 @@
         "eqeqeq": "off",
         "jest-formatting/padding-around-describe-blocks": "off",
         "jest-formatting/padding-around-before-each-blocks": "off",
-        "jest-formatting/padding-around-test-blocks": "off"
+        "jest-formatting/padding-around-test-blocks": "off",
+        "jest-formatting/padding-around-after-each-blocks": "off"
       }
     }
   ]

--- a/api/cdk/lib/iamStack.ts
+++ b/api/cdk/lib/iamStack.ts
@@ -22,15 +22,17 @@ export class IamStack extends Stack {
   readonly serviceName: string;
   public readonly role: iam.Role;
   public readonly backupRole?: iam.Role;
+  public readonly authRole?: iam.Role;
+  public readonly unauthRole?: iam.Role;
 
   constructor(scope: Construct, id: string, props: IamStackProps) {
     super(scope, id, props);
     this.serviceName = API_SERVICE_NAME;
 
-    const shouldCreateBackupRole =
+    const isIamCreatedForDevStagingProdOnly =
       props.stage === DEV_STAGE || props.stage === STAGING_STAGE || props.stage === PROD_STAGE;
 
-    if (shouldCreateBackupRole) {
+    if (isIamCreatedForDevStagingProdOnly) {
       const backupRole = new iam.Role(this, "backupRole", {
         assumedBy: new iam.ServicePrincipal("backup.amazonaws.com"),
         roleName: `Backups`,
@@ -50,6 +52,59 @@ export class IamStack extends Stack {
 
       applyStandardTags(backupRole, props.stage);
       this.backupRole = backupRole;
+
+      const identityPoolIds: string[] =
+        props.stage === DEV_STAGE
+          ? (process.env.SHARED_IDENTITY_POOL_IDS?.split(",").map((id) => id.trim()) ?? [])
+          : process.env.COGNITO_IDENTITY_POOL_ID
+            ? [process.env.COGNITO_IDENTITY_POOL_ID]
+            : [];
+
+      if (props.stage === DEV_STAGE && identityPoolIds.length === 0) {
+        throw new Error("SHARED_IDENTITY_POOL_IDS must be set for dev");
+      }
+
+      if (props.stage !== DEV_STAGE && identityPoolIds.length === 0) {
+        throw new Error("COGNITO_IDENTITY_POOL_ID must be set for this stage");
+      }
+
+      const authRole = new iam.Role(this, "navigatorAuthRole", {
+        roleName: "navigator_authRole",
+        assumedBy: new iam.FederatedPrincipal(
+          "cognito-identity.amazonaws.com",
+          {
+            StringEquals: {
+              "cognito-identity.amazonaws.com:aud": identityPoolIds,
+            },
+            "ForAnyValue:StringLike": {
+              "cognito-identity.amazonaws.com:amr": "authenticated",
+            },
+          },
+          "sts:AssumeRoleWithWebIdentity",
+        ),
+      });
+
+      applyStandardTags(authRole, props.stage);
+      this.authRole = authRole;
+
+      const unauthRole = new iam.Role(this, "navigatorUnauthRole", {
+        roleName: "navigator_unauthRole",
+        assumedBy: new iam.FederatedPrincipal(
+          "cognito-identity.amazonaws.com",
+          {
+            StringEquals: {
+              "cognito-identity.amazonaws.com:aud": identityPoolIds,
+            },
+            "ForAnyValue:StringLike": {
+              "cognito-identity.amazonaws.com:amr": "unauthenticated",
+            },
+          },
+          "sts:AssumeRoleWithWebIdentity",
+        ),
+      });
+
+      applyStandardTags(unauthRole, props.stage);
+      this.unauthRole = unauthRole;
     }
 
     const putMetricDataPolicyInCloudwatch = new iam.PolicyStatement({

--- a/api/cdk/test/iamStack.test.ts
+++ b/api/cdk/test/iamStack.test.ts
@@ -7,12 +7,24 @@ describe("IamStack", () => {
   let app: App;
   let stack: IamStack;
   let template: Template;
+  let originalCognitoIdentityPoolId: string | undefined;
 
   beforeEach(() => {
+    originalCognitoIdentityPoolId = process.env.COGNITO_IDENTITY_POOL_ID;
+    process.env.COGNITO_IDENTITY_POOL_ID = "us-east-1:single-pool-id";
+
     app = new App();
     const props: IamStackProps = { stage: "local" };
     stack = new IamStack(app, "TestIamStack", props);
     template = Template.fromStack(stack);
+  });
+
+  afterEach(() => {
+    if (originalCognitoIdentityPoolId === undefined) {
+      delete process.env.COGNITO_IDENTITY_POOL_ID;
+    } else {
+      process.env.COGNITO_IDENTITY_POOL_ID = originalCognitoIdentityPoolId;
+    }
   });
 
   test("creates the lambda IAM role with correct name", () => {
@@ -202,10 +214,21 @@ describe("IamStack", () => {
   });
 
   test("includes SNS publish policy in dev environment", () => {
+    // Dev stage requires SHARED_IDENTITY_POOL_IDS environment variable
+    const originalSharedIds = process.env.SHARED_IDENTITY_POOL_IDS;
+    process.env.SHARED_IDENTITY_POOL_IDS = "us-east-1:dev-test-pool-id";
+
     const devApp = new App();
     const devProps: IamStackProps = { stage: "dev" };
     const devStack = new IamStack(devApp, "TestIamStackDev", devProps);
     const devTemplate = Template.fromStack(devStack);
+
+    // Restore original env var
+    if (originalSharedIds === undefined) {
+      delete process.env.SHARED_IDENTITY_POOL_IDS;
+    } else {
+      process.env.SHARED_IDENTITY_POOL_IDS = originalSharedIds;
+    }
 
     expect(() => {
       devTemplate.hasResourceProperties("AWS::IAM::Policy", {
@@ -221,5 +244,161 @@ describe("IamStack", () => {
         },
       });
     }).not.toThrow();
+  });
+
+  describe("Cognito Identity Pool roles", () => {
+    let originalSharedIdentityPoolIds: string | undefined;
+
+    beforeEach(() => {
+      originalSharedIdentityPoolIds = process.env.SHARED_IDENTITY_POOL_IDS;
+    });
+
+    afterEach(() => {
+      if (originalSharedIdentityPoolIds === undefined) {
+        delete process.env.SHARED_IDENTITY_POOL_IDS;
+      } else {
+        process.env.SHARED_IDENTITY_POOL_IDS = originalSharedIdentityPoolIds;
+      }
+    });
+
+    test("throws error for dev stage when SHARED_IDENTITY_POOL_IDS not set", () => {
+      delete process.env.SHARED_IDENTITY_POOL_IDS;
+      const testApp = new App();
+      const testProps: IamStackProps = { stage: "dev" };
+
+      expect(() => {
+        new IamStack(testApp, "TestIamStackDevNoEnv", testProps);
+      }).toThrow("SHARED_IDENTITY_POOL_IDS must be set for dev");
+    });
+
+    test("creates auth role with correct configuration for dev stage with multiple pools", () => {
+      process.env.SHARED_IDENTITY_POOL_IDS = "us-east-1:test-pool-id-1, us-east-1:test-pool-id-2";
+      const testApp = new App();
+      const testProps: IamStackProps = { stage: "dev" };
+      const testStack = new IamStack(testApp, "TestIamStackDevWithPools", testProps);
+      const testTemplate = Template.fromStack(testStack);
+
+      expect(() => {
+        testTemplate.hasResourceProperties("AWS::IAM::Role", {
+          RoleName: "navigator_authRole",
+          AssumeRolePolicyDocument: {
+            Statement: [
+              {
+                Action: "sts:AssumeRoleWithWebIdentity",
+                Condition: {
+                  StringEquals: {
+                    "cognito-identity.amazonaws.com:aud": [
+                      "us-east-1:test-pool-id-1",
+                      "us-east-1:test-pool-id-2",
+                    ],
+                  },
+                  "ForAnyValue:StringLike": {
+                    "cognito-identity.amazonaws.com:amr": "authenticated",
+                  },
+                },
+                Effect: "Allow",
+                Principal: {
+                  Federated: "cognito-identity.amazonaws.com",
+                },
+              },
+            ],
+            Version: "2012-10-17",
+          },
+        });
+      }).not.toThrow();
+    });
+
+    test("creates unauth role with correct configuration for dev stage with multiple pools", () => {
+      process.env.SHARED_IDENTITY_POOL_IDS = "us-east-1:test-pool-id-1, us-east-1:test-pool-id-2";
+      const testApp = new App();
+      const testProps: IamStackProps = { stage: "dev" };
+      const testStack = new IamStack(testApp, "TestIamStackDevWithPools2", testProps);
+      const testTemplate = Template.fromStack(testStack);
+
+      expect(() => {
+        testTemplate.hasResourceProperties("AWS::IAM::Role", {
+          RoleName: "navigator_unauthRole",
+          AssumeRolePolicyDocument: {
+            Statement: [
+              {
+                Action: "sts:AssumeRoleWithWebIdentity",
+                Condition: {
+                  StringEquals: {
+                    "cognito-identity.amazonaws.com:aud": [
+                      "us-east-1:test-pool-id-1",
+                      "us-east-1:test-pool-id-2",
+                    ],
+                  },
+                  "ForAnyValue:StringLike": {
+                    "cognito-identity.amazonaws.com:amr": "unauthenticated",
+                  },
+                },
+                Effect: "Allow",
+                Principal: {
+                  Federated: "cognito-identity.amazonaws.com",
+                },
+              },
+            ],
+            Version: "2012-10-17",
+          },
+        });
+      }).not.toThrow();
+    });
+
+    test("creates both auth and unauth roles for dev stage", () => {
+      process.env.SHARED_IDENTITY_POOL_IDS = "us-east-1:test-pool-id";
+      const testApp = new App();
+      const testProps: IamStackProps = { stage: "dev" };
+      const testStack = new IamStack(testApp, "TestIamStackDevWithPool", testProps);
+      const testTemplate = Template.fromStack(testStack);
+
+      const roles = testTemplate.findResources("AWS::IAM::Role");
+      const roleNames = Object.values(roles).map((role) => role.Properties?.RoleName as string);
+
+      expect(roleNames).toContain("navigator_authRole");
+      expect(roleNames).toContain("navigator_unauthRole");
+    });
+
+    test("supports single identity pool ID for non-dev stages", () => {
+      const testApp = new App();
+      const testProps: IamStackProps = { stage: "prod" };
+      const testStack = new IamStack(testApp, "TestIamStackProdSinglePool", testProps);
+      const testTemplate = Template.fromStack(testStack);
+
+      expect(() => {
+        testTemplate.hasResourceProperties("AWS::IAM::Role", {
+          RoleName: "navigator_authRole",
+          AssumeRolePolicyDocument: {
+            Statement: [
+              {
+                Condition: {
+                  StringEquals: {
+                    "cognito-identity.amazonaws.com:aud": ["us-east-1:single-pool-id"],
+                  },
+                  "ForAnyValue:StringLike": Match.anyValue(),
+                },
+                Effect: "Allow",
+                Principal: {
+                  Federated: "cognito-identity.amazonaws.com",
+                },
+              },
+            ],
+          },
+        });
+      }).not.toThrow();
+    });
+
+    test("creates both auth and unauth roles for non-dev stages", () => {
+      const testApp = new App();
+      const testProps: IamStackProps = { stage: "prod" };
+      const testStack = new IamStack(testApp, "TestIamStackProdWithPool", testProps);
+      const testTemplate = Template.fromStack(testStack);
+
+      const roles = testTemplate.findResources("AWS::IAM::Role");
+      const roleNames = Object.values(roles).map((role) => role.Properties?.RoleName as string);
+
+      expect(roleNames).toContain("navigator_authRole");
+      expect(roleNames).toContain("navigator_unauthRole");
+    });
   });
 });

--- a/api/cdk/test/lambdaStack.test.ts
+++ b/api/cdk/test/lambdaStack.test.ts
@@ -9,8 +9,12 @@ describe("LambdaStack", () => {
   let stack: LambdaStack;
   let template: Template;
   let iamStack: IamStack;
+  let originalCognitoIdentityPoolId: string | undefined;
 
   beforeEach(() => {
+    originalCognitoIdentityPoolId = process.env.COGNITO_IDENTITY_POOL_ID;
+    process.env.COGNITO_IDENTITY_POOL_ID = "us-east-1:single-pool-id";
+
     app = new App();
     iamStack = new IamStack(app, "TestIamStack", { stage: "local" } as IamStackProps);
     const defaultProps: LambdaStackProps = {
@@ -28,6 +32,14 @@ describe("LambdaStack", () => {
 
     stack = new LambdaStack(app, "TestLambdaStack", defaultProps);
     template = Template.fromStack(stack);
+  });
+
+  afterEach(() => {
+    if (originalCognitoIdentityPoolId === undefined) {
+      delete process.env.COGNITO_IDENTITY_POOL_ID;
+    } else {
+      process.env.COGNITO_IDENTITY_POOL_ID = originalCognitoIdentityPoolId;
+    }
   });
 
   test("creates the express Lambda with correct environment variables", () => {


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

This PR is focused on migrating the IAM resources from Terraform to CDK, including setting up the Cognito identity pool roles and handling environment-specific IDs

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#17524](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17524).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `request-reviewer` tag on GitHub to show or request reviews
