### PR TITLE
chore: [AB#17520] add topic to kill switch lambda

### DIFF
--- a/api/cdk/bin/app.ts
+++ b/api/cdk/bin/app.ts
@@ -44,7 +44,7 @@ const storageStack = new StorageStack(app, `StorageStack-${stage}`, {
   env,
 });
 
-new MonitoringStack(app, `MonitoringStack-${stage}`, {
+const monitoringStack = new MonitoringStack(app, `MonitoringStack-${stage}`, {
   stage,
   env,
 });
@@ -95,6 +95,7 @@ const lambdaStack = new LambdaStack(app, `LambdaStack-${stage}`, {
   lambdaRole: iamStack.role,
   messagesBucket: storageStack.messagesBucket,
   intercomMacrosBucket: stage === DEV_STAGE ? storageStack.intercomMacrosBucket : undefined,
+  migrationLambdaTopic: monitoringStack.migrationLambdaTopic,
   env,
 });
 

--- a/api/cdk/lib/lambdaStack.ts
+++ b/api/cdk/lib/lambdaStack.ts
@@ -26,6 +26,7 @@ export interface LambdaStackProps extends StackProps {
   lambdaRole: iam.Role;
   messagesBucket: IBucket;
   intercomMacrosBucket?: IBucket;
+  migrationLambdaTopic: sns.ITopic;
 }
 
 export class LambdaStack extends Stack {
@@ -52,7 +53,6 @@ export class LambdaStack extends Stack {
      */
 
     const adminPassword = process.env.ADMIN_PASSWORD ?? "";
-    const account_id = process.env.AWS_ACCOUNT_ID;
     const awsCryptoTaxIdEncryptionKey = process.env.AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY || "";
     const awsCryptoContextStage = process.env.AWS_CRYPTO_CONTEXT_STAGE || "";
     const awsCryptoContextTaxIdEncryptionPurpose =
@@ -433,13 +433,9 @@ export class LambdaStack extends Stack {
     });
     props.messagesBucket.grantWrite(this.lambdas.messagingService);
 
-    const topic = sns.Topic.fromTopicArn(
-      this,
-      `${this.serviceName}-${props.stage}-migrationLambda-Topic`,
-      `arn:aws:sns:us-east-1:${account_id}:bfs-navigator-${props.stage}-migrationLambda-Topic`,
+    props.migrationLambdaTopic.addSubscription(
+      new subs.LambdaSubscription(this.lambdas.updateKillSwitchParameter),
     );
-
-    topic.addSubscription(new subs.LambdaSubscription(this.lambdas.updateKillSwitchParameter));
 
     exportLambdaArn(this, this.lambdas.express, "Express", props.stage);
     exportLambdaArn(this, this.lambdas.migrateUsersVersion, "MigrateUsersVersion", props.stage);

--- a/api/cdk/lib/monitoringStack.ts
+++ b/api/cdk/lib/monitoringStack.ts
@@ -20,6 +20,8 @@ export interface MonitoringStackProps extends StackProps {
 }
 
 export class MonitoringStack extends Stack {
+  public readonly migrationLambdaTopic: sns.Topic;
+
   constructor(scope: Construct, id: string, props: MonitoringStackProps) {
     super(scope, id, props);
 
@@ -132,10 +134,10 @@ export class MonitoringStack extends Stack {
       period: Duration.seconds(300),
     });
 
-    const migrationLambdaTopic = new sns.Topic(this, "migrationLambdaTopic", {
+    this.migrationLambdaTopic = new sns.Topic(this, "migrationLambdaTopic", {
       topicName: `bfs-navigator-${props.stage}-migrationLambda-Topic`,
     });
-    migrationLambdaTopic.applyRemovalPolicy(RemovalPolicy.RETAIN);
+    this.migrationLambdaTopic.applyRemovalPolicy(RemovalPolicy.RETAIN);
 
     const killSwitchAlertsTopic = new sns.Topic(this, "KillSwitchAlertsTopic", {
       topicName: `bfs-navigator-${props.stage}-kill-switch-alerts`,
@@ -182,7 +184,7 @@ export class MonitoringStack extends Stack {
         statistic: "Sum",
         period: Duration.seconds(60),
         dimensionsMap: {
-          TopicName: migrationLambdaTopic.topicName,
+          TopicName: this.migrationLambdaTopic.topicName,
         },
       }),
       threshold: 1,

--- a/api/cdk/test/lambdaStack.test.ts
+++ b/api/cdk/test/lambdaStack.test.ts
@@ -3,12 +3,14 @@ import { Match, Template } from "aws-cdk-lib/assertions";
 import { IBucket } from "aws-cdk-lib/aws-s3";
 import { IamStack, IamStackProps } from "../lib/iamStack";
 import { LambdaStack, LambdaStackProps } from "../lib/lambdaStack";
+import { MonitoringStack } from "../lib/monitoringStack";
 
 describe("LambdaStack", () => {
   let app: App;
   let stack: LambdaStack;
   let template: Template;
   let iamStack: IamStack;
+  let monitoringStack: MonitoringStack;
   let originalCognitoIdentityPoolId: string | undefined;
 
   beforeEach(() => {
@@ -17,6 +19,7 @@ describe("LambdaStack", () => {
 
     app = new App();
     iamStack = new IamStack(app, "TestIamStack", { stage: "local" } as IamStackProps);
+    monitoringStack = new MonitoringStack(app, "TestMonitoringStack", { stage: "local" });
     const defaultProps: LambdaStackProps = {
       stage: "local",
       lambdaRole: iamStack.role,
@@ -28,6 +31,7 @@ describe("LambdaStack", () => {
         bucketName: "intercom-macros-bucket-local",
         grantWrite: () => {},
       } as unknown as IBucket,
+      migrationLambdaTopic: monitoringStack.migrationLambdaTopic,
     };
 
     stack = new LambdaStack(app, "TestLambdaStack", defaultProps);


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
Adds support for the migrationLambdaTopic by wiring the SNS topic from the Monitoring stack into the Lambda stack. The updateKillSwitchParameter Lambda is now subscribed to this topic.

Updates unit tests to account for the new required migrationLambdaTopic dependency when instantiating LambdaStack.

Also includes minor fixes to test setup (type correction and syntax issue).

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#0000](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [X] I have added the `pr-show` or `request-reviewer` tag on GitHub to show or request reviews
