### PR TITLE
fix: remove cross-stack ECR export causing static-site deploy rollback

### DIFF
--- a/api/cdk/bin/app.ts
+++ b/api/cdk/bin/app.ts
@@ -35,20 +35,15 @@ const env = {
   region: region,
 };
 
-const staticSiteRepositoryStack = new StaticSiteRepositoryStack(
-  app,
-  `StaticSiteRepositoryStack-${stage}`,
-  {
-    stage,
-    env,
-  },
-);
+new StaticSiteRepositoryStack(app, `StaticSiteRepositoryStack-${stage}`, {
+  stage,
+  env,
+});
 
 if (isStaticSiteDeploy) {
   new StaticSiteServiceStack(app, `StaticSiteServiceStack-${stage}`, {
     stage,
     env,
-    repository: staticSiteRepositoryStack.repository,
     imageTag: staticSiteImageTag,
   });
 }

--- a/api/cdk/lib/staticSiteRepositoryStack.ts
+++ b/api/cdk/lib/staticSiteRepositoryStack.ts
@@ -1,4 +1,4 @@
-import { CfnOutput, Duration, RemovalPolicy, Stack, StackProps } from "aws-cdk-lib";
+import { Duration, RemovalPolicy, Stack, StackProps } from "aws-cdk-lib";
 import * as ecr from "aws-cdk-lib/aws-ecr";
 import { Construct } from "constructs";
 import { PROD_STAGE, STATIC_SITE_SERVICE_BASE_NAME } from "./constants";
@@ -39,11 +39,6 @@ export class StaticSiteRepositoryStack extends Stack {
     });
 
     applyStandardTags(repository, props.stage);
-
-    new CfnOutput(this, "StaticSiteRepositoryUri", {
-      value: repository.repositoryUri,
-      exportName: `${STATIC_SITE_SERVICE_BASE_NAME}-${props.stage}-repository-uri`,
-    });
 
     this.repository = repository;
   }

--- a/api/cdk/lib/staticSiteServiceStack.ts
+++ b/api/cdk/lib/staticSiteServiceStack.ts
@@ -28,9 +28,6 @@ export interface StaticSiteServiceStackProps extends StackProps {
   /** Deployment stage that owns this ECS service, such as dev, testing, content, staging, or prod. */
   readonly stage: string;
 
-  /** ECR repository that contains the static-site image for this stage. */
-  readonly repository: ecr.IRepository;
-
   /** Immutable image tag that ECS should deploy for this service revision. */
   readonly imageTag: string;
 }
@@ -128,10 +125,15 @@ export class StaticSiteServiceStack extends Stack {
     const alarmTopic = this.createAlarmTopic(props.stage);
     const cluster = this.createCluster(props.stage, network);
     const logGroup = this.createLogGroup(props.stage);
+    const repository = ecr.Repository.fromRepositoryName(
+      this,
+      "StaticSiteRepository",
+      `${STATIC_SITE_SERVICE_BASE_NAME}-${props.stage}`,
+    );
     const taskDefinition = createStaticSiteTaskDefinition({
       scope: this,
       stage: props.stage,
-      repository: props.repository,
+      repository,
       imageTag: props.imageTag,
       logGroup,
     });

--- a/api/cdk/test/staticSiteRepositoryStack.test.ts
+++ b/api/cdk/test/staticSiteRepositoryStack.test.ts
@@ -3,6 +3,16 @@ import { Match, Template } from "aws-cdk-lib/assertions";
 import { StaticSiteRepositoryStack } from "../lib/staticSiteRepositoryStack";
 
 describe("StaticSiteRepositoryStack", () => {
+  test("has no CloudFormation Outputs to prevent cross-stack export dependencies", () => {
+    const app = new App();
+    const stack = new StaticSiteRepositoryStack(app, "TestStaticSiteRepositoryStack", {
+      stage: "dev",
+    });
+    const template = Template.fromStack(stack);
+
+    expect(template.toJSON().Outputs).toBeUndefined();
+  });
+
   test("creates a private dev ECR repository that keeps the latest 50 tagged images", () => {
     const app = new App();
     const stack = new StaticSiteRepositoryStack(app, "TestStaticSiteRepositoryStack", {

--- a/api/cdk/test/staticSiteServiceStack.test.ts
+++ b/api/cdk/test/staticSiteServiceStack.test.ts
@@ -1,7 +1,7 @@
-import { App, Stack } from "aws-cdk-lib";
+import { App } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
-import * as ecr from "aws-cdk-lib/aws-ecr";
 import { STATIC_SITE_CERTIFICATE_ID } from "../lib/constants";
+import { StaticSiteRepositoryStack } from "../lib/staticSiteRepositoryStack";
 import { StaticSiteServiceStack } from "../lib/staticSiteServiceStack";
 
 const TEST_AWS_ACCOUNT_ID = "123456789012";
@@ -21,22 +21,26 @@ const STATIC_SITE_CERTIFICATE_ARN = {
   ],
 };
 
-const createStaticSiteTemplate = (stage: string): Template => {
+const createStaticSiteTemplates = (stage: string) => {
   const app = new App();
-  const repositoryStack = new Stack(app, `${stage}RepositoryStack`, {
+  const repositoryStack = new StaticSiteRepositoryStack(app, `${stage}StaticSiteRepositoryStack`, {
+    stage,
     env: STATIC_SITE_TEST_ENVIRONMENT,
   });
-  const repository = new ecr.Repository(repositoryStack, "StaticSiteRepository", {
-    repositoryName: `bfs-static-site-${stage}`,
-  });
-  const stack = new StaticSiteServiceStack(app, `${stage}StaticSiteServiceStack`, {
+  const serviceStack = new StaticSiteServiceStack(app, `${stage}StaticSiteServiceStack`, {
     stage,
-    repository,
     imageTag: "abc123",
     env: STATIC_SITE_TEST_ENVIRONMENT,
   });
 
-  return Template.fromStack(stack);
+  return {
+    repositoryTemplate: Template.fromStack(repositoryStack),
+    serviceTemplate: Template.fromStack(serviceStack),
+  };
+};
+
+const createStaticSiteTemplate = (stage: string): Template => {
+  return createStaticSiteTemplates(stage).serviceTemplate;
 };
 
 describe("StaticSiteServiceStack", () => {
@@ -242,5 +246,34 @@ describe("StaticSiteServiceStack", () => {
       Endpoint: "https://global.sns-api.chatbot.amazonaws.com",
       Protocol: "https",
     });
+  });
+
+  test("references the ECR repository by name without a cross-stack Fn::ImportValue", () => {
+    const template = createStaticSiteTemplate("dev");
+    const templateJson = JSON.stringify(template.toJSON());
+
+    expect(templateJson).not.toContain("Fn::ImportValue");
+    template.hasResourceProperties("AWS::ECS::TaskDefinition", {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Image: {
+            "Fn::Join": [
+              "",
+              [
+                "123456789012.dkr.ecr.us-east-1.",
+                { Ref: "AWS::URLSuffix" },
+                "/bfs-static-site-dev:abc123",
+              ],
+            ],
+          },
+        }),
+      ]),
+    });
+  });
+
+  test("does not add repository exports when the repository and service stacks are synthesized together", () => {
+    const templates = createStaticSiteTemplates("dev");
+
+    expect(templates.repositoryTemplate.toJSON().Outputs).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Description

The static-site deploy was rolling back on every run due to a CloudFormation cross-stack export dependency that CDK introduced automatically when both stacks were synthesized together.

### Approach

The static-site deploy was failing with `UPDATE_ROLLBACK_COMPLETE` because CDK was generating an automatic CloudFormation cross-stack export (`ExportsOutputRefStaticSiteRepository...`) in `StaticSiteRepositoryStack` when both stacks were synthesized together (i.e. when `STATIC_SITE_IMAGE_TAG` is set). On the next run, when only the repository stack is synthesized (without `STATIC_SITE_IMAGE_TAG`), that export disappears from the template — and CloudFormation rejects the update because `StaticSiteServiceStack` still imports it.

Fix: `StaticSiteServiceStack` now looks up the ECR repository by its deterministic name via `ecr.Repository.fromRepositoryName` instead of receiving it as a CDK object reference from `app.ts`. This eliminates the cross-stack dependency entirely. The unused `CfnOutput` with `exportName` in `StaticSiteRepositoryStack` was also removed.

Two regression tests were added to prevent reintroduction:
- `StaticSiteRepositoryStack` asserts it has no CloudFormation `Outputs`.
- `StaticSiteServiceStack` asserts it contains no `Fn::ImportValue` references.

### Steps to Test

Deploy to dev and confirm the `Deploy Static Site ECR Repository` step completes without rollback.

### Notes

The root cause was that the deploy action runs two separate CDK synth/deploy passes with different env contexts (step 1: no `STATIC_SITE_IMAGE_TAG`; step 3: with `STATIC_SITE_IMAGE_TAG`), so any cross-stack reference that only appears in the combined synthesis will orphan itself on the next isolated deploy.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews