### PR TITLE
feat: [#17711] add learn page with sidebar nav

### DIFF
--- a/packages/static-site/app/[locale]/layout.tsx
+++ b/packages/static-site/app/[locale]/layout.tsx
@@ -12,6 +12,11 @@ import { notFound } from "next/navigation";
 import Script from "next/script";
 import { NextIntlClientProvider } from "next-intl";
 import type { ReactNode } from "react";
+import { GovBanner } from "@/components/landing/GovBanner";
+import { IdentifierSection } from "@/components/landing/IdentifierSection";
+import { SiteFooter } from "@/components/landing/SiteFooter";
+import { SiteHeader } from "@/components/landing/SiteHeader";
+import { SkipNav } from "@/components/landing/SkipNav";
 import { APP_LOCALES, hasAppLocale } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
 
@@ -159,7 +164,7 @@ const LocaleLayout = async ({ children, params }: LocaleLayoutProps) => {
     notFound();
   }
 
-  const applicationMessages = getApplicationMessages({ locale });
+  const messages = getApplicationMessages({ locale });
 
   return (
     <html lang={locale}>
@@ -167,8 +172,19 @@ const LocaleLayout = async ({ children, params }: LocaleLayoutProps) => {
         <link href={NJWDS_STYLESHEET_PATH} rel="stylesheet" />
       </head>
       <body>
-        <NextIntlClientProvider locale={locale} messages={applicationMessages}>
-          {children}
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <SkipNav
+            label={messages.layout.skipNavigationLabel}
+            mainContentId={messages.layout.mainContentId}
+          />
+          <GovBanner content={messages.layout.banner} />
+          <SiteHeader content={messages.layout.header} />
+          <main id={messages.layout.mainContentId}>{children}</main>
+          <SiteFooter
+            content={messages.layout.footer}
+            mainContentId={messages.layout.mainContentId}
+          />
+          <IdentifierSection content={messages.layout.identifier} />
         </NextIntlClientProvider>
         <Script src={NJWDS_SCRIPT_PATH} strategy="afterInteractive" />
       </body>

--- a/packages/static-site/app/[locale]/learn/layout.tsx
+++ b/packages/static-site/app/[locale]/learn/layout.tsx
@@ -1,0 +1,48 @@
+import { notFound } from "next/navigation";
+import type { ReactNode } from "react";
+import { LearnSideNav } from "@/components/learn/LearnSideNav";
+import { hasAppLocale } from "@/domain/i18n/locales";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+
+/**
+ * Describes route params for locale-scoped pages.
+ *
+ * This type defines a stable shape for related data.
+ */
+export interface RouteParams {
+  /** Locale segment captured from the route. */
+  readonly locale: string;
+}
+
+interface PageLayoutProps {
+  /** Child route content rendered within the locale shell. */
+  readonly children: ReactNode;
+  /** Asynchronous route parameters provided by Next.js. */
+  readonly params: Promise<RouteParams>;
+}
+
+const PageLayout = async ({ children, params }: PageLayoutProps) => {
+  const { locale } = await params;
+
+  if (!hasAppLocale(locale)) {
+    notFound();
+  }
+
+  const messages = await getApplicationMessages({ locale });
+
+  return (
+    <main className="grid-container usa-section">
+      <div className="grid-row grid-gap">
+        <div className="tablet:grid-col-3">
+          <LearnSideNav content={messages.learn.sideNav} />
+        </div>
+        <div className="tablet:grid-col-9">{children}</div>
+      </div>
+    </main>
+  );
+};
+
+/**
+ * Exports the locale layout for Next.js app routing.
+ */
+export default PageLayout;

--- a/packages/static-site/app/[locale]/learn/page.tsx
+++ b/packages/static-site/app/[locale]/learn/page.tsx
@@ -21,13 +21,13 @@ const LearnPage = async ({ params }: Props) => {
   const { learn } = await getApplicationMessages({ locale });
 
   return (
-    <main className="grid-container usa-section">
+    <>
       <h1>{learn.name}</h1>
       <p className="usa-intro">{learn.subHeadingText}</p>
       <h2>{learn.heading2}</h2>
       <ul className="usa-card-group">
         {learn.categories.map((category) => (
-          <li key={category.title} className="usa-card tablet:grid-col-3">
+          <li key={category.title} className="usa-card tablet:grid-col-6">
             <div className="usa-card__container">
               <div className="usa-card__header">
                 <h3 className="usa-card__heading">{category.title}</h3>
@@ -44,7 +44,7 @@ const LearnPage = async ({ params }: Props) => {
           </li>
         ))}
       </ul>
-    </main>
+    </>
   );
 };
 

--- a/packages/static-site/app/[locale]/learn/plan/page.tsx
+++ b/packages/static-site/app/[locale]/learn/plan/page.tsx
@@ -1,0 +1,27 @@
+import { notFound } from "next/navigation";
+
+import { hasAppLocale } from "@/domain/i18n/locales";
+
+interface PageParams {
+  readonly locale: string;
+}
+
+interface Props {
+  readonly params: Promise<PageParams>;
+}
+
+const PlanPage = async ({ params }: Props) => {
+  const { locale } = await params;
+
+  if (!hasAppLocale(locale)) {
+    notFound();
+  }
+
+  return (
+    <>
+      <h1>Plan</h1>
+    </>
+  );
+};
+
+export default PlanPage;

--- a/packages/static-site/components/SideNav.tsx
+++ b/packages/static-site/components/SideNav.tsx
@@ -1,0 +1,112 @@
+/**
+ * Renders a USWDS side navigation menu for section-level wayfinding.
+ *
+ * Supports up to three levels: top-level items, child links, and grandchild
+ * links. Active state is indicated via the `isCurrent` flag on each item.
+ */
+
+import { LocalizedLink } from "@/components/landing/LocalizedLink";
+import type { ContentLink } from "@/domain/content/messageTypes";
+
+/**
+ * A grandchild-level navigation item with no further nesting.
+ */
+export interface SideNavGrandchildItem {
+  /** Link metadata for the grandchild item. */
+  readonly link: ContentLink;
+  /** Marks this item as the current page. */
+  readonly isCurrent?: boolean;
+}
+
+/**
+ * A child-level navigation item that may contain grandchild links.
+ */
+export interface SideNavChildItem {
+  /** Link metadata for the child item. */
+  readonly link: ContentLink;
+  /** Marks this item as the current page. */
+  readonly isCurrent?: boolean;
+  /** Optional grandchild links rendered as a nested sublist. */
+  readonly children?: readonly SideNavGrandchildItem[];
+}
+
+/**
+ * A top-level navigation item that may contain child links.
+ */
+export interface SideNavItem {
+  /** Link metadata for the top-level item. */
+  readonly link: ContentLink;
+  /** Marks this item as the current page. */
+  readonly isCurrent?: boolean;
+  /** Optional child links rendered as a nested sublist. */
+  readonly children?: readonly SideNavChildItem[];
+}
+
+/**
+ * Describes props accepted by the SideNav component.
+ */
+export interface SideNavProps {
+  /** Accessible label for the nav landmark. */
+  readonly ariaLabel: string;
+  /** Top-level navigation items to render. */
+  readonly items: readonly SideNavItem[];
+}
+
+/**
+ * Renders a USWDS `usa-sidenav` navigation component.
+ *
+ * @param props Component props.
+ * @param props.ariaLabel Accessible label for the nav landmark.
+ * @param props.items Top-level navigation items to render.
+ * @returns A side navigation element with up to three levels of nesting.
+ * @example
+ * ```tsx
+ * <SideNav
+ *   ariaLabel="Secondary navigation"
+ *   items={[
+ *     { link: { label: "Parent", href: "/parent", isInternal: true, opensInNewTab: false } },
+ *     { link: { label: "Current", href: "/current", isInternal: true, opensInNewTab: false }, isCurrent: true, children: [...] },
+ *   ]}
+ * />
+ * ```
+ */
+export const SideNav = ({ ariaLabel, items }: SideNavProps) => {
+  return (
+    <nav aria-label={ariaLabel}>
+      <ul className="usa-sidenav">
+        {items.map((item) => (
+          <li key={item.link.href} className="usa-sidenav__item">
+            <LocalizedLink
+              link={item.link}
+              className={item.isCurrent ? "usa-current" : undefined}
+            />
+            {item.children && item.children.length > 0 && (
+              <ul className="usa-sidenav__sublist">
+                {item.children.map((child) => (
+                  <li key={child.link.href} className="usa-sidenav__item">
+                    <LocalizedLink
+                      link={child.link}
+                      className={child.isCurrent ? "usa-current" : undefined}
+                    />
+                    {child.children && child.children.length > 0 && (
+                      <ul className="usa-sidenav__sublist">
+                        {child.children.map((grandchild) => (
+                          <li key={grandchild.link.href} className="usa-sidenav__item">
+                            <LocalizedLink
+                              link={grandchild.link}
+                              className={grandchild.isCurrent ? "usa-current" : undefined}
+                            />
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+};

--- a/packages/static-site/components/landing/GovBanner.tsx
+++ b/packages/static-site/components/landing/GovBanner.tsx
@@ -7,7 +7,7 @@
 
 import Image from "next/image";
 
-import type { LandingBannerContent } from "@/domain/content/messageTypes";
+import type { LayoutBannerContent } from "@/domain/content/messageTypes";
 import { LocalizedLink } from "./LocalizedLink";
 
 /**
@@ -18,7 +18,7 @@ import { LocalizedLink } from "./LocalizedLink";
  */
 export interface GovBannerProps {
   /** Localized banner content. */
-  readonly content: LandingBannerContent;
+  readonly content: LayoutBannerContent;
 }
 
 /**

--- a/packages/static-site/components/landing/HeaderPrimaryNav.tsx
+++ b/packages/static-site/components/landing/HeaderPrimaryNav.tsx
@@ -11,7 +11,7 @@ import type {
   HeaderPrimaryItem,
   HeaderPrimaryLinkItem,
   HeaderPrimarySubmenuItem,
-  LandingHeaderContent,
+  LayoutHeaderContent,
 } from "@/domain/content/messageTypes";
 import { LocalizedLink } from "./LocalizedLink";
 
@@ -27,7 +27,7 @@ const NJWDS_CLOSE_ICON_PATH = "/assets/njwds/dist/img/usa-icons/close.svg";
  */
 export interface HeaderPrimaryNavProps {
   /** Header content containing close icon text and primary nav items. */
-  readonly header: LandingHeaderContent;
+  readonly header: LayoutHeaderContent;
 }
 
 /**

--- a/packages/static-site/components/landing/HeaderSecondaryNav.tsx
+++ b/packages/static-site/components/landing/HeaderSecondaryNav.tsx
@@ -5,7 +5,7 @@
  * markup and skips render when no links exist.
  */
 
-import type { LandingHeaderContent } from "@/domain/content/messageTypes";
+import type { LayoutHeaderContent } from "@/domain/content/messageTypes";
 import { LocalizedLink } from "./LocalizedLink";
 
 /**
@@ -15,7 +15,7 @@ import { LocalizedLink } from "./LocalizedLink";
  */
 export interface HeaderSecondaryNavProps {
   /** Header content containing secondary links and search labels. */
-  readonly header: LandingHeaderContent;
+  readonly header: LayoutHeaderContent;
 }
 
 /**
@@ -25,7 +25,7 @@ export interface HeaderSecondaryNavProps {
  */
 interface RenderSecondaryLinkParams {
   /** Secondary link content and index metadata. */
-  readonly link: LandingHeaderContent["secondaryLinks"][number];
+  readonly link: LayoutHeaderContent["secondaryLinks"][number];
   /** Positional index for React key generation fallback. */
   readonly index: number;
 }

--- a/packages/static-site/components/landing/IdentifierSection.tsx
+++ b/packages/static-site/components/landing/IdentifierSection.tsx
@@ -8,8 +8,8 @@
 import Image from "next/image";
 
 import type {
-  LandingIdentifierContent,
   LandingIdentifierRequiredLink,
+  LayoutIdentifierContent,
 } from "@/domain/content/messageTypes";
 import { LocalizedLink } from "./LocalizedLink";
 
@@ -21,7 +21,7 @@ import { LocalizedLink } from "./LocalizedLink";
  */
 export interface IdentifierSectionProps {
   /** Localized identifier content. */
-  readonly content: LandingIdentifierContent;
+  readonly content: LayoutIdentifierContent;
 }
 
 /**

--- a/packages/static-site/components/landing/LandingPage.test.tsx
+++ b/packages/static-site/components/landing/LandingPage.test.tsx
@@ -14,23 +14,6 @@ interface RenderLandingPageForLocaleParams {
 }
 
 /**
- * Parameters required to count secondary navigation items.
- */
-interface CountSecondaryNavigationItemsParams {
-  /** Rendered page container queried for navigation items. */
-  readonly container: HTMLElement;
-}
-
-/**
- * Counts rendered secondary navigation list items.
- */
-const countSecondaryNavigationItems = ({
-  container,
-}: CountSecondaryNavigationItemsParams): number => {
-  return container.querySelectorAll(".usa-nav__secondary-item").length;
-};
-
-/**
  * Escapes a string value for safe regular-expression usage.
  */
 const escapeRegularExpressionValue = (value: string): string => {
@@ -45,51 +28,8 @@ const renderLandingPageForLocale = async ({ locale }: RenderLandingPageForLocale
 
   return {
     ...render(<LandingPage content={messages.landing} />),
-    content: messages.landing,
+    content: messages,
   };
-};
-
-/**
- * Verifies banner government identity appears and placeholder header links are absent.
- */
-const shouldRenderGovernmentIdentityDetails = async () => {
-  const englishPage = await renderLandingPageForLocale({ locale: "en-US" });
-  const englishGovernorName = englishPage.content.banner.governorIdentityLink.label;
-  const englishGovernorLink = screen.getByRole("link", { name: englishGovernorName });
-  const englishSecondaryNavigationItemCount = countSecondaryNavigationItems({
-    container: englishPage.container,
-  });
-
-  expect(englishGovernorLink).toBeTruthy();
-  expect(englishSecondaryNavigationItemCount).toBe(
-    englishPage.content.header.secondaryLinks.length,
-  );
-  expect(screen.queryByRole("searchbox")).toBeNull();
-  expect(screen.queryByText("Secondary link")).toBeNull();
-  expect(screen.queryByText("Another secondary link")).toBeNull();
-  expect(
-    screen.getByRole("link", { name: englishPage.content.banner.updatesLink.label }),
-  ).toBeTruthy();
-
-  englishPage.unmount();
-
-  const spanishPage = await renderLandingPageForLocale({ locale: "es-US" });
-  const spanishGovernorName = spanishPage.content.banner.governorIdentityLink.label;
-  const spanishGovernorLink = screen.getByRole("link", { name: spanishGovernorName });
-  const spanishSecondaryNavigationItemCount = countSecondaryNavigationItems({
-    container: spanishPage.container,
-  });
-
-  expect(spanishGovernorLink).toBeTruthy();
-  expect(spanishSecondaryNavigationItemCount).toBe(
-    spanishPage.content.header.secondaryLinks.length,
-  );
-  expect(screen.queryByRole("searchbox")).toBeNull();
-  expect(screen.queryByText("Enlace secundario")).toBeNull();
-  expect(screen.queryByText("Otro enlace secundario")).toBeNull();
-  expect(
-    screen.getByRole("link", { name: spanishPage.content.banner.updatesLink.label }),
-  ).toBeTruthy();
 };
 
 /**
@@ -98,7 +38,7 @@ const shouldRenderGovernmentIdentityDetails = async () => {
 const shouldRenderKeyLandingSections = async () => {
   const englishPage = await renderLandingPageForLocale({ locale: "en-US" });
   const englishHeroTitlePattern = new RegExp(
-    escapeRegularExpressionValue(englishPage.content.hero.title),
+    escapeRegularExpressionValue(englishPage.content.landing.hero.title),
     "i",
   );
 
@@ -107,7 +47,7 @@ const shouldRenderKeyLandingSections = async () => {
     level: 1,
   });
   const englishTaglineHeading = screen.getByRole("heading", {
-    name: englishPage.content.tagline.title,
+    name: englishPage.content.landing.tagline.title,
     level: 2,
   });
 
@@ -118,7 +58,7 @@ const shouldRenderKeyLandingSections = async () => {
 
   const spanishPage = await renderLandingPageForLocale({ locale: "es-US" });
   const spanishHeroTitlePattern = new RegExp(
-    escapeRegularExpressionValue(spanishPage.content.hero.title),
+    escapeRegularExpressionValue(spanishPage.content.landing.hero.title),
     "i",
   );
 
@@ -127,7 +67,7 @@ const shouldRenderKeyLandingSections = async () => {
     level: 1,
   });
   const spanishTaglineHeading = screen.getByRole("heading", {
-    name: spanishPage.content.tagline.title,
+    name: spanishPage.content.landing.tagline.title,
     level: 2,
   });
 
@@ -170,7 +110,6 @@ const shouldPassAxeAudit = async () => {
  * Defines the landing-page component test suite.
  */
 const runLandingPageSuite = () => {
-  it("renders required government identity content", shouldRenderGovernmentIdentityDetails);
   it("renders key landing sections", shouldRenderKeyLandingSections);
   it("passes automated accessibility checks", shouldPassAxeAudit);
 };

--- a/packages/static-site/components/landing/LandingPage.tsx
+++ b/packages/static-site/components/landing/LandingPage.tsx
@@ -8,13 +8,8 @@
 import type { LandingPageContent } from "@/domain/content/messageTypes";
 import type { Funding } from "@/domain/content/types";
 import { CtaSection } from "./CtaSection";
-import { GovBanner } from "./GovBanner";
 import { GraphicListSection } from "./GraphicListSection";
 import { HeroSection } from "./HeroSection";
-import { IdentifierSection } from "./IdentifierSection";
-import { SiteFooter } from "./SiteFooter";
-import { SiteHeader } from "./SiteHeader";
-import { SkipNav } from "./SkipNav";
 import { TaglineSection } from "./TaglineSection";
 
 export interface LandingPageProps {
@@ -37,44 +32,37 @@ export interface LandingPageProps {
  */
 export const LandingPage = ({ content, fundings }: LandingPageProps) => {
   return (
-    <div>
-      <SkipNav label={content.skipNavigationLabel} mainContentId={content.mainContentId} />
-      <GovBanner content={content.banner} />
-      <SiteHeader content={content.header} />
-      <main id={content.mainContentId}>
-        <HeroSection content={content.hero} />
-        <TaglineSection content={content.tagline} />
-        <GraphicListSection content={content.graphicList} />
-        {fundings && fundings.length > 0 && (
-          <section className="usa-section">
-            <div className="grid-container">
-              <h2 className="font-heading-xl margin-y-0">Featured Funding Opportunities</h2>
-              <ul className="usa-card-group">
-                {fundings.map((funding) => (
-                  <li key={funding.name} className="usa-card tablet:grid-col-4">
-                    <div className="usa-card__container">
-                      <div className="usa-card__header">
-                        <h3 className="usa-card__heading">{funding.name}</h3>
-                      </div>
-                      <div className="usa-card__body">
-                        <p>{funding.summaryDescriptionMd}</p>
-                      </div>
-                      <div className="usa-card__footer">
-                        <a href={funding.callToActionLink} className="usa-button">
-                          {funding.callToActionText}
-                        </a>
-                      </div>
+    <>
+      <HeroSection content={content.hero} />
+      <TaglineSection content={content.tagline} />
+      <GraphicListSection content={content.graphicList} />
+      {fundings && fundings.length > 0 && (
+        <section className="usa-section">
+          <div className="grid-container">
+            <h2 className="font-heading-xl margin-y-0">Featured Funding Opportunities</h2>
+            <ul className="usa-card-group">
+              {fundings.map((funding) => (
+                <li key={funding.name} className="usa-card tablet:grid-col-4">
+                  <div className="usa-card__container">
+                    <div className="usa-card__header">
+                      <h3 className="usa-card__heading">{funding.name}</h3>
                     </div>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </section>
-        )}
-        <CtaSection content={content.callToAction} />
-      </main>
-      <SiteFooter content={content.footer} mainContentId={content.mainContentId} />
-      <IdentifierSection content={content.identifier} />
-    </div>
+                    <div className="usa-card__body">
+                      <p>{funding.summaryDescriptionMd}</p>
+                    </div>
+                    <div className="usa-card__footer">
+                      <a href={funding.callToActionLink} className="usa-button">
+                        {funding.callToActionText}
+                      </a>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      )}
+      <CtaSection content={content.callToAction} />
+    </>
   );
 };

--- a/packages/static-site/components/landing/LocalizedLink.tsx
+++ b/packages/static-site/components/landing/LocalizedLink.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { ReactNode } from "react";
-import type { LandingLink } from "@/domain/content/messageTypes";
+import type { ContentLink } from "@/domain/content/messageTypes";
 import { Link } from "@/domain/i18n/navigation";
 
 /**
@@ -16,7 +16,7 @@ import { Link } from "@/domain/i18n/navigation";
  */
 export interface LocalizedLinkProps {
   /** Link content metadata to render. */
-  readonly link: LandingLink;
+  readonly link: ContentLink;
   /** Optional CSS class list applied to the anchor element. */
   readonly className?: string;
   /** Optional aria-label override for the anchor element. */

--- a/packages/static-site/components/landing/SiteFooter.tsx
+++ b/packages/static-site/components/landing/SiteFooter.tsx
@@ -8,9 +8,9 @@
 import Image from "next/image";
 
 import type {
-  LandingFooterContent,
   LandingFooterPrimaryLink,
   LandingSocialLink,
+  LayoutFooterContent,
 } from "@/domain/content/messageTypes";
 import { LocalizedLink } from "./LocalizedLink";
 
@@ -21,7 +21,7 @@ import { LocalizedLink } from "./LocalizedLink";
  */
 export interface SiteFooterProps {
   /** Localized footer content. */
-  readonly content: LandingFooterContent;
+  readonly content: LayoutFooterContent;
   /** Main-content ID used by the return-to-top anchor. */
   readonly mainContentId: string;
 }

--- a/packages/static-site/components/landing/SiteHeader.tsx
+++ b/packages/static-site/components/landing/SiteHeader.tsx
@@ -5,7 +5,7 @@
  * dedicated navigation subcomponents.
  */
 
-import type { LandingHeaderContent } from "@/domain/content/messageTypes";
+import type { LayoutHeaderContent } from "@/domain/content/messageTypes";
 import { HeaderPrimaryNav } from "./HeaderPrimaryNav";
 import { HeaderSecondaryNav } from "./HeaderSecondaryNav";
 import { LocalizedLink } from "./LocalizedLink";
@@ -17,7 +17,7 @@ import { LocalizedLink } from "./LocalizedLink";
  */
 export interface SiteHeaderProps {
   /** Localized content used by header subcomponents. */
-  readonly content: LandingHeaderContent;
+  readonly content: LayoutHeaderContent;
 }
 
 /**

--- a/packages/static-site/components/learn/LearnSideNav.test.tsx
+++ b/packages/static-site/components/learn/LearnSideNav.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LearnSideNav } from "@/components/learn/LearnSideNav";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+
+vi.mock("next/navigation", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("next/navigation")>()),
+  useSelectedLayoutSegment: vi.fn(),
+}));
+
+const messages = await getApplicationMessages({ locale: "en-US" });
+
+describe("LearnSideNav", () => {
+  describe("nav item order", () => {
+    let navItems: HTMLElement[];
+
+    beforeEach(async () => {
+      render(<LearnSideNav content={messages.learn.sideNav} />);
+      navItems = screen.getAllByRole("listitem");
+    });
+
+    it("first item is Introduction linking to /learn", () => {
+      const link = navItems[0].querySelector("a");
+      expect(link?.textContent).toBe("Introduction");
+      expect(link?.getAttribute("href")).toBe("/learn");
+    });
+
+    it("second item is Plan linking to /learn/plan", () => {
+      const link = navItems[1].querySelector("a");
+      expect(link?.textContent).toBe("Plan");
+      expect(link?.getAttribute("href")).toBe("/learn/plan");
+    });
+
+    it("third item is Start linking to /learn/start", () => {
+      const link = navItems[2].querySelector("a");
+      expect(link?.textContent).toBe("Start");
+      expect(link?.getAttribute("href")).toBe("/learn/start");
+    });
+
+    it("fourth item is Operate linking to /learn/operate", () => {
+      const link = navItems[3].querySelector("a");
+      expect(link?.textContent).toBe("Operate");
+      expect(link?.getAttribute("href")).toBe("/learn/operate");
+    });
+
+    it("fifth item is Grow linking to /learn/grow", () => {
+      const link = navItems[4].querySelector("a");
+      expect(link?.textContent).toBe("Grow");
+      expect(link?.getAttribute("href")).toBe("/learn/grow");
+    });
+  });
+
+  describe("isCurrent is set based on active route segment", () => {
+    it("marks Introduction as current when segment is null", async () => {
+      const { useSelectedLayoutSegment } = vi.mocked(await import("next/navigation"));
+      useSelectedLayoutSegment.mockReturnValue(null);
+
+      render(<LearnSideNav content={messages.learn.sideNav} />);
+
+      expect(screen.getByRole("link", { name: "Introduction" })).toHaveClass("usa-current");
+    });
+
+    it("marks Plan as current when segment is 'plan'", async () => {
+      const { useSelectedLayoutSegment } = vi.mocked(await import("next/navigation"));
+      useSelectedLayoutSegment.mockReturnValue("plan");
+
+      render(<LearnSideNav content={messages.learn.sideNav} />);
+
+      expect(screen.getByRole("link", { name: "Plan" })).toHaveClass("usa-current");
+    });
+
+    it("does not mark Introduction as current when segment is 'plan'", async () => {
+      const { useSelectedLayoutSegment } = vi.mocked(await import("next/navigation"));
+      useSelectedLayoutSegment.mockReturnValue("plan");
+
+      render(<LearnSideNav content={messages.learn.sideNav} />);
+
+      expect(screen.getByRole("link", { name: "Introduction" })).not.toHaveClass("usa-current");
+    });
+  });
+});

--- a/packages/static-site/components/learn/LearnSideNav.tsx
+++ b/packages/static-site/components/learn/LearnSideNav.tsx
@@ -1,0 +1,39 @@
+/**
+ * Renders the learn section side navigation with active state derived from
+ * the current route segment.
+ */
+
+"use client";
+
+import { useSelectedLayoutSegment } from "next/navigation";
+import { SideNav } from "@/components/SideNav";
+import type { LearnSideNavContent } from "@/domain/content/messageTypes";
+
+/**
+ * Describes props accepted by the LearnSideNav component.
+ */
+export interface LearnSideNavProps {
+  /** Ordered list of pages to render in the side navigation. */
+  readonly content: LearnSideNavContent;
+}
+
+/**
+ * Renders a side navigation for the learn section, marking the current page
+ * based on the active route segment below the learn layout.
+ *
+ * @param props Component props.
+ * @param props.pages Ordered nav pages sourced from localized messages.
+ * @returns A side navigation element with the current item highlighted.
+ */
+export const LearnSideNav = ({ content }: LearnSideNavProps) => {
+  const pathSegment = useSelectedLayoutSegment();
+  const activeKey = pathSegment ?? "learn";
+
+  const items = content.pages.map((page) => ({
+    link: page,
+    isCurrent: page.key === activeKey,
+    children: [],
+  }));
+
+  return <SideNav ariaLabel={content.ariaLabel} items={items} />;
+};

--- a/packages/static-site/domain/content/messageTypes.ts
+++ b/packages/static-site/domain/content/messageTypes.ts
@@ -1,5 +1,5 @@
 /**
- * Declares typed landing-page content models used across the static site.
+ * Declares typed content models used across the static site.
  *
  * These interfaces define the contract between localized messages, loaders,
  * and rendered UI sections.
@@ -7,8 +7,6 @@
 
 /**
  * A localized link used by landing-page components.
- *
- * This type defines a stable shape for related data.
  */
 export interface LandingLink {
   /** Human-readable link label rendered in UI. */
@@ -23,8 +21,6 @@ export interface LandingLink {
 
 /**
  * One item in the header primary submenu.
- *
- * This type defines a stable shape for related data.
  */
 export interface HeaderPrimarySubmenuLink {
   /** Link metadata rendered in the submenu. */
@@ -33,8 +29,6 @@ export interface HeaderPrimarySubmenuLink {
 
 /**
  * A primary navigation item that renders as a simple link.
- *
- * This type defines a stable shape for related data.
  */
 export interface HeaderPrimaryLinkItem {
   /** Discriminator for a simple link item. */
@@ -47,8 +41,6 @@ export interface HeaderPrimaryLinkItem {
 
 /**
  * A primary navigation item that renders a submenu accordion trigger.
- *
- * This type defines a stable shape for related data.
  */
 export interface HeaderPrimarySubmenuItem {
   /** Discriminator for a submenu item. */
@@ -65,15 +57,11 @@ export interface HeaderPrimarySubmenuItem {
 
 /**
  * A primary navigation item rendered in the NJWDS header.
- *
- * This type defines a stable shape for related data.
  */
 export type HeaderPrimaryItem = HeaderPrimaryLinkItem | HeaderPrimarySubmenuItem;
 
 /**
  * Localized content for the government identity banner.
- *
- * This type defines a stable shape for related data.
  */
 export interface LandingBannerContent {
   /** Accessible label for the banner section landmark. */
@@ -90,8 +78,6 @@ export interface LandingBannerContent {
 
 /**
  * Localized content for the NJWDS extended header.
- *
- * This type defines a stable shape for related data.
  */
 export interface LandingHeaderContent {
   /** Accessible label for the primary navigation region. */
@@ -122,8 +108,6 @@ export interface LandingHeaderContent {
 
 /**
  * Localized content for the hero section.
- *
- * This type defines a stable shape for related data.
  */
 export interface LandingHeroContent {
   /** Accessible label for the hero section landmark. */
@@ -140,8 +124,6 @@ export interface LandingHeroContent {
 
 /**
  * Localized content for the tagline section.
- *
- * This type defines a stable shape for related data.
  */
 export interface LandingTaglineContent {
   /** Heading text for the tagline section. */
@@ -152,8 +134,6 @@ export interface LandingTaglineContent {
 
 /**
  * Localized content for one graphic-list card.
- *
- * This type defines a stable shape for related data.
  */
 export interface LandingGraphicListItem {
   /** Heading text for the graphic-list item. */
@@ -166,8 +146,6 @@ export interface LandingGraphicListItem {
 
 /**
  * Localized content for the dark graphic-list section.
- *
- * This type defines a stable shape for related data.
  */
 export interface LandingGraphicListContent {
   /** Items rendered in the graphic-list layout. */
@@ -176,8 +154,6 @@ export interface LandingGraphicListContent {
 
 /**
  * Localized content for the section call-to-action block.
- *
- * This type defines a stable shape for related data.
  */
 export interface LandingCallToActionContent {
   /** Element ID used as the CTA section anchor target. */
@@ -192,8 +168,6 @@ export interface LandingCallToActionContent {
 
 /**
  * Localized content for one footer social link.
- *
- * This type defines a stable shape for related data.
  */
 export interface LandingSocialLink {
   /** Class name modifier suffix for NJWDS social icon styling. */
@@ -208,8 +182,6 @@ export interface LandingSocialLink {
 
 /**
  * Localized content for one footer primary link.
- *
- * This type defines a stable shape for related data.
  */
 export interface LandingFooterPrimaryLink {
   /** Link metadata rendered in the footer primary nav list. */
@@ -218,8 +190,6 @@ export interface LandingFooterPrimaryLink {
 
 /**
  * Localized content for the footer section.
- *
- * This type defines a stable shape for related data.
  */
 export interface LandingFooterContent {
   /** Label for the return-to-top link. */
@@ -244,8 +214,6 @@ export interface LandingFooterContent {
 
 /**
  * Localized content for one required identifier link.
- *
- * This type defines a stable shape for related data.
  */
 export interface LandingIdentifierRequiredLink {
   /** Link metadata rendered in the required-links list. */
@@ -254,8 +222,6 @@ export interface LandingIdentifierRequiredLink {
 
 /**
  * Localized content for the identifier section.
- *
- * This type defines a stable shape for related data.
  */
 export interface LandingIdentifierContent {
   /** Accessible label for the agency identifier section. */
@@ -281,11 +247,9 @@ export interface LandingIdentifierContent {
 }
 
 /**
- * All localized content needed to render the landing page.
- *
- * This type defines a stable shape for related data.
+ * Shared localized content rendered on every page of the site.
  */
-export interface LandingPageContent {
+export interface LayoutContent {
   /** Label text rendered by the skip navigation link. */
   readonly skipNavigationLabel: string;
   /** Element ID used for main-content anchor navigation. */
@@ -294,6 +258,16 @@ export interface LandingPageContent {
   readonly banner: LandingBannerContent;
   /** Header section content. */
   readonly header: LandingHeaderContent;
+  /** Footer section content. */
+  readonly footer: LandingFooterContent;
+  /** Identifier section content. */
+  readonly identifier: LandingIdentifierContent;
+}
+
+/**
+ * All localized content needed to render the landing page.
+ */
+export interface LandingPageContent {
   /** Hero section content. */
   readonly hero: LandingHeroContent;
   /** Tagline section content. */
@@ -302,16 +276,10 @@ export interface LandingPageContent {
   readonly graphicList: LandingGraphicListContent;
   /** CTA section content. */
   readonly callToAction: LandingCallToActionContent;
-  /** Footer section content. */
-  readonly footer: LandingFooterContent;
-  /** Identifier section content. */
-  readonly identifier: LandingIdentifierContent;
 }
 
 /**
  * Localized metadata content for the root document.
- *
- * This type defines a stable shape for related data.
  */
 export interface LandingMetadataContent {
   /** Document title used in metadata. */
@@ -322,8 +290,6 @@ export interface LandingMetadataContent {
 
 /**
  * One category card rendered in the learn page grid.
- *
- * This type defines a stable shape for related data.
  */
 export interface LearnCategory {
   /** Heading text for the category card. */
@@ -336,8 +302,6 @@ export interface LearnCategory {
 
 /**
  * All localized content needed to render the learn page.
- *
- * This type defines a stable shape for related data.
  */
 export interface LearnPageContent {
   /** Navigation name for the learn section. */
@@ -352,12 +316,12 @@ export interface LearnPageContent {
 
 /**
  * Complete localized message payload for one locale.
- *
- * This type defines a stable shape for related data.
  */
 export interface ApplicationMessages {
   /** Metadata strings for the localized route. */
   readonly metadata: LandingMetadataContent;
+  /** Shared layout content for banner, header, footer, and identifier on all pages. */
+  readonly layout: LayoutContent;
   /** Landing-page content strings and links. */
   readonly landing: LandingPageContent;
   /** Learn page content strings and links. */

--- a/packages/static-site/domain/content/messageTypes.ts
+++ b/packages/static-site/domain/content/messageTypes.ts
@@ -8,7 +8,7 @@
 /**
  * A localized link used by landing-page components.
  */
-export interface LandingLink {
+export interface ContentLink {
   /** Human-readable link label rendered in UI. */
   readonly label: string;
   /** URL or path destination for the link. */
@@ -17,6 +17,8 @@ export interface LandingLink {
   readonly isInternal: boolean;
   /** Indicates the link should open in a new browser tab. */
   readonly opensInNewTab: boolean;
+  /** Some links need a string key identifier to help us construct link categories */
+  readonly key?: string;
 }
 
 /**
@@ -24,7 +26,7 @@ export interface LandingLink {
  */
 export interface HeaderPrimarySubmenuLink {
   /** Link metadata rendered in the submenu. */
-  readonly link: LandingLink;
+  readonly link: ContentLink;
 }
 
 /**
@@ -34,7 +36,7 @@ export interface HeaderPrimaryLinkItem {
   /** Discriminator for a simple link item. */
   readonly kind: "link";
   /** Link metadata rendered in the primary navigation. */
-  readonly link: LandingLink;
+  readonly link: ContentLink;
   /** Indicates the link points to the current section/page. */
   readonly isCurrent: boolean;
 }
@@ -63,27 +65,27 @@ export type HeaderPrimaryItem = HeaderPrimaryLinkItem | HeaderPrimarySubmenuItem
 /**
  * Localized content for the government identity banner.
  */
-export interface LandingBannerContent {
+export interface LayoutBannerContent {
   /** Accessible label for the banner section landmark. */
   readonly sectionAriaLabel: string;
   /** Alt text for the New Jersey state seal image. */
   readonly stateSealAlt: string;
   /** Link to the official New Jersey state site. */
-  readonly stateSiteLink: LandingLink;
+  readonly stateSiteLink: ContentLink;
   /** Link displaying the governor and lieutenant governor names. */
-  readonly governorIdentityLink: LandingLink;
+  readonly governorIdentityLink: ContentLink;
   /** Link to the state updates subscription destination. */
-  readonly updatesLink: LandingLink;
+  readonly updatesLink: ContentLink;
 }
 
 /**
  * Localized content for the NJWDS extended header.
  */
-export interface LandingHeaderContent {
+export interface LayoutHeaderContent {
   /** Accessible label for the primary navigation region. */
   readonly primaryNavigationAriaLabel: string;
   /** Home link metadata rendered in the logo area. */
-  readonly homeLink: LandingLink;
+  readonly homeLink: ContentLink;
   /** Title attribute for the home link. */
   readonly homeLinkTitle: string;
   /** Aria label for the home link. */
@@ -97,7 +99,7 @@ export interface LandingHeaderContent {
   /** Collection of primary navigation items. */
   readonly primaryItems: readonly HeaderPrimaryItem[];
   /** Collection of secondary navigation links. */
-  readonly secondaryLinks: readonly LandingLink[];
+  readonly secondaryLinks: readonly ContentLink[];
   /** Form action destination for the header search form. */
   readonly searchAction: string;
   /** Accessible label for the search input. */
@@ -119,7 +121,7 @@ export interface LandingHeroContent {
   /** Hero supporting paragraph text. */
   readonly paragraph: string;
   /** Primary hero call-to-action link. */
-  readonly callToActionLink: LandingLink;
+  readonly callToActionLink: ContentLink;
 }
 
 /**
@@ -163,7 +165,7 @@ export interface LandingCallToActionContent {
   /** Introductory paragraph rendered for the CTA section. */
   readonly intro: string;
   /** CTA button link metadata. */
-  readonly callToActionLink: LandingLink;
+  readonly callToActionLink: ContentLink;
 }
 
 /**
@@ -173,7 +175,7 @@ export interface LandingSocialLink {
   /** Class name modifier suffix for NJWDS social icon styling. */
   readonly modifier: string;
   /** Link metadata for the social destination. */
-  readonly link: LandingLink;
+  readonly link: ContentLink;
   /** Alt text for the social icon image. */
   readonly iconAlt: string;
   /** Path to the social icon asset. */
@@ -185,13 +187,13 @@ export interface LandingSocialLink {
  */
 export interface LandingFooterPrimaryLink {
   /** Link metadata rendered in the footer primary nav list. */
-  readonly link: LandingLink;
+  readonly link: ContentLink;
 }
 
 /**
  * Localized content for the footer section.
  */
-export interface LandingFooterContent {
+export interface LayoutFooterContent {
   /** Label for the return-to-top link. */
   readonly returnToTopLabel: string;
   /** Accessible label for footer navigation. */
@@ -207,9 +209,9 @@ export interface LandingFooterContent {
   /** Contact heading rendered above phone/email links. */
   readonly contactHeading: string;
   /** Contact center phone link metadata. */
-  readonly phoneLink: LandingLink;
+  readonly phoneLink: ContentLink;
   /** Contact center email link metadata. */
-  readonly emailLink: LandingLink;
+  readonly emailLink: ContentLink;
 }
 
 /**
@@ -217,13 +219,13 @@ export interface LandingFooterContent {
  */
 export interface LandingIdentifierRequiredLink {
   /** Link metadata rendered in the required-links list. */
-  readonly link: LandingLink;
+  readonly link: ContentLink;
 }
 
 /**
  * Localized content for the identifier section.
  */
-export interface LandingIdentifierContent {
+export interface LayoutIdentifierContent {
   /** Accessible label for the agency identifier section. */
   readonly agencySectionAriaLabel: string;
   /** Alt text for the state logo image. */
@@ -235,7 +237,7 @@ export interface LandingIdentifierContent {
   /** Prefix text rendered before the state link in disclaimer copy. */
   readonly disclaimerPrefix: string;
   /** Link metadata rendered in disclaimer copy. */
-  readonly disclaimerLink: LandingLink;
+  readonly disclaimerLink: ContentLink;
   /** Accessible label for the required links navigation. */
   readonly importantLinksAriaLabel: string;
   /** Required links rendered in identifier navigation. */
@@ -255,13 +257,13 @@ export interface LayoutContent {
   /** Element ID used for main-content anchor navigation. */
   readonly mainContentId: string;
   /** Banner section content. */
-  readonly banner: LandingBannerContent;
+  readonly banner: LayoutBannerContent;
   /** Header section content. */
-  readonly header: LandingHeaderContent;
+  readonly header: LayoutHeaderContent;
   /** Footer section content. */
-  readonly footer: LandingFooterContent;
+  readonly footer: LayoutFooterContent;
   /** Identifier section content. */
-  readonly identifier: LandingIdentifierContent;
+  readonly identifier: LayoutIdentifierContent;
 }
 
 /**
@@ -289,6 +291,16 @@ export interface LandingMetadataContent {
 }
 
 /**
+ * Localized content for the learn section side navigation.
+ */
+export interface LearnSideNavContent {
+  /** Accessible name for the section. */
+  readonly ariaLabel: string;
+  /** Ordered list of pages rendered in the side navigation. */
+  readonly pages: readonly ContentLink[];
+}
+
+/**
  * One category card rendered in the learn page grid.
  */
 export interface LearnCategory {
@@ -297,7 +309,7 @@ export interface LearnCategory {
   /** Supporting text rendered in the category card. */
   readonly description: string;
   /** Link metadata for the category card CTA. */
-  readonly link: LandingLink;
+  readonly link: ContentLink;
 }
 
 /**
@@ -310,6 +322,8 @@ export interface LearnPageContent {
   readonly subHeadingText: string;
   /** Secondary heading text rendered above the categories grid. */
   readonly heading2: string;
+  /** Side navigation content for the learn section. */
+  readonly sideNav: LearnSideNavContent;
   /** Category cards rendered in the learn grid. */
   readonly categories: readonly LearnCategory[];
 }

--- a/packages/static-site/messages/en-US.json
+++ b/packages/static-site/messages/en-US.json
@@ -3,7 +3,7 @@
     "title": "Business.NJ.gov | Plan, Start, and Grow",
     "description": "Landing page prototype for a Next.js and NJWDS-powered business guidance experience."
   },
-  "landing": {
+  "layout": {
     "skipNavigationLabel": "Skip to main content",
     "mainContentId": "main-content",
     "banner": {
@@ -77,60 +77,6 @@
       "searchAction": "/search",
       "searchInputLabel": "Search site",
       "searchSubmitIconAlt": "Search"
-    },
-    "hero": {
-      "sectionAriaLabel": "Introduction",
-      "callout": "Your New Jersey business needs.",
-      "title": "All in one place.",
-      "paragraph": "Get your personalized business starter kit, find funding opportunities, discover your tax obligations, and more.",
-      "callToActionLink": {
-        "label": "Get Your Personalized Guide",
-        "href": "https://account.business.nj.gov/",
-        "isInternal": false,
-        "opensInNewTab": true
-      }
-    },
-    "tagline": {
-      "title": "Start, operate, and grow with confidence",
-      "paragraphs": [
-        "Business.NJ.gov is New Jersey's business-friendly resource, providing you with the information you need to plan, start, operate, and grow your business.",
-        "Use your account to build a personalized roadmap, track applications, and connect with a New Jersey business advocate for no-cost support."
-      ]
-    },
-    "graphicList": {
-      "items": [
-        {
-          "title": "Business Registration",
-          "paragraph": "Start your LLC, corporation, or partnership with clear, step-by-step state guidance.",
-          "imageAlt": "Alt text"
-        },
-        {
-          "title": "Licenses & Permits",
-          "paragraph": "Find required licenses and permits by business type, industry, and location.",
-          "imageAlt": "Alt text"
-        },
-        {
-          "title": "Business Names",
-          "paragraph": "Choose an available name and understand naming rules for your New Jersey business.",
-          "imageAlt": "Alt text"
-        },
-        {
-          "title": "Employer Obligations",
-          "paragraph": "Learn labor, payroll, and registration requirements before hiring employees.",
-          "imageAlt": "Alt text"
-        }
-      ]
-    },
-    "callToAction": {
-      "sectionId": "test-section-id",
-      "title": "For More Support",
-      "intro": "Looking for more expert advice? Explore free personalized guides, connect with a business advocate, and sign up for updates about grants, programs, and regulations likely to affect your business.",
-      "callToActionLink": {
-        "label": "Explore Business.NJ.gov",
-        "href": "https://business.nj.gov/",
-        "isInternal": false,
-        "opensInNewTab": true
-      }
     },
     "footer": {
       "returnToTopLabel": "Return to top",
@@ -333,6 +279,62 @@
       ],
       "usGovernmentSectionAriaLabel": "U.S. government information and services",
       "usGovernmentDescription": "Copyright © 2026 State of New Jersey"
+    }
+  },
+  "landing": {
+    "hero": {
+      "sectionAriaLabel": "Introduction",
+      "callout": "Your New Jersey business needs.",
+      "title": "All in one place.",
+      "paragraph": "Get your personalized business starter kit, find funding opportunities, discover your tax obligations, and more.",
+      "callToActionLink": {
+        "label": "Get Your Personalized Guide",
+        "href": "https://account.business.nj.gov/",
+        "isInternal": false,
+        "opensInNewTab": true
+      }
+    },
+    "tagline": {
+      "title": "Start, operate, and grow with confidence",
+      "paragraphs": [
+        "Business.NJ.gov is New Jersey's business-friendly resource, providing you with the information you need to plan, start, operate, and grow your business.",
+        "Use your account to build a personalized roadmap, track applications, and connect with a New Jersey business advocate for no-cost support."
+      ]
+    },
+    "graphicList": {
+      "items": [
+        {
+          "title": "Business Registration",
+          "paragraph": "Start your LLC, corporation, or partnership with clear, step-by-step state guidance.",
+          "imageAlt": "Alt text"
+        },
+        {
+          "title": "Licenses & Permits",
+          "paragraph": "Find required licenses and permits by business type, industry, and location.",
+          "imageAlt": "Alt text"
+        },
+        {
+          "title": "Business Names",
+          "paragraph": "Choose an available name and understand naming rules for your New Jersey business.",
+          "imageAlt": "Alt text"
+        },
+        {
+          "title": "Employer Obligations",
+          "paragraph": "Learn labor, payroll, and registration requirements before hiring employees.",
+          "imageAlt": "Alt text"
+        }
+      ]
+    },
+    "callToAction": {
+      "sectionId": "test-section-id",
+      "title": "For More Support",
+      "intro": "Looking for more expert advice? Explore free personalized guides, connect with a business advocate, and sign up for updates about grants, programs, and regulations likely to affect your business.",
+      "callToActionLink": {
+        "label": "Explore Business.NJ.gov",
+        "href": "https://business.nj.gov/",
+        "isInternal": false,
+        "opensInNewTab": true
+      }
     }
   },
   "learn": {

--- a/packages/static-site/messages/en-US.json
+++ b/packages/static-site/messages/en-US.json
@@ -338,6 +338,46 @@
     }
   },
   "learn": {
+    "sideNav": {
+      "ariaLabel": "Side navigation",
+      "pages": [
+        {
+          "key": "learn",
+          "label": "Introduction",
+          "href": "/learn",
+          "isInternal": true,
+          "opensInNewTab": false
+        },
+        {
+          "key": "plan",
+          "label": "Plan",
+          "href": "/learn/plan",
+          "isInternal": true,
+          "opensInNewTab": false
+        },
+        {
+          "key": "start",
+          "label": "Start",
+          "href": "/learn/start",
+          "isInternal": true,
+          "opensInNewTab": false
+        },
+        {
+          "key": "operate",
+          "label": "Operate",
+          "href": "/learn/operate",
+          "isInternal": true,
+          "opensInNewTab": false
+        },
+        {
+          "key": "grow",
+          "label": "Grow",
+          "href": "/learn/grow",
+          "isInternal": true,
+          "opensInNewTab": false
+        }
+      ]
+    },
     "name": "Learn",
     "subHeadingText": "Find guides and resources for every stage — from your first idea to long-term growth.",
     "heading2": "Where are you in your business journey?",

--- a/packages/static-site/messages/es-US.json
+++ b/packages/static-site/messages/es-US.json
@@ -341,6 +341,46 @@
     "name": "Learn",
     "subHeadingText": "Find guides and resources for every stage — from your first idea to long-term growth.",
     "heading2": "Where are you in your business journey?",
+    "sideNav": {
+      "ariaLabel": "Side navigation",
+      "pages": [
+        {
+          "key": "learn",
+          "label": "Introducción",
+          "href": "/learn",
+          "isInternal": true,
+          "opensInNewTab": false
+        },
+        {
+          "key": "plan",
+          "label": "Planificar",
+          "href": "/learn/plan",
+          "isInternal": true,
+          "opensInNewTab": false
+        },
+        {
+          "key": "start",
+          "label": "Comenzar",
+          "href": "/learn/start",
+          "isInternal": true,
+          "opensInNewTab": false
+        },
+        {
+          "key": "operate",
+          "label": "Operar",
+          "href": "/learn/operate",
+          "isInternal": true,
+          "opensInNewTab": false
+        },
+        {
+          "key": "grow",
+          "label": "Crecer",
+          "href": "/learn/grow",
+          "isInternal": true,
+          "opensInNewTab": false
+        }
+      ]
+    },
     "categories": [
       {
         "title": "Planning",

--- a/packages/static-site/messages/es-US.json
+++ b/packages/static-site/messages/es-US.json
@@ -3,7 +3,7 @@
     "title": "Business.NJ.gov | Planifique, Comience y Haga Crecer",
     "description": "Prototipo de página principal para una experiencia de orientación empresarial impulsada por Next.js y NJWDS."
   },
-  "landing": {
+  "layout": {
     "skipNavigationLabel": "Saltar al contenido principal",
     "mainContentId": "main-content",
     "banner": {
@@ -77,60 +77,6 @@
       "searchAction": "/search",
       "searchInputLabel": "Buscar en el sitio",
       "searchSubmitIconAlt": "Buscar"
-    },
-    "hero": {
-      "sectionAriaLabel": "Introducción",
-      "callout": "Las necesidades de su negocio en New Jersey.",
-      "title": "Todo en un solo lugar.",
-      "paragraph": "Obtenga su guía personalizada para comenzar su negocio, encuentre oportunidades de financiamiento y descubra sus obligaciones fiscales.",
-      "callToActionLink": {
-        "label": "Obtenga su guía personalizada",
-        "href": "https://account.business.nj.gov/",
-        "isInternal": false,
-        "opensInNewTab": true
-      }
-    },
-    "tagline": {
-      "title": "Planifique, opere y crezca con confianza",
-      "paragraphs": [
-        "Business.NJ.gov es el recurso empresarial del estado para ayudarle a planificar, comenzar, operar y hacer crecer su negocio.",
-        "Use su cuenta para crear una hoja de ruta personalizada, seguir solicitudes y conectarse con un asesor empresarial de New Jersey sin costo."
-      ]
-    },
-    "graphicList": {
-      "items": [
-        {
-          "title": "Registro empresarial",
-          "paragraph": "Inicie su LLC, corporación o sociedad con orientación estatal paso a paso.",
-          "imageAlt": "Texto alternativo"
-        },
-        {
-          "title": "Licencias y permisos",
-          "paragraph": "Encuentre los requisitos de licencias y permisos según su industria y ubicación.",
-          "imageAlt": "Texto alternativo"
-        },
-        {
-          "title": "Nombres comerciales",
-          "paragraph": "Revise disponibilidad y reglas de nombres para su negocio en New Jersey.",
-          "imageAlt": "Texto alternativo"
-        },
-        {
-          "title": "Obligaciones del empleador",
-          "paragraph": "Conozca requisitos laborales, de nómina y de registro antes de contratar.",
-          "imageAlt": "Texto alternativo"
-        }
-      ]
-    },
-    "callToAction": {
-      "sectionId": "test-section-id",
-      "title": "Más apoyo para su negocio",
-      "intro": "¿Busca asesoría más especializada? Explore guías personalizadas gratuitas, conéctese con un asesor empresarial y reciba actualizaciones sobre programas y regulaciones relevantes para su negocio.",
-      "callToActionLink": {
-        "label": "Explorar Business.NJ.gov",
-        "href": "https://business.nj.gov/",
-        "isInternal": false,
-        "opensInNewTab": true
-      }
     },
     "footer": {
       "returnToTopLabel": "Volver arriba",
@@ -333,6 +279,62 @@
       ],
       "usGovernmentSectionAriaLabel": "Información y servicios del gobierno de EE. UU.",
       "usGovernmentDescription": "Copyright © 2026 Estado de New Jersey"
+    }
+  },
+  "landing": {
+    "hero": {
+      "sectionAriaLabel": "Introducción",
+      "callout": "Las necesidades de su negocio en New Jersey.",
+      "title": "Todo en un solo lugar.",
+      "paragraph": "Obtenga su guía personalizada para comenzar su negocio, encuentre oportunidades de financiamiento y descubra sus obligaciones fiscales.",
+      "callToActionLink": {
+        "label": "Obtenga su guía personalizada",
+        "href": "https://account.business.nj.gov/",
+        "isInternal": false,
+        "opensInNewTab": true
+      }
+    },
+    "tagline": {
+      "title": "Planifique, opere y crezca con confianza",
+      "paragraphs": [
+        "Business.NJ.gov es el recurso empresarial del estado para ayudarle a planificar, comenzar, operar y hacer crecer su negocio.",
+        "Use su cuenta para crear una hoja de ruta personalizada, seguir solicitudes y conectarse con un asesor empresarial de New Jersey sin costo."
+      ]
+    },
+    "graphicList": {
+      "items": [
+        {
+          "title": "Registro empresarial",
+          "paragraph": "Inicie su LLC, corporación o sociedad con orientación estatal paso a paso.",
+          "imageAlt": "Texto alternativo"
+        },
+        {
+          "title": "Licencias y permisos",
+          "paragraph": "Encuentre los requisitos de licencias y permisos según su industria y ubicación.",
+          "imageAlt": "Texto alternativo"
+        },
+        {
+          "title": "Nombres comerciales",
+          "paragraph": "Revise disponibilidad y reglas de nombres para su negocio en New Jersey.",
+          "imageAlt": "Texto alternativo"
+        },
+        {
+          "title": "Obligaciones del empleador",
+          "paragraph": "Conozca requisitos laborales, de nómina y de registro antes de contratar.",
+          "imageAlt": "Texto alternativo"
+        }
+      ]
+    },
+    "callToAction": {
+      "sectionId": "test-section-id",
+      "title": "Más apoyo para su negocio",
+      "intro": "¿Busca asesoría más especializada? Explore guías personalizadas gratuitas, conéctese con un asesor empresarial y reciba actualizaciones sobre programas y regulaciones relevantes para su negocio.",
+      "callToActionLink": {
+        "label": "Explorar Business.NJ.gov",
+        "href": "https://business.nj.gov/",
+        "isInternal": false,
+        "opensInNewTab": true
+      }
     }
   },
   "learn": {

--- a/packages/static-site/package.json
+++ b/packages/static-site/package.json
@@ -47,6 +47,7 @@
     "@biomejs/biome": "2.4.15",
     "@playwright/test": "1.59.1",
     "@testing-library/dom": "10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "16.3.2",
     "@types/node": "25.6.2",
     "@types/react": "19.2.14",

--- a/packages/static-site/pnpm-lock.yaml
+++ b/packages/static-site/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
       '@testing-library/react':
         specifier: 16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -95,6 +98,9 @@ importers:
         version: 4.1.6(@types/node@25.6.2)(jsdom@29.1.1)(vite@8.0.12(@types/node@25.6.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -406,11 +412,20 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@formatjs/fast-memoize@3.1.3':
+    resolution: {integrity: sha512-Ocd1vPuD68rW6BJDuAOtnnc1GPeVepY5kZXML1psGVFQ+1Q8CfkftT3Tnam+Mxx97Pz08jIEDCotl/GV+Naccg==}
+
   '@formatjs/fast-memoize@3.1.4':
     resolution: {integrity: sha512-Lbke1aOrsygKKR09Ux0NrZgbTqpDmiwXOgzyDOJ8Owr1zd5qOKTauf62hH+Seeku3ju77rHWH9I5SfX2CN0vuA==}
 
+  '@formatjs/icu-messageformat-parser@3.5.6':
+    resolution: {integrity: sha512-04ZjRIeQCnR/h32wBP9/S7rkyy1hLAs2fXJcNwc7hseJd//K9TMBqK0ukb4dXqnALKQ9m5ruZeOD2qqEkK9ixg==}
+
   '@formatjs/icu-messageformat-parser@3.5.7':
     resolution: {integrity: sha512-wJxRZ+SiUCIMTL86bQlZU9bEKDQqqvgk2ezQ1BySUdWRfHqOzj4IKUVFeUZKS9w58M4e7wMSG0Sl86LAPb7Qww==}
+
+  '@formatjs/icu-skeleton-parser@2.1.6':
+    resolution: {integrity: sha512-9f1VQ2kaaLHK0WPU1OrAmiNKCKJwyoDmwNzQXbUa6XtFBOgHZ4YZURE8sSedHmMr0kvpB75OtplB0hMYkfdwfg==}
 
   '@formatjs/icu-skeleton-parser@2.1.7':
     resolution: {integrity: sha512-cIw1SFP0bi0CUBiJ2jzp99ws3OJNQDfStcHq9Z0iHWzItmiIikihFO+npR8C80yDlp7ZuBCLXCcKjgWjHicksA==}
@@ -903,6 +918,10 @@ packages:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
 
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
   '@testing-library/react@16.3.2':
     resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
     engines: {node: '>=18'}
@@ -1068,6 +1087,9 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -1088,6 +1110,9 @@ packages:
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   element-closest@2.0.2:
     resolution: {integrity: sha512-QCqAWP3kwj8Gz9UXncVXQGdrhnWxD8SQBSeZp5pOsyCcQ6RpL738L1/tfuwBiMi6F1fYkxqPnBrFBR4L+f49Cg==}
@@ -1177,8 +1202,12 @@ packages:
   icu-minify@4.11.2:
     resolution: {integrity: sha512-vZRLaDpZiFNBXZ1tUtekAf4WXl/Tow/BoWx8MWQqQpGckXf11opUXYzG+mXUj+OsDuv9Zz+etLfUWwxaMnYnzw==}
 
-  intl-messageformat@11.2.4:
-    resolution: {integrity: sha512-iKP6+uJXn+XcfRgYfGPE3+mqCoODV2vATrXDLo/YkYgIdelJHJPBEbc0GZThipAYPuk+8QJFiPgOfblU085ABg==}
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  intl-messageformat@11.2.3:
+    resolution: {integrity: sha512-kZthTU+3WLcoWoRg5j6LOkN1TeUBtmkX0OIwSAbcHVIfQAEbGVdmANM8u6GL3eUDOqLwheYoXMUshAh1UdeXlQ==}
 
   is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
@@ -1326,6 +1355,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -1455,6 +1488,10 @@ packages:
   receptor@1.0.0:
     resolution: {integrity: sha512-yvVEqVQDNzEmGkluCkEdbKSXqZb3WGxotI/VukXIQ+4/BXEeXVjWtmC6jWaR1BIsmEAGYQy3OTaNgDj2Svr01w==}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1549,6 +1586,10 @@ packages:
   strip-bom-string@1.0.0:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -1747,6 +1788,8 @@ packages:
     hasBin: true
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -1951,11 +1994,19 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@formatjs/fast-memoize@3.1.3': {}
+
   '@formatjs/fast-memoize@3.1.4': {}
+
+  '@formatjs/icu-messageformat-parser@3.5.6':
+    dependencies:
+      '@formatjs/icu-skeleton-parser': 2.1.6
 
   '@formatjs/icu-messageformat-parser@3.5.7':
     dependencies:
       '@formatjs/icu-skeleton-parser': 2.1.7
+
+  '@formatjs/icu-skeleton-parser@2.1.6': {}
 
   '@formatjs/icu-skeleton-parser@2.1.7': {}
 
@@ -2297,6 +2348,15 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -2450,6 +2510,8 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
+  css.escape@1.5.1: {}
+
   csstype@3.2.3: {}
 
   data-urls@7.0.0:
@@ -2466,6 +2528,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   element-closest@2.0.2: {}
 
@@ -2561,10 +2625,12 @@ snapshots:
     dependencies:
       '@formatjs/icu-messageformat-parser': 3.5.7
 
-  intl-messageformat@11.2.4:
+  indent-string@4.0.0: {}
+
+  intl-messageformat@11.2.3:
     dependencies:
-      '@formatjs/fast-memoize': 3.1.4
-      '@formatjs/icu-messageformat-parser': 3.5.7
+      '@formatjs/fast-memoize': 3.1.3
+      '@formatjs/icu-messageformat-parser': 3.5.6
 
   is-extendable@0.1.1: {}
 
@@ -2705,6 +2771,8 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  min-indent@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -2833,6 +2901,11 @@ snapshots:
       matches-selector: 1.2.0
       object-assign: 4.1.1
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   require-from-string@2.0.2: {}
 
   resolve-id-refs@0.1.0: {}
@@ -2959,6 +3032,10 @@ snapshots:
 
   strip-bom-string@1.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   styled-jsx@5.1.6(react@19.2.6):
     dependencies:
       client-only: 0.0.1
@@ -3011,7 +3088,7 @@ snapshots:
       '@formatjs/fast-memoize': 3.1.4
       '@schummar/icu-type-parser': 1.21.5
       icu-minify: 4.11.2
-      intl-messageformat: 11.2.4
+      intl-messageformat: 11.2.3
       react: 19.2.6
 
   vite@8.0.12(@types/node@25.6.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0):

--- a/packages/static-site/vitest.setup.ts
+++ b/packages/static-site/vitest.setup.ts
@@ -1,3 +1,4 @@
+import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import type { AnchorHTMLAttributes, ReactNode } from "react";
 import { createElement } from "react";


### PR DESCRIPTION
## Description



Adds sidebar navigation to Learn that highlights the current section. Extracts shared page stuff (banner, header, footer, identifier) into a root layout

<img width="1590" height="1114" alt="Screenshot 2026-05-13 at 11 29 11" src="https://github.com/user-attachments/assets/1547b944-3a5a-454f-a8fc-eb048172d051" />
n sub-

<img width="1482" height="637" alt="Screenshot 2026-05-13 at 12 26 07" src="https://github.com/user-attachments/assets/eb995505-f07f-407d-b2c2-f281f827d936" />


### Ticket

This pull request resolves [#17711](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17711).

### Approach

- Moved shared layout elements (banner, header, footer, identifier) out of the landing page and into the root layout.
- Introduced Next layout for `/learn` route and its subroutes that includes sidebar navigation. Introduces a generic `SideNav` NJWDS component. Also a `LearnSideNav` component that is client-rendered and uses the current route path to highlight active page.
- Updated messages and message types with side nav content, including a new shared layout key

### Steps to Test

- Navigate to `/en-US/learn` — sidebar should render with "Introduction" highlighted
- Navigate to `/en-US/learn/plan` — sidebar should render with "Plan" highlighted and "Introduction" not highlighted
- Navigate to `/es-US/learn` — sidebar labels should appear in Spanish

### Notes


## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews