### PR TITLE
fix: seed static site image before deploy

### DIFF
--- a/.github/actions/deploy-cdk/action.yml
+++ b/.github/actions/deploy-cdk/action.yml
@@ -59,7 +59,6 @@ runs:
         stacks=(
           "StaticSiteClusterStack"
           "StaticSiteRepositoryStack"
-          "StaticSiteServiceStack-${STAGE}"
           "DataStack-${STAGE}"
           "IamStack-${STAGE}"
           "StorageStack-${STAGE}"

--- a/.github/actions/deploy-static-site/action.yml
+++ b/.github/actions/deploy-static-site/action.yml
@@ -51,6 +51,16 @@ runs:
         echo "STATIC_SITE_IMAGE_NAME=$image_name" >> "$GITHUB_ENV"
         echo "STATIC_SITE_IMAGE_VERSION=$IMAGE_VERSION" >> "$GITHUB_ENV"
 
+    - name: Deploy Static Site ECS Service Stack
+      shell: bash
+      run: |
+        echo "Deploying static site ECS service stack: StaticSiteServiceStack-${STAGE}"
+        STATIC_SITE_INFRA_ONLY=true yarn workspace @businessnjgovnavigator/api-cdk cdk deploy "StaticSiteServiceStack-${STAGE}" \
+          --qualifier biz-nj \
+          --verbose \
+          --region us-east-1 \
+          --require-approval never
+
     - name: Deploy Static Site to ECS
       shell: bash
       run: |


### PR DESCRIPTION
## Description

This resolves the static site deployment race where the account CDK deploy can try to create or update `StaticSiteServiceStack-${STAGE}` before GitHub Actions has pushed the deployable static-site image. In dev, the existing mutable tag was also an ARM64 image while the task definition is pinned to `X86_64`, so checking only for tag presence would still let ECS fail before the workflow can overwrite the tag with an AMD64 image.

### Approach

- Remove `StaticSiteServiceStack-${STAGE}` from the general `deploy-cdk` stack list.
- Keep `StaticSiteClusterStack` and `StaticSiteRepositoryStack` in the normal CDK deploy path so the repo and shared cluster are available first.
- After `deploy-static-site` builds and pushes the `linux/amd64` image tags, deploy `StaticSiteServiceStack-${STAGE}`.
- Continue forcing a new ECS deployment after the image and service stack are both in place.

### Steps to Test

- Confirmed the changed composite action YAML parses.
- Ran `yarn workspace @businessnjgovnavigator/api-cdk build`.
- Ran `git diff --check`.

### Notes

This lets first-time environments seed ECR from GitHub Actions before ECS is asked to stabilize the service. It also avoids treating a stale or wrong-architecture mutable tag as proof that the service can safely start.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews