### PR TITLE
feat: add analytics for login modal open/close

### DIFF
--- a/web/src/components/auth/NeedsAccountModal.tsx
+++ b/web/src/components/auth/NeedsAccountModal.tsx
@@ -50,7 +50,10 @@ export const NeedsAccountModal = (): ReactElement => {
     <>
       <ModalZeroButton
         isOpen={showNeedsAccountModal}
-        close={(): void => setShowNeedsAccountModal(false)}
+        close={(): void => {
+          analytics.event.guest_modal.click.close_NeedsAccountModal();
+          setShowNeedsAccountModal(false);
+        }}
         title={Config.selfRegistration.needsAccountModalTitle}
       >
         <div data-testid="self-reg-modal">

--- a/web/src/lib/utils/analytics.ts
+++ b/web/src/lib/utils/analytics.ts
@@ -165,7 +165,8 @@ type Clicked =
   | "log_out"
   | "unlinked_myNJ_account"
   | "get_unlinked_myNJ_account_modal"
-  | "link_your_myNJ_account";
+  | "link_your_myNJ_account"
+  | "close_NeedsAccountModal";
 
 type OnSiteSection =
   | "landing_page"
@@ -743,6 +744,27 @@ export default {
             legacy_event_category: "guest_modal",
             legacy_event_label: "go_to_myNJ_login",
             clicked: "go_to_myNJ_login",
+            item: "guest_modal",
+          });
+        },
+        close_NeedsAccountModal: () => {
+          eventRunner.track({
+            event: "account_clicks",
+            legacy_event_action: "click",
+            legacy_event_category: "guest_modal",
+            legacy_event_label: "close_NeedsAccountModal",
+            clicked: "close_NeedsAccountModal",
+            item: "guest_modal",
+          });
+        },
+      },
+      appears: {
+        open_NeedsAccountModal: () => {
+          eventRunner.track({
+            event: "account_clicks",
+            legacy_event_action: "appears",
+            legacy_event_category: "guest_modal",
+            legacy_event_label: "open_NeedsAccountModal",
             item: "guest_modal",
           });
         },

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -84,6 +84,13 @@ const App = ({ Component, pageProps }: AppProps): ReactElement => {
   const config = getMergedConfig();
   const showGtm = !(process.env.DISABLE_GTM === "true");
 
+  const setShowNeedsAccountModalAndSendAnalytics = (isOpening: boolean): void => {
+    if (isOpening) {
+      analytics.event.guest_modal.appears.open_NeedsAccountModal();
+    }
+    setShowNeedsAccountModal(isOpening);
+  };
+
   useEffect(() => {
     if (router?.isReady) {
       router.events.on("routeChangeComplete", analytics.pageview);
@@ -259,7 +266,7 @@ const App = ({ Component, pageProps }: AppProps): ReactElement => {
                               registrationStatus: registrationStatus,
                               setRegistrationStatus: setRegistrationStatusInStateAndStorage,
                               setShowNeedsAccountSnackbar,
-                              setShowNeedsAccountModal,
+                              setShowNeedsAccountModal: setShowNeedsAccountModalAndSendAnalytics,
                               showContinueWithoutSaving,
                               setShowContinueWithoutSaving,
                               userWantsToContinueWithoutSaving,


### PR DESCRIPTION
## Description

Add analytics tracking events for when the NeedsAccountModal (login modal) opens and closes. This enables tracking of user interactions with the guest/login prompt modal.

### Ticket

This pull request resolves [#17759](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17759).

### Approach

- Added a `close_NeedsAccountModal` click event in the analytics utility, fired when the modal is dismissed
- Added an `open_NeedsAccountModal` appears event, fired when the modal opens
- Created a wrapper function `setShowNeedsAccountModalAndSendAnalytics` in `_app.tsx` that fires the open event before showing the modal
- Passed the wrapper through context instead of the raw setter

### Steps to Test
There are two ways you can test that the event is being sent to analytics.

#### Option 1: Google Tag Assistant
1. Go to https://tagmanager.google.com > business.nj.gov - Both Sites .
2. Click the "Preview" button on the top right. This will open Tag Assistant in a new tab.
3. Connect Tag Assistant to `http://localhost:3000/`.
2. Trigger the login modal with an action that requires an account (e.g., go to NAICS code task and type in the field)
4. In the Tag Assistant tab, verify that there is an "analytics_event" that fires when the modal appears, and the API call should have `legacy_event_category: "guest-modal"`,  and`legacy_event_label: "open_NeedsAccountModal"`. <img width="715" height="491" alt="Screenshot 2026-05-19 at 6 08 28 PM" src="https://github.com/user-attachments/assets/528bca33-1e6b-46df-82b9-160ee42e2bdd" />

5. Close the modal and verify the  "analytics_event" with `legacy_event_category: "guest-modal"` and `legacy_event_label: "close_NeedsAccountModal"` event fires as well. <img width="670" height="473" alt="Screenshot 2026-05-19 at 6 08 57 PM" src="https://github.com/user-attachments/assets/1b4e6463-d05d-4fea-8d8c-c0f0a8e38a99" />

#### Option 2: Browser Dev Tools 
1. Open your browser dev tools on localhost:3000 and go to the Network tab.
2. Onboard as a new business (make sure you are not logged in!).
3. Trigger an action that requires an account (e.g., go to NAICS code task and type in the field).
4. In Network, look for requests to analytics.google.com, open them, and look for `guest-modal` and `open_NeedsAccountModal` in the Request Payload, like so: <img width="1294" height="717" alt="Screenshot 2026-05-19 at 6 20 50 PM" src="https://github.com/user-attachments/assets/315edb17-3757-4ddf-b4f9-2c862c160733" /> (there may be multiple requests to analytics.google.com, in which case only one of them should have this)
6. Close the modal and look for another request to analytics.google.com that has `close_NeedsAccountModal` in the Request Payload.


## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews