### PR TITLE
fix: [AB#17752] address bug when clicking "Start my NJ business step b…

### DIFF
--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -315,11 +315,18 @@ const OnboardingPage = (props: Props): ReactElement => {
 
     setProfileData(newProfileData);
     setCurrentFlow(flowType);
+
+    /* The logic below used to skip the first step of onboarding for STARTING businesses,
+    it has been temporarily commented out because it is incompatible with our current AB
+    test to skip the second onboarding step.
+
     if (flowType === "OWNING") {
       setPage({ current: 1, previous: 1 });
     } else {
       setPage({ current: 2, previous: 1 });
     }
+    */
+
     updateQueue?.queueProfileData(newProfileData);
   };
 

--- a/web/test/pages/onboarding/onboarding-shared.test.tsx
+++ b/web/test/pages/onboarding/onboarding-shared.test.tsx
@@ -273,7 +273,8 @@ describe("onboarding - shared", () => {
     expect(currentBusiness().profileData.industryId).toEqual("e-commerce");
   });
 
-  describe("when query parameter sets onboarding flow", () => {
+  // This suite is skipped because routing between steps has been disabled for the duration of the AB test
+  describe.skip("when query parameter sets onboarding flow", () => {
     it("routes user to step 2 when query parameter exists and value is starting", async () => {
       useMockRouter({ isReady: true, query: { flow: "starting" } });
       const { page } = renderPage({ userData: generateExperienceAUserData() });


### PR DESCRIPTION
…y step"

<!-- Please complete the following sections as necessary. -->

## Description

Half of the users who clicked the "Start my NJ business step by step" button on the homepage would get redirected to an empty Step 2 of onboarding, because they got randomly assigned Experience B, which removes Step 2.

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/f19a545c-c4ed-4bcd-8507-cc4b0ec7a6ad" />

Because the `abExperience` assignment doesn't happen instantly, it's hard to check/guard against it, so modifying the logic that sends a user to Step 2 based on URL params to account for ExperienceB doesn't work consistently. The simplest solution is to remove the logic entirely.

I added a comment in case we want to restore this functionality in the future, when our AB test is no longer running.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#17752](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17752).

### Approach

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [ ] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
