### PR TITLE
chore: add permits deploy role to aws

### DIFF
--- a/api/cdk/lib/iamStack.ts
+++ b/api/cdk/lib/iamStack.ts
@@ -41,7 +41,7 @@ export class IamStack extends Stack {
     };
 
     const allowedStages = deployRoleAllowlist[props.stage] ?? [];
-    const shouldCreateWarehouseDeployRole = props.stage !== "local";
+    const shouldCreateDeployRoles = props.stage !== "local";
 
     if (isIamCreatedForDevStagingProdOnly) {
       const githubOidcProvider = iam.OpenIdConnectProvider.fromOpenIdConnectProviderArn(
@@ -60,6 +60,7 @@ export class IamStack extends Stack {
             },
             StringLike: {
               "token.actions.githubusercontent.com:sub": [
+                "repo:newjersey/permits.nj.gov:ref:refs/heads/main",
                 "repo:newjersey/business-data-warehouse-cdk:ref:refs/heads/main",
                 "repo:newjersey/business-data-warehouse-cdk:environment:dev",
                 "repo:newjersey/business-data-warehouse-cdk:environment:production",
@@ -73,10 +74,15 @@ export class IamStack extends Stack {
       this.githubOidcRole.addToPolicy(
         new iam.PolicyStatement({
           actions: ["sts:AssumeRole"],
-          resources: allowedStages.map(
-            (stage) =>
-              `arn:aws:iam::${this.account}:role/njbfs-business-data-warehouse-deploy-${stage}`,
-          ),
+          resources: [
+            ...allowedStages.map(
+              (stage) =>
+                `arn:aws:iam::${this.account}:role/njbfs-business-data-warehouse-deploy-${stage}`,
+            ),
+            ...allowedStages.map(
+              (stage) => `arn:aws:iam::${this.account}:role/njbfs-permits-deploy-${stage}`,
+            ),
+          ],
         }),
       );
 
@@ -324,7 +330,13 @@ export class IamStack extends Stack {
     const githubRoleArn = this.githubOidcRole
       ? this.githubOidcRole.roleArn
       : `arn:aws:iam::${this.account}:role/bfs_github_actions_oidc_role`;
-    if (shouldCreateWarehouseDeployRole) {
+    if (shouldCreateDeployRoles) {
+      const permitsDeployRole = new iam.Role(this, "PermitsDeployRole", {
+        roleName: `njbfs-permits-deploy-${props.stage}`,
+        assumedBy: new iam.ArnPrincipal(githubRoleArn),
+        description: `Deploy role for Permits.nj.gov repo`,
+      });
+
       const warehouseDeployRole = new iam.Role(this, "WarehouseDeployRole", {
         roleName: `njbfs-business-data-warehouse-deploy-${props.stage}`,
         assumedBy: new iam.ArnPrincipal(githubRoleArn),
@@ -374,6 +386,46 @@ export class IamStack extends Stack {
       );
 
       applyStandardTags(warehouseDeployRole, props.stage);
+
+      permitsDeployRole.addToPolicy(
+        new iam.PolicyStatement({
+          actions: [
+            "cloudformation:*",
+            "ec2:Describe*",
+            "ec2:CreateVpc",
+            "ec2:DeleteVpc",
+            "ec2:CreateSubnet",
+            "ec2:DeleteSubnet",
+            "ec2:CreateRouteTable",
+            "ec2:DeleteRouteTable",
+            "ec2:AssociateRouteTable",
+            "ec2:DisassociateRouteTable",
+            "ec2:CreateInternetGateway",
+            "ec2:AttachInternetGateway",
+            "ec2:DetachInternetGateway",
+            "ec2:DeleteInternetGateway",
+            "ec2:CreateNatGateway",
+            "ec2:DeleteNatGateway",
+            "ec2:AllocateAddress",
+            "ec2:ReleaseAddress",
+            "ec2:CreateSecurityGroup",
+            "ec2:DeleteSecurityGroup",
+            "ec2:AuthorizeSecurityGroupIngress",
+            "ec2:AuthorizeSecurityGroupEgress",
+            "ec2:RevokeSecurityGroupIngress",
+            "ec2:RevokeSecurityGroupEgress",
+            "ec2:CreateTags",
+            "ec2:DeleteTags",
+            "rds:*",
+            "secretsmanager:*",
+            "iam:PassRole",
+            "logs:*",
+            "kms:*",
+          ],
+          resources: ["*"],
+        }),
+      );
+      applyStandardTags(permitsDeployRole, props.stage);
     }
   }
 }


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
This PR introduces a dedicated PermitsDeployRole to support GitHub Actions deployments for the permits.nj.gov repository through the existing GitHub OIDC integration.

The new role enables the permits platform to assume a stage-specific deployment role from GitHub Actions and provision backend infrastructure resources required for the Frappe integration work and future platform runtime components.

- `Added njbfs-permits-deploy-${stage} IAM role`
- Updated the GitHub OIDC role to allow assuming the permits deploy role
- Added infrastructure deployment permissions required for:
   -  CloudFormation deployments
   - VPC/networking resources
   - RDS provisioning
   - Secrets Manager
   - KMS
   - CloudWatch Logs
   - Renamed deployment role creation flag for improved readability and clarity
  
# Purpose
This establishes the deployment foundation for the permits.nj.gov platform and enables GitHub Actions workflows to securely deploy backend AWS infrastructure using OIDC-based role assumption.

This work is also foundational for the upcoming Frappe infrastructure integration, including:
- RDS MariaDB provisioning
- networking/security configuration
- application runtime infrastructure
- future ECS/runtime deployment components
### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#0000](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
