### PR TITLE
chore: [AB#17523] create encryption resources

### DIFF
--- a/.github/actions/deploy-cdk/action.yml
+++ b/.github/actions/deploy-cdk/action.yml
@@ -20,11 +20,11 @@ runs:
           --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess || \
           echo "Bootstrap already completed or not required."
 
-    - name: Import Monitoring resources in CDK MonitoringStack
+    - name: Import resources in CDK EncryptionStack
       shell: bash
       run: |
-        echo "Importing monitoring resources for stage: $STAGE"
-        yarn workspace @businessnjgovnavigator/api-cdk cdk deploy MonitoringStack-${{ env.STAGE }} \
+        echo "Importing encryption resources for stage: $STAGE"
+        yarn workspace @businessnjgovnavigator/api-cdk cdk deploy EncryptionStack-${{ env.STAGE }} \
           --import-existing-resources \
           --qualifier biz-nj \
           --verbose \

--- a/api/cdk/bin/app.ts
+++ b/api/cdk/bin/app.ts
@@ -1,10 +1,12 @@
 import * as cdk from "aws-cdk-lib";
 import * as dotenv from "dotenv";
+import * as iam from "aws-cdk-lib/aws-iam";
 import { ApiStack } from "../lib/apiStack";
 import { DataStack } from "../lib/dataStack";
 import { IamStack } from "../lib/iamStack";
 import { LambdaStack } from "../lib/lambdaStack";
 import { StorageStack } from "../lib/storageStack";
+import { EncryptionStack } from "../lib/encryptionStack";
 import {
   BUSINESSES_TABLE,
   CONTENT_STAGE,
@@ -42,6 +44,18 @@ const iamStack = new IamStack(app, `IamStack-${stage}`, {
 const storageStack = new StorageStack(app, `StorageStack-${stage}`, {
   stage,
   env,
+});
+
+const taxKMSRole = iam.Role.fromRoleName(
+  iamStack,
+  `TaxKMSRole-${stage}`,
+  "iamRoleForTaxIdEncryptionAndHashing",
+);
+
+new EncryptionStack(app, `EncryptionStack-${stage}`, {
+  stage,
+  env,
+  taxKMSRole,
 });
 
 const monitoringStack = new MonitoringStack(app, `MonitoringStack-${stage}`, {

--- a/api/cdk/lib/encryptionStack.ts
+++ b/api/cdk/lib/encryptionStack.ts
@@ -1,0 +1,40 @@
+import { RemovalPolicy, Stack, StackProps } from "aws-cdk-lib";
+import { Construct } from "constructs";
+import * as kms from "aws-cdk-lib/aws-kms";
+import * as iam from "aws-cdk-lib/aws-iam";
+
+export interface EncryptionStackProps extends StackProps {
+  taxKMSRole: iam.IRole;
+  stage: string;
+}
+
+export class EncryptionStack extends Stack {
+  public readonly taxIdEncryptionKey: kms.Key;
+  public readonly taxIdHashingKey: kms.Key;
+
+  constructor(scope: Construct, id: string, props: EncryptionStackProps) {
+    super(scope, id, props);
+
+    this.taxIdHashingKey = new kms.Key(this, "TaxIdHashingKey", {
+      description: `Tax Id Hashing Key for ${props.stage}`,
+      enableKeyRotation: true,
+      removalPolicy: RemovalPolicy.RETAIN,
+    });
+
+    this.taxIdHashingKey.addAlias(`alias/${props.stage}/HashingTaxId`);
+
+    this.taxIdHashingKey.grantEncryptDecrypt(props.taxKMSRole);
+    this.taxIdHashingKey.grant(props.taxKMSRole, "kms:GenerateDataKey*");
+
+    this.taxIdEncryptionKey = new kms.Key(this, "TaxIdEncryptionKey", {
+      description: `Tax Id Encryption Key for ${props.stage}`,
+      enableKeyRotation: true,
+      removalPolicy: RemovalPolicy.RETAIN,
+    });
+
+    this.taxIdEncryptionKey.addAlias(`alias/${props.stage}/EncryptionTaxId`);
+
+    this.taxIdEncryptionKey.grantEncryptDecrypt(props.taxKMSRole);
+    this.taxIdEncryptionKey.grant(props.taxKMSRole, "kms:GenerateDataKey*");
+  }
+}


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
This PR introduces KMS key management in CDK as part of the broader Terraform → CDK migration.
A new EncryptionStack has been added to provision and manage KMS keys for Tax ID encryption and hashing. This replaces the previous Terraform-managed approach and establishes CDK as the source of truth for these resources.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

- Added encryptionStack
- Provisions two KMS keys (TaxIDEncryptionKey and TaxIDHashingKey)


### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#17523](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17523).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [X] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
