### PR TITLE
fix: [AB#17520] add retain policy to monitoring resources

### DIFF
--- a/api/cdk/lib/monitoringStack.ts
+++ b/api/cdk/lib/monitoringStack.ts
@@ -102,6 +102,7 @@ export class MonitoringStack extends Stack {
         statistic: "Sum",
         period: Duration.seconds(120),
       });
+      dataMigrationTopic.applyRemovalPolicy(RemovalPolicy.RETAIN);
 
       const dataMigrationAlarm = new cloudwatch.Alarm(this, "DataMigrationErrorAlarm", {
         alarmName: `${props.stage}-bfs-navigator-data-migration-errors`,
@@ -114,6 +115,7 @@ export class MonitoringStack extends Stack {
       });
 
       dataMigrationAlarm.addAlarmAction(new cloudwatch_actions.SnsAction(dataMigrationTopic));
+      dataMigrationAlarm.applyRemovalPolicy(RemovalPolicy.RETAIN);
 
       const navigatorApiErrorTopic = new sns.Topic(this, "NavigatorApiErrorTopic", {
         topicName: `bfs-navigator-errors-${props.stage}`,
@@ -129,6 +131,7 @@ export class MonitoringStack extends Stack {
         statistic: "Sum",
         period: Duration.seconds(60),
       });
+      navigatorApiErrorTopic.applyRemovalPolicy(RemovalPolicy.RETAIN);
 
       const myAccountNicUsaErrorAlarm = new cloudwatch.Alarm(this, "MyAccountNicUsaErrorAlarm", {
         alarmName: `${props.stage}-bfs-navigator-nicusa-errors`,
@@ -143,6 +146,7 @@ export class MonitoringStack extends Stack {
       myAccountNicUsaErrorAlarm.addAlarmAction(
         new cloudwatch_actions.SnsAction(navigatorApiErrorTopic),
       );
+      myAccountNicUsaErrorAlarm.applyRemovalPolicy(RemovalPolicy.RETAIN);
 
       const apiErrorMetric = apiErrorMetricFilter.metric({
         statistic: "Sum",
@@ -160,10 +164,12 @@ export class MonitoringStack extends Stack {
       });
 
       apiErrorAlarm.addAlarmAction(new cloudwatch_actions.SnsAction(navigatorApiErrorTopic));
+      apiErrorAlarm.applyRemovalPolicy(RemovalPolicy.RETAIN);
 
       const healthCheckErrorTopic = new sns.Topic(this, "HealthCheckErrorTopic", {
         topicName: `bfs-navigator-${props.stage}-health-check-errors`,
       });
+      healthCheckErrorTopic.applyRemovalPolicy(RemovalPolicy.RETAIN);
 
       new sns.Subscription(this, "healthCheckErrorTopicSubscription", {
         topic: healthCheckErrorTopic,
@@ -183,7 +189,7 @@ export class MonitoringStack extends Stack {
           },
         });
 
-        const alarm = new cloudwatch.Alarm(this, `HealthCheckAlarm-${key}`, {
+        const healthCheckalarm = new cloudwatch.Alarm(this, `HealthCheckAlarm-${key}`, {
           alarmName: `${props.stage}-bfs-navigator-healthcheck-${key}-alarm`,
           metric,
           threshold: 1,
@@ -193,9 +199,9 @@ export class MonitoringStack extends Stack {
           treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
         });
 
-        alarm.addAlarmAction(new cloudwatch_actions.SnsAction(healthCheckErrorTopic));
-
-        alarm.addOkAction(new cloudwatch_actions.SnsAction(healthCheckErrorTopic));
+        healthCheckalarm.addAlarmAction(new cloudwatch_actions.SnsAction(healthCheckErrorTopic));
+        healthCheckalarm.addOkAction(new cloudwatch_actions.SnsAction(healthCheckErrorTopic));
+        healthCheckalarm.applyRemovalPolicy(RemovalPolicy.RETAIN);
       }
     }
   }


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

This PR fixes deployment by adding retaining policy to monitoring resources. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#17520](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17520).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `request-reviewer` tag on GitHub to show or request reviews
