### PR TITLE
fix: make tests less chatty and less flaky

### DIFF
--- a/.github/actions/perform-integration-tests/action.yml
+++ b/.github/actions/perform-integration-tests/action.yml
@@ -42,3 +42,19 @@ runs:
           --browser=${{ inputs.browser }} \
           --record=${{ inputs.enable-dashboard }} \
           --env SUITE=${{ inputs.suite }}
+
+    - name: Upload Cypress Screenshots
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: cypress-screenshots-${{ inputs.suite }}
+        path: web/cypress/screenshots/
+        retention-days: 7
+
+    - name: Upload Cypress Test Results
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: cypress-results-${{ inputs.suite }}
+        path: web/cypress/results/
+        retention-days: 7

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -177,7 +177,7 @@ jobs:
         with:
           name: jest-test-results-${{ matrix.shard }}
           path: coverage/test_results
-          retention-days: 3
+          retention-days: 7
 
       - name: Upload Jest Coverage
         if: always()
@@ -185,7 +185,7 @@ jobs:
         with:
           name: jest-coverage-${{ matrix.shard }}
           path: coverage
-          retention-days: 3
+          retention-days: 7
 
   integration-group-1:
     name: Integration Tests - Group 1

--- a/api/cdk/jest.config.ts
+++ b/api/cdk/jest.config.ts
@@ -5,8 +5,9 @@ import sharedConfig from "../../jest.shared";
 export default {
   ...sharedConfig,
   displayName: "api-cdk",
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "mjs", "json", "node"],
   testMatch: ["**/cdk/test/**/*.test.ts"],
   setupFiles: [],
-  setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ["<rootDir>/test/setupSilentBundlingOutput.ts"],
   testEnvironment: "node",
 };

--- a/api/cdk/lib/stackUtils.ts
+++ b/api/cdk/lib/stackUtils.ts
@@ -10,7 +10,7 @@ import {
 import { ISecurityGroup, ISubnet, IVpc } from "aws-cdk-lib/aws-ec2";
 import { Role } from "aws-cdk-lib/aws-iam";
 import { IFunction, Runtime } from "aws-cdk-lib/aws-lambda";
-import { NodejsFunction, NodejsFunctionProps } from "aws-cdk-lib/aws-lambda-nodejs";
+import { LogLevel, NodejsFunction, NodejsFunctionProps } from "aws-cdk-lib/aws-lambda-nodejs";
 import * as logs from "aws-cdk-lib/aws-logs";
 import { ConfigurationSet } from "aws-cdk-lib/aws-ses";
 import { Construct, IConstruct } from "constructs";
@@ -67,6 +67,7 @@ export function createLambda(stack: Stack, props: LambdaFunctionProps): NodejsFu
     },
     bundling: {
       externalModules: [],
+      logLevel: LogLevel.ERROR,
       minify: true,
       sourceMap: true,
       ...props.bundling,

--- a/api/cdk/test/setupSilentBundlingOutput.ts
+++ b/api/cdk/test/setupSilentBundlingOutput.ts
@@ -1,0 +1,34 @@
+const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+type StderrWriteCallback = (error?: Error | null) => void;
+
+const isBundlingProgressMessage = (chunk: unknown): boolean => {
+  const message =
+    typeof chunk === "string" ? chunk : Buffer.isBuffer(chunk) ? chunk.toString("utf8") : "";
+
+  return /^Bundling asset .+\.\.\.\n$/.test(message);
+};
+
+const getWriteCallback = (
+  encodingOrCallback?: BufferEncoding | StderrWriteCallback,
+  callback?: StderrWriteCallback,
+): StderrWriteCallback | undefined => {
+  return typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+};
+
+process.stderr.write = ((
+  chunk: string | Uint8Array,
+  encodingOrCallback?: BufferEncoding | StderrWriteCallback,
+  callback?: StderrWriteCallback,
+): boolean => {
+  if (isBundlingProgressMessage(chunk)) {
+    getWriteCallback(encodingOrCallback, callback)?.();
+    return true;
+  }
+
+  if (typeof encodingOrCallback === "function") {
+    return originalStderrWrite(chunk, encodingOrCallback);
+  }
+
+  return originalStderrWrite(chunk, encodingOrCallback, callback);
+}) as typeof process.stderr.write;

--- a/api/jest.config.ts
+++ b/api/jest.config.ts
@@ -36,7 +36,7 @@ export default {
     "@scripts/(.*)": "<rootDir>/../scripts/$1",
     "\\.(html|txt)$": "<rootDir>/test/jestRawLoader.js",
   },
-  testPathIgnorePatterns: ["<rootDir>/lib/", "<rootDir>/node_modules/"],
+  testPathIgnorePatterns: ["<rootDir>/cdk/", "<rootDir>/lib/", "<rootDir>/node_modules/"],
   globalSetup: "<rootDir>/test/globalSetup.ts",
   globalTeardown: "<rootDir>/test/teardownTests.ts",
 };

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,7 @@ import sharedConfig from "./jest.shared";
 /** @type {import('jest').Config} */
 export default {
   ...sharedConfig,
-  projects: ["<rootDir>/api", "<rootDir>/shared", "<rootDir>/web"],
+  projects: ["<rootDir>/api", "<rootDir>/api/cdk", "<rootDir>/shared", "<rootDir>/web"],
   reporters: [
     "default",
     [

--- a/web/src/components/filings-calendar/tax-access/TaxAccess.test.tsx
+++ b/web/src/components/filings-calendar/tax-access/TaxAccess.test.tsx
@@ -205,7 +205,9 @@ describe("<TaxAccess />", () => {
         expect(currentBusiness().profileData.legalStructureId).toBe("c-corporation");
       });
 
-      fireEvent.click(screen.getByText(Config.taxAccess.stepTwoBackButton));
+      fireEvent.click(
+        await screen.findByRole("button", { name: Config.taxAccess.stepTwoBackButton }),
+      );
       await waitFor(() => {
         expect(screen.getByText(Config.taxAccess.stepOneHeader)).toBeInTheDocument();
       });

--- a/web/src/lib/static/admin/findDeadLinks.test.ts
+++ b/web/src/lib/static/admin/findDeadLinks.test.ts
@@ -109,12 +109,16 @@ const setupContentScanMocks = (files: { name: string; content: string }[]): void
 };
 
 describe("findDeadContentLinks", () => {
+  let consoleLogSpy: jest.SpyInstance<void, Parameters<typeof console.log>>;
+
   beforeEach(() => {
     jest.resetAllMocks();
     global.fetch = jest.fn();
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
   });
 
   afterEach(() => {
+    consoleLogSpy.mockRestore();
     jest.restoreAllMocks();
   });
 

--- a/web/src/scripts/webflow/categoryPull.test.ts
+++ b/web/src/scripts/webflow/categoryPull.test.ts
@@ -50,8 +50,15 @@ const generateWebflowCategory = (
 };
 
 describe("categoryPull", () => {
+  let consoleLogSpy: jest.SpyInstance<void, Parameters<typeof console.log>>;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
   });
 
   describe("webflowCategoryToNavigatorFormat", () => {

--- a/web/src/scripts/webflow/categoryPull.ts
+++ b/web/src/scripts/webflow/categoryPull.ts
@@ -92,10 +92,12 @@ const main = async (): Promise<void> => {
   process.exit(0);
 };
 
-// eslint-disable-next-line unicorn/prefer-top-level-await
-(async (): Promise<void> => {
-  await main();
-})();
+if (process.env.NODE_ENV !== "test") {
+  // eslint-disable-next-line unicorn/prefer-top-level-await
+  (async (): Promise<void> => {
+    await main();
+  })();
+}
 
 export {
   getCurrentWebflowCategories,

--- a/web/src/scripts/webflow/covidPull.test.ts
+++ b/web/src/scripts/webflow/covidPull.test.ts
@@ -55,8 +55,15 @@ const generateWebflowCovid = (
 });
 
 describe("covidPull", () => {
+  let consoleLogSpy: jest.SpyInstance<void, Parameters<typeof console.log>>;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
   });
 
   describe("topicOptionMap", () => {

--- a/web/src/scripts/webflow/covidPull.ts
+++ b/web/src/scripts/webflow/covidPull.ts
@@ -125,10 +125,12 @@ const main = async (): Promise<void> => {
   process.exit(0);
 };
 
-// eslint-disable-next-line unicorn/prefer-top-level-await
-(async (): Promise<void> => {
-  await main();
-})();
+if (process.env.NODE_ENV !== "test") {
+  // eslint-disable-next-line unicorn/prefer-top-level-await
+  (async (): Promise<void> => {
+    await main();
+  })();
+}
 
 export {
   getCurrentWebflowCovids,

--- a/web/src/scripts/webflow/faqPull.test.ts
+++ b/web/src/scripts/webflow/faqPull.test.ts
@@ -58,8 +58,15 @@ const generateWebflowFaq = (
 });
 
 describe("faqPull", () => {
+  let consoleLogSpy: jest.SpyInstance<void, Parameters<typeof console.log>>;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
   });
 
   describe("loadAllFaqsFromNavigator", () => {

--- a/web/src/scripts/webflow/faqPull.ts
+++ b/web/src/scripts/webflow/faqPull.ts
@@ -156,10 +156,12 @@ const main = async (): Promise<void> => {
   process.exit(0);
 };
 
-// eslint-disable-next-line unicorn/prefer-top-level-await
-(async (): Promise<void> => {
-  await main();
-})();
+if (process.env.NODE_ENV !== "test") {
+  // eslint-disable-next-line unicorn/prefer-top-level-await
+  (async (): Promise<void> => {
+    await main();
+  })();
+}
 
 export {
   categoryOptionMap,

--- a/web/src/scripts/webflow/fundingSync.test.ts
+++ b/web/src/scripts/webflow/fundingSync.test.ts
@@ -48,6 +48,8 @@ const mockedHelpers = helpers as jest.Mocked<typeof helpers>;
 const mockedMethods = methods as jest.Mocked<typeof methods>;
 
 describe("fundingSync", () => {
+  let consoleLogSpy: jest.SpyInstance<void, Parameters<typeof console.log>>;
+
   const mockFundings: Funding[] = [
     generateMockFunding({
       sector: ["clean-energy"], // Must use sectors from mockSectors
@@ -98,6 +100,7 @@ describe("fundingSync", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     Object.defineProperty(process.env, "NODE_ENV", { value: "test", writable: true });
 
     mockedFundingExport.loadAllFundings.mockReturnValue(mockFundings);
@@ -145,6 +148,10 @@ describe("fundingSync", () => {
       const slice = stop === -1 ? lines.slice(start) : lines.slice(start, stop);
       return slice.join(" ");
     });
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
   });
 
   describe("contentMdToObject", () => {
@@ -537,16 +544,12 @@ Eligibility here.
 
   describe("syncFundings", () => {
     it("runs full sync process in correct order", async () => {
-      const consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
-
       await syncFundings();
 
       expect(consoleLogSpy).toHaveBeenCalledWith("deleting unused fundings");
       expect(consoleLogSpy).toHaveBeenCalledWith("updating fundings");
       expect(consoleLogSpy).toHaveBeenCalledWith("creating new fundings");
       expect(consoleLogSpy).toHaveBeenCalledWith("Complete Funding Sync!");
-
-      consoleLogSpy.mockRestore();
     });
 
     it("calls all sync operations", async () => {

--- a/web/src/scripts/webflow/industrySync.ts
+++ b/web/src/scripts/webflow/industrySync.ts
@@ -173,9 +173,11 @@ const main = async (): Promise<void> => {
   await syncIndustries();
 };
 
-// eslint-disable-next-line unicorn/prefer-top-level-await
-(async (): Promise<void> => {
-  await main();
-})();
+if (process.env.NODE_ENV !== "test") {
+  // eslint-disable-next-line unicorn/prefer-top-level-await
+  (async (): Promise<void> => {
+    await main();
+  })();
+}
 
 export {};

--- a/web/src/scripts/webflow/licenseSync.ts
+++ b/web/src/scripts/webflow/licenseSync.ts
@@ -246,8 +246,10 @@ const main = async (): Promise<void> => {
   process.exit(0);
 };
 
-// eslint-disable-next-line unicorn/prefer-top-level-await
-(async (): Promise<void> => {
-  await main();
-})();
+if (process.env.NODE_ENV !== "test") {
+  // eslint-disable-next-line unicorn/prefer-top-level-await
+  (async (): Promise<void> => {
+    await main();
+  })();
+}
 export {};

--- a/web/src/scripts/webflow/pagePull.test.ts
+++ b/web/src/scripts/webflow/pagePull.test.ts
@@ -56,8 +56,15 @@ const generateWebflowPage = (
 });
 
 describe("pagePull", () => {
+  let consoleLogSpy: jest.SpyInstance<void, Parameters<typeof console.log>>;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
   });
 
   describe("loadCategoryMap", () => {

--- a/web/src/scripts/webflow/pagePull.ts
+++ b/web/src/scripts/webflow/pagePull.ts
@@ -172,10 +172,12 @@ const main = async (): Promise<void> => {
   process.exit(0);
 };
 
-// eslint-disable-next-line unicorn/prefer-top-level-await
-(async (): Promise<void> => {
-  await main();
-})();
+if (process.env.NODE_ENV !== "test") {
+  // eslint-disable-next-line unicorn/prefer-top-level-await
+  (async (): Promise<void> => {
+    await main();
+  })();
+}
 
 export {
   getCurrentWebflowPages,

--- a/web/src/scripts/webflow/recentPull.test.ts
+++ b/web/src/scripts/webflow/recentPull.test.ts
@@ -57,8 +57,15 @@ const generateWebflowRecent = (
 });
 
 describe("recentPull", () => {
+  let consoleLogSpy: jest.SpyInstance<void, Parameters<typeof console.log>>;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
   });
 
   describe("topicsOptionMap", () => {

--- a/web/src/scripts/webflow/recentPull.ts
+++ b/web/src/scripts/webflow/recentPull.ts
@@ -127,10 +127,12 @@ const main = async (): Promise<void> => {
   process.exit(0);
 };
 
-// eslint-disable-next-line unicorn/prefer-top-level-await
-(async (): Promise<void> => {
-  await main();
-})();
+if (process.env.NODE_ENV !== "test") {
+  // eslint-disable-next-line unicorn/prefer-top-level-await
+  (async (): Promise<void> => {
+    await main();
+  })();
+}
 
 export {
   agencyOptionMap,

--- a/web/src/scripts/webflow/tropicalStormIdaPull.ts
+++ b/web/src/scripts/webflow/tropicalStormIdaPull.ts
@@ -120,10 +120,12 @@ const main = async (): Promise<void> => {
   process.exit(0);
 };
 
-// eslint-disable-next-line unicorn/prefer-top-level-await
-(async (): Promise<void> => {
-  await main();
-})();
+if (process.env.NODE_ENV !== "test") {
+  // eslint-disable-next-line unicorn/prefer-top-level-await
+  (async (): Promise<void> => {
+    await main();
+  })();
+}
 
 export {
   getCurrentWebflowIdas,

--- a/web/test/pages/profile/profile-shared.test.tsx
+++ b/web/test/pages/profile/profile-shared.test.tsx
@@ -394,7 +394,7 @@ describe("profile - shared", () => {
 
       renderPage({ business });
 
-      selectByText("Industry", updatedIndustry.name);
+      selectByValue("Industry", updatedIndustry.id);
       clickSave();
 
       await waitFor(() => {


### PR DESCRIPTION
## Description

Reduces test noise and improves test reliability across the monorepo. Also adds CI artifact uploads for Cypress test results.

### Approach

- **Silence noisy test output:** Mock `console.log` in webflow script tests and dead link tests to suppress progress messages during test runs. Add a CDK test setup file that filters out "Bundling asset..." stderr messages, and set esbuild bundling log level to ERROR.
- **Prevent script auto-execution in tests:** Wrap webflow script IIFEs in `if (process.env.NODE_ENV !== "test")` guards so importing the modules for testing doesn't trigger `main()`.
- **Fix flaky assertions:** Use `findByRole("button")` instead of `getByText` in TaxAccess test (async-safe query), and `selectByValue` instead of `selectByText` in profile test.
- **Jest config:** Add `api/cdk` as a separate Jest project with its own setup, and exclude it from the main `api` project's test path.
- **CI artifact uploads:** Upload Cypress screenshots (on failure) and JUnit test results as GitHub Actions artifacts with 7-day retention. Increase Jest artifact retention from 3 to 7 days.

### Steps to Test

Run the full test suite and confirm reduced console noise and no flaky failures:

```shell
yarn test
```

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews