### PR TITLE
feat: re-enable storybook deploy

### DIFF
--- a/.github/actions/deploy-storybook/action.yml
+++ b/.github/actions/deploy-storybook/action.yml
@@ -1,5 +1,5 @@
 name: "Deploy Storybook"
-description: "Clears the Storybook S3 bucket and deploys the Storybook site."
+description: "Builds Storybook, uploads it to S3, and configures the S3 website."
 
 inputs:
   storybook_s3_bucket:
@@ -9,13 +9,19 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Clear Storybook S3 Bucket
+    - name: Build Storybook
       shell: bash
       run: |
-        aws s3 rm s3://${{ inputs.storybook_s3_bucket }} --recursive
+        yarn workspace @businessnjgovnavigator/web build-storybook -o .storybook/build
 
-    - name: Deploy Storybook
+    - name: Upload Storybook to S3
       shell: bash
       run: |
-        yarn workspace @businessnjgovnavigator/web deploy:storybook \
-          --bucket-path ${{ inputs.storybook_s3_bucket }} --aws-profile=NONE
+        aws s3 sync web/.storybook/build s3://${{ inputs.storybook_s3_bucket }} --delete
+
+    - name: Configure Storybook S3 Website
+      shell: bash
+      run: |
+        aws s3 website s3://${{ inputs.storybook_s3_bucket }} \
+          --index-document index.html \
+          --error-document index.html

--- a/.github/workflows/deploy-dev-environment.yml
+++ b/.github/workflows/deploy-dev-environment.yml
@@ -137,7 +137,7 @@ jobs:
         uses: ./.github/actions/deploy
         with:
           service_name: bfs-navigator
-#      - name: Deploy Storybook
-#        uses: ./.github/actions/deploy-storybook
-#        with:
-#          storybook_s3_bucket: ${{ vars.STORYBOOK_S3_BUCKET }}
+      - name: Deploy Storybook
+        uses: ./.github/actions/deploy-storybook
+        with:
+          storybook_s3_bucket: ${{ vars.STORYBOOK_S3_BUCKET }}

--- a/web/.storybook/main.js
+++ b/web/.storybook/main.js
@@ -23,16 +23,7 @@ export default {
     name: getAbsolutePath("@storybook/nextjs-vite"),
     options: {},
   },
-  core: {
-    builder: {
-      name: getAbsolutePath("@storybook/builder-webpack5"),
-      options: {
-        fsCache: true,
-        lazyCompilation: true,
-      },
-    },
-  },
-  webpackFinal: async (config) => {
+  viteFinal: async (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
       "/img": resolve(__dirname, "../public/img"),
@@ -47,6 +38,20 @@ export default {
       "@businessnjgovnavigator/shared": resolve(__dirname, "../../shared/lib/shared/src"),
       "@/test": resolve(__dirname, "../test"),
     };
+    config.plugins = [
+      ...(config.plugins ?? []),
+      {
+        name: "raw-markdown-loader",
+        transform(code, id) {
+          if (id.endsWith(".md")) {
+            return {
+              code: `export default ${JSON.stringify(code)};`,
+              map: null,
+            };
+          }
+        },
+      },
+    ];
     return config;
   },
   features: {


### PR DESCRIPTION
## Description

Re-enable the Storybook deployment that was previously commented out in the dev environment workflow. The deploy action is rewritten to align with the Storybook v10 + Vite setup: it now builds Storybook with `build-storybook`, syncs the output to S3, and configures the S3 website endpoint. The Storybook config itself is updated to use `viteFinal` instead of `webpackFinal`, removing the webpack5 builder in favor of the Vite-based `@storybook/nextjs-vite` framework, and adds a Vite plugin for raw markdown file imports.

### Approach

- Replaced the `deploy-storybook` action steps: build → S3 sync (with `--delete`) → S3 website config, instead of the old clear-bucket + deploy-script approach.
- Uncommented the Storybook deploy step in `deploy-dev-environment.yml`.
- Switched `.storybook/main.js` from `webpackFinal` / webpack5 builder to `viteFinal` with a custom raw-markdown-loader Vite plugin.

### Steps to Test

1. Run `yarn workspace @businessnjgovnavigator/web build-storybook -o .storybook/build` locally and verify it builds successfully.
2. Confirm the Storybook deploy runs in the dev environment CI workflow.

### Notes

The old deploy used a custom `deploy:storybook` yarn script that is no longer needed with the direct `aws s3 sync` approach.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews