### PR TITLE
fix: scope label removal to pr-review/pr-show

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -125,7 +125,12 @@ jobs:
           COMMENT_ID: ${{ steps.find-comment.outputs.comment-id }}
 
   remove-label:
-    if: always()
+    needs: pickaroo
+    if: >-
+      always() && (
+        github.event.label.name == 'pr-review' ||
+        github.event.label.name == 'pr-show'
+      )
     runs-on: ubuntu-latest
     permissions: {}
     steps:


### PR DESCRIPTION
## Description

Fixes the `remove-label` job in the PR review workflow so it only fires when triggered by a `pr-review` or `pr-show` label event, and only after the `pickaroo` job completes. Previously the job ran unconditionally (`always()`), which could cause labels to be removed in unintended situations.

### Approach

Added `needs: pickaroo` to the `remove-label` job so it only runs after Pickaroo finishes. Narrowed the `if` condition from `always()` to check that the triggering label is either `pr-review` or `pr-show` before removing it.

### Steps to Test

1. Add a `pr-review` or `pr-show` label to a PR — confirm the label is removed after the workflow completes.
2. Add an unrelated label to a PR — confirm the `remove-label` job is skipped entirely.

### Notes

No dependencies changed. Workflow-only change.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews