### PR TITLE
[static-site] fix: load all page content regardless of ordering continuity

### DIFF
--- a/packages/static-site/components/learn/PageContent.test.tsx
+++ b/packages/static-site/components/learn/PageContent.test.tsx
@@ -1,3 +1,4 @@
+/** biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: <explanation> */
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { PageItem } from "@/domain/content/types";
@@ -78,5 +79,42 @@ describe("PageContent", () => {
     );
     expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(3);
     expect(document.querySelectorAll("hr")).toHaveLength(3);
+  });
+
+  it("renders multiple sections if page content does not follow standard numeric ordering", () => {
+    render(
+      <PageContent
+        page={page({
+          "heading-2": "Section One",
+          "heading-4": "Section Two",
+          "heading-7": "Section Three",
+        })}
+      />,
+    );
+    expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(3);
+    expect(document.querySelectorAll("hr")).toHaveLength(3);
+  });
+
+  it("renders up to 11 page sections", () => {
+    render(
+      <PageContent
+        page={page({
+          "heading-1": "Section One",
+          "heading-2": "Section Two",
+          "heading-3": "Section Three",
+          "heading-4": "Section Four",
+          "heading-5": "Section Five",
+          "heading-6": "Section Six",
+          "heading-7": "Section Seven",
+          "heading-8": "Section Eight",
+          "heading-9": "Section Nine",
+          "heading-10": "Section Ten",
+          "heading-11": "Section Eleven",
+          "heading-12": "Section Twelve",
+        })}
+      />,
+    );
+    expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(11);
+    expect(document.querySelectorAll("hr")).toHaveLength(11);
   });
 });

--- a/packages/static-site/components/learn/PageContent.tsx
+++ b/packages/static-site/components/learn/PageContent.tsx
@@ -19,20 +19,22 @@ const PageContent = ({ page }: Props) => {
   const sections: Section[] = [];
 
   let n = 1;
-  while (
-    page[`heading-${n}`] ||
-    page[`main-text-${n}`] ||
-    page[`link-text-${n}`] ||
-    page[`tip-${n}`]
-  ) {
-    sections.push({
-      heading: page[`heading-${n}`],
-      body: page[`main-text-${n}`],
-      linkText: page[`link-text-${n}`],
-      linkUrl: page[`link-url-${n}`],
-      tip: page[`tip-${n}`],
-      index: n,
-    });
+  while (n <= 11) {
+    const heading = page[`heading-${n}`];
+    const body = page[`main-text-${n}`];
+    const linkText = page[`link-text-${n}`];
+    const linkUrl = page[`link-url-${n}`];
+    const tip = page[`tip-${n}`];
+
+    if (heading || body || (linkText && linkUrl) || tip)
+      sections.push({
+        heading: page[`heading-${n}`],
+        body: page[`main-text-${n}`],
+        linkText: page[`link-text-${n}`],
+        linkUrl: page[`link-url-${n}`],
+        tip: page[`tip-${n}`],
+        index: n,
+      });
     n++;
   }
 


### PR DESCRIPTION
## Description

Addresses a bug where page content was not loaded in the static site if content sections did not follow an expected order.

### Approach

`<PageContent>` has a function that scaffolds page sections by iterating over the source Markdown file's front-matter props for `main-text`, `heading`, `link-text`, `link-url`, and `tip`. There are up to 11 of these sections. The function previously assumed that content would only be added in sequential order (e.g. the first section would be `heading-1`, `main-text-1`, etc.). This is not the case. Content may start in a section other than 1. Content may also have breaks, where sections 2 and 4 are used, but not 3. This was causing page content to either partially load, or not load at all.

### Steps to Test

**All page content should load on every page.**
- Pick a page where ordering is not sequential (e.g. /en-US/pages/covid19)
- Confirm all content is loaded on the page

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [X] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
