### PR TITLE
feat: [AB#17622] deploy static site to ECS across environments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,16 @@
 .yarn
 !.yarn/releases
 !.yarn/plugins
+.git
+.next
+**/.next
+coverage
+**/coverage
+test-results
+**/test-results
+playwright-report
+**/playwright-report
 node_modules
 **/node_modules
+.DS_Store
+**/.DS_Store

--- a/.github/actions/deploy-setup/action.yml
+++ b/.github/actions/deploy-setup/action.yml
@@ -8,7 +8,7 @@ runs:
       uses: ./.github/actions/configure-and-build
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Deploy CDK
       uses: ./.github/actions/deploy-cdk

--- a/.github/actions/deploy-static-site/action.yml
+++ b/.github/actions/deploy-static-site/action.yml
@@ -1,0 +1,65 @@
+name: "Deploy Static Site"
+description: "Builds the static-site image, pushes it to ECR, and deploys the ECS Fargate service."
+
+inputs:
+  image_tag:
+    description: "Immutable image tag to deploy. Defaults to the current Git SHA."
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve Static Site Image Tag
+      id: image-tag
+      shell: bash
+      run: |
+        image_tag="${{ inputs.image_tag }}"
+        if [ -z "$image_tag" ]; then
+          image_tag="$GITHUB_SHA"
+        fi
+
+        echo "image_tag=$image_tag" >> "$GITHUB_OUTPUT"
+
+    - name: Deploy Static Site ECR Repository
+      shell: bash
+      run: |
+        yarn workspace @businessnjgovnavigator/api-cdk cdk deploy "StaticSiteRepositoryStack-${STAGE}" \
+          --qualifier biz-nj \
+          --verbose \
+          --region us-east-1 \
+          --require-approval never
+
+    - name: Login to Amazon ECR
+      shell: bash
+      run: |
+        aws ecr get-login-password --region "$AWS_REGION" \
+          | docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+
+    - name: Build Static Site Docker Image
+      shell: bash
+      env:
+        IMAGE_TAG: ${{ steps.image-tag.outputs.image_tag }}
+      run: |
+        image_repo="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/bfs-static-site-${STAGE}"
+        image_uri="${image_repo}:${IMAGE_TAG}"
+
+        docker build -f packages/static-site/Dockerfile . \
+          --build-arg NEXT_PUBLIC_WEB_BASE_URL="${NEXT_PUBLIC_WEB_BASE_URL:-}" \
+          -t "$image_uri"
+
+        echo "STATIC_SITE_IMAGE_URI=$image_uri" >> "$GITHUB_ENV"
+        echo "STATIC_SITE_IMAGE_TAG=$IMAGE_TAG" >> "$GITHUB_ENV"
+
+    - name: Push Static Site Docker Image
+      shell: bash
+      run: docker push "$STATIC_SITE_IMAGE_URI"
+
+    - name: Deploy Static Site ECS Service
+      shell: bash
+      run: |
+        yarn workspace @businessnjgovnavigator/api-cdk cdk deploy "StaticSiteServiceStack-${STAGE}" \
+          --qualifier biz-nj \
+          --verbose \
+          --region us-east-1 \
+          --require-approval never

--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8
 
     - name: Generate Release Notes
       shell: bash

--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -8,7 +8,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 14

--- a/.github/workflows/deploy-content-environment.yml
+++ b/.github/workflows/deploy-content-environment.yml
@@ -171,3 +171,5 @@ jobs:
       - uses: ./.github/actions/deploy
         with:
           service_name: bfs-navigator-content
+      - name: Deploy Static Site
+        uses: ./.github/actions/deploy-static-site

--- a/.github/workflows/deploy-dev-environment.yml
+++ b/.github/workflows/deploy-dev-environment.yml
@@ -138,6 +138,8 @@ jobs:
         uses: ./.github/actions/deploy
         with:
           service_name: bfs-navigator
+      - name: Deploy Static Site
+        uses: ./.github/actions/deploy-static-site
       - name: Deploy Storybook
         uses: ./.github/actions/deploy-storybook
         with:

--- a/.github/workflows/deploy-staging-environment.yml
+++ b/.github/workflows/deploy-staging-environment.yml
@@ -121,3 +121,5 @@ jobs:
         uses: ./.github/actions/deploy
         with:
           service_name: bfs-navigator
+      - name: Deploy Static Site
+        uses: ./.github/actions/deploy-static-site

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -184,3 +184,13 @@ jobs:
         uses: ./.github/actions/deploy
         with:
           service_name: bfs-navigator
+
+      - name: Read Release Version
+        id: release-version
+        shell: bash
+        run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy Static Site to Production
+        uses: ./.github/actions/deploy-static-site
+        with:
+          image_tag: ${{ steps.release-version.outputs.version }}

--- a/.github/workflows/static-site-deploy-ecs.yml
+++ b/.github/workflows/static-site-deploy-ecs.yml
@@ -1,12 +1,6 @@
 name: Deploy Static Site to ECS
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "packages/static-site/**"
-      - ".github/workflows/static-site-deploy-ecs.yml"
   workflow_dispatch:
 
 env:
@@ -14,75 +8,38 @@ env:
 
 jobs:
   deploy:
-    if: vars.STATIC_SITE_ECS_ENABLED == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
+    environment: dev
     env:
-      ECR_REPOSITORY: ${{ vars.STATIC_SITE_ECR_REPOSITORY }}
-      ECS_CLUSTER: ${{ vars.STATIC_SITE_ECS_CLUSTER }}
-      ECS_SERVICE: ${{ vars.STATIC_SITE_ECS_SERVICE }}
-      ECS_CONTAINER_NAME: ${{ vars.STATIC_SITE_CONTAINER_NAME || 'static-site' }}
-      ECS_TASK_DEFINITION_PATH:
-        ${{ vars.STATIC_SITE_TASK_DEFINITION_PATH ||
-        'packages/static-site/deploy/ecs-task-definition.json' }}
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID_DEV }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_DEV }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }}
+      AWS_REGION: ${{ vars.AWS_CRYPTO_CONTEXT_ORIGIN }}
+      BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
+      BASIC_AUTH_USERNAME: ${{ vars.BASIC_AUTH_USERNAME }}
+      NEXT_PUBLIC_WEB_BASE_URL: ${{ vars.WEB_BASE_URL_DEV }}
+      SG_ID: ${{ vars.SG_ID_AWS_DEV }}
+      STAGE: ${{ vars.STAGE_DEV }}
+      SUBNET_ID_01: ${{ vars.SUBNET_ID_01_AWS_DEV }}
+      SUBNET_ID_02: ${{ vars.SUBNET_ID_02_AWS_DEV }}
+      VPC_ID: ${{ vars.VPC_ID_AWS_DEV }}
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Validate workflow configuration
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - name: Install Dependencies
         shell: bash
-        run: |
-          required_vars=(ECR_REPOSITORY ECS_CLUSTER ECS_SERVICE ECS_TASK_DEFINITION_PATH ECS_CONTAINER_NAME)
-          for variable_name in "${required_vars[@]}"; do
-            if [ -z "${!variable_name}" ]; then
-              echo "Missing required configuration: ${variable_name}"
-              exit 1
-            fi
-          done
+        run: yarn install --immutable
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Build, tag, and push Docker image
-        id: build-image
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: ${{ github.sha }}
-        shell: bash
-        run: |
-          image_uri="${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
-          latest_uri="${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
-
-          docker build -f packages/static-site/Dockerfile -t "${image_uri}" -t "${latest_uri}" packages/static-site
-
-          docker push "${image_uri}"
-          docker push "${latest_uri}"
-
-          echo "image=${image_uri}" >> "$GITHUB_OUTPUT"
-
-      - name: Render Amazon ECS task definition
-        id: task-definition
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
-        with:
-          task-definition: ${{ env.ECS_TASK_DEFINITION_PATH }}
-          container-name: ${{ env.ECS_CONTAINER_NAME }}
-          image: ${{ steps.build-image.outputs.image }}
-
-      - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
-        with:
-          task-definition: ${{ steps.task-definition.outputs.task-definition }}
-          service: ${{ env.ECS_SERVICE }}
-          cluster: ${{ env.ECS_CLUSTER }}
-          wait-for-service-stability: true
+      - name: Deploy Static Site
+        uses: ./.github/actions/deploy-static-site

--- a/.github/workflows/testing-deployment-trigger.yml
+++ b/.github/workflows/testing-deployment-trigger.yml
@@ -130,3 +130,5 @@ jobs:
         uses: ./.github/actions/deploy
         with:
           service_name: bfs-navigator-testing
+      - name: Deploy Static Site
+        uses: ./.github/actions/deploy-static-site

--- a/.github/workflows/validate-content.yml
+++ b/.github/workflows/validate-content.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Send Slack notification on failure
         if: steps.spellcheck.outputs.exit_code != '0'
-        uses: slackapi/slack-github-action@v2
+        uses: slackapi/slack-github-action@v3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_OAUTH_TOKEN }}

--- a/api/cdk/bin/app.ts
+++ b/api/cdk/bin/app.ts
@@ -7,6 +7,8 @@ import { IamStack } from "../lib/iamStack";
 import { LambdaStack } from "../lib/lambdaStack";
 import { StorageStack } from "../lib/storageStack";
 import { EncryptionStack } from "../lib/encryptionStack";
+import { StaticSiteRepositoryStack } from "../lib/staticSiteRepositoryStack";
+import { StaticSiteServiceStack } from "../lib/staticSiteServiceStack";
 import {
   BUSINESSES_TABLE,
   CONTENT_STAGE,
@@ -25,98 +27,122 @@ const app = new cdk.App();
 const region = "us-east-1";
 const stage = process.env.STAGE || "local";
 const account_id = process.env.AWS_ACCOUNT_ID;
+const staticSiteImageTag = process.env.STATIC_SITE_IMAGE_TAG;
+const isStaticSiteDeploy = staticSiteImageTag !== undefined && staticSiteImageTag.trim().length > 0;
+const isMyAccountDeploy = !isStaticSiteDeploy;
 
 const env = {
   account: account_id,
   region: region,
 };
 
-new DataStack(app, `DataStack-${stage}`, {
-  stage: stage,
-  env,
-});
-
-const iamStack = new IamStack(app, `IamStack-${stage}`, {
-  stage,
-  env,
-});
-
-const storageStack = new StorageStack(app, `StorageStack-${stage}`, {
-  stage,
-  env,
-});
-
-const taxKMSRole = iam.Role.fromRoleName(
-  iamStack,
-  "TaxKMSRole",
-  "iamRoleForTaxIdEncryptionAndHashing",
+const staticSiteRepositoryStack = new StaticSiteRepositoryStack(
+  app,
+  `StaticSiteRepositoryStack-${stage}`,
+  {
+    stage,
+    env,
+  },
 );
 
-new EncryptionStack(app, `EncryptionStack-${stage}`, {
-  stage,
-  env,
-  taxKMSRole,
-});
-
-const monitoringStack = new MonitoringStack(app, `MonitoringStack-${stage}`, {
-  stage,
-  env,
-});
-
-if (stage === DEV_STAGE) {
-  new BackupStack(app, `BackupStack-${DEV_STAGE}-shared`, {
+if (isStaticSiteDeploy) {
+  new StaticSiteServiceStack(app, `StaticSiteServiceStack-${stage}`, {
+    stage,
     env,
-    backupRole: iamStack.backupRole!,
-    tableNames: [
-      `${BUSINESSES_TABLE}-${DEV_STAGE}`,
-      `${USERS_TABLE}-${DEV_STAGE}`,
-      `${MESSAGES_TABLE}-${DEV_STAGE}`,
-      `${BUSINESSES_TABLE}-${CONTENT_STAGE}`,
-      `${MESSAGES_TABLE}-${CONTENT_STAGE}`,
-      `${USERS_TABLE}-${CONTENT_STAGE}`,
-      `${BUSINESSES_TABLE}-${TESTING_STAGE}`,
-      `${MESSAGES_TABLE}-${TESTING_STAGE}`,
-      `${USERS_TABLE}-${TESTING_STAGE}`,
-    ],
+    repository: staticSiteRepositoryStack.repository,
+    imageTag: staticSiteImageTag,
   });
 }
 
-if (stage === STAGING_STAGE) {
-  new BackupStack(app, `BackupStack-${STAGING_STAGE}`, {
+if (isMyAccountDeploy) {
+  new DataStack(app, `DataStack-${stage}`, {
+    stage: stage,
     env,
-    backupRole: iamStack.backupRole!,
-    tableNames: [
-      `${BUSINESSES_TABLE}-${STAGING_STAGE}`,
-      `${MESSAGES_TABLE}-${STAGING_STAGE}`,
-      `${USERS_TABLE}-${STAGING_STAGE}`,
-    ],
+  });
+
+  const iamStack = new IamStack(app, `IamStack-${stage}`, {
+    stage,
+    env,
+  });
+
+  const storageStack = new StorageStack(app, `StorageStack-${stage}`, {
+    stage,
+    env,
+  });
+
+  const taxKMSRole = iam.Role.fromRoleName(
+    iamStack,
+    "TaxKMSRole",
+    "iamRoleForTaxIdEncryptionAndHashing",
+  );
+
+  new EncryptionStack(app, `EncryptionStack-${stage}`, {
+    stage,
+    env,
+    taxKMSRole,
+  });
+
+  const monitoringStack = new MonitoringStack(app, `MonitoringStack-${stage}`, {
+    stage,
+    env,
+  });
+
+  if (stage === DEV_STAGE) {
+    new BackupStack(app, `BackupStack-${DEV_STAGE}-shared`, {
+      env,
+      backupRole: iamStack.backupRole!,
+      tableNames: [
+        `${BUSINESSES_TABLE}-${DEV_STAGE}`,
+        `${USERS_TABLE}-${DEV_STAGE}`,
+        `${MESSAGES_TABLE}-${DEV_STAGE}`,
+        `${BUSINESSES_TABLE}-${CONTENT_STAGE}`,
+        `${MESSAGES_TABLE}-${CONTENT_STAGE}`,
+        `${USERS_TABLE}-${CONTENT_STAGE}`,
+        `${BUSINESSES_TABLE}-${TESTING_STAGE}`,
+        `${MESSAGES_TABLE}-${TESTING_STAGE}`,
+        `${USERS_TABLE}-${TESTING_STAGE}`,
+      ],
+    });
+  }
+
+  if (stage === STAGING_STAGE) {
+    new BackupStack(app, `BackupStack-${STAGING_STAGE}`, {
+      env,
+      backupRole: iamStack.backupRole!,
+      tableNames: [
+        `${BUSINESSES_TABLE}-${STAGING_STAGE}`,
+        `${MESSAGES_TABLE}-${STAGING_STAGE}`,
+        `${USERS_TABLE}-${STAGING_STAGE}`,
+      ],
+    });
+  }
+
+  if (stage === PROD_STAGE) {
+    new BackupStack(app, `BackupStack-${PROD_STAGE}`, {
+      env,
+      backupRole: iamStack.backupRole!,
+      tableNames: [
+        `${BUSINESSES_TABLE}-${PROD_STAGE}`,
+        `${MESSAGES_TABLE}-${PROD_STAGE}`,
+        `${USERS_TABLE}-${PROD_STAGE}`,
+      ],
+    });
+  }
+
+  const lambdaStack = new LambdaStack(app, `LambdaStack-${stage}`, {
+    stage: stage,
+    lambdaRole: iamStack.role,
+    messagesBucket: storageStack.messagesBucket,
+    intercomMacrosBucket: stage === DEV_STAGE ? storageStack.intercomMacrosBucket : undefined,
+    migrationLambdaTopic: monitoringStack.migrationLambdaTopic,
+    env,
+  });
+
+  new ApiStack(app, `ApiStack-${stage}`, {
+    stage,
+    lambdas: {
+      express: { lambda: lambdaStack.expressLambda },
+      githubOauth2: { lambda: lambdaStack.githubOauth2Lambda },
+    },
   });
 }
-
-if (stage === PROD_STAGE) {
-  new BackupStack(app, `BackupStack-${PROD_STAGE}`, {
-    env,
-    backupRole: iamStack.backupRole!,
-    tableNames: [
-      `${BUSINESSES_TABLE}-${PROD_STAGE}`,
-      `${MESSAGES_TABLE}-${PROD_STAGE}`,
-      `${USERS_TABLE}-${PROD_STAGE}`,
-    ],
-  });
-}
-const lambdaStack = new LambdaStack(app, `LambdaStack-${stage}`, {
-  stage: stage,
-  lambdaRole: iamStack.role,
-  messagesBucket: storageStack.messagesBucket,
-  intercomMacrosBucket: stage === DEV_STAGE ? storageStack.intercomMacrosBucket : undefined,
-  migrationLambdaTopic: monitoringStack.migrationLambdaTopic,
-  env,
-});
-
-new ApiStack(app, `ApiStack-${stage}`, {
-  stage,
-  lambdas: {
-    express: { lambda: lambdaStack.expressLambda },
-    githubOauth2: { lambda: lambdaStack.githubOauth2Lambda },
-  },
-});

--- a/api/cdk/lib/constants.ts
+++ b/api/cdk/lib/constants.ts
@@ -1,4 +1,3 @@
-// lib/constants.ts
 export const CONTENT_STAGE = "content";
 export const TESTING_STAGE = "testing";
 export const STAGING_STAGE = "staging";
@@ -16,6 +15,22 @@ export const NAVIGATOR_DB_CLIENT = "NavigatorDBClient";
 export const HEALTH_CHECK_SERVICE = "HealthCheckService";
 export const ECS_SERVICE_NAME = "bfs-navigator";
 export const ECS_CLUSTER_NAME = "bfs_container_cluster";
+/** Base name used for static-site AWS resources that are duplicated per stage. */
+export const STATIC_SITE_SERVICE_BASE_NAME = "bfs-static-site";
+/** ECS container name used in the static-site task definition and ALB target mapping. */
+export const STATIC_SITE_CONTAINER_NAME = "static-site";
+/** Port exposed by the static-site Next.js standalone server inside the Fargate task. */
+export const STATIC_SITE_CONTAINER_PORT = 3000;
+/** Health-check route served by the static site for ALB and container health checks. */
+export const STATIC_SITE_HEALTH_CHECK_PATH = "/healthz";
+/** Public hostnames that external DNS and WAF configuration map to each internal ALB origin. */
+export const STATIC_SITE_HOSTNAMES: Record<string, string> = {
+  [DEV_STAGE]: "dev.next.business.nj.gov",
+  [TESTING_STAGE]: "testing.next.business.nj.gov",
+  [CONTENT_STAGE]: "content.next.business.nj.gov",
+  [STAGING_STAGE]: "staging.next.business.nj.gov",
+  [PROD_STAGE]: "next.business.nj.gov",
+};
 export const HEALTH_CHECK_ENDPOINTS: Record<string, string> = {
   self: "self",
   elevator: "dynamics/elevator",

--- a/api/cdk/lib/staticSiteMonitoring.ts
+++ b/api/cdk/lib/staticSiteMonitoring.ts
@@ -1,0 +1,138 @@
+import { Duration, RemovalPolicy } from "aws-cdk-lib";
+import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+import * as cloudwatchActions from "aws-cdk-lib/aws-cloudwatch-actions";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import * as events from "aws-cdk-lib/aws-events";
+import * as eventsTargets from "aws-cdk-lib/aws-events-targets";
+import * as sns from "aws-cdk-lib/aws-sns";
+import { Construct } from "constructs";
+import { STATIC_SITE_SERVICE_BASE_NAME } from "./constants";
+import { applyStandardTags } from "./stackUtils";
+
+/**
+ * CloudWatch alarm evaluation period for the static-site service.
+ *
+ * Five minutes matches the existing ECS monitoring cadence and avoids noisy alarms from short
+ * deployment transitions while still surfacing real service failures promptly.
+ */
+export const STATIC_SITE_ALARM_PERIOD = Duration.minutes(5);
+
+/** Inputs for creating static-site CloudWatch alarms. */
+export interface CreateStaticSiteAlarmsProps {
+  /** Construct scope that owns the CloudWatch alarms. */
+  readonly scope: Construct;
+
+  /** Deployment stage that appears in alarm names and tags. */
+  readonly stage: string;
+
+  /** ECS cluster whose Container Insights metrics report service task counts. */
+  readonly cluster: ecs.ICluster;
+
+  /** Fargate service whose running task count is monitored. */
+  readonly service: ecs.FargateService;
+
+  /** ALB target group whose health and 5xx metrics are monitored. */
+  readonly targetGroup: elbv2.ApplicationTargetGroup;
+
+  /** Desired running task count used as the lower bound alarm threshold. */
+  readonly desiredCount: number;
+
+  /** SNS topic that receives alarm and OK notifications. */
+  readonly alarmTopic: sns.ITopic;
+}
+
+/** Inputs for creating the static-site ECS deployment failure notification rule. */
+export interface CreateStaticSiteDeploymentFailureRuleProps {
+  /** Construct scope that owns the EventBridge rule. */
+  readonly scope: Construct;
+
+  /** Deployment stage that appears in the rule name and tags. */
+  readonly stage: string;
+
+  /** ECS cluster whose deployment state change events are matched. */
+  readonly cluster: ecs.ICluster;
+
+  /** Fargate service whose deployment failures are matched. */
+  readonly service: ecs.FargateService;
+
+  /** SNS topic that receives deployment failure notifications. */
+  readonly alarmTopic: sns.ITopic;
+}
+
+/** Create CloudWatch alarms for target health, target 5xx responses, and running task count. */
+export const createStaticSiteAlarms = (props: CreateStaticSiteAlarmsProps): void => {
+  const unhealthyTargetAlarm = new cloudwatch.Alarm(props.scope, "StaticSiteUnhealthyTargetAlarm", {
+    alarmName: `${props.stage}-${STATIC_SITE_SERVICE_BASE_NAME}-unhealthy-targets`,
+    metric: props.targetGroup.metrics.unhealthyHostCount({
+      period: STATIC_SITE_ALARM_PERIOD,
+      statistic: "Average",
+    }),
+    threshold: 1,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  });
+  const targetFiveHundredAlarm = new cloudwatch.Alarm(props.scope, "StaticSiteTarget5xxAlarm", {
+    alarmName: `${props.stage}-${STATIC_SITE_SERVICE_BASE_NAME}-target-5xx`,
+    metric: props.targetGroup.metrics.httpCodeTarget(elbv2.HttpCodeTarget.TARGET_5XX_COUNT, {
+      period: STATIC_SITE_ALARM_PERIOD,
+      statistic: "Sum",
+    }),
+    threshold: 1,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  });
+  const runningTaskCountAlarm = new cloudwatch.Alarm(
+    props.scope,
+    "StaticSiteRunningTaskCountAlarm",
+    {
+      alarmName: `${props.stage}-${STATIC_SITE_SERVICE_BASE_NAME}-running-task-count`,
+      metric: new cloudwatch.Metric({
+        namespace: "ECS/ContainerInsights",
+        metricName: "RunningTaskCount",
+        statistic: "Average",
+        period: STATIC_SITE_ALARM_PERIOD,
+        dimensionsMap: {
+          ClusterName: props.cluster.clusterName,
+          ServiceName: props.service.serviceName,
+        },
+      }),
+      threshold: props.desiredCount,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.BREACHING,
+    },
+  );
+
+  for (const alarm of [unhealthyTargetAlarm, targetFiveHundredAlarm, runningTaskCountAlarm]) {
+    alarm.addAlarmAction(new cloudwatchActions.SnsAction(props.alarmTopic));
+    alarm.addOkAction(new cloudwatchActions.SnsAction(props.alarmTopic));
+    alarm.applyRemovalPolicy(RemovalPolicy.RETAIN);
+  }
+};
+
+/** Create an EventBridge rule that publishes ECS deployment failures to the alarm topic. */
+export const createStaticSiteDeploymentFailureRule = (
+  props: CreateStaticSiteDeploymentFailureRuleProps,
+): void => {
+  const rule = new events.Rule(props.scope, "StaticSiteDeploymentFailureRule", {
+    ruleName: `${props.stage}-${STATIC_SITE_SERVICE_BASE_NAME}-deployment-failures`,
+    eventPattern: {
+      source: ["aws.ecs"],
+      detailType: ["ECS Deployment State Change"],
+      detail: {
+        eventName: ["SERVICE_DEPLOYMENT_FAILED"],
+        clusterArn: [props.cluster.clusterArn],
+        serviceArn: [props.service.serviceArn],
+      },
+    },
+  });
+
+  rule.addTarget(new eventsTargets.SnsTopic(props.alarmTopic));
+  applyStandardTags(rule, props.stage);
+};

--- a/api/cdk/lib/staticSiteOutputs.ts
+++ b/api/cdk/lib/staticSiteOutputs.ts
@@ -1,0 +1,50 @@
+import { CfnOutput } from "aws-cdk-lib";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { Construct } from "constructs";
+import { STATIC_SITE_HOSTNAMES, STATIC_SITE_SERVICE_BASE_NAME } from "./constants";
+
+/** Inputs for creating static-site CloudFormation outputs. */
+export interface CreateStaticSiteOutputsProps {
+  /** Construct scope that owns the CloudFormation outputs. */
+  readonly scope: Construct;
+
+  /** Deployment stage used in output names and hostname selection. */
+  readonly stage: string;
+
+  /** Internal ALB whose DNS name is exported for Terraform and WAF origin wiring. */
+  readonly loadBalancer: elbv2.ApplicationLoadBalancer;
+
+  /** ALB target group whose ARN is exported for operational visibility. */
+  readonly targetGroup: elbv2.ApplicationTargetGroup;
+
+  /** ECS cluster whose name is exported for deployment and operational visibility. */
+  readonly cluster: ecs.ICluster;
+
+  /** ECS service whose name is exported for deployment and operational visibility. */
+  readonly service: ecs.FargateService;
+}
+
+/** Create the static-site outputs consumed by DNS, WAF, deployment, and operators. */
+export const createStaticSiteOutputs = (props: CreateStaticSiteOutputsProps): void => {
+  new CfnOutput(props.scope, "StaticSiteHostname", {
+    value: STATIC_SITE_HOSTNAMES[props.stage] ?? `${props.stage}.next.business.nj.gov`,
+    exportName: `${STATIC_SITE_SERVICE_BASE_NAME}-${props.stage}-hostname`,
+  });
+  new CfnOutput(props.scope, "StaticSiteLoadBalancerDnsName", {
+    value: props.loadBalancer.loadBalancerDnsName,
+    exportName: `${STATIC_SITE_SERVICE_BASE_NAME}-${props.stage}-alb-dns-name`,
+  });
+  new CfnOutput(props.scope, "StaticSiteTargetGroupArn", {
+    value: props.targetGroup.targetGroupArn,
+    exportName: `${STATIC_SITE_SERVICE_BASE_NAME}-${props.stage}-target-group-arn`,
+  });
+  new CfnOutput(props.scope, "StaticSiteClusterName", {
+    value: props.cluster.clusterName,
+    exportName: `${STATIC_SITE_SERVICE_BASE_NAME}-${props.stage}-cluster-name`,
+  });
+  new CfnOutput(props.scope, "StaticSiteServiceName", {
+    value: props.service.serviceName,
+    exportName: `${STATIC_SITE_SERVICE_BASE_NAME}-${props.stage}-service-name`,
+  });
+};

--- a/api/cdk/lib/staticSiteRepositoryStack.ts
+++ b/api/cdk/lib/staticSiteRepositoryStack.ts
@@ -1,0 +1,50 @@
+import { CfnOutput, Duration, RemovalPolicy, Stack, StackProps } from "aws-cdk-lib";
+import * as ecr from "aws-cdk-lib/aws-ecr";
+import { Construct } from "constructs";
+import { PROD_STAGE, STATIC_SITE_SERVICE_BASE_NAME } from "./constants";
+import { applyStandardTags } from "./stackUtils";
+
+/** Properties for creating the per-stage static-site ECR repository stack. */
+export interface StaticSiteRepositoryStackProps extends StackProps {
+  /** Deployment stage that owns this repository, such as dev, testing, content, staging, or prod. */
+  readonly stage: string;
+}
+
+/** CDK stack that owns the static-site ECR repository and image lifecycle policy. */
+export class StaticSiteRepositoryStack extends Stack {
+  /** Private ECR repository that stores static-site images for this stage. */
+  public readonly repository: ecr.Repository;
+
+  constructor(scope: Construct, id: string, props: StaticSiteRepositoryStackProps) {
+    super(scope, id, props);
+
+    const repository = new ecr.Repository(this, "StaticSiteRepository", {
+      repositoryName: `${STATIC_SITE_SERVICE_BASE_NAME}-${props.stage}`,
+      imageScanOnPush: true,
+      removalPolicy: RemovalPolicy.RETAIN,
+      emptyOnDelete: false,
+    });
+
+    repository.addLifecycleRule({
+      description: "Expire untagged images after seven days.",
+      tagStatus: ecr.TagStatus.UNTAGGED,
+      maxImageAge: Duration.days(7),
+    });
+
+    repository.addLifecycleRule({
+      description: "Keep the latest tagged static-site images.",
+      tagStatus: ecr.TagStatus.TAGGED,
+      tagPatternList: ["*"],
+      maxImageCount: props.stage === PROD_STAGE ? 20 : 50,
+    });
+
+    applyStandardTags(repository, props.stage);
+
+    new CfnOutput(this, "StaticSiteRepositoryUri", {
+      value: repository.repositoryUri,
+      exportName: `${STATIC_SITE_SERVICE_BASE_NAME}-${props.stage}-repository-uri`,
+    });
+
+    this.repository = repository;
+  }
+}

--- a/api/cdk/lib/staticSiteServiceStack.ts
+++ b/api/cdk/lib/staticSiteServiceStack.ts
@@ -1,0 +1,295 @@
+import { Duration, RemovalPolicy, Stack, StackProps } from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as ecr from "aws-cdk-lib/aws-ecr";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import * as logs from "aws-cdk-lib/aws-logs";
+import * as sns from "aws-cdk-lib/aws-sns";
+import { Construct } from "constructs";
+import { STATIC_SITE_HEALTH_CHECK_PATH, STATIC_SITE_SERVICE_BASE_NAME } from "./constants";
+import {
+  createStaticSiteAlarms,
+  createStaticSiteDeploymentFailureRule,
+} from "./staticSiteMonitoring";
+import { createStaticSiteOutputs } from "./staticSiteOutputs";
+import {
+  createStaticSiteServiceName,
+  createStaticSiteTaskDefinition,
+} from "./staticSiteTaskDefinition";
+import { applyStandardTags } from "./stackUtils";
+
+/** Properties for creating the per-stage static-site ECS service stack. */
+export interface StaticSiteServiceStackProps extends StackProps {
+  /** Deployment stage that owns this ECS service, such as dev, testing, content, staging, or prod. */
+  readonly stage: string;
+
+  /** ECR repository that contains the static-site image for this stage. */
+  readonly repository: ecr.IRepository;
+
+  /** Immutable image tag that ECS should deploy for this service revision. */
+  readonly imageTag: string;
+}
+
+interface RequiredEnvironmentValue {
+  /** Environment variable name to validate. */
+  readonly name: string;
+
+  /** Environment variable value to validate. */
+  readonly value: string | undefined;
+}
+
+interface StaticSiteNetwork {
+  /** Imported VPC that contains the private ECS and ALB subnets. */
+  readonly vpc: ec2.IVpc;
+
+  /** Private subnets used by the internal ALB and Fargate service. */
+  readonly subnets: ec2.ISubnet[];
+
+  /** Existing security group used by the current bfs-navigator ECS service pattern. */
+  readonly securityGroup: ec2.ISecurityGroup;
+}
+
+interface CreateStaticSiteServiceProps {
+  /** Deployment stage used in the ECS service name and tags. */
+  readonly stage: string;
+
+  /** ECS cluster that runs the Fargate service. */
+  readonly cluster: ecs.ICluster;
+
+  /** Task definition revision that the service should run. */
+  readonly taskDefinition: ecs.FargateTaskDefinition;
+
+  /** Imported VPC, private subnet, and security group resources used by the service. */
+  readonly network: StaticSiteNetwork;
+}
+
+/**
+ * Number of static-site tasks to run initially.
+ *
+ * The first deployment is intentionally single-instance because autoscaling is out of scope and the
+ * external WAF can retry against the same internal ALB origin.
+ */
+const STATIC_SITE_DESIRED_COUNT = 1;
+
+/**
+ * Maximum healthy percentage for rolling ECS deployments.
+ *
+ * Two hundred percent allows ECS to start one replacement task before stopping the existing task
+ * when subnet capacity is available.
+ */
+const STATIC_SITE_DEPLOYMENT_MAX_PERCENT = 200;
+
+/**
+ * Minimum healthy percentage for rolling ECS deployments.
+ *
+ * Zero percent lets a single-task service recover from bad or stuck tasks without requiring a
+ * second healthy task to exist first.
+ */
+const STATIC_SITE_DEPLOYMENT_MIN_HEALTHY_PERCENT = 0;
+
+const requireEnvironmentValue = (props: RequiredEnvironmentValue): string => {
+  if (props.value === undefined || props.value.trim().length === 0) {
+    throw new Error(`${props.name} must be set to deploy the static site service`);
+  }
+
+  return props.value;
+};
+
+const createStaticSiteClusterName = (stage: string): string => {
+  return `${STATIC_SITE_SERVICE_BASE_NAME}-${stage}-cluster`;
+};
+
+const createStaticSiteAlbName = (stage: string): string => {
+  return `${STATIC_SITE_SERVICE_BASE_NAME}-${stage}-alb`;
+};
+
+const createStaticSiteTargetGroupName = (stage: string): string => {
+  return `${STATIC_SITE_SERVICE_BASE_NAME}-${stage}-tg`;
+};
+
+/** CDK stack that runs the static site in ECS Fargate behind an internal ALB. */
+export class StaticSiteServiceStack extends Stack {
+  constructor(scope: Construct, id: string, props: StaticSiteServiceStackProps) {
+    super(scope, id, props);
+
+    const network = this.createNetwork();
+    const alarmTopic = this.createAlarmTopic(props.stage);
+    const cluster = this.createCluster(props.stage, network);
+    const logGroup = this.createLogGroup(props.stage);
+    const taskDefinition = createStaticSiteTaskDefinition({
+      scope: this,
+      stage: props.stage,
+      repository: props.repository,
+      imageTag: props.imageTag,
+      logGroup,
+    });
+    const loadBalancer = this.createLoadBalancer(props.stage, network);
+    const targetGroup = this.createTargetGroup(props.stage, network);
+    const listener = loadBalancer.addListener("StaticSiteListener", {
+      port: 80,
+      protocol: elbv2.ApplicationProtocol.HTTP,
+      defaultTargetGroups: [targetGroup],
+    });
+    const service = this.createService({
+      stage: props.stage,
+      cluster,
+      taskDefinition,
+      network,
+    });
+
+    service.attachToApplicationTargetGroup(targetGroup);
+    createStaticSiteAlarms({
+      scope: this,
+      stage: props.stage,
+      cluster,
+      service,
+      targetGroup,
+      desiredCount: STATIC_SITE_DESIRED_COUNT,
+      alarmTopic,
+    });
+    createStaticSiteDeploymentFailureRule({
+      scope: this,
+      stage: props.stage,
+      cluster,
+      service,
+      alarmTopic,
+    });
+    createStaticSiteOutputs({
+      scope: this,
+      stage: props.stage,
+      loadBalancer,
+      targetGroup,
+      cluster,
+      service,
+    });
+
+    applyStandardTags(listener, props.stage);
+  }
+
+  private createNetwork(): StaticSiteNetwork {
+    const subnetId01 = requireEnvironmentValue({
+      name: "SUBNET_ID_01",
+      value: process.env.SUBNET_ID_01,
+    });
+    const subnetId02 = requireEnvironmentValue({
+      name: "SUBNET_ID_02",
+      value: process.env.SUBNET_ID_02,
+    });
+
+    return {
+      vpc: ec2.Vpc.fromVpcAttributes(this, "StaticSiteVpc", {
+        vpcId: requireEnvironmentValue({ name: "VPC_ID", value: process.env.VPC_ID }),
+        availabilityZones: ["us-east-1a", "us-east-1b"],
+        privateSubnetIds: [subnetId01, subnetId02],
+      }),
+      subnets: [
+        ec2.Subnet.fromSubnetId(this, "StaticSiteSubnet01", subnetId01),
+        ec2.Subnet.fromSubnetId(this, "StaticSiteSubnet02", subnetId02),
+      ],
+      securityGroup: ec2.SecurityGroup.fromSecurityGroupId(
+        this,
+        "StaticSiteSecurityGroup",
+        requireEnvironmentValue({ name: "SG_ID", value: process.env.SG_ID }),
+        { mutable: false },
+      ),
+    };
+  }
+
+  private createCluster(stage: string, network: StaticSiteNetwork): ecs.Cluster {
+    const cluster = new ecs.Cluster(this, "StaticSiteCluster", {
+      clusterName: createStaticSiteClusterName(stage),
+      vpc: network.vpc,
+      containerInsightsV2: ecs.ContainerInsights.ENABLED,
+    });
+
+    applyStandardTags(cluster, stage);
+    return cluster;
+  }
+
+  private createAlarmTopic(stage: string): sns.Topic {
+    const alarmTopic = new sns.Topic(this, "StaticSiteAlarmTopic", {
+      topicName: `${STATIC_SITE_SERVICE_BASE_NAME}-errors-${stage}`,
+    });
+
+    new sns.Subscription(this, "StaticSiteAlarmTopicSubscription", {
+      topic: alarmTopic,
+      protocol: sns.SubscriptionProtocol.HTTPS,
+      endpoint: "https://global.sns-api.chatbot.amazonaws.com",
+    });
+
+    alarmTopic.applyRemovalPolicy(RemovalPolicy.RETAIN);
+    applyStandardTags(alarmTopic, stage);
+    return alarmTopic;
+  }
+
+  private createLogGroup(stage: string): logs.LogGroup {
+    const logGroup = new logs.LogGroup(this, "StaticSiteLogGroup", {
+      logGroupName: `/ecs/${STATIC_SITE_SERVICE_BASE_NAME}/${stage}`,
+      retention: logs.RetentionDays.SIX_MONTHS,
+      removalPolicy: RemovalPolicy.RETAIN,
+    });
+
+    applyStandardTags(logGroup, stage);
+    return logGroup;
+  }
+
+  private createLoadBalancer(
+    stage: string,
+    network: StaticSiteNetwork,
+  ): elbv2.ApplicationLoadBalancer {
+    const loadBalancer = new elbv2.ApplicationLoadBalancer(this, "StaticSiteLoadBalancer", {
+      loadBalancerName: createStaticSiteAlbName(stage),
+      vpc: network.vpc,
+      internetFacing: false,
+      securityGroup: network.securityGroup,
+      vpcSubnets: { subnets: network.subnets },
+      deletionProtection: true,
+    });
+
+    applyStandardTags(loadBalancer, stage);
+    return loadBalancer;
+  }
+
+  private createTargetGroup(
+    stage: string,
+    network: StaticSiteNetwork,
+  ): elbv2.ApplicationTargetGroup {
+    const targetGroup = new elbv2.ApplicationTargetGroup(this, "StaticSiteTargetGroup", {
+      targetGroupName: createStaticSiteTargetGroupName(stage),
+      vpc: network.vpc,
+      protocol: elbv2.ApplicationProtocol.HTTP,
+      port: 80,
+      targetType: elbv2.TargetType.IP,
+      healthCheck: {
+        enabled: true,
+        path: STATIC_SITE_HEALTH_CHECK_PATH,
+        healthyHttpCodes: "200",
+        interval: Duration.seconds(30),
+        timeout: Duration.seconds(5),
+        healthyThresholdCount: 3,
+        unhealthyThresholdCount: 3,
+      },
+    });
+
+    applyStandardTags(targetGroup, stage);
+    return targetGroup;
+  }
+
+  private createService(props: CreateStaticSiteServiceProps): ecs.FargateService {
+    const service = new ecs.FargateService(this, "StaticSiteService", {
+      serviceName: createStaticSiteServiceName(props.stage),
+      cluster: props.cluster,
+      taskDefinition: props.taskDefinition,
+      desiredCount: STATIC_SITE_DESIRED_COUNT,
+      assignPublicIp: false,
+      securityGroups: [props.network.securityGroup],
+      vpcSubnets: { subnets: props.network.subnets },
+      maxHealthyPercent: STATIC_SITE_DEPLOYMENT_MAX_PERCENT,
+      minHealthyPercent: STATIC_SITE_DEPLOYMENT_MIN_HEALTHY_PERCENT,
+      circuitBreaker: { rollback: true },
+    });
+
+    applyStandardTags(service, props.stage);
+    return service;
+  }
+}

--- a/api/cdk/lib/staticSiteTaskDefinition.ts
+++ b/api/cdk/lib/staticSiteTaskDefinition.ts
@@ -1,0 +1,210 @@
+import { Duration } from "aws-cdk-lib";
+import * as ecr from "aws-cdk-lib/aws-ecr";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as logs from "aws-cdk-lib/aws-logs";
+import { Construct } from "constructs";
+import {
+  CONTENT_STAGE,
+  DEV_STAGE,
+  PROD_STAGE,
+  STATIC_SITE_CONTAINER_NAME,
+  STATIC_SITE_CONTAINER_PORT,
+  STATIC_SITE_SERVICE_BASE_NAME,
+  STAGING_STAGE,
+  TESTING_STAGE,
+} from "./constants";
+import { applyStandardTags } from "./stackUtils";
+
+/** Inputs for creating the static-site ECS task definition and IAM roles. */
+export interface CreateStaticSiteTaskDefinitionProps {
+  /** Construct scope that owns the task definition and task IAM roles. */
+  readonly scope: Construct;
+
+  /** Deployment stage used in names and tags. */
+  readonly stage: string;
+
+  /** ECR repository that contains the static-site image. */
+  readonly repository: ecr.IRepository;
+
+  /** Immutable ECR image tag that this task definition revision should run. */
+  readonly imageTag: string;
+
+  /** CloudWatch log group that receives container logs. */
+  readonly logGroup: logs.ILogGroup;
+}
+
+/**
+ * Fargate CPU units for the static-site task.
+ *
+ * This is half of the existing Next.js application task size and matches AWS's smallest practical
+ * size for a lightweight standalone Next.js server.
+ */
+const STATIC_SITE_CPU_UNITS = 512;
+
+/**
+ * Fargate memory limit for the static-site task.
+ *
+ * This is half of the existing Next.js application memory allocation and pairs with 512 CPU units
+ * as a supported Fargate size.
+ */
+const STATIC_SITE_MEMORY_MIB = 1024;
+
+/**
+ * Container health-check timeout.
+ *
+ * Two seconds is shorter than the ECS health-check timeout so the Node process exits before ECS
+ * marks the check itself as timed out.
+ */
+const STATIC_SITE_HEALTH_CHECK_TIMEOUT_MS = 2000;
+
+/**
+ * Stages where the public static-site origin should require Basic Auth.
+ *
+ * These pre-launch protected stages are reached through external WAF routing, while local
+ * development is intentionally unaffected.
+ */
+const STATIC_SITE_BASIC_AUTH_STAGES = new Set([
+  DEV_STAGE,
+  CONTENT_STAGE,
+  TESTING_STAGE,
+  STAGING_STAGE,
+  PROD_STAGE,
+]);
+
+/** Inputs for creating runtime environment variables injected into the static-site ECS container. */
+export interface StaticSiteContainerEnvironmentProps {
+  /** Deployment stage that determines whether Basic Auth should be enabled. Expected values are the known CDK stages. */
+  readonly stage: string;
+}
+
+/** Basic Auth credential variables supplied by GitHub Actions during CDK deployment. */
+interface StaticSiteBasicAuthEnvironment {
+  /** Username injected into the ECS task for protected-stage Basic Auth. */
+  readonly username: string;
+
+  /** Password injected into the ECS task for protected-stage Basic Auth. */
+  readonly password: string;
+}
+
+/** Create the consistent per-stage ECS service and task-definition family name. */
+export const createStaticSiteServiceName = (stage: string): string => {
+  return `${STATIC_SITE_SERVICE_BASE_NAME}-${stage}`;
+};
+
+const isStaticSiteBasicAuthStage = (stage: string): boolean => {
+  return STATIC_SITE_BASIC_AUTH_STAGES.has(stage);
+};
+
+/**
+ * Reads a GitHub Actions-provided environment variable required for protected-stage Basic Auth.
+ */
+const readRequiredEnvironmentValue = (name: string): string => {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`${name} is required to deploy Basic Auth for the static-site ECS service.`);
+  }
+
+  return value;
+};
+
+/**
+ * Reads Basic Auth credentials from the deployment environment.
+ */
+const readStaticSiteBasicAuthEnvironment = (): StaticSiteBasicAuthEnvironment => {
+  return {
+    username: readRequiredEnvironmentValue("BASIC_AUTH_USERNAME"),
+    password: readRequiredEnvironmentValue("BASIC_AUTH_PASSWORD"),
+  };
+};
+
+/**
+ * Creates the ECS container environment while enabling Basic Auth for pre-launch protected stages.
+ */
+const createStaticSiteContainerEnvironment = (
+  props: StaticSiteContainerEnvironmentProps,
+): Record<string, string> => {
+  const baseEnvironment = {
+    HOSTNAME: "0.0.0.0",
+    NODE_ENV: "production",
+    PORT: STATIC_SITE_CONTAINER_PORT.toString(),
+  };
+
+  if (!isStaticSiteBasicAuthStage(props.stage)) {
+    return {
+      ...baseEnvironment,
+      USE_BASIC_AUTH: "false",
+    };
+  }
+
+  const basicAuthEnvironment = readStaticSiteBasicAuthEnvironment();
+
+  return {
+    ...baseEnvironment,
+    USE_BASIC_AUTH: "true",
+    BASIC_AUTH_USERNAME: basicAuthEnvironment.username,
+    BASIC_AUTH_PASSWORD: basicAuthEnvironment.password,
+  };
+};
+
+const createStaticSiteHealthCheckScript = (): string => {
+  return `const http=require('node:http');const request=http.get('http://127.0.0.1:3000/healthz',(response)=>{process.exit(response.statusCode===200?0:1)});request.on('error',()=>process.exit(1));request.setTimeout(${STATIC_SITE_HEALTH_CHECK_TIMEOUT_MS},()=>{request.destroy();process.exit(1)})`;
+};
+
+const createStaticSiteHealthCheckCommand = (): string => {
+  return ["node", "-e", JSON.stringify(createStaticSiteHealthCheckScript())].join(" ");
+};
+
+/** Create the Fargate task definition and IAM roles for the static-site container. */
+export const createStaticSiteTaskDefinition = (
+  props: CreateStaticSiteTaskDefinitionProps,
+): ecs.FargateTaskDefinition => {
+  const taskExecutionRole = new iam.Role(props.scope, "StaticSiteTaskExecutionRole", {
+    roleName: `${STATIC_SITE_SERVICE_BASE_NAME}-${props.stage}-execution-role`,
+    assumedBy: new iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
+    managedPolicies: [
+      iam.ManagedPolicy.fromAwsManagedPolicyName("service-role/AmazonECSTaskExecutionRolePolicy"),
+    ],
+  });
+  const taskRole = new iam.Role(props.scope, "StaticSiteTaskRole", {
+    roleName: `${STATIC_SITE_SERVICE_BASE_NAME}-${props.stage}-task-role`,
+    assumedBy: new iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
+  });
+  const taskDefinition = new ecs.FargateTaskDefinition(props.scope, "StaticSiteTaskDefinition", {
+    family: createStaticSiteServiceName(props.stage),
+    cpu: STATIC_SITE_CPU_UNITS,
+    memoryLimitMiB: STATIC_SITE_MEMORY_MIB,
+    executionRole: taskExecutionRole,
+    taskRole,
+  });
+
+  taskDefinition.addContainer("StaticSiteContainer", {
+    containerName: STATIC_SITE_CONTAINER_NAME,
+    image: ecs.ContainerImage.fromEcrRepository(props.repository, props.imageTag),
+    essential: true,
+    environment: createStaticSiteContainerEnvironment({ stage: props.stage }),
+    healthCheck: {
+      command: ["CMD-SHELL", createStaticSiteHealthCheckCommand()],
+      interval: Duration.seconds(30),
+      timeout: Duration.seconds(3),
+      retries: 3,
+    },
+    logging: ecs.LogDrivers.awsLogs({
+      logGroup: props.logGroup,
+      streamPrefix: STATIC_SITE_CONTAINER_NAME,
+    }),
+    portMappings: [
+      {
+        containerPort: STATIC_SITE_CONTAINER_PORT,
+        hostPort: STATIC_SITE_CONTAINER_PORT,
+        protocol: ecs.Protocol.TCP,
+      },
+    ],
+  });
+
+  applyStandardTags(taskExecutionRole, props.stage);
+  applyStandardTags(taskRole, props.stage);
+  applyStandardTags(taskDefinition, props.stage);
+  return taskDefinition;
+};

--- a/api/cdk/test/staticSiteRepositoryStack.test.ts
+++ b/api/cdk/test/staticSiteRepositoryStack.test.ts
@@ -1,0 +1,76 @@
+import { App } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { StaticSiteRepositoryStack } from "../lib/staticSiteRepositoryStack";
+
+describe("StaticSiteRepositoryStack", () => {
+  test("creates a private dev ECR repository that keeps the latest 50 tagged images", () => {
+    const app = new App();
+    const stack = new StaticSiteRepositoryStack(app, "TestStaticSiteRepositoryStack", {
+      stage: "dev",
+    });
+    const template = Template.fromStack(stack);
+
+    expect(template.toJSON()).toBeDefined();
+    template.hasResourceProperties("AWS::ECR::Repository", {
+      RepositoryName: "bfs-static-site-dev",
+      ImageScanningConfiguration: {
+        ScanOnPush: true,
+      },
+      LifecyclePolicy: {
+        LifecyclePolicyText: Match.serializedJson(
+          Match.objectLike({
+            rules: Match.arrayWith([
+              Match.objectLike({
+                selection: Match.objectLike({
+                  tagStatus: "untagged",
+                  countType: "sinceImagePushed",
+                  countNumber: 7,
+                  countUnit: "days",
+                }),
+              }),
+              Match.objectLike({
+                selection: Match.objectLike({
+                  tagStatus: "tagged",
+                  tagPatternList: ["*"],
+                  countType: "imageCountMoreThan",
+                  countNumber: 50,
+                }),
+              }),
+            ]),
+          }),
+        ),
+      },
+      Tags: Match.arrayWith([{ Key: "STAGE", Value: "dev" }]),
+    });
+  });
+
+  test("creates a private prod ECR repository that keeps the latest 20 tagged images", () => {
+    const app = new App();
+    const stack = new StaticSiteRepositoryStack(app, "TestStaticSiteRepositoryStackProd", {
+      stage: "prod",
+    });
+    const template = Template.fromStack(stack);
+
+    expect(template.toJSON()).toBeDefined();
+    template.hasResourceProperties("AWS::ECR::Repository", {
+      RepositoryName: "bfs-static-site-prod",
+      LifecyclePolicy: {
+        LifecyclePolicyText: Match.serializedJson(
+          Match.objectLike({
+            rules: Match.arrayWith([
+              Match.objectLike({
+                selection: Match.objectLike({
+                  tagStatus: "tagged",
+                  tagPatternList: ["*"],
+                  countType: "imageCountMoreThan",
+                  countNumber: 20,
+                }),
+              }),
+            ]),
+          }),
+        ),
+      },
+      Tags: Match.arrayWith([{ Key: "STAGE", Value: "prod" }]),
+    });
+  });
+});

--- a/api/cdk/test/staticSiteServiceStack.test.ts
+++ b/api/cdk/test/staticSiteServiceStack.test.ts
@@ -1,0 +1,203 @@
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import * as ecr from "aws-cdk-lib/aws-ecr";
+import { StaticSiteServiceStack } from "../lib/staticSiteServiceStack";
+
+const createStaticSiteTemplate = (stage: string): Template => {
+  const app = new App();
+  const repositoryStack = new Stack(app, `${stage}RepositoryStack`);
+  const repository = new ecr.Repository(repositoryStack, "StaticSiteRepository", {
+    repositoryName: `bfs-static-site-${stage}`,
+  });
+  const stack = new StaticSiteServiceStack(app, `${stage}StaticSiteServiceStack`, {
+    stage,
+    repository,
+    imageTag: "abc123",
+  });
+
+  return Template.fromStack(stack);
+};
+
+describe("StaticSiteServiceStack", () => {
+  const originalEnvironment = { ...process.env };
+
+  beforeEach(() => {
+    process.env.BASIC_AUTH_PASSWORD = "test-password";
+    process.env.BASIC_AUTH_USERNAME = "test-user";
+    process.env.VPC_ID = "vpc-1234567890abcdef0";
+    process.env.SUBNET_ID_01 = "subnet-11111111111111111";
+    process.env.SUBNET_ID_02 = "subnet-22222222222222222";
+    process.env.SG_ID = "sg-1234567890abcdef0";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnvironment };
+  });
+
+  test("creates an internal ALB-backed Fargate service for the static site", () => {
+    const template = createStaticSiteTemplate("dev");
+
+    expect(template.toJSON()).toBeDefined();
+    template.hasResourceProperties("AWS::ElasticLoadBalancingV2::LoadBalancer", {
+      Name: "bfs-static-site-dev-alb",
+      Scheme: "internal",
+      Type: "application",
+      LoadBalancerAttributes: Match.arrayWith([
+        { Key: "deletion_protection.enabled", Value: "true" },
+      ]),
+    });
+    template.hasResourceProperties("AWS::ElasticLoadBalancingV2::TargetGroup", {
+      Name: "bfs-static-site-dev-tg",
+      HealthCheckPath: "/healthz",
+      Matcher: { HttpCode: "200" },
+      Port: 80,
+      Protocol: "HTTP",
+      TargetType: "ip",
+    });
+    template.hasResourceProperties("AWS::ECS::TaskDefinition", {
+      Family: "bfs-static-site-dev",
+      Cpu: "512",
+      Memory: "1024",
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Name: "static-site",
+          Essential: true,
+          HealthCheck: Match.objectLike({
+            Command: Match.arrayWith(["CMD-SHELL", Match.stringLikeRegexp("/healthz")]),
+          }),
+          PortMappings: Match.arrayWith([
+            Match.objectLike({
+              ContainerPort: 3000,
+              HostPort: 3000,
+              Protocol: "tcp",
+            }),
+          ]),
+        }),
+      ]),
+    });
+    template.hasResourceProperties("AWS::ECS::Service", {
+      ServiceName: "bfs-static-site-dev",
+      DesiredCount: 1,
+      LaunchType: "FARGATE",
+      DeploymentConfiguration: Match.objectLike({
+        MaximumPercent: 200,
+        MinimumHealthyPercent: 0,
+      }),
+    });
+  });
+
+  test("injects Basic Auth runtime settings for protected static-site tasks", () => {
+    const template = createStaticSiteTemplate("dev");
+
+    expect(template.toJSON()).toBeDefined();
+    template.hasResourceProperties("AWS::ECS::TaskDefinition", {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Environment: Match.arrayWith([
+            { Name: "USE_BASIC_AUTH", Value: "true" },
+            { Name: "BASIC_AUTH_USERNAME", Value: "test-user" },
+            { Name: "BASIC_AUTH_PASSWORD", Value: "test-password" },
+          ]),
+        }),
+      ]),
+    });
+  });
+
+  test("requires Basic Auth credentials for protected static-site tasks", () => {
+    delete process.env.BASIC_AUTH_PASSWORD;
+
+    expect(() => createStaticSiteTemplate("dev")).toThrow(
+      "BASIC_AUTH_PASSWORD is required to deploy Basic Auth for the static-site ECS service.",
+    );
+  });
+
+  test("injects Basic Auth runtime settings for production static-site tasks", () => {
+    const template = createStaticSiteTemplate("prod");
+
+    expect(template.toJSON()).toBeDefined();
+    template.hasResourceProperties("AWS::ECS::TaskDefinition", {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Environment: Match.arrayWith([
+            { Name: "USE_BASIC_AUTH", Value: "true" },
+            { Name: "BASIC_AUTH_USERNAME", Value: "test-user" },
+            { Name: "BASIC_AUTH_PASSWORD", Value: "test-password" },
+          ]),
+        }),
+      ]),
+    });
+  });
+
+  test("creates a static-site log group with six-month retention", () => {
+    const template = createStaticSiteTemplate("dev");
+
+    expect(template.toJSON()).toBeDefined();
+    template.hasResourceProperties("AWS::Logs::LogGroup", {
+      LogGroupName: "/ecs/bfs-static-site/dev",
+      RetentionInDays: 180,
+      Tags: Match.arrayWith([{ Key: "STAGE", Value: "dev" }]),
+    });
+  });
+
+  test("creates CloudWatch alarms with expected thresholds and periods", () => {
+    const template = createStaticSiteTemplate("dev");
+
+    expect(template.toJSON()).toBeDefined();
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "dev-bfs-static-site-unhealthy-targets",
+      MetricName: "UnHealthyHostCount",
+      Namespace: "AWS/ApplicationELB",
+      Period: 300,
+      Statistic: "Average",
+      Threshold: 1,
+      TreatMissingData: "notBreaching",
+    });
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "dev-bfs-static-site-target-5xx",
+      MetricName: "HTTPCode_Target_5XX_Count",
+      Namespace: "AWS/ApplicationELB",
+      Period: 300,
+      Statistic: "Sum",
+      Threshold: 1,
+      TreatMissingData: "notBreaching",
+    });
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "dev-bfs-static-site-running-task-count",
+      MetricName: "RunningTaskCount",
+      Namespace: "ECS/ContainerInsights",
+      Period: 300,
+      Statistic: "Average",
+      Threshold: 1,
+      TreatMissingData: "breaching",
+    });
+    template.hasResourceProperties("AWS::Events::Rule", {
+      Name: "dev-bfs-static-site-deployment-failures",
+    });
+  });
+
+  test("exports the stage-specific hostname for Terraform and WAF origin wiring", () => {
+    const template = createStaticSiteTemplate("prod");
+
+    expect(template.toJSON()).toBeDefined();
+    template.hasOutput("StaticSiteHostname", {
+      Value: "next.business.nj.gov",
+      Export: {
+        Name: "bfs-static-site-prod-hostname",
+      },
+    });
+  });
+
+  test("creates an SNS topic and Chatbot subscription for static-site alerts", () => {
+    const template = createStaticSiteTemplate("dev");
+
+    expect(template.toJSON()).toBeDefined();
+    template.hasResourceProperties("AWS::SNS::Topic", {
+      TopicName: "bfs-static-site-errors-dev",
+      Tags: Match.arrayWith([{ Key: "STAGE", Value: "dev" }]),
+    });
+    template.hasResourceProperties("AWS::SNS::Subscription", {
+      Endpoint: "https://global.sns-api.chatbot.amazonaws.com",
+      Protocol: "https",
+    });
+  });
+});

--- a/packages/static-site/Dockerfile
+++ b/packages/static-site/Dockerfile
@@ -8,20 +8,34 @@ RUN corepack enable
 FROM base AS dependencies
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml ./
+COPY packages/content-types /content-types
+COPY packages/static-site/package.json packages/static-site/pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
 FROM base AS builder
 WORKDIR /app
 
+ARG NEXT_PUBLIC_WEB_BASE_URL
+
 COPY --from=dependencies /app/node_modules ./node_modules
-COPY . .
+COPY --from=dependencies /content-types /content-types
+COPY packages/static-site .
+COPY content/lib /content/lib
+COPY content/src /content/src
 
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_PUBLIC_WEB_BASE_URL=$NEXT_PUBLIC_WEB_BASE_URL
+RUN pnpm exec tsc --build /content-types/tsconfig.json
 RUN pnpm build
 
 FROM node:24-alpine AS runner
 WORKDIR /app
+
+LABEL org.opencontainers.image.title="Business.NJ.gov static site"
+LABEL org.opencontainers.image.description="Next.js static site for Business.NJ.gov"
+LABEL org.opencontainers.image.source="https://github.com/newjersey/navigator.business.nj.gov"
+LABEL org.opencontainers.image.vendor="New Jersey Innovation Authority"
+LABEL org.opencontainers.image.licenses="MIT"
 
 ENV HOSTNAME=0.0.0.0
 ENV NEXT_TELEMETRY_DISABLED=1
@@ -34,6 +48,7 @@ RUN adduser -S nextjs -G nodejs
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /content /content
 
 USER nextjs
 

--- a/packages/static-site/Dockerfile.dev
+++ b/packages/static-site/Dockerfile.dev
@@ -1,4 +1,10 @@
-FROM node:24-alpine
+FROM node:26-alpine
+
+LABEL org.opencontainers.image.title="Business.NJ.gov static site development"
+LABEL org.opencontainers.image.description="Development container for the Business.NJ.gov Next.js static site"
+LABEL org.opencontainers.image.source="https://github.com/newjersey/navigator.business.nj.gov"
+LABEL org.opencontainers.image.vendor="New Jersey Innovation Authority"
+LABEL org.opencontainers.image.licenses="MIT"
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
@@ -7,9 +13,15 @@ RUN corepack enable
 
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml ./
+COPY packages/content-types /content-types
+COPY packages/static-site/package.json packages/static-site/pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
+RUN pnpm exec tsc --build /content-types/tsconfig.json
 
-EXPOSE 3000
+COPY packages/static-site .
+COPY content/lib /content/lib
+COPY content/src /content/src
 
-CMD ["pnpm", "dev", "--hostname", "0.0.0.0", "--port", "3000"]
+EXPOSE 4000
+
+CMD ["pnpm", "dev", "--hostname", "0.0.0.0", "--port", "4000"]

--- a/packages/static-site/README.md
+++ b/packages/static-site/README.md
@@ -87,13 +87,18 @@ pnpm test:accessibility
 
 ## Docker
 
-Run from `packages/static-site`.
+Build the production image from the repository root so Docker can include the
+static-site package, generated content, and content type package.
 
 ```bash
 # Production image (Next.js standalone output)
-docker build -f Dockerfile -t static-site:prod .
+docker build -f packages/static-site/Dockerfile -t static-site:prod .
 docker run --rm -p 3000:3000 static-site:prod
+```
 
+Run local development containers from `packages/static-site`.
+
+```bash
 # Local dev with hot reload
 docker compose up --build
 ```
@@ -104,15 +109,17 @@ This package includes two deployment targets.
 
 - ECS/Fargate via ECR + GitHub Actions:
   - CI workflow: `.github/workflows/static-site-ci.yml`
-  - Deploy workflow: `.github/workflows/static-site-deploy-ecs.yml`
-  - Task definition template: `packages/static-site/deploy/ecs-task-definition.json`
+  - Deploy action: `.github/actions/deploy-static-site/action.yml`
+  - Infrastructure: `api/cdk/lib/staticSiteRepositoryStack.ts` and
+    `api/cdk/lib/staticSiteServiceStack.ts`
 - AWS Amplify:
   - Build config: `amplify.yml` at repository root
 
-ECS deploy workflow uses the existing AWS credential secret pattern and static-site-specific
-resource variables (`STATIC_SITE_*`). Set `STATIC_SITE_ECS_ENABLED=true` in repository variables to
-enable automatic deploys on `main`. Replace the placeholder role ARNs in
-`packages/static-site/deploy/ecs-task-definition.json` before first deployment.
+Static-site ECS deploys run from the existing environment deployment workflows. Non-production
+images are tagged with the Git SHA. Production images are tagged with the root `package.json`
+version. Pre-launch ECS deployments enable HTTP Basic Auth from the repository-level
+`BASIC_AUTH_USERNAME` variable and `BASIC_AUTH_PASSWORD` secret. Local runs leave Basic Auth
+disabled by default.
 
 ## Contributing
 

--- a/packages/static-site/app/[locale]/layout.tsx
+++ b/packages/static-site/app/[locale]/layout.tsx
@@ -23,7 +23,7 @@ import { getApplicationMessages } from "@/domain/i18n/messages";
 /**
  * Stores the logo path used in metadata icons and social previews.
  */
-const NJ_LOGO_IMAGE_PATH = "/vendor/img/nj-logo-gray-20.png";
+const NJ_LOGO_IMAGE_PATH = "/assets/njwds/dist/img/nj-logo-gray-20.png";
 
 /**
  * Stores the canonical production URL for metadata URL resolution.

--- a/packages/static-site/app/healthz/route.ts
+++ b/packages/static-site/app/healthz/route.ts
@@ -1,0 +1,9 @@
+/** Return a lightweight health response for load balancers and container health checks. */
+export const GET = (): Response => {
+  return new Response("OK", {
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+    },
+    status: 200,
+  });
+};

--- a/packages/static-site/app/proxy.test.ts
+++ b/packages/static-site/app/proxy.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+
+import { isBasicAuthAuthorized } from "@/proxyAuth";
+
+const createBasicAuthorizationHeader = (username: string, password: string): string => {
+  return `Basic ${btoa(`${username}:${password}`)}`;
+};
+
+describe("static site proxy Basic Auth", () => {
+  test("authorizes a request when Basic Auth credentials match", () => {
+    const isAuthorized = isBasicAuthAuthorized({
+      authorizationHeader: createBasicAuthorizationHeader("businessuser", "secret"),
+      credentials: {
+        username: "businessuser",
+        password: "secret",
+      },
+    });
+
+    expect(isAuthorized).toBe(true);
+  });
+
+  test("rejects a request when Basic Auth credentials do not match", () => {
+    const isAuthorized = isBasicAuthAuthorized({
+      authorizationHeader: createBasicAuthorizationHeader("businessuser", "wrong"),
+      credentials: {
+        username: "businessuser",
+        password: "secret",
+      },
+    });
+
+    expect(isAuthorized).toBe(false);
+  });
+
+  test("rejects a request when the authorization header is missing", () => {
+    const isAuthorized = isBasicAuthAuthorized({
+      authorizationHeader: null,
+      credentials: {
+        username: "businessuser",
+        password: "secret",
+      },
+    });
+
+    expect(isAuthorized).toBe(false);
+  });
+});

--- a/packages/static-site/components/landing/GovBanner.tsx
+++ b/packages/static-site/components/landing/GovBanner.tsx
@@ -11,6 +11,11 @@ import type { LayoutBannerContent } from "@/domain/content/messageTypes";
 import { LocalizedLink } from "./LocalizedLink";
 
 /**
+ * Public path for the synced NJWDS SVG sprite.
+ */
+const NJWDS_SPRITE_PATH = "/assets/njwds/dist/img/sprite.svg";
+
+/**
  * Describes the props used to render the government banner.
  *
  * Keep banner content typed so all required links and labels are present
@@ -64,7 +69,7 @@ export const GovBanner = ({ content }: GovBannerProps) => {
                     className="usa-icon usa-icon--size-3 nj-banner__mail-icon margin-right-05"
                     focusable="false"
                   >
-                    <use xlinkHref="/vendor/img/sprite.svg#mail" />
+                    <use xlinkHref={`${NJWDS_SPRITE_PATH}#mail`} />
                   </svg>
                   {content.updatesLink.label}
                 </LocalizedLink>

--- a/packages/static-site/components/landing/GraphicListSection.tsx
+++ b/packages/static-site/components/landing/GraphicListSection.tsx
@@ -20,6 +20,11 @@ import type {
 const GRAPHIC_LIST_ROW_SIZE = 2;
 
 /**
+ * Public path for the synced NJWDS graphic-list image.
+ */
+const GRAPHIC_LIST_IMAGE_PATH = "/assets/njwds/dist/img/circle-124.png";
+
+/**
  * Describes props used by the graphic-list section component.
  *
  * This type defines a stable shape for related data.
@@ -105,7 +110,7 @@ const renderGraphicListItem = ({ item, itemIndex }: RenderGraphicListItemParams)
         alt={item.imageAlt}
         className="usa-media-block__img"
         height={124}
-        src="/vendor/img/circle-124.png"
+        src={GRAPHIC_LIST_IMAGE_PATH}
         width={124}
       />
       <div className="usa-media-block__body">

--- a/packages/static-site/components/landing/IdentifierSection.tsx
+++ b/packages/static-site/components/landing/IdentifierSection.tsx
@@ -14,6 +14,11 @@ import type {
 import { LocalizedLink } from "./LocalizedLink";
 
 /**
+ * Public path for the synced NJWDS New Jersey logo image.
+ */
+const NJ_LOGO_IMAGE_PATH = "/assets/njwds/dist/img/nj-logo-gray-20.png";
+
+/**
  * Describes props used by the identifier section component.
  *
  * The content payload includes all labels, links, and alt text needed by the
@@ -81,7 +86,7 @@ export const IdentifierSection = ({ content }: IdentifierSectionProps) => {
                 alt={content.stateLogoAlt}
                 className="usa-identifier__logo-img"
                 height={20}
-                src="/vendor/img/nj-logo-gray-20.png"
+                src={NJ_LOGO_IMAGE_PATH}
                 unoptimized
                 width={20}
               />

--- a/packages/static-site/components/landing/SiteFooter.tsx
+++ b/packages/static-site/components/landing/SiteFooter.tsx
@@ -15,6 +15,11 @@ import type {
 import { LocalizedLink } from "./LocalizedLink";
 
 /**
+ * Public path for the synced NJWDS footer logo image.
+ */
+const FOOTER_LOGO_IMAGE_PATH = "/assets/njwds/dist/img/logo-img.png";
+
+/**
  * Describes props used by the site footer component.
  *
  * This type defines a stable shape for related data.
@@ -139,7 +144,7 @@ export const SiteFooter = ({ content, mainContentId }: SiteFooterProps) => {
                   alt={content.agencyLogoAlt}
                   className="usa-footer__logo-img"
                   height={80}
-                  src="/vendor/img/logo-img.png"
+                  src={FOOTER_LOGO_IMAGE_PATH}
                   unoptimized
                   width={80}
                 />

--- a/packages/static-site/deploy/ecs-task-definition.json
+++ b/packages/static-site/deploy/ecs-task-definition.json
@@ -30,6 +30,10 @@
         {
           "name": "PORT",
           "value": "3000"
+        },
+        {
+          "name": "USE_BASIC_AUTH",
+          "value": "false"
         }
       ]
     }

--- a/packages/static-site/docker-compose.yml
+++ b/packages/static-site/docker-compose.yml
@@ -1,8 +1,10 @@
 services:
   static-site:
     build:
-      context: .
-      dockerfile: Dockerfile.dev
+      context: ../..
+      dockerfile: packages/static-site/Dockerfile.dev
+    container_name: static-site
+    image: businessnjgovnavigator-static-site:dev
     command: pnpm dev --hostname 0.0.0.0 --port 3000
     environment:
       CHOKIDAR_USEPOLLING: "true"
@@ -10,11 +12,28 @@ services:
       WATCHPACK_POLLING: "true"
     ports:
       - "3000:3000"
+    networks:
+      - static_site_network
+    tmpfs:
+      - /tmp
     volumes:
-      - ./:/app
-      - static_site_node_modules:/app/node_modules
+      - ./app:/app/app
+      - ./components:/app/components
+      - ./domain:/app/domain
+      - ./messages:/app/messages
+      - ./public:/app/public
+      - ./scripts:/app/scripts
+      - ./next.config.ts:/app/next.config.ts
+      - ./proxy.ts:/app/proxy.ts
+      - ./proxyAuth.ts:/app/proxyAuth.ts
+      - ./tsconfig.json:/app/tsconfig.json
+      - ../../content:/content
       - static_site_next:/app/.next
+
+networks:
+  static_site_network:
+    name: static-site-network
 
 volumes:
   static_site_next:
-  static_site_node_modules:
+    name: static-site-next

--- a/packages/static-site/domain/content/loadContent.ts
+++ b/packages/static-site/domain/content/loadContent.ts
@@ -18,9 +18,52 @@ import type {
   Task,
 } from "./types";
 
-const CONTENT_LIB_DIR = path.resolve(process.cwd(), "../../content/lib");
+/**
+ * Possible content roots for package scripts and the Next standalone server.
+ */
+const CONTENT_ROOT_DIRECTORY_CANDIDATES = [
+  path.resolve(process.cwd(), "../../content"),
+  path.resolve(process.cwd(), "../../../../content"),
+] as const;
 
-const CONTENT_SRC_DIR = path.resolve(process.cwd(), "../../content/src");
+/**
+ * Checks whether a resolved content directory is present on disk.
+ */
+const isExistingDirectory = (directoryPath: string): boolean => {
+  return fs.existsSync(directoryPath);
+};
+
+/**
+ * Resolves the repository content package root for the current runtime layout.
+ */
+const resolveContentRootDirectory = (): string => {
+  const contentRootDirectory = CONTENT_ROOT_DIRECTORY_CANDIDATES.find(isExistingDirectory);
+
+  if (!contentRootDirectory) {
+    throw new Error(
+      `Unable to locate the content package. Checked: ${CONTENT_ROOT_DIRECTORY_CANDIDATES.join(
+        ", ",
+      )}.`,
+    );
+  }
+
+  return contentRootDirectory;
+};
+
+/**
+ * Root directory of the repository content package.
+ */
+const CONTENT_ROOT_DIR = resolveContentRootDirectory();
+
+/**
+ * Built content JSON emitted by the repository content package.
+ */
+const CONTENT_LIB_DIR = path.join(CONTENT_ROOT_DIR, "lib");
+
+/**
+ * Source content managed by the repository content package.
+ */
+const CONTENT_SRC_DIR = path.join(CONTENT_ROOT_DIR, "src");
 
 const readContentJson = (filename: string): unknown => {
   const filePath = path.join(CONTENT_LIB_DIR, filename);

--- a/packages/static-site/messages/en-US.json
+++ b/packages/static-site/messages/en-US.json
@@ -135,7 +135,7 @@
             "opensInNewTab": true
           },
           "iconAlt": "GitHub",
-          "iconPath": "/vendor/img/usa-icons/github.svg"
+          "iconPath": "/assets/njwds/dist/img/usa-icons/github.svg"
         },
         {
           "modifier": "facebook",
@@ -146,7 +146,7 @@
             "opensInNewTab": true
           },
           "iconAlt": "Facebook",
-          "iconPath": "/vendor/img/usa-icons/facebook.svg"
+          "iconPath": "/assets/njwds/dist/img/usa-icons/facebook.svg"
         },
         {
           "modifier": "youtube",
@@ -157,7 +157,7 @@
             "opensInNewTab": true
           },
           "iconAlt": "YouTube",
-          "iconPath": "/vendor/img/usa-icons/youtube.svg"
+          "iconPath": "/assets/njwds/dist/img/usa-icons/youtube.svg"
         }
       ],
       "contactHeading": "Business.NJ.gov Contact Center",

--- a/packages/static-site/messages/es-US.json
+++ b/packages/static-site/messages/es-US.json
@@ -135,7 +135,7 @@
             "opensInNewTab": true
           },
           "iconAlt": "GitHub",
-          "iconPath": "/vendor/img/usa-icons/github.svg"
+          "iconPath": "/assets/njwds/dist/img/usa-icons/github.svg"
         },
         {
           "modifier": "facebook",
@@ -146,7 +146,7 @@
             "opensInNewTab": true
           },
           "iconAlt": "Facebook",
-          "iconPath": "/vendor/img/usa-icons/facebook.svg"
+          "iconPath": "/assets/njwds/dist/img/usa-icons/facebook.svg"
         },
         {
           "modifier": "youtube",
@@ -157,7 +157,7 @@
             "opensInNewTab": true
           },
           "iconAlt": "YouTube",
-          "iconPath": "/vendor/img/usa-icons/youtube.svg"
+          "iconPath": "/assets/njwds/dist/img/usa-icons/youtube.svg"
         }
       ],
       "contactHeading": "Centro de contacto de Business.NJ.gov",

--- a/packages/static-site/proxy.ts
+++ b/packages/static-site/proxy.ts
@@ -5,17 +5,90 @@
  * assets and API paths.
  */
 
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import createMiddleware from "next-intl/middleware";
 
 import { routing } from "@/domain/i18n/routing";
+import { type BasicAuthCredentials, isBasicAuthAuthorized } from "@/proxyAuth";
+
+/**
+ * Authentication realm shown by browsers when a protected deployment asks for static-site
+ * credentials.
+ */
+const BASIC_AUTH_REALM = "Business.NJ.gov";
 
 /**
  * Creates locale middleware for page requests.
- *
- * This module wires `next-intl` middleware into the app so locale-prefixed
- * routes resolve correctly.
  */
-const proxy = createMiddleware(routing);
+const localeProxy = createMiddleware(routing);
+
+/**
+ * Reads runtime environment values supplied by ECS.
+ */
+const getRuntimeEnvironmentValue = (name: string): string | undefined => {
+  // biome-ignore lint/style/noProcessEnv: ECS injects Basic Auth deployment settings at runtime.
+  return process.env[name];
+};
+
+/**
+ * Indicates whether Basic Auth should guard the current deployment.
+ */
+const isBasicAuthEnabled = (): boolean => {
+  return getRuntimeEnvironmentValue("USE_BASIC_AUTH") === "true";
+};
+
+/**
+ * Reads configured Basic Auth credentials for the current deployment.
+ */
+const getBasicAuthCredentials = (): BasicAuthCredentials | undefined => {
+  const username = getRuntimeEnvironmentValue("BASIC_AUTH_USERNAME");
+  const password = getRuntimeEnvironmentValue("BASIC_AUTH_PASSWORD");
+
+  if (!username || !password) {
+    return undefined;
+  }
+
+  return { username, password };
+};
+
+/**
+ * Creates the browser challenge response for missing or invalid Basic Auth credentials.
+ */
+const createUnauthorizedResponse = (): NextResponse => {
+  return new NextResponse("Authentication required.", {
+    status: 401,
+    headers: {
+      "WWW-Authenticate": `Basic realm="${BASIC_AUTH_REALM}"`,
+    },
+  });
+};
+
+/**
+ * Applies Basic Auth for protected deployments before locale routing.
+ */
+const proxy = (request: NextRequest): NextResponse => {
+  if (!isBasicAuthEnabled()) {
+    return localeProxy(request);
+  }
+
+  const credentials = getBasicAuthCredentials();
+
+  if (!credentials) {
+    return createUnauthorizedResponse();
+  }
+
+  const isAuthorized = isBasicAuthAuthorized({
+    authorizationHeader: request.headers.get("authorization"),
+    credentials,
+  });
+
+  if (!isAuthorized) {
+    return createUnauthorizedResponse();
+  }
+
+  return localeProxy(request);
+};
 
 /**
  * Exports the locale middleware for Next.js route handling.
@@ -25,8 +98,8 @@ export default proxy;
 /**
  * Declares which routes should pass through locale middleware.
  *
- * The matcher excludes API routes, framework assets, and file requests.
+ * The matcher excludes API routes, health checks, framework assets, and file requests.
  */
 export const config = {
-  matcher: ["/((?!api|_next|_vercel|.*\\..*).*)"],
+  matcher: ["/((?!api|healthz|_next|_vercel|.*\\..*).*)"],
 };

--- a/packages/static-site/proxyAuth.ts
+++ b/packages/static-site/proxyAuth.ts
@@ -1,0 +1,82 @@
+/**
+ * Header prefix used by HTTP Basic auth credentials.
+ *
+ * Basic auth is intentionally a deployment-only guard for protected environments, so a simple
+ * standard header check is enough here.
+ */
+const BASIC_AUTH_HEADER_PREFIX = "Basic ";
+
+/** Credentials used to authorize a Basic Auth request. */
+export interface BasicAuthCredentials {
+  /** Username expected in the Basic Auth header. This value is required when Basic Auth is enabled. */
+  readonly username: string;
+
+  /** Password expected in the Basic Auth header. This value is required when Basic Auth is enabled. */
+  readonly password: string;
+}
+
+/** Inputs for checking whether a request satisfies Basic Auth. */
+export interface IsBasicAuthAuthorizedProps {
+  /** Value of the request `Authorization` header. Pass `null` when the header is absent. */
+  readonly authorizationHeader: string | null;
+
+  /** Credentials the request must match to be authorized. */
+  readonly credentials: BasicAuthCredentials;
+}
+
+/**
+ * Result of decoding the Basic Auth header payload.
+ */
+type BasicAuthDecodeResult =
+  | {
+      readonly type: "valid";
+      readonly credentials: BasicAuthCredentials;
+    }
+  | {
+      readonly type: "invalid";
+    };
+
+/**
+ * Decodes a Basic Auth credential payload.
+ */
+const decodeBasicAuthPayload = (payload: string): BasicAuthDecodeResult => {
+  try {
+    const decodedPayload = atob(payload);
+    const separatorIndex = decodedPayload.indexOf(":");
+
+    if (separatorIndex < 0) {
+      return { type: "invalid" };
+    }
+
+    return {
+      type: "valid",
+      credentials: {
+        username: decodedPayload.slice(0, separatorIndex),
+        password: decodedPayload.slice(separatorIndex + 1),
+      },
+    };
+  } catch {
+    return { type: "invalid" };
+  }
+};
+
+/**
+ * Checks whether a request's Basic Auth header matches the configured credentials.
+ */
+export const isBasicAuthAuthorized = (props: IsBasicAuthAuthorizedProps): boolean => {
+  if (!props.authorizationHeader?.startsWith(BASIC_AUTH_HEADER_PREFIX)) {
+    return false;
+  }
+
+  const payload = props.authorizationHeader.slice(BASIC_AUTH_HEADER_PREFIX.length);
+  const decodeResult = decodeBasicAuthPayload(payload);
+
+  if (decodeResult.type === "invalid") {
+    return false;
+  }
+
+  return (
+    decodeResult.credentials.username === props.credentials.username &&
+    decodeResult.credentials.password === props.credentials.password
+  );
+};

--- a/packages/static-site/scripts/syncNjwdsAssets.ts
+++ b/packages/static-site/scripts/syncNjwdsAssets.ts
@@ -183,6 +183,34 @@ const REQUIRED_NJWDS_ASSETS: readonly RequiredNjwdsAsset[] = [
     relativePath: "js/uswds.min.js",
     description: "NJWDS runtime script",
   },
+  {
+    relativePath: "img/circle-124.png",
+    description: "NJWDS graphic-list image",
+  },
+  {
+    relativePath: "img/logo-img.png",
+    description: "NJWDS footer logo image",
+  },
+  {
+    relativePath: "img/nj-logo-gray-20.png",
+    description: "NJWDS New Jersey logo image",
+  },
+  {
+    relativePath: "img/sprite.svg",
+    description: "NJWDS icon sprite",
+  },
+  {
+    relativePath: "img/usa-icons/facebook.svg",
+    description: "NJWDS Facebook icon",
+  },
+  {
+    relativePath: "img/usa-icons/github.svg",
+    description: "NJWDS GitHub icon",
+  },
+  {
+    relativePath: "img/usa-icons/youtube.svg",
+    description: "NJWDS YouTube icon",
+  },
 ];
 
 /**


### PR DESCRIPTION
## Description

Prepares the new static site for deployment to ECS so that the team can run acceptance testing against live environments and enable continuous deployment for engineers going forward.

The near-term deployment target is an internal ALB in the configured project VPC for each environment. In Innov-Dev, that means `bfs-dev-vpc`, which we treat as the default project VPC even though AWS does not mark it as the account's EC2 default VPC. Those internal ALBs can then be used as origins by the external ALB in the separate edge account and placed behind WAF for dev, content, testing, staging, and prod.

Images are pushed to the stage's owning AWS account:

- Innov-Dev: `dev`, `content`, and `testing`
- Innov-Staging: `staging`
- Innov-Prod: `prod`

### Ticket

This pull request resolves [#17622](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17622).

### Approach

Adds a reusable `deploy-static-site` GitHub Actions composite action that builds the Next.js standalone container, pushes it to the stage-specific ECR repository, and deploys the ECS Fargate service via CDK. The action is wired into the existing deployment paths:

- `dev` deploys from new commits to `main`
- `content` deploys from new commits to `content-repo`
- `testing` deploys from new commits to `testing-repo`
- `staging` deploys through the staging deployment process
- `prod` deploys through the release pipeline, using the release version as the image tag

#### GitHub Actions Deployment Flow

```mermaid
flowchart TD
  main["Push to main"] --> dev["Deploy Dev Environment"]
  content["Push to content-repo"] --> contentDeploy["Deploy Content Environment"]
  testing["Push to testing-repo"] --> testingDeploy["Deploy Testing Environment"]
  staging["Staging deploy process"] --> stagingDeploy["Deploy Staging Environment"]
  release["Release pipeline"] --> prodDeploy["Deploy Production"]

  dev --> sharedDeploy["Existing deploy action updates bfs-navigator"]
  contentDeploy --> sharedDeployContent["Existing deploy action updates bfs-navigator-content"]
  testingDeploy --> sharedDeployTesting["Existing deploy action updates bfs-navigator-testing"]
  stagingDeploy --> sharedDeploy
  prodDeploy --> sharedDeploy

  sharedDeploy --> staticAction["deploy-static-site composite action"]
  sharedDeployContent --> staticAction
  sharedDeployTesting --> staticAction

  staticAction --> staticMode["Set STATIC_SITE_ONLY_DEPLOY=true"]
  staticMode --> repositoryStack["CDK deploy StaticSiteRepositoryStack-STAGE"]
  repositoryStack --> dockerLogin["Log in to stage ECR registry"]
  dockerLogin --> dockerBuild["Build packages/static-site Docker image"]
  dockerBuild --> dockerPush["Push bfs-static-site-STAGE:IMAGE_TAG"]
  dockerPush --> imageTag["Export STATIC_SITE_IMAGE_TAG"]
  imageTag --> serviceStack["CDK deploy StaticSiteServiceStack-STAGE"]
  serviceStack --> ecs["ECS service rolls to task definition using new ECR image"]
```

#### Static Site Deployment Architecture

```mermaid
flowchart LR
  user["Browser request to next hostname"] --> edgeWaf["WAF"]
  edgeWaf --> externalAlb["External ALB in edge account"]
  externalAlb --> internalAlb["Internal ALB in environment account"]

  subgraph envAccount["Environment AWS account"]
    internalAlb --> targetGroup["ALB target group"]
    targetGroup --> ecsService["ECS Fargate service"]
    ecsService --> task["Static-site task"]
    task --> container["Next.js standalone container on port 3000"]
    ecr["Stage-specific ECR repository"] --> task
    container --> content["Bundled content package"]
    container --> healthz["/healthz route"]
    ecsService --> logs["CloudWatch logs and alarms"]
  end

  subgraph stages["Stage ownership"]
    devStages["Innov-Dev: dev, content, testing"]
    stagingStage["Innov-Staging: staging"]
    prodStage["Innov-Prod: prod"]
  end

  outputs["CloudFormation outputs: hostname, internal ALB DNS, target group, cluster, service"] --> externalAlb
```

Also:

- Adds CDK stacks for the static-site ECR repository, ECS Fargate service, task definition, internal ALB, monitoring, and CloudFormation outputs consumed by DNS/WAF/origin wiring
- Adds ECR lifecycle rules so old static-site images are pruned automatically while repositories are retained
- Replaces environment-variable-driven content path discovery in `loadContent.ts` with filesystem-based resolution that works in both local and standalone Next.js server layouts
- Adds Basic Auth middleware (`proxyAuth.ts` / `proxy.ts`) for guarding non-production deployed environments, with a `/healthz` exclusion in the route matcher
- Refactors `docker-compose.yml` to use granular volume mounts matching the Dockerfile build context and a named network
- Adds missing NJWDS image/icon assets to `syncNjwdsAssets.ts` and corrects icon paths in locale message files
- Adds a health check route at `app/healthz/route.ts`
- Cleans up `static-site-deploy-ecs.yml` to be a manual-only workflow now that deployment is handled by the shared action

### Steps to Test

1. Trigger the dev deploy workflow and confirm the `Deploy Static Site` step succeeds.
2. Confirm the ECR repository exists for the stage and the workflow-pushed image tag is present.
3. Confirm the ECS service updates to a task definition using the new static-site ECR image.
4. Visit the deployed dev URL; confirm Basic Auth prompts with correct credentials accepted and invalid credentials rejected.
5. Hit `/healthz`; it should return `200` without triggering Basic Auth.
6. Confirm social icons (GitHub, Facebook, YouTube) render correctly in the footer.

### Notes

Content path resolution now probes two candidate directories (`../../content` and `../../../../content`) so the same build artifact works in both the dev workspace layout and the Next.js standalone server output directory.

Local self-review verification included CDK synths for the repository and service stacks, targeted CDK tests, static-site proxy tests, a production Docker image build, and container smoke checks for `/healthz`, locale redirect behavior, and Basic Auth behavior.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
