### PR TITLE
feat: [AB#17705] add checkboxes to roadmap redesign

### DIFF
--- a/content/src/fieldConfig/business-structure-task.json
+++ b/content/src/fieldConfig/business-structure-task.json
@@ -2,6 +2,8 @@
   "businessStructureTask": {
     "uncompletedTooltip": "Select and then save to complete this task.",
     "completedTooltip": "This task is complete. You can edit your business structure selection below.",
+    "uncompletedRoadmapTooltip": "Complete this task to mark it done.",
+    "completedRoadmapTooltip": "This task is complete.",
     "infoCallout": ":::miniCallout{ calloutType=\"informational\" hideIcon=\"true\" }\n\n**You need to pick a business structure before forming your business.**\n\nBusiness structure impacts who is responsible for debts and what rules you must follow.\n\nYou can change your business structure up until the “Register Your Business” step.\n\n:::",
     "saveButton": "Save Business Structure",
     "completedHeader": "Your business structure:",

--- a/web/decap-config/collections/06-tasks.yml
+++ b/web/decap-config/collections/06-tasks.yml
@@ -2509,7 +2509,7 @@ collections:
             widget: object
             fields:
               - {
-                  label: Tooltip - Not Complete,
+                  label: Task Page Tooltip - Not Complete,
                   name: uncompletedTooltip,
                   widget: text,
                   hint:
@@ -2518,11 +2518,28 @@ collections:
                     the task.,
                 }
               - {
-                  label: Tooltip - Completed,
+                  label: Task Page Tooltip - Completed,
                   name: completedTooltip,
                   widget: text,
                   hint: This tooltip shows if the user hovers over a completed checkbox.,
                 }
+              - {
+                  label: Roadmap Page Tooltip - Not Complete,
+                  name: uncompletedRoadmapTooltip,
+                  widget: text,
+                  hint:
+                    This tooltip shows if the user hovers over the checkbox on the dashboard page
+                    showing the roadmap.,
+                }
+              - {
+                  label: Roadmap Page Tooltip - Completed,
+                  name: completedRoadmapTooltip,
+                  widget: text,
+                  hint:
+                    This tooltip shows if the user hovers over a completed checkbox on the dashboard
+                    page showing the roadmap.,
+                }
+
               - {
                   label: Info Callout,
                   name: infoCallout,

--- a/web/src/components/Step.tsx
+++ b/web/src/components/Step.tsx
@@ -10,6 +10,8 @@ import { ModifiedContent } from "./ModifiedContent";
 interface Props {
   step: types.Step;
   last: boolean;
+  hideVerticalLine?: boolean;
+  showCheckboxes?: boolean;
 }
 
 export const Step = (props: Props): ReactElement => {
@@ -17,7 +19,7 @@ export const Step = (props: Props): ReactElement => {
   const { roadmap } = useRoadmap();
   return (
     <div
-      className={`margin-top-3 ${props.last ? "margin-bottom-1" : "padding-bottom-105"}`}
+      className={`margin-top-4  ${!props.last && "margin-bottom-4"}`}
       id={`vertical-content-${props.step.stepNumber}`}
     >
       <div className="tablet:margin-right-4 minh-4">
@@ -26,6 +28,7 @@ export const Step = (props: Props): ReactElement => {
             stepNumber={props.step.stepNumber}
             last={props.last}
             completed={isStepCompleted(roadmap, props.step, business)}
+            hideVerticalLine={props.hideVerticalLine}
           />
 
           <div className="margin-left-6 margin-top-neg-2px tablet:margin-left-205 font-body-md margin-bottom-105">
@@ -45,7 +48,9 @@ export const Step = (props: Props): ReactElement => {
           </div>
         </div>
 
-        <div className="tablet:margin-left-6 padding-left-05">
+        <div
+          className={`${props.hideVerticalLine ? "padding-left-05" : "tablet:margin-left-6 padding-left-05"} `}
+        >
           <p className="margin-bottom-205">{props.step.description}</p>
           <ul className="usa-list usa-list--unstyled">
             {roadmap?.tasks
@@ -53,7 +58,7 @@ export const Step = (props: Props): ReactElement => {
                 return task.stepNumber === props.step.stepNumber;
               })
               .map((task) => {
-                return <Task key={task.id} task={task} />;
+                return <Task key={task.id} task={task} showCheckbox={props.showCheckboxes} />;
               })}
           </ul>
         </div>

--- a/web/src/components/Task.tsx
+++ b/web/src/components/Task.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { TaskProgressCheckbox } from "@/components/TaskProgressCheckbox";
 import { TaskProgressTagLookup } from "@/components/TaskProgressTagLookup";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
@@ -11,6 +12,7 @@ import { ReactElement, ReactNode } from "react";
 
 interface Props {
   task: types.Task;
+  showCheckbox?: boolean;
 }
 
 export const Task = (props: Props): ReactElement => {
@@ -33,6 +35,20 @@ export const Task = (props: Props): ReactElement => {
     );
   };
 
+  const getDisabledTooltipText = (taskId: string, taskProgress: string): string => {
+    // Block users from checking off the business structure task without completing it
+    // since the formation task changes depending on business structure
+    if (taskId === "business-structure") {
+      if (taskProgress === "COMPLETED") {
+        return Config.businessStructureTask.completedRoadmapTooltip;
+      } else {
+        return Config.businessStructureTask.uncompletedRoadmapTooltip;
+      }
+    }
+
+    return "";
+  };
+
   return (
     <li className="margin-0">
       <div
@@ -42,7 +58,14 @@ export const Task = (props: Props): ReactElement => {
       >
         {isTabletAndUp && (
           <span className="margin-right-205 margin-top-05 padding-top-2px">
-            {TaskProgressTagLookup[taskProgress]}
+            {props.showCheckbox ? (
+              <TaskProgressCheckbox
+                taskId={props.task.id}
+                disabledTooltipText={getDisabledTooltipText(props.task.id, taskProgress)}
+              />
+            ) : (
+              TaskProgressTagLookup[taskProgress]
+            )}
           </span>
         )}
         <div>

--- a/web/src/components/TaskProgressCheckbox.tsx
+++ b/web/src/components/TaskProgressCheckbox.tsx
@@ -219,7 +219,7 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
   };
 
   return (
-    <div className={"flex flex-align-center"}>
+    <div className={"flex flex-align-start"}>
       <>{congratulatoryModal}</>
 
       <div className="margin-right-2">
@@ -234,7 +234,7 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
         )}
       </div>
 
-      <span className="flex flex-align-center">{TaskProgressTagLookup[currentTaskProgress]}</span>
+      <span className="flex flex-align-start">{TaskProgressTagLookup[currentTaskProgress]}</span>
 
       <TaskStatusChangeSnackbar
         isOpen={successSnackbarIsOpen}

--- a/web/src/components/dashboard/MiniSectionAccordion.test.tsx
+++ b/web/src/components/dashboard/MiniSectionAccordion.test.tsx
@@ -1,0 +1,82 @@
+import { MiniSectionAccordion } from "@/components/dashboard/MiniSectionAccordion";
+import { useMockRoadmap } from "@/test/mock/mockUseRoadmap";
+import {
+  currentBusiness,
+  setupStatefulUserDataContext,
+  WithStatefulUserData,
+} from "@/test/mock/withStatefulUserData";
+import { SectionType } from "@businessnjgovnavigator/shared/";
+import {
+  generateBusiness,
+  generatePreferences,
+  generateUserDataForBusiness,
+} from "@businessnjgovnavigator/shared/test";
+import { Business } from "@businessnjgovnavigator/shared/userData";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+
+jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
+jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
+
+describe("<SectionAccordion />", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    setupStatefulUserDataContext();
+    useMockRoadmap({});
+  });
+
+  const statefulRender = (type: SectionType, business: Business): void => {
+    render(
+      <WithStatefulUserData initialUserData={generateUserDataForBusiness(business)}>
+        <MiniSectionAccordion sectionType={type}>BODY CONTENT</MiniSectionAccordion>
+      </WithStatefulUserData>,
+    );
+  };
+
+  it("expands and collapses the accordion", async () => {
+    statefulRender(
+      "PLAN",
+      generateBusiness({
+        preferences: generatePreferences({
+          roadmapOpenSections: [],
+        }),
+      }),
+    );
+
+    expect(within(screen.getByTestId("section-plan")).getByText("BODY CONTENT")).not.toBeVisible();
+
+    fireEvent.click(screen.getByTestId("plan-header"));
+    await waitFor(() => {
+      return expect(
+        within(screen.getByTestId("section-plan")).getByText("BODY CONTENT"),
+      ).toBeVisible();
+    });
+
+    fireEvent.click(screen.getByTestId("plan-header"));
+    await waitFor(() => {
+      return expect(
+        within(screen.getByTestId("section-plan")).getByText("BODY CONTENT"),
+      ).not.toBeVisible();
+    });
+  });
+
+  it("adds and removes section from preferences on accordion open/close", () => {
+    statefulRender(
+      "PLAN",
+      generateBusiness({
+        preferences: generatePreferences({
+          roadmapOpenSections: ["PLAN", "START"],
+        }),
+      }),
+    );
+
+    const sectionPlan = screen.getByTestId("plan-header");
+
+    expect(sectionPlan).toBeInTheDocument();
+    fireEvent.click(sectionPlan);
+    expect(currentBusiness().preferences.roadmapOpenSections).toEqual(["START"]);
+    fireEvent.click(sectionPlan);
+    expect(currentBusiness().preferences.roadmapOpenSections).toEqual(
+      expect.arrayContaining(["PLAN", "START"]),
+    );
+  });
+});

--- a/web/src/components/dashboard/MiniSectionAccordion.tsx
+++ b/web/src/components/dashboard/MiniSectionAccordion.tsx
@@ -1,6 +1,5 @@
 import { Heading } from "@/components/njwds-extended/Heading";
 import { Icon } from "@/components/njwds/Icon";
-import { ProgressBar } from "@/components/ProgressBar";
 import { SectionAccordionContext } from "@/contexts/sectionAccordionContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
@@ -9,33 +8,16 @@ import { SectionType } from "@businessnjgovnavigator/shared";
 import { Accordion, AccordionDetails, AccordionSummary } from "@mui/material";
 import { ReactElement, ReactNode } from "react";
 
-interface Props {
+interface MiniSectionAccordionProps {
   sectionType: SectionType;
   children: ReactNode;
-  mini?: boolean;
   isDividerDisabled?: boolean;
-  progressPercentage?: number;
 }
 
-type ProgressLabelStage = "zero" | "low" | "mid" | "high";
-
-const PROGRESS_STAGE_LOW_THRESHOLD = 50;
-const PROGRESS_STAGE_MID_THRESHOLD = 90;
-
-const progressLabelStage = (percentage: number): ProgressLabelStage => {
-  if (percentage === 0) return "zero";
-  if (percentage < PROGRESS_STAGE_LOW_THRESHOLD) return "low";
-  if (percentage < PROGRESS_STAGE_MID_THRESHOLD) return "mid";
-  return "high";
-};
-
-export const SectionAccordion = (props: Props): ReactElement => {
+export const MiniSectionAccordion = (props: MiniSectionAccordionProps): ReactElement => {
   const { updateQueue, business } = useUserData();
-  const dropdownIconClasses = props.mini
-    ? "usa-icon--size-5 text-base-light"
-    : "usa-icon--size-5 margin-left-1";
-  const headerClasses = props.mini ? "" : "margin-top-3 tablet:margin-left-3";
-  const dividerClasses = props.mini ? "margin-y-2" : "margin-y-3";
+  const dropdownIconClasses = "usa-icon--size-5 text-base-light";
+  const dividerClasses = "margin-y-2";
   const sectionName = props.sectionType.toLowerCase();
   const isOpen = business?.preferences.roadmapOpenSections.includes(props.sectionType) ?? false;
   const { Config } = useConfig();
@@ -72,32 +54,10 @@ export const SectionAccordion = (props: Props): ReactElement => {
             aria-controls={`${sectionName}-content`}
             id={`${sectionName}-header`}
             data-testid={`${sectionName}-header`}
-            sx={{ position: "relative" }}
           >
-            <div className="flex flex-column width-full">
-              <Heading
-                level={3}
-                className={`flex flex-align-center margin-0-override ${headerClasses}`}
-              >
-                <div className="inline">{Config.sectionHeaders[props.sectionType]}</div>
-              </Heading>
-              {props.progressPercentage !== undefined && (
-                <div className="section-progress-bar-row">
-                  <ProgressBar
-                    label={`${Config.sectionHeaders[props.sectionType]} section task progress`}
-                    percentage={props.progressPercentage}
-                    data-testid="section-progress-bar"
-                  />
-                </div>
-              )}
-            </div>
-            {props.progressPercentage !== undefined && (
-              <span
-                className={`section-progress-bar-label section-progress-bar-label--${progressLabelStage(props.progressPercentage)}`}
-              >
-                {props.progressPercentage}%
-              </span>
-            )}
+            <Heading level={3} className="flex flex-align-center margin-0-override">
+              <div className="inline">{Config.sectionHeaders[props.sectionType]}</div>
+            </Heading>
           </AccordionSummary>
           <AccordionDetails>{props.children}</AccordionDetails>
         </Accordion>

--- a/web/src/components/dashboard/Roadmap.tsx
+++ b/web/src/components/dashboard/Roadmap.tsx
@@ -1,5 +1,5 @@
 import { BusinessStructurePrompt } from "@/components/dashboard/BusinessStructurePrompt";
-import { SectionAccordion } from "@/components/dashboard/SectionAccordion";
+import { SectionAccordionCard } from "@/components/dashboard/SectionAccordionCard";
 import { Step } from "@/components/Step";
 import { useRoadmap } from "@/lib/data-hooks/useRoadmap";
 import { useUserData } from "@/lib/data-hooks/useUserData";
@@ -37,18 +37,29 @@ export const Roadmap = (): ReactElement => {
         const percentage = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
 
         return (
-          <SectionAccordion key={section} sectionType={section} progressPercentage={percentage}>
+          <SectionAccordionCard key={section} sectionType={section} progressPercentage={percentage}>
             {section === "START" &&
             !completedBusinessStructure &&
             displayBusinessStructurePrompt ? (
               <BusinessStructurePrompt />
             ) : (
-              roadmap &&
-              roadmap.steps.filter(isInSection).map((step, index, array) => {
-                return <Step key={step.stepNumber} step={step} last={index === array.length - 1} />;
+              roadmap?.steps.filter(isInSection).map((step, index, array) => {
+                return (
+                  <div key={step.stepNumber}>
+                    <Step
+                      step={step}
+                      last={index === array.length - 1}
+                      hideVerticalLine
+                      showCheckboxes
+                    />
+                    {index !== array.length - 1 && (
+                      <div className="margin-bottom-3 border-1px border-cool-lighter" />
+                    )}
+                  </div>
+                );
               })
             )}
-          </SectionAccordion>
+          </SectionAccordionCard>
         );
       })}
     </>

--- a/web/src/components/dashboard/SectionAccordionCard.test.tsx
+++ b/web/src/components/dashboard/SectionAccordionCard.test.tsx
@@ -1,4 +1,4 @@
-import { SectionAccordion } from "@/components/dashboard/SectionAccordion";
+import { SectionAccordionCard } from "@/components/dashboard/SectionAccordionCard";
 import { useMockRoadmap } from "@/test/mock/mockUseRoadmap";
 import {
   currentBusiness,
@@ -17,7 +17,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
 jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
 
-describe("<SectionAccordion />", () => {
+describe("<SectionAccordionCard />", () => {
   beforeEach(() => {
     jest.resetAllMocks();
     setupStatefulUserDataContext();
@@ -27,7 +27,7 @@ describe("<SectionAccordion />", () => {
   const statefulRender = (type: SectionType, business: Business): void => {
     render(
       <WithStatefulUserData initialUserData={generateUserDataForBusiness(business)}>
-        <SectionAccordion sectionType={type}>BODY CONTENT</SectionAccordion>
+        <SectionAccordionCard sectionType={type}>BODY CONTENT</SectionAccordionCard>
       </WithStatefulUserData>,
     );
   };
@@ -89,9 +89,9 @@ describe("<SectionAccordion />", () => {
           }),
         )}
       >
-        <SectionAccordion sectionType="PLAN" progressPercentage={60}>
+        <SectionAccordionCard sectionType="PLAN" progressPercentage={60}>
           BODY CONTENT
-        </SectionAccordion>
+        </SectionAccordionCard>
       </WithStatefulUserData>,
     );
     expect(screen.getByTestId("section-progress-bar")).toBeInTheDocument();
@@ -106,7 +106,7 @@ describe("<SectionAccordion />", () => {
           }),
         )}
       >
-        <SectionAccordion sectionType="PLAN">BODY CONTENT</SectionAccordion>
+        <SectionAccordionCard sectionType="PLAN">BODY CONTENT</SectionAccordionCard>
       </WithStatefulUserData>,
     );
     expect(screen.queryByTestId("section-progress-bar")).not.toBeInTheDocument();

--- a/web/src/components/dashboard/SectionAccordionCard.tsx
+++ b/web/src/components/dashboard/SectionAccordionCard.tsx
@@ -1,0 +1,109 @@
+import { Heading } from "@/components/njwds-extended/Heading";
+import { Icon } from "@/components/njwds/Icon";
+import { ProgressBar } from "@/components/ProgressBar";
+import { SectionAccordionContext } from "@/contexts/sectionAccordionContext";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { useUserData } from "@/lib/data-hooks/useUserData";
+import analytics from "@/lib/utils/analytics";
+import { SectionType } from "@businessnjgovnavigator/shared";
+import { Accordion, AccordionDetails, AccordionSummary } from "@mui/material";
+import { ReactElement, ReactNode } from "react";
+
+interface SectionAccordionCardProps {
+  sectionType: SectionType;
+  children: ReactNode;
+  isDividerDisabled?: boolean;
+  progressPercentage?: number;
+}
+
+type ProgressLabelStage = "zero" | "low" | "mid" | "high";
+
+const PROGRESS_STAGE_LOW_THRESHOLD = 50;
+const PROGRESS_STAGE_MID_THRESHOLD = 90;
+
+const progressLabelStage = (percentage: number): ProgressLabelStage => {
+  if (percentage === 0) return "zero";
+  if (percentage < PROGRESS_STAGE_LOW_THRESHOLD) return "low";
+  if (percentage < PROGRESS_STAGE_MID_THRESHOLD) return "mid";
+  return "high";
+};
+
+export const SectionAccordionCard = (props: SectionAccordionCardProps): ReactElement => {
+  const { updateQueue, business } = useUserData();
+  const dropdownIconClasses = "usa-icon--size-5 margin-left-1";
+  const headerClasses = "margin-top-3 tablet:margin-left-3";
+  const sectionName = props.sectionType.toLowerCase();
+  const isOpen = business?.preferences.roadmapOpenSections.includes(props.sectionType) ?? false;
+  const { Config } = useConfig();
+
+  const handleAccordionStateChange = async (): Promise<void> => {
+    const roadmapOpenSections = business?.preferences.roadmapOpenSections;
+    if (!roadmapOpenSections) {
+      return;
+    }
+    analytics.event.roadmap_section.click.expand_contract();
+    if (isOpen) {
+      await updateQueue
+        ?.queuePreferences({
+          roadmapOpenSections: roadmapOpenSections?.filter((roadmapOpenSection) => {
+            return roadmapOpenSection !== props.sectionType;
+          }),
+        })
+        .update();
+    } else {
+      await updateQueue
+        ?.queuePreferences({
+          roadmapOpenSections: [...roadmapOpenSections, props.sectionType],
+        })
+        .update();
+    }
+  };
+
+  return (
+    <div
+      data-testid={`section-${sectionName}`}
+      className="border-2px radius-lg border-cool-lighter overflow-hidden margin-y-4"
+    >
+      <SectionAccordionContext.Provider value={{ isOpen }}>
+        <Accordion expanded={isOpen} onChange={handleAccordionStateChange}>
+          <AccordionSummary
+            expandIcon={<Icon className={dropdownIconClasses} iconName="expand_more" />}
+            aria-controls={`${sectionName}-content`}
+            id={`${sectionName}-header`}
+            data-testid={`${sectionName}-header`}
+            sx={{ position: "relative" }}
+            className="padding-3"
+          >
+            <div className="flex flex-column width-full">
+              <Heading
+                level={3}
+                className={`flex flex-align-center margin-0-override ${headerClasses}`}
+              >
+                <div className="inline">{Config.sectionHeaders[props.sectionType]}</div>
+              </Heading>
+              {props.progressPercentage !== undefined && (
+                <div className="section-progress-bar-row">
+                  <ProgressBar
+                    label={`${Config.sectionHeaders[props.sectionType]} section task progress`}
+                    percentage={props.progressPercentage}
+                    data-testid="section-progress-bar"
+                  />
+                </div>
+              )}
+            </div>
+            {props.progressPercentage !== undefined && (
+              <span
+                className={`section-progress-bar-label section-progress-bar-label--${progressLabelStage(props.progressPercentage)}`}
+              >
+                {props.progressPercentage}%
+              </span>
+            )}
+          </AccordionSummary>
+          <AccordionDetails>
+            <div className="padding-x-3 padding-bottom-3">{props.children}</div>
+          </AccordionDetails>
+        </Accordion>
+      </SectionAccordionContext.Provider>
+    </div>
+  );
+};

--- a/web/src/components/njwds-extended/VerticalStepIndicator.tsx
+++ b/web/src/components/njwds-extended/VerticalStepIndicator.tsx
@@ -11,6 +11,7 @@ interface Props {
   completed?: boolean;
   miniRoadmap?: boolean;
   miniRoadmapSubtaskisOpen?: boolean;
+  hideVerticalLine?: boolean;
 }
 
 export const VerticalStepIndicator = (props: Props): ReactElement => {
@@ -21,8 +22,9 @@ export const VerticalStepIndicator = (props: Props): ReactElement => {
     `vertical-content-${props.stepNumber}`,
   )?.offsetHeight;
   const renderVerticalBar =
-    (isTabletAndUp && sectionIsOpen && !props.miniRoadmap) ||
-    (props.miniRoadmap && sectionIsOpen && (!props.last || props.miniRoadmapSubtaskisOpen));
+    !props.hideVerticalLine &&
+    ((isTabletAndUp && sectionIsOpen && !props.miniRoadmap) ||
+      (props.miniRoadmap && sectionIsOpen && (!props.last || props.miniRoadmapSubtaskisOpen)));
 
   const resizeVerticalBarToContent = (): void => {
     const content = document.getElementById(`vertical-content-${props.stepNumber}`);

--- a/web/src/components/roadmap/MiniRoadmap.tsx
+++ b/web/src/components/roadmap/MiniRoadmap.tsx
@@ -1,5 +1,5 @@
 import { BusinessStructurePrompt } from "@/components/dashboard/BusinessStructurePrompt";
-import { SectionAccordion } from "@/components/dashboard/SectionAccordion";
+import { MiniSectionAccordion } from "@/components/dashboard/MiniSectionAccordion";
 import { MiniRoadmapStep } from "@/components/roadmap/MiniRoadmapStep";
 import { useRoadmap } from "@/lib/data-hooks/useRoadmap";
 import { useUserData } from "@/lib/data-hooks/useUserData";
@@ -56,7 +56,7 @@ export const MiniRoadmap = (props: Props): ReactElement => {
     <>
       {sectionNamesInRoadmap.map((section) => {
         return (
-          <SectionAccordion key={section} sectionType={section} mini={true}>
+          <MiniSectionAccordion key={section} sectionType={section}>
             {section === "START" &&
             !completedBusinessStructure &&
             displayBusinessStructurePrompt ? (
@@ -81,7 +81,7 @@ export const MiniRoadmap = (props: Props): ReactElement => {
                   );
                 })
             )}
-          </SectionAccordion>
+          </MiniSectionAccordion>
         );
       })}
     </>

--- a/web/src/styles/components/progress-bar.scss
+++ b/web/src/styles/components/progress-bar.scss
@@ -1,6 +1,6 @@
 @use "../sass-files/variables";
 
-$progress-bar-label-offset: 16px;
+$progress-bar-label-offset: 33px;
 
 .section-progress-bar-row {
   margin-top: 1.5rem;
@@ -9,7 +9,7 @@ $progress-bar-label-offset: 16px;
 .section-progress-bar-label {
   font-size: 0.9rem;
   position: absolute;
-  bottom: 0;
+  bottom: 16px;
   right: $progress-bar-label-offset;
   font-weight: bold;
 


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Implements the redesign of the roadmap to use a card-style accordion layout with checkboxes next to each task.

| Before    | After |
| -------- | ------- |
| <img width="805" height="825" alt="Screenshot 2026-05-26 at 2 17 31 PM" src="https://github.com/user-attachments/assets/48da9d4e-2a2a-4642-9a79-b3c987278afb" />  | <img width="842" height="873" alt="Screenshot 2026-05-26 at 2 00 26 PM" src="https://github.com/user-attachments/assets/4890ed20-b8a0-4ccd-8f58-679fa3a8d184" />   |



### Ticket

This pull request resolves [#17705](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17705).

### Approach

- Moved progress bar logic from `SectionAccordion` into `SectionAccordionCard`, which also has the card styling, checkboxes, and removes the vertical line for each step section. The original `SectionAccordion` remains in use on the left sidebar of task specific pages. 
- Added roadmap-specific tooltip fields (`completedRoadmapTooltip`, `uncompletedRoadmapTooltip`) for the business structure task
- Updated CMS config with new tooltip fields for roadmap page

### Steps to Test

1. Onboard as a new business
2. Verify roadmap sections display in bordered card-style accordions with progress bars and checkboxes. If not logged in with MyNJ, clicking the checkboxes should trigger a login modal.
4. Hover over the business structure task checkbox, and see that it shows the tooltip text "Complete this task to mark it done."

### Notes

Still finalizing mobile designs since checkboxes take up scarce horizontal space, mobile responsive design to be addressed in follow up PR.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews