### PR TITLE
chore: HTTPS support for static site load balancer

### DIFF
--- a/api/cdk/lib/constants.ts
+++ b/api/cdk/lib/constants.ts
@@ -31,6 +31,8 @@ export const STATIC_SITE_HOSTNAMES: Record<string, string> = {
   [STAGING_STAGE]: "staging.next.business.nj.gov",
   [PROD_STAGE]: "next.business.nj.gov",
 };
+/** Shared ACM certificate ID covering every static-site hostname. */
+export const STATIC_SITE_CERTIFICATE_ID = "97592b7b-b08f-41f0-9667-68a0e8927687";
 export const HEALTH_CHECK_ENDPOINTS: Record<string, string> = {
   self: "self",
   elevator: "dynamics/elevator",

--- a/api/cdk/lib/staticSiteServiceStack.ts
+++ b/api/cdk/lib/staticSiteServiceStack.ts
@@ -1,4 +1,5 @@
-import { Duration, RemovalPolicy, Stack, StackProps } from "aws-cdk-lib";
+import { ArnFormat, Duration, RemovalPolicy, Stack, StackProps } from "aws-cdk-lib";
+import * as acm from "aws-cdk-lib/aws-certificatemanager";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as ecr from "aws-cdk-lib/aws-ecr";
 import * as ecs from "aws-cdk-lib/aws-ecs";
@@ -6,7 +7,11 @@ import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import * as logs from "aws-cdk-lib/aws-logs";
 import * as sns from "aws-cdk-lib/aws-sns";
 import { Construct } from "constructs";
-import { STATIC_SITE_HEALTH_CHECK_PATH, STATIC_SITE_SERVICE_BASE_NAME } from "./constants";
+import {
+  STATIC_SITE_CERTIFICATE_ID,
+  STATIC_SITE_HEALTH_CHECK_PATH,
+  STATIC_SITE_SERVICE_BASE_NAME,
+} from "./constants";
 import {
   createStaticSiteAlarms,
   createStaticSiteDeploymentFailureRule,
@@ -87,6 +92,12 @@ const STATIC_SITE_DEPLOYMENT_MAX_PERCENT = 200;
  */
 const STATIC_SITE_DEPLOYMENT_MIN_HEALTHY_PERCENT = 0;
 
+/** HTTP ingress port retained for existing upstream origin routing to the static-site ALB. */
+const STATIC_SITE_HTTP_INGRESS_PORT = 80;
+
+/** HTTPS ingress port used by the static-site ALB listener. */
+const STATIC_SITE_HTTPS_INGRESS_PORT = 443;
+
 const requireEnvironmentValue = (props: RequiredEnvironmentValue): string => {
   if (props.value === undefined || props.value.trim().length === 0) {
     throw new Error(`${props.name} must be set to deploy the static site service`);
@@ -113,6 +124,7 @@ export class StaticSiteServiceStack extends Stack {
     super(scope, id, props);
 
     const network = this.createNetwork();
+    this.configureLoadBalancerIngress(network);
     const alarmTopic = this.createAlarmTopic(props.stage);
     const cluster = this.createCluster(props.stage, network);
     const logGroup = this.createLogGroup(props.stage);
@@ -125,9 +137,13 @@ export class StaticSiteServiceStack extends Stack {
     });
     const loadBalancer = this.createLoadBalancer(props.stage, network);
     const targetGroup = this.createTargetGroup(props.stage, network);
+    const certificate = this.createCertificate();
     const listener = loadBalancer.addListener("StaticSiteListener", {
-      port: 80,
-      protocol: elbv2.ApplicationProtocol.HTTP,
+      port: STATIC_SITE_HTTPS_INGRESS_PORT,
+      protocol: elbv2.ApplicationProtocol.HTTPS,
+      certificates: [elbv2.ListenerCertificate.fromCertificateManager(certificate)],
+      sslPolicy: elbv2.SslPolicy.RECOMMENDED_TLS,
+      open: false,
       defaultTargetGroups: [targetGroup],
     });
     const service = this.createService({
@@ -190,9 +206,22 @@ export class StaticSiteServiceStack extends Stack {
         this,
         "StaticSiteSecurityGroup",
         requireEnvironmentValue({ name: "SG_ID", value: process.env.SG_ID }),
-        { mutable: false },
+        { mutable: true },
       ),
     };
+  }
+
+  private configureLoadBalancerIngress(network: StaticSiteNetwork): void {
+    network.securityGroup.addIngressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(STATIC_SITE_HTTP_INGRESS_PORT),
+      "Allow HTTP traffic to the static-site load balancer.",
+    );
+    network.securityGroup.addIngressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(STATIC_SITE_HTTPS_INGRESS_PORT),
+      "Allow HTTPS traffic to the static-site load balancer.",
+    );
   }
 
   private createCluster(stage: string, network: StaticSiteNetwork): ecs.Cluster {
@@ -220,6 +249,19 @@ export class StaticSiteServiceStack extends Stack {
     alarmTopic.applyRemovalPolicy(RemovalPolicy.RETAIN);
     applyStandardTags(alarmTopic, stage);
     return alarmTopic;
+  }
+
+  private createCertificate(): acm.ICertificate {
+    return acm.Certificate.fromCertificateArn(
+      this,
+      "StaticSiteCertificate",
+      this.formatArn({
+        service: "acm",
+        resource: "certificate",
+        resourceName: STATIC_SITE_CERTIFICATE_ID,
+        arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
+      }),
+    );
   }
 
   private createLogGroup(stage: string): logs.LogGroup {

--- a/api/cdk/test/staticSiteServiceStack.test.ts
+++ b/api/cdk/test/staticSiteServiceStack.test.ts
@@ -1,11 +1,31 @@
 import { App, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import * as ecr from "aws-cdk-lib/aws-ecr";
+import { STATIC_SITE_CERTIFICATE_ID } from "../lib/constants";
 import { StaticSiteServiceStack } from "../lib/staticSiteServiceStack";
+
+const TEST_AWS_ACCOUNT_ID = "123456789012";
+const TEST_AWS_REGION = "us-east-1";
+const STATIC_SITE_TEST_ENVIRONMENT = {
+  account: TEST_AWS_ACCOUNT_ID,
+  region: TEST_AWS_REGION,
+};
+const STATIC_SITE_CERTIFICATE_ARN = {
+  "Fn::Join": [
+    "",
+    [
+      "arn:",
+      { Ref: "AWS::Partition" },
+      `:acm:${TEST_AWS_REGION}:${TEST_AWS_ACCOUNT_ID}:certificate/${STATIC_SITE_CERTIFICATE_ID}`,
+    ],
+  ],
+};
 
 const createStaticSiteTemplate = (stage: string): Template => {
   const app = new App();
-  const repositoryStack = new Stack(app, `${stage}RepositoryStack`);
+  const repositoryStack = new Stack(app, `${stage}RepositoryStack`, {
+    env: STATIC_SITE_TEST_ENVIRONMENT,
+  });
   const repository = new ecr.Repository(repositoryStack, "StaticSiteRepository", {
     repositoryName: `bfs-static-site-${stage}`,
   });
@@ -13,6 +33,7 @@ const createStaticSiteTemplate = (stage: string): Template => {
     stage,
     repository,
     imageTag: "abc123",
+    env: STATIC_SITE_TEST_ENVIRONMENT,
   });
 
   return Template.fromStack(stack);
@@ -34,7 +55,7 @@ describe("StaticSiteServiceStack", () => {
     process.env = { ...originalEnvironment };
   });
 
-  test("creates an internal ALB-backed Fargate service for the static site", () => {
+  test("creates an internal HTTPS ALB-backed Fargate service for the static site", () => {
     const template = createStaticSiteTemplate("dev");
 
     expect(template.toJSON()).toBeDefined();
@@ -45,6 +66,28 @@ describe("StaticSiteServiceStack", () => {
       LoadBalancerAttributes: Match.arrayWith([
         { Key: "deletion_protection.enabled", Value: "true" },
       ]),
+    });
+    template.hasResourceProperties("AWS::ElasticLoadBalancingV2::Listener", {
+      Port: 443,
+      Protocol: "HTTPS",
+      Certificates: [{ CertificateArn: STATIC_SITE_CERTIFICATE_ARN }],
+      SslPolicy: "ELBSecurityPolicy-TLS13-1-2-2021-06",
+    });
+    template.hasResourceProperties("AWS::EC2::SecurityGroupIngress", {
+      GroupId: "sg-1234567890abcdef0",
+      IpProtocol: "tcp",
+      FromPort: 80,
+      ToPort: 80,
+      CidrIp: "0.0.0.0/0",
+      Description: "Allow HTTP traffic to the static-site load balancer.",
+    });
+    template.hasResourceProperties("AWS::EC2::SecurityGroupIngress", {
+      GroupId: "sg-1234567890abcdef0",
+      IpProtocol: "tcp",
+      FromPort: 443,
+      ToPort: 443,
+      CidrIp: "0.0.0.0/0",
+      Description: "Allow HTTPS traffic to the static-site load balancer.",
     });
     template.hasResourceProperties("AWS::ElasticLoadBalancingV2::TargetGroup", {
       Name: "bfs-static-site-dev-tg",


### PR DESCRIPTION
## Description

### Approach

Switches the static site ALB listener from HTTP (port 80) to HTTPS (port 443) using a shared ACM certificate referenced by ID (`STATIC_SITE_CERTIFICATE_ID`) via `acm.Certificate.fromCertificateArn`. The TLS policy is set to `RECOMMENDED_TLS` (TLS 1.3/1.2).

Security group ingress rules are now added explicitly for both ports 80 and 443 — port 80 is retained to avoid breaking any existing upstream origin routing that still points to the ALB over HTTP. The security group mutability was changed to `true` to allow CDK to add these ingress rules.

### Steps to Test

1. Deploy to `dev` and confirm HTTPS traffic reaches the static site at `dev.next.business.nj.gov` (or equivalent).
2. Confirm any upstream services routing to port 80 on the ALB still receive a valid response.
3. Verify the ALB listener in the AWS console shows `HTTPS:443` with the correct certificate and TLS policy.

### Notes

The ACM certificate (`97592b7b-b08f-41f0-9667-68a0e8927687`) is shared across all static site hostnames (dev/staging/prod). `Stack.formatArn` is used instead of a hardcoded ARN string so the cert reference remains account/region-portable.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews