### PR TITLE
chore: explicit CDK stack targeting in GHA actions

### DIFF
--- a/.github/actions/deploy-cdk/action.yml
+++ b/.github/actions/deploy-cdk/action.yml
@@ -1,5 +1,5 @@
 name: "Deploy CDK"
-description: "Clears CDK context, runs CDK bootstrap, and deploys all stacks."
+description: "Clears CDK context, runs CDK bootstrap, and deploys the account application stacks."
 
 runs:
   using: "composite"
@@ -56,8 +56,24 @@ runs:
     - name: Deploy CDK
       shell: bash
       run: |
+        stacks=(
+          "DataStack-${STAGE}"
+          "IamStack-${STAGE}"
+          "StorageStack-${STAGE}"
+          "EncryptionStack-${STAGE}"
+          "MonitoringStack-${STAGE}"
+          "LambdaStack-${STAGE}"
+          "ApiStack-${STAGE}"
+        )
+
+        if [ "$STAGE" = "dev" ]; then
+          stacks+=("BackupStack-dev-shared")
+        elif [ "$STAGE" = "staging" ] || [ "$STAGE" = "prod" ]; then
+          stacks+=("BackupStack-${STAGE}")
+        fi
+
         yarn workspace @businessnjgovnavigator/api-cdk cdk deploy \
-          --all \
+          "${stacks[@]}" \
           --qualifier biz-nj \
           --verbose \
           --region us-east-1 \

--- a/.github/actions/deploy-static-site/action.yml
+++ b/.github/actions/deploy-static-site/action.yml
@@ -21,7 +21,25 @@ runs:
 
         echo "image_tag=$image_tag" >> "$GITHUB_OUTPUT"
 
+    - name: Check Static Site ECR Repository
+      id: repository
+      shell: bash
+      run: |
+        repository_name="bfs-static-site-${STAGE}"
+
+        if repository_output=$(aws ecr describe-repositories \
+          --repository-names "$repository_name" \
+          --region "$AWS_REGION" 2>&1); then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+        elif echo "$repository_output" | grep -q "RepositoryNotFoundException"; then
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "$repository_output"
+          exit 1
+        fi
+
     - name: Deploy Static Site ECR Repository
+      if: steps.repository.outputs.exists == 'false'
       shell: bash
       run: |
         yarn workspace @businessnjgovnavigator/api-cdk cdk deploy "StaticSiteRepositoryStack-${STAGE}" \
@@ -59,6 +77,16 @@ runs:
       shell: bash
       run: |
         yarn workspace @businessnjgovnavigator/api-cdk cdk deploy "StaticSiteServiceStack-${STAGE}" \
+          --qualifier biz-nj \
+          --verbose \
+          --region us-east-1 \
+          --require-approval never
+
+    - name: Update Static Site ECR Repository Stack
+      if: steps.repository.outputs.exists == 'true'
+      shell: bash
+      run: |
+        yarn workspace @businessnjgovnavigator/api-cdk cdk deploy "StaticSiteRepositoryStack-${STAGE}" \
           --qualifier biz-nj \
           --verbose \
           --region us-east-1 \


### PR DESCRIPTION
## Description

### Summary

Replaces `cdk deploy --all` with an explicit list of named stacks and adds conditional BackupStack inclusion per environment. In the static site action, adds a pre-check step for the ECR repository's existence so the deploy/update steps are gated appropriately.

### Approach

- **deploy-cdk**: Replaced `--all` with an explicit stack array (DataStack, IamStack, StorageStack, EncryptionStack, MonitoringStack, LambdaStack, ApiStack). Conditionally appends `BackupStack-dev-shared` for `dev` and `BackupStack-${STAGE}` for `staging`/`prod`.
- **deploy-static-site**: Added a `Check Static Site ECR Repository` step that sets an `exists` output. The existing deploy step now only runs when the repo doesn't exist; a new update step runs when it does, preventing CDK errors on re-deploys.

### Steps to Test

No user-facing changes. Verify via a GHA deployment run that:
1. Only the listed stacks are deployed (not unexpected ones).
2. The BackupStack variant matches the target stage.
3. The static site ECR check correctly gates the deploy vs. update path.

### Notes

Using `--all` can inadvertently deploy stacks that aren't ready. Explicit stack targeting gives safer, more predictable deployments.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews