### PR TITLE
feat: add feature flag scaffolding scripts

### DIFF
--- a/scripts/_feature_flag.py
+++ b/scripts/_feature_flag.py
@@ -1,0 +1,466 @@
+"""
+Shared utilities for add-api-feature-flag.py and add-web-feature-flag.py.
+
+Not intended to be run directly.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from functools import partial
+from pathlib import Path
+from typing import Callable
+
+ROOT = Path(__file__).resolve().parent.parent
+"""Absolute path to the repository root, used to build file paths and display relative paths."""
+
+
+# ---------------------------------------------------------------------------
+# Anchor patterns
+#
+# Each constant is a named engineering decision encoding a structural fact
+# about a specific file. The last line matching the anchor is used as the
+# insertion point, so each new flag lands after the previously added one.
+#
+# When a file's structure changes, update the constant and its comment to
+# describe the new reference point.
+# ---------------------------------------------------------------------------
+
+BUILD_AND_TEST_ANCHOR: str = r'  FEATURE_\S+: "(?:true|false)"'
+"""
+build-and-test.yml: flags are hard-coded as YAML string scalars, not GitHub
+expressions, so CI runs are hermetic and independent of any environment
+variable state in GitHub. New flags are inserted into this same hard-coded
+block so the CI behaviour is always predictable.
+"""
+
+DEPLOY_DEV_ANCHOR: str = r"      FEATURE_\S+: \$\{\{ vars\.FEATURE_\S+_DEV \}\}"
+"""
+deploy-dev-environment.yml: each flag maps to a per-flag GitHub variable
+suffixed with _DEV, scoped to the "dev" environment in GitHub Actions so
+it cannot be confused with staging or production values.
+"""
+
+DEPLOY_STAGING_ANCHOR: str = r"      FEATURE_\S+: \$\{\{ vars\.FEATURE_\S+_STAGING \}\}"
+"""
+deploy-staging-environment.yml: analogous to the dev anchor but scoped to
+the "staging" environment in GitHub Actions.
+"""
+
+DEPLOY_GENERIC_ANCHOR: str = r"      FEATURE_\S+: \$\{\{ vars\.FEATURE_\S+ \}\}"
+"""
+deploy-content-environment.yml and testing-deployment-trigger.yml: these
+workflows mix variable suffixes (_DEV, _CONTENT, _TESTING), so a
+suffix-agnostic anchor is used. New flags default to _DEV.
+"""
+
+RELEASE_PIPELINE_ANCHOR: str = (
+    r'          echo "FEATURE_\S+=\$\{\{ vars\.FEATURE_\S+_PROD \}\}" >> \$GITHUB_ENV'
+)
+"""
+release-pipeline.yml: production flags are exported via bash echo rather
+than a top-level env: block, which is a structural difference from the
+dev/staging workflows. The anchor matches the echo statement form used
+for all existing production feature flags.
+"""
+
+LAMBDA_STACK_CONST_ANCHOR: str = r'    const feature\w+ = process\.env\.FEATURE_\w+ \|\| "";'
+"""
+api/cdk/lib/lambdaStack.ts: the block of const declarations that read feature
+flag environment variables from the CDK deployment context before passing them
+to createLambda. New consts are appended here.
+"""
+
+LAMBDA_STACK_ENV_ANCHOR: str = r"        FEATURE_\w+: \w+,"
+"""
+api/cdk/lib/lambdaStack.ts: the environment object passed to createLambda.
+New entries are appended here to expose the flag to the Lambda function at
+runtime. Without this entry the flag reads as undefined in the Lambda even
+when the CDK stack was deployed with the variable set.
+"""
+
+NEXT_CONFIG_ANCHOR: str = r'    FEATURE_\S+: process\.env\.FEATURE_\S+ \?\? "false",'
+"""
+web/next.config.js: the env block that bakes environment variables into the
+Next.js build output. Without an entry here, process.env.FEATURE_X is
+undefined in both server-side and client-side Next.js code regardless of
+whether the variable is present in the Docker environment at build time.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Insertion:
+    """
+    Specifies where and what to insert within file content.
+
+    anchor:   Regex pattern identifying the insertion point. The last line
+              matching the pattern is used so that successive additions are
+              naturally appended after one another.
+    new_line: The complete line to insert after the anchor match.
+              Do not include a trailing newline; insert_after_last_match adds one.
+    """
+
+    anchor: str
+    new_line: str
+
+
+@dataclass(frozen=True)
+class FileEdit:
+    """
+    Associates a file path with the content transformation to apply to it.
+
+    Declaring edits as a typed list of FileEdit objects before any I/O begins
+    lets --dry-run validate all transforms against the current file contents
+    without writing anything.
+    """
+
+    path: Path
+    transform: Callable[[str], str]
+
+
+@dataclass(frozen=True)
+class CiConfig:
+    """
+    Configuration for a single entry in the build-and-test.yml env block.
+
+    ci_value is hard-coded (not a GitHub expression) to keep CI hermetic:
+    tests always run against a known flag state regardless of the GitHub
+    variable configured for any given environment.
+    """
+
+    flag: str
+    """The FEATURE_* environment variable name, e.g. FEATURE_MY_FLAG."""
+
+    ci_value: str
+    """Hard-coded CI value: "true" or "false"."""
+
+
+@dataclass(frozen=True)
+class DeployConfig:
+    """
+    Configuration for a YAML env block entry in a deploy workflow.
+
+    The suffix controls which GitHub environment variable is referenced.
+    For example, suffix="DEV" produces FEATURE_X_DEV, scoped to the "dev"
+    environment in GitHub Actions.
+    """
+
+    flag: str
+    """The FEATURE_* environment variable name."""
+
+    suffix: str
+    """GitHub variable suffix: DEV, STAGING, PROD, CONTENT, TESTING, etc."""
+
+
+# ---------------------------------------------------------------------------
+# Core utilities
+# ---------------------------------------------------------------------------
+
+
+def normalize_flag_name(name: str) -> str:
+    """
+    Return the canonical FEATURE_* environment variable name.
+
+    Adds the FEATURE_ prefix if absent and uppercases the result. Raises
+    SystemExit with a descriptive message if the name contains invalid
+    characters, so the error is surfaced before any file is touched.
+    """
+    upper = name.strip().upper()
+    if not upper.startswith("FEATURE_"):
+        upper = f"FEATURE_{upper}"
+    if not re.fullmatch(r"FEATURE_[A-Z][A-Z0-9_]*", upper):
+        raise SystemExit(
+            f"Error: invalid flag name {name!r}. "
+            "Use only ASCII letters, digits, and underscores (e.g. MY_NEW_FEATURE)."
+        )
+    return upper
+
+
+def to_camel_case(flag_name: str) -> str:
+    """
+    Convert a FEATURE_* name to camelCase for use as a TypeScript variable name.
+
+    Example: FEATURE_MY_NEW_FLAG → featureMyNewFlag
+    """
+    parts = flag_name.lower().split("_")
+    return parts[0] + "".join(part.capitalize() for part in parts[1:])
+
+
+def insert_after_last_match(content: str, spec: Insertion) -> str:
+    """
+    Return content with spec.new_line inserted after the last line matching spec.anchor.
+
+    Raises ValueError (not SystemExit) so that callers can annotate the error
+    with the file path before surfacing it to the user.
+    """
+    matches = list(re.finditer(spec.anchor, content, re.MULTILINE))
+    if not matches:
+        raise ValueError(
+            "could not find an insertion point.\n"
+            f"Expected a line matching: {spec.anchor!r}\n"
+            "The file may have diverged from the expected structure."
+        )
+    last = matches[-1]
+    line_end = content.find("\n", last.start())
+    if line_end == -1:
+        line_end = len(content)
+    return content[: line_end + 1] + spec.new_line + "\n" + content[line_end + 1 :]
+
+
+# ---------------------------------------------------------------------------
+# File I/O — split on the dry_run axis rather than using a boolean parameter
+# ---------------------------------------------------------------------------
+
+
+def preview_file_update(edit: FileEdit, flag: str) -> None:
+    """
+    Validate that edit.transform would succeed and print what would be written,
+    without making any changes to disk.
+
+    Skips with a diagnostic message if flag is already present in the file.
+    Raises SystemExit if the transform cannot find its insertion anchor, so
+    a dry run surfaces structural errors in the same way a live run would.
+    """
+    content = edit.path.read_text()
+    if flag in content:
+        print(f"  skip  {edit.path.relative_to(ROOT)}  (already present)")
+        return
+    try:
+        edit.transform(content)
+    except ValueError as exc:
+        raise SystemExit(f"Error: {edit.path.relative_to(ROOT)}\n{exc}") from exc
+    print(f"  [dry] {edit.path.relative_to(ROOT)}")
+
+
+def apply_file_update(edit: FileEdit, flag: str) -> None:
+    """
+    Apply edit.transform to the file at edit.path and write the result to disk.
+
+    Skips with a diagnostic message if flag is already present in the file.
+    Raises SystemExit if the transform cannot find its insertion anchor.
+    """
+    content = edit.path.read_text()
+    if flag in content:
+        print(f"  skip  {edit.path.relative_to(ROOT)}  (already present)")
+        return
+    try:
+        updated = edit.transform(content)
+    except ValueError as exc:
+        raise SystemExit(f"Error: {edit.path.relative_to(ROOT)}\n{exc}") from exc
+    edit.path.write_text(updated)
+    print(f"  ok    {edit.path.relative_to(ROOT)}")
+
+
+# ---------------------------------------------------------------------------
+# Workflow file transforms
+# ---------------------------------------------------------------------------
+
+
+def transform_build_and_test(config: CiConfig, content: str) -> str:
+    """Insert a hard-coded flag entry in the CI env block of build-and-test.yml."""
+    return insert_after_last_match(
+        content,
+        Insertion(
+            anchor=BUILD_AND_TEST_ANCHOR,
+            new_line=f'  {config.flag}: "{config.ci_value}"',
+        ),
+    )
+
+
+def transform_deploy_dev(flag: str, content: str) -> str:
+    """Map FEATURE_X to ${{ vars.FEATURE_X_DEV }} in deploy-dev-environment.yml."""
+    return insert_after_last_match(
+        content,
+        Insertion(
+            anchor=DEPLOY_DEV_ANCHOR,
+            new_line=f"      {flag}: ${{{{ vars.{flag}_DEV }}}}",
+        ),
+    )
+
+
+def transform_deploy_staging(flag: str, content: str) -> str:
+    """Map FEATURE_X to ${{ vars.FEATURE_X_STAGING }} in deploy-staging-environment.yml."""
+    return insert_after_last_match(
+        content,
+        Insertion(
+            anchor=DEPLOY_STAGING_ANCHOR,
+            new_line=f"      {flag}: ${{{{ vars.{flag}_STAGING }}}}",
+        ),
+    )
+
+
+def transform_deploy_generic(config: DeployConfig, content: str) -> str:
+    """
+    Map FEATURE_X to ${{ vars.FEATURE_X_{SUFFIX} }} using a suffix-agnostic anchor.
+
+    Used for workflows that mix variable suffixes (deploy-content, testing-trigger).
+    """
+    return insert_after_last_match(
+        content,
+        Insertion(
+            anchor=DEPLOY_GENERIC_ANCHOR,
+            new_line=f"      {config.flag}: ${{{{ vars.{config.flag}_{config.suffix} }}}}",
+        ),
+    )
+
+
+def transform_release_pipeline(flag: str, content: str) -> str:
+    """Append a PROD echo line to the environment export block in release-pipeline.yml."""
+    return insert_after_last_match(
+        content,
+        Insertion(
+            anchor=RELEASE_PIPELINE_ANCHOR,
+            new_line=f'          echo "{flag}=${{{{ vars.{flag}_PROD }}}}" >> $GITHUB_ENV',
+        ),
+    )
+
+
+def build_workflow_edits(flag: str, ci_value: str) -> list[FileEdit]:
+    """
+    Return FileEdit objects for the five workflow files modified by both
+    add-api-feature-flag.py and add-web-feature-flag.py.
+    """
+    workflows = ROOT / ".github" / "workflows"
+    return [
+        FileEdit(
+            path=workflows / "build-and-test.yml",
+            transform=partial(transform_build_and_test, CiConfig(flag=flag, ci_value=ci_value)),
+        ),
+        FileEdit(
+            path=workflows / "deploy-dev-environment.yml",
+            transform=partial(transform_deploy_dev, flag),
+        ),
+        FileEdit(
+            path=workflows / "deploy-staging-environment.yml",
+            transform=partial(transform_deploy_staging, flag),
+        ),
+        FileEdit(
+            path=workflows / "deploy-content-environment.yml",
+            transform=partial(transform_deploy_generic, DeployConfig(flag=flag, suffix="DEV")),
+        ),
+        FileEdit(
+            path=workflows / "testing-deployment-trigger.yml",
+            transform=partial(transform_deploy_generic, DeployConfig(flag=flag, suffix="DEV")),
+        ),
+        FileEdit(
+            path=workflows / "release-pipeline.yml",
+            transform=partial(transform_release_pipeline, flag),
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# GitHub CLI integration — split on the dry_run axis
+# ---------------------------------------------------------------------------
+
+
+def _invoke_gh_variable(env_name: str, var_name: str) -> str | None:
+    """
+    Set a single GitHub environment variable to "false" via the gh CLI.
+
+    Returns a failure description if the command exits non-zero, or None on
+    success. The initial value of "false" is intentionally conservative;
+    enable the flag via the GitHub UI or a follow-up gh command once it is
+    ready to be activated.
+    """
+    cmd = ["gh", "variable", "set", var_name, "--env", env_name, "--body", "false"]
+    print(f"  $ {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        return f"{var_name} in {env_name}: {result.stderr.strip()}"
+    return None
+
+
+def preview_gh_commands(flag: str) -> None:
+    """Print the gh CLI commands that run_gh_commands would execute."""
+    for env_name, var_name in _gh_entries(flag):
+        print(f"  [dry] $ gh variable set {var_name} --env {env_name} --body false")
+
+
+def run_gh_commands(flag: str) -> None:
+    """
+    Create GitHub environment variables for dev, staging, and prod via the gh CLI.
+
+    Runs all three commands before reporting failures so that a partial success
+    does not go unnoticed. Raises SystemExit if any command fails.
+    """
+    failures: list[str] = []
+    for env_name, var_name in _gh_entries(flag):
+        error = _invoke_gh_variable(env_name, var_name)
+        if error is not None:
+            failures.append(error)
+    if failures:
+        raise SystemExit(
+            "GitHub variable creation failed:\n" + "\n".join(f"  {f}" for f in failures)
+        )
+
+
+def _gh_entries(flag: str) -> list[tuple[str, str]]:
+    """Return the (environment, variable_name) pairs for the three GitHub environments."""
+    return [
+        ("dev", f"{flag}_DEV"),
+        ("staging", f"{flag}_STAGING"),
+        ("prod", f"{flag}_PROD"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# AWS SSM integration — split on the dry_run axis
+# ---------------------------------------------------------------------------
+
+
+def _invoke_ssm_parameter(stage: str, flag: str) -> str | None:
+    """
+    Create or overwrite an AWS SSM String parameter at /{stage}/{flag}.
+
+    Returns a failure description if the command exits non-zero, or None on
+    success. The initial value is "false"; update via the AWS console or CLI
+    when the flag is ready to activate.
+    """
+    param_name = f"/{stage}/{flag}"
+    cmd = [
+        "aws", "ssm", "put-parameter",
+        "--name", param_name,
+        "--value", "false",
+        "--type", "String",
+        "--overwrite",
+    ]
+    print(f"  $ {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        return f"{param_name}: {result.stderr.strip()}"
+    return None
+
+
+def preview_ssm_commands(flag: str) -> None:
+    """Print the aws CLI commands that run_ssm_commands would execute."""
+    for stage in ("dev", "staging", "prod"):
+        print(
+            f"  [dry] $ aws ssm put-parameter --name /{stage}/{flag} "
+            "--value false --type String --overwrite"
+        )
+
+
+def run_ssm_commands(flag: str) -> None:
+    """
+    Create AWS SSM String parameters for dev, staging, and prod via the AWS CLI.
+
+    Runs all three commands before reporting failures. Raises SystemExit if
+    any command fails.
+    """
+    failures: list[str] = []
+    for stage in ("dev", "staging", "prod"):
+        error = _invoke_ssm_parameter(stage, flag)
+        if error is not None:
+            failures.append(error)
+    if failures:
+        raise SystemExit(
+            "SSM parameter creation failed:\n" + "\n".join(f"  {f}" for f in failures)
+        )

--- a/scripts/add-api-feature-flag.py
+++ b/scripts/add-api-feature-flag.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Add a new API feature flag to all relevant configuration files.
+
+Edits:
+  api/.env-template
+  api/cdk/lib/lambdaStack.ts          (Lambda runtime env vars)
+  .github/workflows/build-and-test.yml
+  .github/workflows/deploy-dev-environment.yml
+  .github/workflows/deploy-staging-environment.yml
+  .github/workflows/deploy-content-environment.yml
+  .github/workflows/testing-deployment-trigger.yml
+  .github/workflows/release-pipeline.yml
+
+Usage:
+  python3 scripts/add-api-feature-flag.py MY_NEW_FEATURE
+  python3 scripts/add-api-feature-flag.py MY_NEW_FEATURE --gh --ci-value true
+  python3 scripts/add-api-feature-flag.py MY_NEW_FEATURE --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from functools import partial
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _feature_flag import (
+    LAMBDA_STACK_CONST_ANCHOR,
+    LAMBDA_STACK_ENV_ANCHOR,
+    ROOT,
+    FileEdit,
+    Insertion,
+    apply_file_update,
+    build_workflow_edits,
+    insert_after_last_match,
+    normalize_flag_name,
+    preview_file_update,
+    preview_gh_commands,
+    preview_ssm_commands,
+    run_gh_commands,
+    run_ssm_commands,
+    to_camel_case,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse and return command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Add a new API feature flag to all configuration files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "name",
+        help=(
+            "Flag name, e.g. MY_FEATURE or FEATURE_MY_FEATURE. "
+            "The FEATURE_ prefix is added automatically if absent."
+        ),
+    )
+    parser.add_argument(
+        "--gh",
+        action="store_true",
+        help="Create GitHub environment variables for dev/staging/prod via the gh CLI.",
+    )
+    parser.add_argument(
+        "--ssm",
+        action="store_true",
+        help="Create AWS SSM String parameters at /dev|staging|prod/FEATURE_X via the AWS CLI.",
+    )
+    parser.add_argument(
+        "--ci-value",
+        default="false",
+        choices=["true", "false"],
+        dest="ci_value",
+        help="Value hard-coded in CI (build-and-test.yml). Default: false.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        dest="dry_run",
+        help="Show what would change without writing any files.",
+    )
+    return parser.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# API-specific transforms
+# ---------------------------------------------------------------------------
+
+
+def transform_api_env_template(flag: str, content: str) -> str:
+    """Append FEATURE_NAME= to api/.env-template."""
+    return content.rstrip("\n") + f"\n{flag}=\n"
+
+
+def transform_lambda_stack(flag: str, content: str) -> str:
+    """
+    Add two entries to api/cdk/lib/lambdaStack.ts:
+      1. A const that reads the env var:  const featureX = process.env.FEATURE_X || "";
+      2. An environment object entry:     FEATURE_X: featureX,
+
+    The const must be inserted before the env entry because the env entry
+    references the const by name. Without entry (2), the flag reads as
+    undefined in the Lambda at runtime even when the CDK stack was deployed
+    with the variable present.
+    """
+    camel = to_camel_case(flag)
+    with_const = insert_after_last_match(
+        content,
+        Insertion(
+            anchor=LAMBDA_STACK_CONST_ANCHOR,
+            new_line=f'    const {camel} = process.env.{flag} || "";',
+        ),
+    )
+    return insert_after_last_match(
+        with_const,
+        Insertion(
+            anchor=LAMBDA_STACK_ENV_ANCHOR,
+            new_line=f"        {flag}: {camel},",
+        ),
+    )
+
+
+def build_api_edits(flag: str, ci_value: str) -> list[FileEdit]:
+    """Return all FileEdit objects for an API feature flag, in execution order."""
+    return [
+        FileEdit(
+            path=ROOT / "api" / ".env-template",
+            transform=partial(transform_api_env_template, flag),
+        ),
+        FileEdit(
+            path=ROOT / "api" / "cdk" / "lib" / "lambdaStack.ts",
+            transform=partial(transform_lambda_stack, flag),
+        ),
+        *build_workflow_edits(flag, ci_value),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Orchestrate all file edits and optional external tool calls."""
+    args = parse_args()
+    flag = normalize_flag_name(args.name)
+
+    print(f"Adding API feature flag: {flag}")
+    if args.dry_run:
+        print("  (dry run — no files will be written)\n")
+
+    update = preview_file_update if args.dry_run else apply_file_update
+    for edit in build_api_edits(flag, args.ci_value):
+        update(edit, flag)
+
+    if args.gh:
+        print("\nSetting GitHub environment variables:")
+        gh_fn = preview_gh_commands if args.dry_run else run_gh_commands
+        gh_fn(flag)
+
+    if args.ssm:
+        print("\nCreating AWS SSM parameters:")
+        ssm_fn = preview_ssm_commands if args.dry_run else run_ssm_commands
+        ssm_fn(flag)
+
+    print(f"\nDone. Use the flag in your Express app:")
+    print(f'  if ((process.env.{flag} ?? "false") === "true") {{ ... }}')
+    if args.ssm:
+        print(
+            f"\nNote: for runtime toggling without redeployment, add {flag!r} to CONFIG_VARS "
+            f"in api/src/libs/ssmUtils.ts and call getConfigValue('{flag}') "
+            "instead of reading process.env directly."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/add-web-feature-flag.py
+++ b/scripts/add-web-feature-flag.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Add a new web feature flag to all relevant configuration files.
+
+Edits:
+  web/.env-template
+  web/next.config.js                  (build-time env exposure)
+  .github/workflows/build-and-test.yml
+  .github/workflows/deploy-dev-environment.yml
+  .github/workflows/deploy-staging-environment.yml
+  .github/workflows/deploy-content-environment.yml
+  .github/workflows/testing-deployment-trigger.yml
+  .github/workflows/release-pipeline.yml
+
+Usage:
+  python3 scripts/add-web-feature-flag.py MY_NEW_FEATURE
+  python3 scripts/add-web-feature-flag.py MY_NEW_FEATURE --gh --ci-value true
+  python3 scripts/add-web-feature-flag.py MY_NEW_FEATURE --dry-run
+
+Note: web feature flags are baked into the Next.js build output via the
+next.config.js env block. They do NOT require the NEXT_PUBLIC_ prefix because
+Next.js exposes all entries in that block to both server-side and client-side
+code at build time. Consume them as: process.env.FEATURE_X === "true"
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from functools import partial
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _feature_flag import (
+    NEXT_CONFIG_ANCHOR,
+    ROOT,
+    FileEdit,
+    Insertion,
+    apply_file_update,
+    build_workflow_edits,
+    insert_after_last_match,
+    normalize_flag_name,
+    preview_file_update,
+    preview_gh_commands,
+    preview_ssm_commands,
+    run_gh_commands,
+    run_ssm_commands,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse and return command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Add a new web feature flag to all configuration files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "name",
+        help=(
+            "Flag name, e.g. MY_FEATURE or FEATURE_MY_FEATURE. "
+            "The FEATURE_ prefix is added automatically if absent."
+        ),
+    )
+    parser.add_argument(
+        "--gh",
+        action="store_true",
+        help="Create GitHub environment variables for dev/staging/prod via the gh CLI.",
+    )
+    parser.add_argument(
+        "--ssm",
+        action="store_true",
+        help="Create AWS SSM String parameters at /dev|staging|prod/FEATURE_X via the AWS CLI.",
+    )
+    parser.add_argument(
+        "--ci-value",
+        default="false",
+        choices=["true", "false"],
+        dest="ci_value",
+        help="Value hard-coded in CI (build-and-test.yml). Default: false.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        dest="dry_run",
+        help="Show what would change without writing any files.",
+    )
+    return parser.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# Web-specific transforms
+# ---------------------------------------------------------------------------
+
+
+def transform_web_env_template(flag: str, content: str) -> str:
+    """Append FEATURE_NAME= to web/.env-template."""
+    return content.rstrip("\n") + f"\n{flag}=\n"
+
+
+def transform_next_config(flag: str, content: str) -> str:
+    """
+    Insert the flag into the env block of web/next.config.js.
+
+    Without this entry, process.env.FEATURE_X is undefined in both server-side
+    and client-side Next.js code even if the variable is set in the environment
+    at build time. The default of "false" matches the convention used by all
+    existing feature flags in that block.
+    """
+    return insert_after_last_match(
+        content,
+        Insertion(
+            anchor=NEXT_CONFIG_ANCHOR,
+            new_line=f'    {flag}: process.env.{flag} ?? "false",',
+        ),
+    )
+
+
+def build_web_edits(flag: str, ci_value: str) -> list[FileEdit]:
+    """Return all FileEdit objects for a web feature flag, in execution order."""
+    return [
+        FileEdit(
+            path=ROOT / "web" / ".env-template",
+            transform=partial(transform_web_env_template, flag),
+        ),
+        FileEdit(
+            path=ROOT / "web" / "next.config.js",
+            transform=partial(transform_next_config, flag),
+        ),
+        *build_workflow_edits(flag, ci_value),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Orchestrate all file edits and optional external tool calls."""
+    args = parse_args()
+    flag = normalize_flag_name(args.name)
+
+    print(f"Adding web feature flag: {flag}")
+    if args.dry_run:
+        print("  (dry run — no files will be written)\n")
+
+    update = preview_file_update if args.dry_run else apply_file_update
+    for edit in build_web_edits(flag, args.ci_value):
+        update(edit, flag)
+
+    if args.gh:
+        print("\nSetting GitHub environment variables:")
+        gh_fn = preview_gh_commands if args.dry_run else run_gh_commands
+        gh_fn(flag)
+
+    if args.ssm:
+        print("\nCreating AWS SSM parameters:")
+        ssm_fn = preview_ssm_commands if args.dry_run else run_ssm_commands
+        ssm_fn(flag)
+
+    short = flag.replace("FEATURE_", "")
+    component_name = "".join(part.capitalize() for part in short.split("_"))
+    print(f"\nDone. Use the flag in your components:")
+    print(f'  const is{component_name}Enabled = process.env.{flag} === "true";')
+    if args.ssm:
+        print(
+            f"\nNote: web flags are baked in at build time (next.config.js). "
+            f"The SSM parameter at /<stage>/{flag} will not be read by Next.js automatically."
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Adds two Python CLI scripts to automate registering a new feature flag across all relevant configuration files, with options to add the feature flag to GitHub or SSM.

Currently, adding a feature flag requires manually editing 8+ files (`.env-template`, `lambdaStack.ts` or `next.config.js`, and 6 GitHub Actions workflows), and it's easy to miss a step. These scripts automate much of that process away.

- `scripts/add-api-feature-flag.py` — for API (Lambda runtime env) feature flags
- `scripts/add-web-feature-flag.py` — for web (Next.js build-time env) feature flags

Both scripts accept a flag name and optional `--gh`, `--ssm`, `--ci-value`, and `--dry-run` flags. Shared logic lives in `scripts/_feature_flag.py`.

### Approach

Shared insertion logic uses regex anchor patterns to find the last matching line in each file and inserts the new flag entry immediately after it. Each file type has its own named anchor constant and transform function. The `--dry-run` flag validates all transforms without writing to disk.

Both entry-point scripts import from `_feature_flag.py` via `sys.path.insert`, keeping the shared module co-located with the scripts without requiring a package structure.

### Steps to Test

1. Source the install script:
   ```shell
   . scripts/install.sh
   ```

2. Set up the Python environment:
   ```shell
   uv venv --managed-python .venv
   source .venv/bin/activate
   uv sync
   ```

3. Dry-run the API script to preview all changes:
   ```shell
   python scripts/add-api-feature-flag.py MY_TEST_FLAG --dry-run
   ```

4. Dry-run the web script:
   ```shell
   python scripts/add-web-feature-flag.py MY_TEST_FLAG --dry-run
   ```

5. Apply the API script and verify the 8 files were updated:
   ```shell
   python scripts/add-api-feature-flag.py MY_TEST_FLAG
   grep -r FEATURE_MY_TEST_FLAG api/.env-template api/cdk/lib/lambdaStack.ts .github/workflows/
   ```

6. Verify idempotency — running again should skip all files:
   ```shell
   python scripts/add-api-feature-flag.py MY_TEST_FLAG
   ```

7. Revert the test changes when done:
   ```shell
   git checkout -- api/.env-template api/cdk/lib/lambdaStack.ts .github/workflows/
   ```

### Notes

Web flags are baked into the Next.js build at build time via `next.config.js`. SSM parameters created with `--ssm` will not be read by Next.js automatically — the output message reminds the user of this.

For API flags that need runtime toggling without redeployment, `CONFIG_VARS` in `api/src/libs/ssmUtils.ts` must be updated manually (the script prints a reminder when `--ssm` is used).

## Code author checklist

- [x] I have run my changes locally and verified they work
- [x] I've run existing tests locally to ensure no regressions
- [x] I have NOT left any debugging code in the codebase, like console.log
- [x] I have NOT committed any secrets or sensitive values
- [x] My changes do not require a database migration
- [x] My code adheres to team conventions and follows the patterns of the surrounding code
- [x] I have NOT modified or removed any existing tests without reviewing with my team
- [x] I have added new tests for the functionality I've added
- [x] I have NOT changed any audit logged values (or have consulted with the team on changes)
- [x] I have NOT altered any critical user flows that need accessibility testing (or have consulted with the team on changes)
- [x] I have updated any relevant documentation
- [x] I have tagged reviewers appropriately