### PR TITLE
fix: stabilize formation address factory

### DIFF
--- a/web/cypress/support/helpers/factories.ts
+++ b/web/cypress/support/helpers/factories.ts
@@ -24,7 +24,9 @@ export const generateMunicipality = (overrides: Partial<Municipality>): Municipa
     ...overrides,
   };
 };
-export const generateFormationUSAddress = (overrides: Partial<FormationAddress>): FormationAddress => {
+export const generateFormationUSAddress = (
+  overrides: Partial<FormationAddress>,
+): FormationAddress => {
   return {
     addressLine1: `some-address-1-${randomInt()}`,
     addressLine2: `some-address-2-${randomInt()}`,
@@ -35,9 +37,10 @@ export const generateFormationUSAddress = (overrides: Partial<FormationAddress>)
           state.shortCode !== "NJ" &&
           state.shortCode !== "AS" &&
           state.shortCode !== "VI" &&
+          state.shortCode !== "Outside of the USA" &&
           state.shortCode !== "GU"
         );
-      })
+      }),
     ),
     addressCountry: "US",
     addressZipCode: randomInt(5).toString(),
@@ -47,7 +50,9 @@ export const generateFormationUSAddress = (overrides: Partial<FormationAddress>)
     ...overrides,
   };
 };
-export const generateFormationForeignAddress = (overrides: Partial<FormationAddress>): FormationAddress => {
+export const generateFormationForeignAddress = (
+  overrides: Partial<FormationAddress>,
+): FormationAddress => {
   return {
     addressLine1: `some-address-1-${randomInt()}`,
     addressLine2: `some-address-2-${randomInt()}`,
@@ -58,14 +63,16 @@ export const generateFormationForeignAddress = (overrides: Partial<FormationAddr
     addressCountry: randomElementFromArray(
       countries.filter((item) => {
         return item.shortCode !== "US";
-      })
+      }),
     ).shortCode,
     addressProvince: `some-address-province-${randomInt()}`,
     addressZipCode: randomInt(11).toString(),
     ...overrides,
   };
 };
-export const generateFormationNJAddress = (overrides: Partial<FormationAddress>): FormationAddress => {
+export const generateFormationNJAddress = (
+  overrides: Partial<FormationAddress>,
+): FormationAddress => {
   return {
     addressLine1: `some-address-1-${randomInt()}`,
     addressLine2: `some-address-2-${randomInt()}`,
@@ -88,7 +95,7 @@ export const generateFormationMember = (overrides: Partial<FormationMember>): Fo
 };
 export const generateFormationSigner = (
   overrides: Partial<FormationSigner>,
-  legalStructureId?: FormationLegalType
+  legalStructureId?: FormationLegalType,
 ): FormationSigner => {
   return {
     name: `some-signer-name-${randomInt()}`,
@@ -101,6 +108,6 @@ const getSignerType = (legalStructureId?: FormationLegalType) => {
   return randomElementFromArray(
     legalStructureId
       ? BusinessSignerTypeMap[legalStructureId]
-      : BusinessSignerTypeMap[randomFormationLegalType()]
+      : BusinessSignerTypeMap[randomFormationLegalType()],
   );
 };


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Updates the Cypress formation address factory so generated US formation addresses cannot randomly use `Outside of the USA` as a state. That option is excluded from the member address modal, which caused the business formation e2e test to fail when the random factory selected it.

### Approach

Filtered `Outside of the USA` out of `generateFormationUSAddress`, matching the intent of US address generation and the modal dropdown behavior.

### Steps to Test

- Run `yarn typecheck:cypress`
- Run the business formation Cypress spec and confirm member address state selection no longer fails when generated address data is used.

### Notes

This is a test-data fix only. No runtime dependencies or user-facing behavior changed.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
