### PR TITLE
feat: add API gateway load balancers

### DIFF
--- a/api/cdk/bin/app.ts
+++ b/api/cdk/bin/app.ts
@@ -127,6 +127,7 @@ if (isMyAccountDeploy) {
 
   new ApiStack(app, `ApiStack-${stage}`, {
     stage,
+    lambdaRole: iamStack.role,
     lambdas: {
       express: { lambda: lambdaStack.expressLambda },
       githubOauth2: { lambda: lambdaStack.githubOauth2Lambda },

--- a/api/cdk/lib/apiStack.ts
+++ b/api/cdk/lib/apiStack.ts
@@ -3,22 +3,108 @@ import {
   REMINDER_EMAIL_CONFIG_SET_BASE,
   WELCOME_EMAIL_CONFIG_SET_BASE,
 } from "@businessnjgovnavigator/api/src/libs/constants";
-import { CfnOutput, Stack, StackProps } from "aws-cdk-lib";
+import { CfnOutput, Duration, Stack, StackProps } from "aws-cdk-lib";
 import * as acm from "aws-cdk-lib/aws-certificatemanager";
 import * as apigateway from "aws-cdk-lib/aws-apigateway";
 import * as cognito from "aws-cdk-lib/aws-cognito";
-import { IFunction } from "aws-cdk-lib/aws-lambda";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import * as elbv2Targets from "aws-cdk-lib/aws-elasticloadbalancingv2-targets";
+import * as iam from "aws-cdk-lib/aws-iam";
+import { Runtime } from "aws-cdk-lib/aws-lambda";
+import type { IFunction } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
-import { applyStandardTags, attachLambdaToResource, createSesConfigSet } from "./stackUtils";
+import path from "node:path";
+import {
+  applyStandardTags,
+  attachLambdaToResource,
+  createLambda,
+  createSesConfigSet,
+} from "./stackUtils";
 
-interface LambdaConfig {
-  lambda?: IFunction;
+/** Lambda function configuration consumed by API Gateway routes. */
+export interface LambdaConfig {
+  /** Lambda function to attach to API Gateway routes; optional for stage-specific routes. */
+  readonly lambda?: IFunction;
 }
 
-interface ApiStackProps extends StackProps {
-  stage: string;
-  lambdas: Record<string, LambdaConfig>;
+/** Properties required to create the API Gateway stack. */
+export interface ApiStackProps extends StackProps {
+  /** Deployment stage used for API names, tags, and stage-specific routing. */
+  readonly stage: string;
+
+  /** Shared Lambda IAM role used by API-owned Lambda functions. */
+  readonly lambdaRole: iam.Role;
+
+  /** Lambda functions used by API Gateway integrations. */
+  readonly lambdas: Record<string, LambdaConfig>;
 }
+
+interface RequiredEnvironmentValue {
+  /** Environment variable name to validate. */
+  readonly name: string;
+
+  /** Environment variable value to validate. */
+  readonly value: string | undefined;
+}
+
+interface ApiLoadBalancerNetwork {
+  /** Imported VPC that contains the internal API load balancer. */
+  readonly vpc: ec2.IVpc;
+
+  /** Imported private subnets used by the internal API load balancer. */
+  readonly subnets: ec2.ISubnet[];
+
+  /** Existing security group attached to the internal API load balancer. */
+  readonly securityGroup: ec2.ISecurityGroup;
+}
+
+interface CustomDomainConfig {
+  /** Custom domain name assigned to the API Gateway stage. */
+  readonly domainName: string;
+
+  /** ACM certificate ARN used by the API Gateway custom domain. */
+  readonly certificateArn: string;
+}
+
+interface CreateLoadBalancerOutputsProps {
+  /** Deployment stage used in exported output names. */
+  readonly stage: string;
+
+  /** Internal API load balancer whose DNS name is exported. */
+  readonly loadBalancer: elbv2.ApplicationLoadBalancer;
+
+  /** Lambda target group whose ARN is exported. */
+  readonly targetGroup: elbv2.ApplicationTargetGroup;
+
+  /** HTTPS listener whose ARN is exported. */
+  readonly listener: elbv2.ApplicationListener;
+}
+
+/** HTTPS ingress port used by the internal API load balancer. */
+const API_LOAD_BALANCER_HTTPS_INGRESS_PORT = 443;
+
+/** Health route that the internal API load balancer forwards through the proxy Lambda. */
+const API_LOAD_BALANCER_HEALTH_CHECK_PATH = "/health";
+
+/** Number of seconds the internal API proxy Lambda can spend forwarding one request. */
+const API_LOAD_BALANCER_PROXY_TIMEOUT_SECONDS = 30;
+
+const requireEnvironmentValue = (props: RequiredEnvironmentValue): string => {
+  if (props.value === undefined || props.value.trim().length === 0) {
+    throw new Error(`${props.name} must be set to deploy the API load balancer`);
+  }
+
+  return props.value;
+};
+
+const createApiLoadBalancerName = (stage: string): string => {
+  return `${API_SERVICE_NAME}-${stage}-alb`;
+};
+
+const createApiLoadBalancerTargetGroupName = (stage: string): string => {
+  return `${API_SERVICE_NAME}-${stage}-tg`;
+};
 
 export class ApiStack extends Stack {
   public readonly restApi: apigateway.RestApi;
@@ -94,6 +180,7 @@ export class ApiStack extends Stack {
     this.setupApiRoutes(expressLambda!, githubLambda);
 
     this.configureCustomDomain(props.stage);
+    this.configureApiLoadBalancer(props.stage, props.lambdaRole);
 
     new CfnOutput(this, "ApiGatewayId", {
       value: this.restApi.restApiId,
@@ -190,7 +277,7 @@ export class ApiStack extends Stack {
     }
   }
 
-  private getCustomDomainConfig(stage: string): { domainName: string; certificateArn: string } {
+  private getCustomDomainConfig(stage: string): CustomDomainConfig {
     const certificateArn = process.env.API_GATEWAY_CERT_ARN;
 
     if (!certificateArn) {
@@ -235,6 +322,144 @@ export class ApiStack extends Stack {
       domainName: domain,
       restApi: this.restApi,
       stage: this.restApi.deploymentStage,
+    });
+  }
+
+  private configureApiLoadBalancer(stage: string, lambdaRole: iam.Role): void {
+    const network = this.createLoadBalancerNetwork();
+    this.configureLoadBalancerIngress(network);
+    const loadBalancer = this.createLoadBalancer(stage, network);
+    const proxyLambda = this.createLoadBalancerProxyLambda(stage, lambdaRole);
+    const targetGroup = this.createLoadBalancerTargetGroup(stage, proxyLambda);
+    const certificate = this.createCertificate();
+    const listener = loadBalancer.addListener("ApiLoadBalancerListener", {
+      port: API_LOAD_BALANCER_HTTPS_INGRESS_PORT,
+      protocol: elbv2.ApplicationProtocol.HTTPS,
+      certificates: [elbv2.ListenerCertificate.fromCertificateManager(certificate)],
+      sslPolicy: elbv2.SslPolicy.RECOMMENDED_TLS,
+      open: false,
+      defaultTargetGroups: [targetGroup],
+    });
+
+    applyStandardTags(listener, stage);
+    this.createLoadBalancerOutputs({ stage, loadBalancer, targetGroup, listener });
+  }
+
+  private createLoadBalancerNetwork(): ApiLoadBalancerNetwork {
+    const subnetId01 = requireEnvironmentValue({
+      name: "SUBNET_ID_01",
+      value: process.env.SUBNET_ID_01,
+    });
+    const subnetId02 = requireEnvironmentValue({
+      name: "SUBNET_ID_02",
+      value: process.env.SUBNET_ID_02,
+    });
+
+    return {
+      vpc: ec2.Vpc.fromVpcAttributes(this, "ApiLoadBalancerVpc", {
+        vpcId: requireEnvironmentValue({ name: "VPC_ID", value: process.env.VPC_ID }),
+        availabilityZones: ["us-east-1a", "us-east-1b"],
+        privateSubnetIds: [subnetId01, subnetId02],
+      }),
+      subnets: [
+        ec2.Subnet.fromSubnetId(this, "ApiLoadBalancerSubnet01", subnetId01),
+        ec2.Subnet.fromSubnetId(this, "ApiLoadBalancerSubnet02", subnetId02),
+      ],
+      securityGroup: ec2.SecurityGroup.fromSecurityGroupId(
+        this,
+        "ApiLoadBalancerSecurityGroup",
+        requireEnvironmentValue({ name: "SG_ID", value: process.env.SG_ID }),
+        { mutable: true },
+      ),
+    };
+  }
+
+  private configureLoadBalancerIngress(network: ApiLoadBalancerNetwork): void {
+    network.securityGroup.addIngressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(API_LOAD_BALANCER_HTTPS_INGRESS_PORT),
+      "Allow HTTPS traffic to the API load balancer.",
+    );
+  }
+
+  private createLoadBalancer(
+    stage: string,
+    network: ApiLoadBalancerNetwork,
+  ): elbv2.ApplicationLoadBalancer {
+    const loadBalancer = new elbv2.ApplicationLoadBalancer(this, "ApiLoadBalancer", {
+      loadBalancerName: createApiLoadBalancerName(stage),
+      vpc: network.vpc,
+      internetFacing: false,
+      securityGroup: network.securityGroup,
+      vpcSubnets: { subnets: network.subnets },
+      deletionProtection: true,
+    });
+
+    applyStandardTags(loadBalancer, stage);
+    return loadBalancer;
+  }
+
+  private createLoadBalancerProxyLambda(stage: string, lambdaRole: iam.Role): IFunction {
+    return createLambda(this, {
+      role: lambdaRole,
+      id: `${API_SERVICE_NAME}-${stage}-apiGatewayLoadBalancerProxy`,
+      stage,
+      functionName: `${API_SERVICE_NAME}-${stage}-apiGatewayLoadBalancerProxy`,
+      entry: path.join(__dirname, "../../src/functions/apiGatewayLoadBalancerProxy/app.ts"),
+      handler: "handler",
+      runtime: Runtime.NODEJS_22_X,
+      timeout: Duration.seconds(API_LOAD_BALANCER_PROXY_TIMEOUT_SECONDS),
+      environment: {
+        API_GATEWAY_PROXY_BASE_URL: this.restApi.url,
+      },
+    });
+  }
+
+  private createLoadBalancerTargetGroup(
+    stage: string,
+    proxyLambda: IFunction,
+  ): elbv2.ApplicationTargetGroup {
+    const targetGroup = new elbv2.ApplicationTargetGroup(this, "ApiLoadBalancerTargetGroup", {
+      targetGroupName: createApiLoadBalancerTargetGroupName(stage),
+      targetType: elbv2.TargetType.LAMBDA,
+      targets: [new elbv2Targets.LambdaTarget(proxyLambda)],
+      healthCheck: {
+        enabled: true,
+        path: API_LOAD_BALANCER_HEALTH_CHECK_PATH,
+        interval: Duration.seconds(30),
+        timeout: Duration.seconds(5),
+        healthyThresholdCount: 3,
+        unhealthyThresholdCount: 3,
+      },
+    });
+
+    applyStandardTags(targetGroup, stage);
+    return targetGroup;
+  }
+
+  private createCertificate(): acm.ICertificate {
+    return acm.Certificate.fromCertificateArn(
+      this,
+      "ApiLoadBalancerCertificate",
+      requireEnvironmentValue({
+        name: "API_GATEWAY_CERT_ARN",
+        value: process.env.API_GATEWAY_CERT_ARN,
+      }),
+    );
+  }
+
+  private createLoadBalancerOutputs(props: CreateLoadBalancerOutputsProps): void {
+    new CfnOutput(this, "ApiLoadBalancerDnsName", {
+      value: props.loadBalancer.loadBalancerDnsName,
+      exportName: `${API_SERVICE_NAME}-${props.stage}-ApiLoadBalancerDnsName`,
+    });
+    new CfnOutput(this, "ApiLoadBalancerTargetGroupArn", {
+      value: props.targetGroup.targetGroupArn,
+      exportName: `${API_SERVICE_NAME}-${props.stage}-ApiLoadBalancerTargetGroupArn`,
+    });
+    new CfnOutput(this, "ApiLoadBalancerListenerArn", {
+      value: props.listener.listenerArn,
+      exportName: `${API_SERVICE_NAME}-${props.stage}-ApiLoadBalancerListenerArn`,
     });
   }
 }

--- a/api/cdk/test/apiStack.test.ts
+++ b/api/cdk/test/apiStack.test.ts
@@ -1,0 +1,191 @@
+import { API_SERVICE_NAME } from "@businessnjgovnavigator/api/src/libs/constants";
+import { App, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { ApiStack } from "../lib/apiStack";
+
+const TEST_AWS_ACCOUNT_ID = "123456789012";
+const TEST_AWS_REGION = "us-east-1";
+const TEST_API_STACK_ENVIRONMENT = {
+  account: TEST_AWS_ACCOUNT_ID,
+  region: TEST_AWS_REGION,
+};
+const TEST_API_GATEWAY_CERT_ARN = `arn:aws:acm:${TEST_AWS_REGION}:${TEST_AWS_ACCOUNT_ID}:certificate/test-certificate-id`;
+
+interface TestApiStackTemplate {
+  /** Synthesized CloudFormation template for the API stack under test. */
+  readonly template: Template;
+}
+
+interface CreateTestLambdaRoleProps {
+  /** Stack that owns the Lambda role. */
+  readonly stack: Stack;
+}
+
+interface CreateImportedLambdaProps {
+  /** Stack that owns the imported Lambda reference. */
+  readonly stack: Stack;
+
+  /** Construct identifier and Lambda function name suffix. */
+  readonly id: string;
+}
+
+const createTestLambdaRole = (props: CreateTestLambdaRoleProps): iam.Role => {
+  return new iam.Role(props.stack, "ApiStackTestLambdaRole", {
+    assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
+  });
+};
+
+const createImportedLambda = (props: CreateImportedLambdaProps): lambda.IFunction => {
+  return lambda.Function.fromFunctionArn(
+    props.stack,
+    props.id,
+    `arn:aws:lambda:${TEST_AWS_REGION}:${TEST_AWS_ACCOUNT_ID}:function:${props.id}`,
+  );
+};
+
+const createApiStackTemplate = (stage: string): TestApiStackTemplate => {
+  const app = new App();
+  const dependencyStack = new Stack(app, `${stage}ApiStackDependencies`, {
+    env: TEST_API_STACK_ENVIRONMENT,
+  });
+  const stack = new ApiStack(app, `${stage}ApiStack`, {
+    stage,
+    env: TEST_API_STACK_ENVIRONMENT,
+    lambdaRole: createTestLambdaRole({ stack: dependencyStack }),
+    lambdas: {
+      express: { lambda: createImportedLambda({ stack: dependencyStack, id: "ExpressLambda" }) },
+      githubOauth2: {
+        lambda: createImportedLambda({ stack: dependencyStack, id: "GithubOauth2Lambda" }),
+      },
+    },
+  });
+
+  return {
+    template: Template.fromStack(stack),
+  };
+};
+
+describe("ApiStack", () => {
+  const originalEnvironment = { ...process.env };
+
+  beforeEach(() => {
+    process.env.API_GATEWAY_CERT_ARN = TEST_API_GATEWAY_CERT_ARN;
+    process.env.COGNITO_USER_POOL_ID = "us-east-1_test-user-pool";
+    process.env.SG_ID = "sg-1234567890abcdef0";
+    process.env.SUBNET_ID_01 = "subnet-11111111111111111";
+    process.env.SUBNET_ID_02 = "subnet-22222222222222222";
+    process.env.VPC_ID = "vpc-1234567890abcdef0";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnvironment };
+  });
+
+  test("creates a REST API without HTTP API resources", () => {
+    const { template } = createApiStackTemplate("dev");
+
+    expect(template.toJSON()).toBeDefined();
+    template.hasResourceProperties("AWS::ApiGateway::RestApi", {
+      Name: `${API_SERVICE_NAME}-dev`,
+    });
+    template.resourceCountIs("AWS::ApiGatewayV2::Api", 0);
+    template.resourceCountIs("AWS::ApiGatewayV2::Stage", 0);
+  });
+
+  test("creates an internal HTTPS API load balancer", () => {
+    const { template } = createApiStackTemplate("dev");
+
+    expect(template.toJSON()).toBeDefined();
+    template.hasResourceProperties("AWS::ElasticLoadBalancingV2::LoadBalancer", {
+      Name: `${API_SERVICE_NAME}-dev-alb`,
+      Scheme: "internal",
+      Type: "application",
+      LoadBalancerAttributes: Match.arrayWith([
+        { Key: "deletion_protection.enabled", Value: "true" },
+      ]),
+    });
+    template.hasResourceProperties("AWS::ElasticLoadBalancingV2::Listener", {
+      Port: 443,
+      Protocol: "HTTPS",
+      Certificates: [{ CertificateArn: TEST_API_GATEWAY_CERT_ARN }],
+      SslPolicy: "ELBSecurityPolicy-TLS13-1-2-2021-06",
+      DefaultActions: Match.arrayWith([
+        Match.objectLike({
+          Type: "forward",
+          TargetGroupArn: Match.anyValue(),
+        }),
+      ]),
+    });
+    template.hasResourceProperties("AWS::EC2::SecurityGroupIngress", {
+      GroupId: "sg-1234567890abcdef0",
+      IpProtocol: "tcp",
+      FromPort: 443,
+      ToPort: 443,
+      CidrIp: "0.0.0.0/0",
+      Description: "Allow HTTPS traffic to the API load balancer.",
+    });
+    template.hasOutput("ApiLoadBalancerDnsName", {
+      Value: Match.anyValue(),
+      Export: {
+        Name: `${API_SERVICE_NAME}-dev-ApiLoadBalancerDnsName`,
+      },
+    });
+    template.hasOutput("ApiLoadBalancerTargetGroupArn", {
+      Value: Match.anyValue(),
+      Export: {
+        Name: `${API_SERVICE_NAME}-dev-ApiLoadBalancerTargetGroupArn`,
+      },
+    });
+    template.hasOutput("ApiLoadBalancerListenerArn", {
+      Value: Match.anyValue(),
+      Export: {
+        Name: `${API_SERVICE_NAME}-dev-ApiLoadBalancerListenerArn`,
+      },
+    });
+  });
+
+  test("routes the API load balancer to the REST API proxy Lambda target group", () => {
+    const { template } = createApiStackTemplate("dev");
+
+    expect(template.toJSON()).toBeDefined();
+    template.hasResourceProperties("AWS::ElasticLoadBalancingV2::TargetGroup", {
+      Name: `${API_SERVICE_NAME}-dev-tg`,
+      TargetType: "lambda",
+      HealthCheckEnabled: true,
+      HealthCheckPath: "/health",
+      Targets: Match.arrayWith([
+        Match.objectLike({
+          Id: Match.anyValue(),
+        }),
+      ]),
+    });
+    template.hasResourceProperties("AWS::Lambda::Function", {
+      FunctionName: `${API_SERVICE_NAME}-dev-apiGatewayLoadBalancerProxy`,
+      Runtime: "nodejs22.x",
+      Environment: {
+        Variables: Match.objectLike({
+          API_GATEWAY_PROXY_BASE_URL: Match.anyValue(),
+          STAGE: "dev",
+        }),
+      },
+    });
+    template.hasResourceProperties("AWS::Lambda::Permission", {
+      Action: "lambda:InvokeFunction",
+      Principal: "elasticloadbalancing.amazonaws.com",
+    });
+  });
+
+  test("does not create an API load balancer for the local API stack", () => {
+    const { template } = createApiStackTemplate("local");
+
+    expect(template.toJSON()).toBeDefined();
+    template.hasResourceProperties("AWS::ApiGateway::RestApi", {
+      Name: "LocalApi-local",
+    });
+    template.resourceCountIs("AWS::ElasticLoadBalancingV2::LoadBalancer", 0);
+    template.resourceCountIs("AWS::ElasticLoadBalancingV2::Listener", 0);
+    template.resourceCountIs("AWS::ElasticLoadBalancingV2::TargetGroup", 0);
+  });
+});

--- a/api/src/functions/apiGatewayLoadBalancerProxy/README.md
+++ b/api/src/functions/apiGatewayLoadBalancerProxy/README.md
@@ -1,0 +1,142 @@
+# API Gateway Load Balancer Proxy
+
+## Why This Lambda Exists
+
+This Lambda is an interim target for the internal Application Load Balancers created by `ApiStack`.
+It lets us put a load-balancer boundary in front of the existing API Gateway REST APIs without also
+changing the API Gateway endpoint type in the same PR.
+
+The long-term goal is to move the API Gateways behind private REST API endpoints. That path requires
+REST APIs; HTTP APIs do not support private API Gateway endpoints in the same way. The current API
+stack already uses `aws-cdk-lib/aws-apigateway.RestApi`, so this work focuses on adding the
+load-balancer layer first while leaving the existing public API Gateway endpoint behavior unchanged.
+
+The proxy is needed because an Application Load Balancer routes to registered targets. The public
+`execute-api` hostname is service-managed by AWS and is not a stable target group member. Registering
+resolved public API Gateway IP addresses would be brittle because AWS can change those addresses.
+Instead, the ALB invokes this narrow Lambda target, and the Lambda forwards the request to the
+deployed REST API stage URL from CDK.
+
+This keeps the interim architecture explicit:
+
+1. Client or upstream origin reaches the internal API ALB.
+2. ALB invokes `apiGatewayLoadBalancerProxy`.
+3. The proxy rebuilds the HTTP request and sends it to the existing deployed REST API stage URL.
+4. API Gateway continues routing to the existing API Lambda integrations.
+
+The proxy strips hop-by-hop headers such as `host`, `connection`, and `content-length` before
+forwarding. Those headers describe the ALB-to-Lambda request, not the rebuilt upstream request to API
+Gateway, and preserving them can cause incorrect routing or body framing.
+
+## How To Deploy
+
+This Lambda is not deployed independently from this folder. CDK creates and bundles it as part of
+`ApiStack`.
+
+The standard deployment path is the existing CDK deployment workflow:
+
+1. Ensure the target environment has the existing API/CDK environment variables configured,
+   including `STAGE`, `AWS_ACCOUNT_ID`, `API_GATEWAY_CERT_ARN`, `VPC_ID`, `SUBNET_ID_01`,
+   `SUBNET_ID_02`, `SG_ID`, and `COGNITO_USER_POOL_ID`.
+2. Run the normal environment deployment workflow, which uses `.github/actions/deploy-cdk/action.yml`.
+   That action clears CDK context, bootstraps, imports prerequisite stacks, and runs:
+
+   ```shell
+   yarn workspace @businessnjgovnavigator/api-cdk cdk deploy --all --qualifier biz-nj --verbose --region us-east-1
+   ```
+
+3. CDK deploys `ApiStack-${STAGE}`, which creates:
+   - the internal API Application Load Balancer,
+   - the HTTPS listener,
+   - the Lambda target group,
+   - this proxy Lambda,
+   - Lambda invoke permission for Elastic Load Balancing, and
+   - stack outputs for the ALB DNS name, target group ARN, and listener ARN.
+
+For local verification before deploy, run:
+
+```shell
+yarn workspace @businessnjgovnavigator/api-cdk test apiStack.test.ts --runInBand
+yarn test api/src/functions/apiGatewayLoadBalancerProxy/app.test.ts --selectProjects api --runInBand
+yarn workspace @businessnjgovnavigator/api-cdk build
+yarn workspace @businessnjgovnavigator/api typecheck
+```
+
+After deployment, verify the CloudFormation outputs from `ApiStack-${STAGE}`:
+
+- `ApiLoadBalancerDnsName`
+- `ApiLoadBalancerTargetGroupArn`
+- `ApiLoadBalancerListenerArn`
+
+Those outputs are the handoff points for later DNS, WAF, or upstream origin wiring.
+
+## What Comes Next
+
+The next infrastructure step is to decide how traffic should reach the new internal API ALBs in each
+environment. That likely means wiring the exported ALB DNS names into the external routing layer that
+will own the public hostname or upstream origin behavior.
+
+The private API Gateway migration is separate and should be handled deliberately. At that point:
+
+1. Create or import the API Gateway interface VPC endpoint for each relevant VPC.
+2. Convert the REST API endpoint configuration to the private API pattern.
+3. Add the API Gateway resource policy that allows only the intended VPC endpoint or VPC source.
+4. Replace the Lambda proxy target path with the private REST API/VPC endpoint target pattern.
+5. Update CDK tests to assert the private endpoint resources and remove the Lambda proxy assertions.
+6. Validate that existing clients use the load-balanced path before disabling any older public path.
+
+The CDK shape should change in `ApiStack` when that migration happens:
+
+1. Import or create the execute-api interface endpoint in the same VPC used by the internal API ALB.
+   If the endpoint already exists, import it by ID and private IP addresses rather than creating a
+   second endpoint per API.
+2. Update the `RestApi` construct to use an explicit private endpoint configuration:
+
+   ```ts
+   endpointConfiguration: {
+     types: [apigateway.EndpointType.PRIVATE],
+     vpcEndpoints: [executeApiEndpoint],
+   },
+   ```
+
+3. Add a resource policy to the REST API that denies invoke requests unless they come from the
+   approved VPC endpoint, usually by checking `aws:SourceVpce`. This should live next to the REST API
+   construction so private access and the API resource policy are reviewed together.
+4. Replace `createLoadBalancerProxyLambda` and the Lambda target group with a target group that
+   reaches API Gateway through the private endpoint path. The likely shape is:
+   - keep the internal ALB and HTTPS listener,
+   - create an API Gateway target group backed by the interface endpoint private IPs,
+   - use HTTPS health checks against a route that does not require Cognito, such as `/health`, and
+   - preserve or explicitly set the `Host` behavior required by the private API/custom domain path.
+5. Revisit `configureCustomDomain`. Public custom domains cannot simply be converted into private
+   custom domains, so the private API path may need a separate private custom domain, endpoint
+   association, or host-header based routing rule depending on the final DNS design.
+6. Remove `API_GATEWAY_PROXY_BASE_URL` from the stack because the ALB should no longer invoke this
+   Lambda or call the public REST API stage URL.
+
+The private cutover should also add CDK assertions that prove the API is private and reachable only
+through the intended path:
+
+- `AWS::ApiGateway::RestApi` has `EndpointConfiguration.Types: ["PRIVATE"]`.
+- The REST API resource policy includes the expected `aws:SourceVpce` condition.
+- The ALB target group no longer has `TargetType: "lambda"`.
+- The proxy Lambda and `AWS::Lambda::Permission` for `elasticloadbalancing.amazonaws.com` no longer
+  exist.
+- The replacement target group points at the private endpoint or private custom domain routing
+  resources expected by the final architecture.
+
+## When This Lambda Can Be Removed
+
+Remove this Lambda only after all of the following are true:
+
+- The API Gateway REST APIs that need this path have moved to the private endpoint architecture.
+- The internal API ALB listener no longer forwards to a Lambda target group.
+- The replacement ALB target path reaches the private REST API through the approved VPC endpoint
+  pattern.
+- DNS, WAF, and upstream origins no longer depend on the Lambda proxy behavior.
+- CloudWatch metrics or logs confirm there is no expected production traffic invoking this proxy.
+- The CDK tests have been updated to assert the replacement private routing model.
+
+When those conditions are met, delete this folder, remove `createLoadBalancerProxyLambda` and the
+Lambda target group wiring from `ApiStack`, and replace the proxy unit tests with coverage for the
+new private routing resources.

--- a/api/src/functions/apiGatewayLoadBalancerProxy/app.test.ts
+++ b/api/src/functions/apiGatewayLoadBalancerProxy/app.test.ts
@@ -1,0 +1,190 @@
+import { proxyApiGatewayRequest } from "@functions/apiGatewayLoadBalancerProxy/app";
+import type {
+  ApiGatewayLoadBalancerEvent,
+  FetchRequest,
+} from "@functions/apiGatewayLoadBalancerProxy/app";
+
+interface CapturedFetchCall {
+  /** URL requested by the proxy. */
+  readonly input: URL;
+
+  /** Request options sent by the proxy. */
+  readonly init: RequestInit;
+}
+
+interface CapturedFetch {
+  /** Fetch-compatible function that captures every call. */
+  readonly fetchRequest: FetchRequest;
+
+  /** Calls captured by the fetch-compatible function. */
+  readonly calls: CapturedFetchCall[];
+}
+
+interface CreateCapturedFetchProps {
+  /** Response returned by the fetch-compatible function. */
+  readonly response: Response;
+}
+
+const createCapturedFetch = (props: CreateCapturedFetchProps): CapturedFetch => {
+  const calls: CapturedFetchCall[] = [];
+  const fetchRequest: FetchRequest = async (input: URL, init: RequestInit): Promise<Response> => {
+    calls.push({ input, init });
+
+    return props.response;
+  };
+
+  return { fetchRequest, calls };
+};
+
+const createBaseEvent = (): ApiGatewayLoadBalancerEvent => {
+  return {
+    httpMethod: "GET",
+    path: "/health",
+    headers: {
+      accept: "application/json",
+      host: "internal-api-alb.example.com",
+    },
+    queryStringParameters: undefined,
+    body: undefined,
+    isBase64Encoded: false,
+  };
+};
+
+/** Fetch-compatible function that simulates an upstream network failure. */
+const failingFetchRequest: FetchRequest = async (): Promise<Response> => {
+  throw new Error("network unavailable");
+};
+
+describe("apiGatewayLoadBalancerProxy", () => {
+  test("forwards method, path, query string, headers, and body to the REST API", async () => {
+    const capturedFetch = createCapturedFetch({
+      response: new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+      }),
+    });
+    const event: ApiGatewayLoadBalancerEvent = {
+      ...createBaseEvent(),
+      httpMethod: "POST",
+      path: "/api/users",
+      headers: {
+        authorization: "Bearer token",
+        "content-length": "20",
+        "content-type": "application/json",
+        host: "internal-api-alb.example.com",
+      },
+      queryStringParameters: {
+        search: "business",
+      },
+      body: JSON.stringify({ name: "Navigator" }),
+    };
+
+    const response = await proxyApiGatewayRequest({
+      event,
+      apiGatewayBaseUrl: "https://abc123.execute-api.us-east-1.amazonaws.com/dev/",
+      fetchRequest: capturedFetch.fetchRequest,
+    });
+
+    expect(capturedFetch.calls).toHaveLength(1);
+    expect(capturedFetch.calls[0].input.toString()).toBe(
+      "https://abc123.execute-api.us-east-1.amazonaws.com/dev/api/users?search=business",
+    );
+    expect(capturedFetch.calls[0].init).toMatchObject({
+      method: "POST",
+      headers: {
+        authorization: "Bearer token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ name: "Navigator" }),
+    });
+    expect(capturedFetch.calls[0].init.headers).not.toMatchObject({
+      "content-length": "20",
+      host: "internal-api-alb.example.com",
+    });
+    expect(response).toMatchObject({
+      statusCode: 200,
+      statusDescription: "200 OK",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ ok: true }),
+      isBase64Encoded: false,
+    });
+  });
+
+  test("preserves base64-encoded request bodies", async () => {
+    const capturedFetch = createCapturedFetch({
+      response: new Response("created", {
+        status: 201,
+        statusText: "Created",
+        headers: { "content-type": "text/plain" },
+      }),
+    });
+    const event: ApiGatewayLoadBalancerEvent = {
+      ...createBaseEvent(),
+      httpMethod: "PUT",
+      path: "/api/documents",
+      body: Buffer.from("encoded-body").toString("base64"),
+      isBase64Encoded: true,
+    };
+
+    const response = await proxyApiGatewayRequest({
+      event,
+      apiGatewayBaseUrl: "https://abc123.execute-api.us-east-1.amazonaws.com/dev",
+      fetchRequest: capturedFetch.fetchRequest,
+    });
+
+    expect(capturedFetch.calls[0].input.toString()).toBe(
+      "https://abc123.execute-api.us-east-1.amazonaws.com/dev/api/documents",
+    );
+    expect(capturedFetch.calls[0].init.body).toEqual(Buffer.from("encoded-body"));
+    expect(response.statusCode).toBe(201);
+  });
+
+  test("uses multi-value query parameters when they are present", async () => {
+    const capturedFetch = createCapturedFetch({
+      response: new Response("ok", {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/plain" },
+      }),
+    });
+    const event: ApiGatewayLoadBalancerEvent = {
+      ...createBaseEvent(),
+      path: "/api/search",
+      multiValueQueryStringParameters: {
+        filter: ["formation", "tax"],
+      },
+      queryStringParameters: {
+        filter: "ignored",
+      },
+    };
+
+    await proxyApiGatewayRequest({
+      event,
+      apiGatewayBaseUrl: "https://abc123.execute-api.us-east-1.amazonaws.com/dev/",
+      fetchRequest: capturedFetch.fetchRequest,
+    });
+
+    expect(capturedFetch.calls[0].input.toString()).toBe(
+      "https://abc123.execute-api.us-east-1.amazonaws.com/dev/api/search?filter=formation&filter=tax",
+    );
+  });
+
+  test("returns a clear bad gateway response when the upstream request fails", async () => {
+    const response = await proxyApiGatewayRequest({
+      event: createBaseEvent(),
+      apiGatewayBaseUrl: "https://abc123.execute-api.us-east-1.amazonaws.com/dev/",
+      fetchRequest: failingFetchRequest,
+    });
+
+    expect(response).toEqual({
+      statusCode: 502,
+      statusDescription: "502 Bad Gateway",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message: "Failed to proxy request to API Gateway." }),
+      isBase64Encoded: false,
+    });
+  });
+});

--- a/api/src/functions/apiGatewayLoadBalancerProxy/app.ts
+++ b/api/src/functions/apiGatewayLoadBalancerProxy/app.ts
@@ -1,0 +1,276 @@
+/**
+ * Fetch-compatible function used by the API Gateway load balancer proxy.
+ */
+export type FetchRequest = (input: URL, init: RequestInit) => Promise<Response>;
+
+/**
+ * Application Load Balancer event fields consumed by the API Gateway proxy Lambda.
+ */
+export interface ApiGatewayLoadBalancerEvent {
+  /** HTTP method supplied by the load balancer, such as GET, POST, PUT, PATCH, or DELETE. */
+  readonly httpMethod: string;
+
+  /** Request path supplied by the load balancer; optional only for malformed test events. */
+  readonly path?: string;
+
+  /** Single-value request headers supplied by the load balancer; optional when no headers exist. */
+  readonly headers?: Record<string, string | undefined>;
+
+  /** Multi-value request headers supplied by the load balancer; optional when no headers repeat. */
+  readonly multiValueHeaders?: Record<string, readonly string[] | undefined>;
+
+  /** Single-value query string parameters supplied by the load balancer; optional when absent. */
+  readonly queryStringParameters?: Record<string, string | undefined>;
+
+  /** Multi-value query string parameters supplied by the load balancer; optional when absent. */
+  readonly multiValueQueryStringParameters?: Record<string, readonly string[] | undefined>;
+
+  /** Request body supplied by the load balancer; optional for methods without a body. */
+  readonly body?: string | null;
+
+  /** True when the body is base64 encoded by the load balancer; optional and defaults to false. */
+  readonly isBase64Encoded?: boolean;
+}
+
+/**
+ * Application Load Balancer Lambda response shape returned by the proxy.
+ */
+export interface ApiGatewayLoadBalancerResponse {
+  /** HTTP status code returned to the load balancer. */
+  readonly statusCode: number;
+
+  /** HTTP status line returned to the load balancer; optional when the status code is enough. */
+  readonly statusDescription?: string;
+
+  /** Response headers returned to the load balancer; optional when no headers are needed. */
+  readonly headers?: Record<string, string>;
+
+  /** Response body returned to the load balancer; optional when the response is empty. */
+  readonly body?: string;
+
+  /** True when the response body is base64 encoded; optional and defaults to false. */
+  readonly isBase64Encoded?: boolean;
+}
+
+/**
+ * Dependencies and request data required to proxy an ALB request to API Gateway.
+ */
+export interface ProxyApiGatewayRequestProps {
+  /** Application Load Balancer event to forward to the regional REST API. */
+  readonly event: ApiGatewayLoadBalancerEvent;
+
+  /** Base URL of the deployed REST API stage, such as https://id.execute-api.region.amazonaws.com/dev/. */
+  readonly apiGatewayBaseUrl: string;
+
+  /** Fetch-compatible HTTP client used to send the upstream request. */
+  readonly fetchRequest: FetchRequest;
+}
+
+/**
+ * Header names that cannot be safely forwarded through a reverse proxy.
+ */
+const NON_FORWARDABLE_HEADER_NAMES = new Set([
+  "connection",
+  "content-length",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+/** Content types that can be returned to ALB as plain text. */
+const TEXT_RESPONSE_CONTENT_TYPES = [
+  "application/json",
+  "application/problem+json",
+  "application/x-www-form-urlencoded",
+  "application/xml",
+  "text/",
+];
+
+const requireApiGatewayBaseUrl = (): string => {
+  const apiGatewayBaseUrl = process.env.API_GATEWAY_PROXY_BASE_URL;
+
+  if (apiGatewayBaseUrl === undefined || apiGatewayBaseUrl.trim().length === 0) {
+    throw new Error("Missing required env var: API_GATEWAY_PROXY_BASE_URL");
+  }
+
+  return apiGatewayBaseUrl;
+};
+
+const normalizeApiGatewayBaseUrl = (apiGatewayBaseUrl: string): string => {
+  return apiGatewayBaseUrl.endsWith("/") ? apiGatewayBaseUrl : `${apiGatewayBaseUrl}/`;
+};
+
+const normalizeRequestPath = (path: string | undefined): string => {
+  return path === undefined ? "" : path.replace(/^\/+/, "");
+};
+
+const appendSingleValueQueryParameters = (
+  targetUrl: URL,
+  queryStringParameters: Record<string, string | undefined> | undefined,
+): void => {
+  for (const [name, value] of Object.entries(queryStringParameters ?? {})) {
+    if (value !== undefined) {
+      targetUrl.searchParams.append(name, value);
+    }
+  }
+};
+
+const appendMultiValueQueryParameters = (
+  targetUrl: URL,
+  queryStringParameters: Record<string, readonly string[] | undefined> | undefined,
+): void => {
+  for (const [name, values] of Object.entries(queryStringParameters ?? {})) {
+    for (const value of values ?? []) {
+      targetUrl.searchParams.append(name, value);
+    }
+  }
+};
+
+const createTargetUrl = (apiGatewayBaseUrl: string, event: ApiGatewayLoadBalancerEvent): URL => {
+  const normalizedBaseUrl = normalizeApiGatewayBaseUrl(apiGatewayBaseUrl);
+  const targetUrl = new URL(normalizeRequestPath(event.path), normalizedBaseUrl);
+
+  if (event.multiValueQueryStringParameters !== undefined) {
+    appendMultiValueQueryParameters(targetUrl, event.multiValueQueryStringParameters);
+    return targetUrl;
+  }
+
+  appendSingleValueQueryParameters(targetUrl, event.queryStringParameters);
+  return targetUrl;
+};
+
+const isForwardableHeader = (name: string): boolean => {
+  return !NON_FORWARDABLE_HEADER_NAMES.has(name.toLowerCase());
+};
+
+const createForwardedHeaders = (event: ApiGatewayLoadBalancerEvent): Record<string, string> => {
+  const forwardedHeaders: Record<string, string> = {};
+
+  for (const [name, value] of Object.entries(event.headers ?? {})) {
+    if (value !== undefined && isForwardableHeader(name)) {
+      forwardedHeaders[name] = value;
+    }
+  }
+
+  for (const [name, values] of Object.entries(event.multiValueHeaders ?? {})) {
+    if (isForwardableHeader(name)) {
+      forwardedHeaders[name] = values?.join(", ") ?? "";
+    }
+  }
+
+  return forwardedHeaders;
+};
+
+const methodCanIncludeBody = (method: string): boolean => {
+  return method !== "GET" && method !== "HEAD";
+};
+
+const createForwardedBody = (
+  event: ApiGatewayLoadBalancerEvent,
+): RequestInit["body"] | undefined => {
+  if (event.body === undefined || event.body === null || !methodCanIncludeBody(event.httpMethod)) {
+    return undefined;
+  }
+
+  return event.isBase64Encoded ? Buffer.from(event.body, "base64") : event.body;
+};
+
+const createFetchInit = (event: ApiGatewayLoadBalancerEvent): RequestInit => {
+  return {
+    method: event.httpMethod,
+    headers: createForwardedHeaders(event),
+    body: createForwardedBody(event),
+  };
+};
+
+const isTextResponse = (contentType: string | null): boolean => {
+  if (contentType === null) {
+    return true;
+  }
+
+  for (const textContentType of TEXT_RESPONSE_CONTENT_TYPES) {
+    if (contentType.toLowerCase().includes(textContentType)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const createResponseHeaders = (response: Response): Record<string, string> => {
+  const responseHeaders: Record<string, string> = {};
+
+  for (const [name, value] of response.headers.entries()) {
+    if (isForwardableHeader(name)) {
+      responseHeaders[name] = value;
+    }
+  }
+
+  return responseHeaders;
+};
+
+const createProxyResponse = async (response: Response): Promise<ApiGatewayLoadBalancerResponse> => {
+  const contentType = response.headers.get("content-type");
+
+  if (isTextResponse(contentType)) {
+    return {
+      statusCode: response.status,
+      statusDescription: `${response.status} ${response.statusText}`,
+      headers: createResponseHeaders(response),
+      body: await response.text(),
+      isBase64Encoded: false,
+    };
+  }
+
+  return {
+    statusCode: response.status,
+    statusDescription: `${response.status} ${response.statusText}`,
+    headers: createResponseHeaders(response),
+    body: Buffer.from(await response.arrayBuffer()).toString("base64"),
+    isBase64Encoded: true,
+  };
+};
+
+const createProxyFailureResponse = (): ApiGatewayLoadBalancerResponse => {
+  return {
+    statusCode: 502,
+    statusDescription: "502 Bad Gateway",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ message: "Failed to proxy request to API Gateway." }),
+    isBase64Encoded: false,
+  };
+};
+
+/**
+ * Forward an Application Load Balancer Lambda event to the configured API Gateway REST API.
+ */
+export const proxyApiGatewayRequest = async (
+  props: ProxyApiGatewayRequestProps,
+): Promise<ApiGatewayLoadBalancerResponse> => {
+  try {
+    const targetUrl = createTargetUrl(props.apiGatewayBaseUrl, props.event);
+    const response = await props.fetchRequest(targetUrl, createFetchInit(props.event));
+
+    return await createProxyResponse(response);
+  } catch {
+    return createProxyFailureResponse();
+  }
+};
+
+/**
+ * Lambda entry point used by the API Gateway internal load balancer.
+ */
+export const handler = async (
+  event: ApiGatewayLoadBalancerEvent,
+): Promise<ApiGatewayLoadBalancerResponse> => {
+  return await proxyApiGatewayRequest({
+    event,
+    apiGatewayBaseUrl: requireApiGatewayBaseUrl(),
+    fetchRequest: fetch,
+  });
+};


### PR DESCRIPTION
## Description

Adds internal load balancers in front of the CDK-managed API Gateway REST APIs while intentionally keeping the existing API Gateway endpoint configuration unchanged. This gives us a stable load-balancer boundary now, without combining that infrastructure change with the larger behavior change of moving the APIs from their current public endpoint setup to private REST API endpoints.

The proxy Lambda is needed for the interim state because an Application Load Balancer forwards to registered targets, not directly to the service-managed public API Gateway hostname. Registering public API Gateway IPs would be brittle because those addresses are owned and changed by AWS, and switching directly to private API Gateway endpoints in this PR would create more deployment churn than necessary. Instead, the ALB forwards to a narrow Lambda target that preserves the incoming request shape and calls the deployed REST API stage URL. Later, when we intentionally switch the REST APIs to private, the ALB routing can be moved to the private REST API/VPC endpoint pattern.

### Ticket

This pull request partially resolves [#17509](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17509). The other changes needed in this ticket are infrastructure tickets with our partners, then there will be a follow-up ticket to resolve this work by switching these API Gateways private and these load balancers to those API Gateways directly.

### Approach

- Adds an internal HTTPS Application Load Balancer to non-local API stacks using the existing imported VPC, subnet, security group, and API Gateway certificate environment values.
- Adds a dedicated `apiGatewayLoadBalancerProxy` Lambda target that forwards ALB requests to the deployed REST API stage URL.
- Exports the API load balancer DNS name, target group ARN, and listener ARN for future DNS/WAF/private endpoint wiring.
- Adds CDK assertions for REST API usage, ALB creation, Lambda target routing, and local-stage exclusion.
- Adds unit tests for proxy request forwarding, base64 body handling, multi-value query strings, and upstream failure handling.

### Steps to Test

- `yarn workspace @businessnjgovnavigator/api-cdk test apiStack.test.ts --runInBand`
- `yarn test api/src/functions/apiGatewayLoadBalancerProxy/app.test.ts --selectProjects api --runInBand`
- `yarn workspace @businessnjgovnavigator/api-cdk build`
- `yarn workspace @businessnjgovnavigator/api typecheck`

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
