### PR TITLE
feat: [AB#17525] transfer bucket ownership to CDK

### DIFF
--- a/.github/actions/deploy-cdk/action.yml
+++ b/.github/actions/deploy-cdk/action.yml
@@ -20,6 +20,17 @@ runs:
           --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess || \
           echo "Bootstrap already completed or not required."
 
+    - name: Import StorageStack resources in CDK
+      shell: bash
+      run: |
+        echo "Importing StorageStack resources for stage: $STAGE"
+        yarn workspace @businessnjgovnavigator/api-cdk cdk deploy StorageStack-${{ env.STAGE }} \
+          --import-existing-resources \
+          --qualifier biz-nj \
+          --verbose \
+          --region us-east-1 \
+          --require-approval never
+
     - name: Import IAM resources in CDK IamStack
       shell: bash
       run: |

--- a/api/cdk/bin/app.ts
+++ b/api/cdk/bin/app.ts
@@ -1,6 +1,5 @@
 import * as cdk from "aws-cdk-lib";
 import * as dotenv from "dotenv";
-import * as iam from "aws-cdk-lib/aws-iam";
 import { ApiStack } from "../lib/apiStack";
 import { DataStack } from "../lib/dataStack";
 import { IamStack } from "../lib/iamStack";
@@ -70,16 +69,9 @@ if (isMyAccountDeploy) {
     env,
   });
 
-  const taxKMSRole = iam.Role.fromRoleName(
-    iamStack,
-    "TaxKMSRole",
-    "iamRoleForTaxIdEncryptionAndHashing",
-  );
-
   new EncryptionStack(app, `EncryptionStack-${stage}`, {
     stage,
     env,
-    taxKMSRole,
   });
 
   const monitoringStack = new MonitoringStack(app, `MonitoringStack-${stage}`, {

--- a/api/cdk/lib/encryptionStack.ts
+++ b/api/cdk/lib/encryptionStack.ts
@@ -4,7 +4,6 @@ import * as kms from "aws-cdk-lib/aws-kms";
 import * as iam from "aws-cdk-lib/aws-iam";
 
 export interface EncryptionStackProps extends StackProps {
-  taxKMSRole: iam.IRole;
   stage: string;
 }
 
@@ -15,6 +14,12 @@ export class EncryptionStack extends Stack {
   constructor(scope: Construct, id: string, props: EncryptionStackProps) {
     super(scope, id, props);
 
+    const taxKMSRole = iam.Role.fromRoleArn(
+      this,
+      "TaxKMSRole",
+      `arn:aws:iam::${this.account}:role/iamRoleForTaxIdEncryptionAndHashing`,
+    );
+
     this.taxIdHashingKey = new kms.Key(this, "TaxIdHashingKey", {
       description: `Tax Id Hashing Key for ${props.stage}`,
       enableKeyRotation: true,
@@ -23,8 +28,8 @@ export class EncryptionStack extends Stack {
 
     this.taxIdHashingKey.addAlias(`alias/${props.stage}/HashingTaxId`);
 
-    this.taxIdHashingKey.grantEncryptDecrypt(props.taxKMSRole);
-    this.taxIdHashingKey.grant(props.taxKMSRole, "kms:GenerateDataKey*");
+    this.taxIdHashingKey.grantEncryptDecrypt(taxKMSRole);
+    this.taxIdHashingKey.grant(taxKMSRole, "kms:GenerateDataKey*");
 
     this.taxIdEncryptionKey = new kms.Key(this, "TaxIdEncryptionKey", {
       description: `Tax Id Encryption Key for ${props.stage}`,
@@ -34,7 +39,7 @@ export class EncryptionStack extends Stack {
 
     this.taxIdEncryptionKey.addAlias(`alias/${props.stage}/EncryptionTaxId`);
 
-    this.taxIdEncryptionKey.grantEncryptDecrypt(props.taxKMSRole);
-    this.taxIdEncryptionKey.grant(props.taxKMSRole, "kms:GenerateDataKey*");
+    this.taxIdEncryptionKey.grantEncryptDecrypt(taxKMSRole);
+    this.taxIdEncryptionKey.grant(taxKMSRole, "kms:GenerateDataKey*");
   }
 }

--- a/api/cdk/lib/storageStack.ts
+++ b/api/cdk/lib/storageStack.ts
@@ -1,5 +1,6 @@
 import { RemovalPolicy, Stack, StackProps } from "aws-cdk-lib";
 import * as s3 from "aws-cdk-lib/aws-s3";
+import * as iam from "aws-cdk-lib/aws-iam";
 import { Construct } from "constructs";
 import { DEV_STAGE, LOWER_STAGES } from "./constants";
 
@@ -10,12 +11,62 @@ export interface StorageStackProps extends StackProps {
 export class StorageStack extends Stack {
   public readonly messagesBucket: s3.Bucket;
   public readonly intercomMacrosBucket?: s3.Bucket;
+  public readonly userDocumentsBucket: s3.Bucket;
+  public readonly userDocumentsLocalBucket?: s3.Bucket;
 
   constructor(scope: Construct, id: string, props: StorageStackProps) {
     super(scope, id, props);
 
     const isLowerEnv = LOWER_STAGES.includes(props.stage);
     const removalPolicy = isLowerEnv ? RemovalPolicy.DESTROY : RemovalPolicy.RETAIN;
+    const cognitoPrefix = "${cognito-identity.amazonaws.com:sub}"; // eslint-disable-line no-useless-escape
+
+    const authRole = iam.Role.fromRoleArn(
+      this,
+      "CognitoAuthRole",
+      `arn:aws:iam::${this.account}:role/navigator_authRole`,
+    );
+
+    const unauthRole = iam.Role.fromRoleArn(
+      this,
+      "CognitoUnauthRole",
+      `arn:aws:iam::${this.account}:role/navigator_unauthRole`,
+    );
+
+    this.userDocumentsBucket = new s3.Bucket(this, "UserDocumentsBucket", {
+      bucketName: `nj-bfs-user-documents-${props.stage}`,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: RemovalPolicy.RETAIN,
+      autoDeleteObjects: false,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      versioned: false,
+    });
+
+    this.userDocumentsBucket.addToResourcePolicy(
+      new iam.PolicyStatement({
+        sid: "ListYourObjects",
+        principals: [authRole, unauthRole],
+        actions: ["s3:ListBucket"],
+        resources: [this.userDocumentsBucket.bucketArn],
+        conditions: {
+          StringLike: {
+            "s3:prefix": [cognitoPrefix, `${cognitoPrefix}/*`],
+          },
+        },
+      }),
+    );
+
+    this.userDocumentsBucket.addToResourcePolicy(
+      new iam.PolicyStatement({
+        sid: "ReadDeleteYourObjects",
+        principals: [authRole, unauthRole],
+        actions: ["s3:GetObject", "s3:DeleteObject"],
+        resources: [
+          `${this.userDocumentsBucket.bucketArn}/${cognitoPrefix}`,
+          `${this.userDocumentsBucket.bucketArn}/${cognitoPrefix}/*`,
+        ],
+      }),
+    );
 
     this.messagesBucket = new s3.Bucket(this, "UserMessagesBucket", {
       bucketName: `nj-bfs-user-messages-${props.stage}`,
@@ -33,6 +84,13 @@ export class StorageStack extends Stack {
         autoDeleteObjects: false,
         encryption: s3.BucketEncryption.S3_MANAGED,
         versioned: false,
+      });
+
+      this.userDocumentsLocalBucket = new s3.Bucket(this, "UserDocumentsLocalBucket", {
+        bucketName: "nj-bfs-user-documents-local",
+        blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+        removalPolicy: RemovalPolicy.RETAIN,
+        encryption: s3.BucketEncryption.S3_MANAGED,
       });
     }
   }


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

This PR transfers ownership and policy management of the relevant S3 bucket(s) to CDK and updates the bucket access model to align with Cognito-based roles instead of allowing access via AnyPrincipal().

<!-- Summary of the changes, related issue, relevant motivation, and context -->
1. Bucket Ownership Moved to CDK:  The bucket configuration is now fully managed in CDK, ensuring:
- Infrastructure is defined as code
- Policies are versioned and auditable
- Environment parity across dev/content/testing/staging/prod
- No drift between Terraform version and CDK

2. Updated the Bucket Policy To Use Cognito Roles: The previous policy was effectively open to AnyPrincipal (*) and relied entirely on conditions (Cognito identity prefix) to restrict access. The new policy explicitly grants access to the two roles  
   - `navigator_authRole`
   - `navigator_unauthRole`
This removes reliance on AnyPrincipal and scopes permissions to known IAM roles.
3. This improves the security as it replaced the broadly scoped principal with explicity role based access
   - Maintains Cognito sub-based object isolation.
   - Aligns with least-privilege principles.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#17525](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17525).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [X] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
