### PR TITLE
chore: [AB#17520] set up remaining Alarms

### DIFF
--- a/api/cdk/lib/constants.ts
+++ b/api/cdk/lib/constants.ts
@@ -14,6 +14,8 @@ export const AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY = process.env.AWS_CRYPTO_TAX_ID_EN
 export const NAVIGATOR_WEBSERVICE = "NavigatorWebService";
 export const NAVIGATOR_DB_CLIENT = "NavigatorDBClient";
 export const HEALTH_CHECK_SERVICE = "HealthCheckService";
+export const ECS_SERVICE_NAME = "bfs-navigator";
+export const ECS_CLUSTER_NAME = "bfs_container_cluster";
 export const HEALTH_CHECK_ENDPOINTS: Record<string, string> = {
   self: "self",
   elevator: "dynamics/elevator",

--- a/api/cdk/lib/monitoringStack.ts
+++ b/api/cdk/lib/monitoringStack.ts
@@ -11,6 +11,8 @@ import {
   HEALTH_CHECK_ENDPOINTS,
   USERS_TABLE,
   BUSINESSES_TABLE,
+  ECS_SERVICE_NAME,
+  ECS_CLUSTER_NAME,
 } from "./constants";
 
 export interface MonitoringStackProps extends StackProps {
@@ -374,13 +376,155 @@ export class MonitoringStack extends Stack {
       );
       dynamoDbBusinessesLatencyAlarm.applyRemovalPolicy(RemovalPolicy.RETAIN);
 
+      const ecsTaskCountMetric = new cloudwatch.Metric({
+        namespace: "ECS/ContainerInsights",
+        metricName: "DesiredTaskCount",
+        statistic: "Average",
+        period: Duration.seconds(300),
+        dimensionsMap: {
+          ServiceName: ECS_SERVICE_NAME,
+          ClusterName: ECS_CLUSTER_NAME,
+        },
+      });
+
+      const ecsTaskCountAlarm = new cloudwatch.Alarm(this, "EcsTaskCountAlarm", {
+        alarmName: `${props.stage}-ecs-bfs-navigator-task-count`,
+        metric: ecsTaskCountMetric,
+        threshold: 2,
+        evaluationPeriods: 1,
+        comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      });
+
+      ecsTaskCountAlarm.addAlarmAction(new cloudwatch_actions.SnsAction(navigatorApiErrorTopic));
+      ecsTaskCountAlarm.addOkAction(new cloudwatch_actions.SnsAction(navigatorApiErrorTopic));
+      ecsTaskCountAlarm.applyRemovalPolicy(RemovalPolicy.RETAIN);
+
+      const ecsCpuMetric = new cloudwatch.Metric({
+        namespace: "AWS/ECS",
+        metricName: "CPUUtilization",
+        statistic: "Average",
+        period: Duration.seconds(300),
+        dimensionsMap: {
+          ServiceName: ECS_SERVICE_NAME,
+          ClusterName: ECS_CLUSTER_NAME,
+        },
+      });
+
+      const ecsCpuAlarm = new cloudwatch.Alarm(this, "EcsCpuAlarm", {
+        alarmName: `${props.stage}-ecs-bfs-navigator-cpu`,
+        metric: ecsCpuMetric,
+        threshold: 80,
+        evaluationPeriods: 1,
+        datapointsToAlarm: 1,
+        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      });
+
+      ecsCpuAlarm.addAlarmAction(new cloudwatch_actions.SnsAction(navigatorApiErrorTopic));
+      ecsCpuAlarm.addOkAction(new cloudwatch_actions.SnsAction(navigatorApiErrorTopic));
+      ecsCpuAlarm.applyRemovalPolicy(RemovalPolicy.RETAIN);
+
+      const ecsMemoryMetric = new cloudwatch.Metric({
+        namespace: "AWS/ECS",
+        metricName: "MemoryUtilization",
+        statistic: "Average",
+        period: Duration.seconds(300),
+        dimensionsMap: {
+          ServiceName: ECS_SERVICE_NAME,
+          ClusterName: ECS_CLUSTER_NAME,
+        },
+      });
+
+      const ecsMemoryAlarm = new cloudwatch.Alarm(this, "EcsMemoryAlarm", {
+        alarmName: `${props.stage}-ecs-bfs-navigator-memory`,
+        metric: ecsMemoryMetric,
+        threshold: 80,
+        evaluationPeriods: 1,
+        datapointsToAlarm: 1,
+        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      });
+
+      ecsMemoryAlarm.addAlarmAction(new cloudwatch_actions.SnsAction(navigatorApiErrorTopic));
+      ecsMemoryAlarm.addOkAction(new cloudwatch_actions.SnsAction(navigatorApiErrorTopic));
+      ecsMemoryAlarm.applyRemovalPolicy(RemovalPolicy.RETAIN);
+
+      const backupMetric = new cloudwatch.Metric({
+        namespace: "AWS/Backup",
+        metricName: "NumberOfBackupJobsCompleted",
+        statistic: "Sum",
+        period: Duration.hours(7),
+        dimensionsMap: {
+          BackupVaultName: "BizX_dynamodb_backups",
+        },
+      });
+
+      const backupAlarm = new cloudwatch.Alarm(this, "BackupJobAlarm", {
+        alarmName: `${props.stage}-backup-job-error`,
+        metric: backupMetric,
+        threshold: 2,
+        evaluationPeriods: 1,
+        datapointsToAlarm: 1,
+        comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      });
+
+      backupAlarm.addAlarmAction(new cloudwatch_actions.SnsAction(navigatorApiErrorTopic));
+      backupAlarm.addOkAction(new cloudwatch_actions.SnsAction(navigatorApiErrorTopic));
+      backupAlarm.applyRemovalPolicy(RemovalPolicy.RETAIN);
+
+      const lambdaAnomalyAlarm = new cloudwatch.CfnAlarm(this, "LambdaAnomalyAlarm", {
+        alarmName: `${props.stage}-bfs-navigator-lambda-excessive-executions`,
+        comparisonOperator: "GreaterThanUpperThreshold",
+        evaluationPeriods: 1,
+        thresholdMetricId: "ad1",
+        treatMissingData: "notBreaching",
+
+        metrics: [
+          {
+            id: "m1",
+            metricStat: {
+              metric: {
+                namespace: "AWS/Lambda",
+                metricName: "Invocations",
+                dimensions: [
+                  {
+                    name: "FunctionName",
+                    value: `businessnjgov-api-v2-${props.stage}-express`,
+                  },
+                  {
+                    name: "Resource",
+                    value: `businessnjgov-api-v2-${props.stage}-express`,
+                  },
+                ],
+              },
+              period: 300,
+              stat: "Average",
+            },
+            returnData: false,
+          },
+          {
+            id: "ad1",
+            expression: "ANOMALY_DETECTION_BAND(m1, 2)",
+            label: "Expected Invocations",
+            returnData: true,
+          },
+        ],
+
+        alarmActions: [navigatorApiErrorTopic.topicArn],
+        okActions: [navigatorApiErrorTopic.topicArn],
+      });
+
+      lambdaAnomalyAlarm.applyRemovalPolicy(RemovalPolicy.RETAIN);
+
       const lambdaErrorMetricFilter = new logs.MetricFilter(this, "LambdaErrorMetricFilter", {
         logGroup: expressLogGroup,
         filterName: `LambdaErrorCount-${props.stage}`,
         metricNamespace: "BFS/Navigator/Lambda",
         metricName: "LambdaErrorCount",
         filterPattern: logs.FilterPattern.literal("error"),
-        metricValue: "2",
+        metricValue: "1",
         defaultValue: 0,
       });
 
@@ -402,6 +546,30 @@ export class MonitoringStack extends Stack {
       lambdaErrorAlarm.addAlarmAction(new cloudwatch_actions.SnsAction(navigatorApiErrorTopic));
       lambdaErrorAlarm.addOkAction(new cloudwatch_actions.SnsAction(navigatorApiErrorTopic));
       lambdaErrorAlarm.applyRemovalPolicy(RemovalPolicy.RETAIN);
+
+      const lambdaDurationMetric = new cloudwatch.Metric({
+        namespace: "AWS/Lambda",
+        metricName: "Duration",
+        statistic: "Average",
+        period: Duration.seconds(180),
+        dimensionsMap: {
+          FunctionName: `businessnjgov-api-v2-${props.stage}-express`,
+        },
+      });
+
+      const lambdaDurationAlarm = new cloudwatch.Alarm(this, "LambdaDurationAlarm", {
+        alarmName: `${props.stage}-bfs-navigator-lambda-long-requests`,
+        metric: lambdaDurationMetric,
+        threshold: 2000,
+        evaluationPeriods: 2,
+        datapointsToAlarm: 2,
+        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      });
+
+      lambdaDurationAlarm.addAlarmAction(new cloudwatch_actions.SnsAction(navigatorApiErrorTopic));
+      lambdaDurationAlarm.addOkAction(new cloudwatch_actions.SnsAction(navigatorApiErrorTopic));
+      lambdaDurationAlarm.applyRemovalPolicy(RemovalPolicy.RETAIN);
 
       const healthCheckErrorTopic = new sns.Topic(this, "HealthCheckErrorTopic", {
         topicName: `bfs-navigator-${props.stage}-health-check-errors`,


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

This PR migrates CloudWatch alarms and metric filters from Terraform to CDK and standardizes monitoring across Lambda, ECS, DynamoDB, and Backup services. It also fixes incorrect metric scaling and aligns alarm behavior with intended operational semantics.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Changes

Changes
1. Lambda Monitoring:
   - Alarm: bfs-navigator-lambda-errors
   - Source: businessnjgov-api-v2-${stage}-express logs
   - Metric: LambdaErrorCount
   - Filter: "error"
   - Fix: Changed metricValue from 2 → 1 so each error log counts as a single event
   - Threshold: > 10 errors in 1 minute

2. ECS Monitoring
    - Alarm: ecs-bfs-navigator-task-count
    - Metric: ECS/ContainerInsights → DesiredTaskCount
    - Change: Updated comparison operator to LESS_THAN_THRESHOLD
    - Why: This alarm is meant to detect service degradation, not scaling behavior. It now correctly triggers only when running tasks drop below the minimum expected threshold (2).

3. DynamoDB Monitoring
    - Alarms:  `dynamodb-users-latency` and `dynamodb-businesses-latency`
    - Metric: SuccessfulRequestLatency (Query)
    - Scope: separated by table (Users / Businesses)
    - Threshold: 30ms
   
4. Lambda Anomaly Detection
     - Alarm: bfs-navigator-lambda-excessive-executions
     - Migrated to CfnAlarm
     - Uses anomaly detection: ANOMALY_DETECTION_BAND(m1, 2)
     - Metric: Lambda Invocations
     
5. Backup Monitoring
    - Alarm: backup-job-error
    - Metric: AWS/Backup → NumberOfBackupJobsCompleted
    - Threshold: < 2 completed jobs


6. Lambda Duration
    - Alarm: bfs-navigator-lambda-long-requests
    - Metric: Duration
    - Threshold: 2000ms
    - Target: businessnjgov-api-v2-${stage}-express

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#17520](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17520).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `request-reviewer` tag on GitHub to show or request reviews
