### PR TITLE
chore: reorder husky step after yarn install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ api/src/functions/messagingService/email-templates/*.txt
 
 # Generated user schema (produced by generate:user-schema, prebuild, prestart)
 api/src/domain/userSchema.generated.ts
+
+.claude/settings.json

--- a/scripts/_install.sh
+++ b/scripts/_install.sh
@@ -261,14 +261,7 @@ corepack prepare pnpm@latest --activate && echo "pnpm activated." || { echo "Fai
 
 # ============================================================
 echo ""
-echo "=== [6/7] Git hooks (Husky) ==="
-# ============================================================
-
-yarn run prepare && echo "Git hooks installed." || { echo "Failed to install git hooks."; exit 1; }
-
-# ============================================================
-echo ""
-echo "=== [7/7] Install dependencies and build ==="
+echo "=== [6/7] Install dependencies and build ==="
 # ============================================================
 
 yarn install && yarn build || { echo "Root install or build failed."; exit 1; }
@@ -281,3 +274,10 @@ yarn install && yarn build || { echo "Root install or build failed."; exit 1; }
     exit 1
 }
 echo "Dependencies installed and projects built."
+
+# ============================================================
+echo ""
+echo "=== [7/7] Git hooks (Husky) ==="
+# ============================================================
+
+yarn run prepare && echo "Git hooks installed." || { echo "Failed to install git hooks."; exit 1; }


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Right now, starting from a clean slate, the install script fails on the Husky step because it requires `node_modules` to exist.

This moves the Husky git hooks installation step to after `yarn install && yarn build` in `_install.sh` (Husky requires node_modules to be present, so this ordering is more correct)

Also adds `.claude/settings.json` to `.gitignore` to prevent Claude Code's local settings from being committed.

### Ticket

This pull request resolves [#0000](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000).

### Approach

- In `scripts/_install.sh`, step 6 and step 7 are swapped: dependencies/build now runs first, then Husky `prepare` runs after. This avoids a potential failure where Husky tries to set up hooks before `node_modules` exists.
- `.claude/settings.json` added to `.gitignore` so local Claude Code configuration stays untracked.

### Steps to Test

Run `scripts/_install.sh` on a clean environment and verify it completes successfully with git hooks installed at the end.

### Notes

No behavioral change to the final state — only the ordering of steps 6/7 changes.

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [ ] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews