### PR TITLE
chore: add OIDC and deploy role for warehouse

### DIFF
--- a/api/cdk/lib/iamStack.ts
+++ b/api/cdk/lib/iamStack.ts
@@ -25,6 +25,7 @@ export class IamStack extends Stack {
   public readonly taxKMSRole?: iam.Role;
   public readonly authRole?: iam.Role;
   public readonly unauthRole?: iam.Role;
+  public readonly githubOidcRole?: iam.Role;
 
   constructor(scope: Construct, id: string, props: IamStackProps) {
     super(scope, id, props);
@@ -33,7 +34,51 @@ export class IamStack extends Stack {
     const isIamCreatedForDevStagingProdOnly =
       props.stage === DEV_STAGE || props.stage === STAGING_STAGE || props.stage === PROD_STAGE;
 
+    const deployRoleAllowlist: Record<string, string[]> = {
+      dev: ["dev", "testing", "content"],
+      staging: ["staging"],
+      prod: ["prod"],
+    };
+
+    const allowedStages = deployRoleAllowlist[props.stage] ?? [];
+
     if (isIamCreatedForDevStagingProdOnly) {
+      const githubOidcProvider = iam.OpenIdConnectProvider.fromOpenIdConnectProviderArn(
+        this,
+        "GitHubOIDC",
+        `arn:aws:iam::${this.account}:oidc-provider/token.actions.githubusercontent.com`,
+      );
+
+      this.githubOidcRole = new iam.Role(this, "GitHubOidcRole", {
+        roleName: "bfs_github_actions_oidc_role",
+        assumedBy: new iam.FederatedPrincipal(
+          githubOidcProvider.openIdConnectProviderArn,
+          {
+            StringEquals: {
+              "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+            },
+            StringLike: {
+              "token.actions.githubusercontent.com:sub": [
+                "repo:newjersey/business-data-warehouse-cdk:ref:refs/heads/main",
+              ],
+            },
+          },
+          "sts:AssumeRoleWithWebIdentity",
+        ),
+      });
+
+      this.githubOidcRole.addToPolicy(
+        new iam.PolicyStatement({
+          actions: ["sts:AssumeRole"],
+          resources: allowedStages.map(
+            (stage) =>
+              `arn:aws:iam::${this.account}:role/njbfs-business-data-warehouse-deploy-${stage}`,
+          ),
+        }),
+      );
+
+      applyStandardTags(this.githubOidcRole, props.stage);
+
       const backupRole = new iam.Role(this, "backupRole", {
         assumedBy: new iam.ServicePrincipal("backup.amazonaws.com"),
         roleName: `Backups`,
@@ -272,5 +317,50 @@ export class IamStack extends Stack {
     applyStandardTags(lambdaRole, props.stage);
 
     this.role = lambdaRole;
+
+    const warehouseDeployRole = new iam.Role(this, "WarehouseDeployRole", {
+      roleName: `njbfs-business-data-warehouse-deploy-${props.stage}`,
+      assumedBy: new iam.ArnPrincipal(this.githubOidcRole!.roleArn),
+      description: `Deploy role for Business Data Warehouse`,
+    });
+
+    // Permissions are intentionally broad to allow for bootstrap for data warehouse project.
+    warehouseDeployRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: [
+          "s3:*",
+          "dynamodb:*",
+          "glue:*",
+          "athena:*",
+          "sns:*",
+          "events:*",
+          "cloudwatch:*",
+          "logs:*",
+          "kms:*",
+          "lambda:*",
+          "cloudformation:*",
+          "states:*",
+          "iam:CreateRole",
+          "iam:DeleteRole",
+          "iam:UpdateRole",
+          "iam:UpdateAssumeRolePolicy",
+          "iam:PutRolePolicy",
+          "iam:DeleteRolePolicy",
+          "iam:AttachRolePolicy",
+          "iam:DetachRolePolicy",
+          "iam:TagRole",
+          "iam:UntagRole",
+          "iam:GetRole",
+          "iam:GetRolePolicy",
+          "iam:ListRolePolicies",
+          "iam:ListAttachedRolePolicies",
+          "iam:PassRole",
+          "iam:CreateServiceLinkedRole",
+        ],
+        resources: ["*"],
+      }),
+    );
+
+    applyStandardTags(warehouseDeployRole, props.stage);
   }
 }


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
This change configures GitHub OIDC authentication for the Business Data Warehouse deployment by importing the existing OIDC provider in the AWS accounts and introducing a dedicated GitHub role that assumes the warehouseDeployRole.

**What This Does**
- Imports the existing GitHub OIDC provider in accounts where it already exists.
- Avoids recreating account-level OIDC infrastructure.
- Creates a new GitHub OIDC entry role used by GitHub Actions.
- Grants that role permission to assume the warehouseDeployRole.
- The warehouseDeployRole contains the actual deployment permissions for the Business Data Warehouse stack.


**Deployment Flow**

The GitHub Actions Pipeline will:
1. Authenticate using the existing OIDC provider.
2. Assume the GitHub OIDC role.
3. That role will assume the warehouseDeployRole.
4. The warehouseDeployRole performs infrastructure deployments.
<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#0000](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
