### PR TITLE
feat: [AB#17710] add category dropdowns to side nav

### DIFF
--- a/packages/static-site/app/[locale]/(learn)/layout.tsx
+++ b/packages/static-site/app/[locale]/(learn)/layout.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import type { ReactNode } from "react";
 import { LearnSideNav } from "@/components/learn/LearnSideNav";
+import { CATEGORY_HIERARCHY } from "@/domain/categories";
 import { hasAppLocale } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
 
@@ -30,11 +31,39 @@ const PageLayout = async ({ children, params }: PageLayoutProps) => {
 
   const messages = await getApplicationMessages({ locale });
 
+  const introductionLabel = messages.learn.sideNav.learnCategory.title;
+
+  const categoryChildren = Object.fromEntries(
+    messages.learn.categories.map((category) => {
+      const pages = (CATEGORY_HIERARCHY[category.key]?.children ?? [])
+        .filter((page) => page.hideFromCategoryPage !== "true")
+        .map((page) => ({
+          link: {
+            label: page.name,
+            href: `/pages/${page.slug}`,
+            isInternal: true,
+            opensInNewTab: false,
+          },
+        }));
+
+      const introItem = {
+        link: {
+          label: introductionLabel,
+          href: category.link.href,
+          isInternal: true,
+          opensInNewTab: false,
+        },
+      };
+
+      return [category.key, [introItem, ...pages]];
+    }),
+  );
+
   return (
     <main className="grid-container usa-section">
       <div className="grid-row grid-gap">
         <div className="tablet:grid-col-4 learn-side-nav">
-          <LearnSideNav content={messages.learn} />
+          <LearnSideNav content={messages.learn} categoryChildren={categoryChildren} />
         </div>
         <div className="tablet:grid-col-8">{children}</div>
       </div>

--- a/packages/static-site/app/globals.css
+++ b/packages/static-site/app/globals.css
@@ -53,6 +53,8 @@ div.usa-card__container {
 
   .learn-side-nav nav {
     margin-right: 48px;
+    position: sticky;
+    top: 20px;
   }
 }
 
@@ -62,4 +64,35 @@ li {
 
 :is(h1, h2, h3, h4, h5, h6).dark-blue {
   color: var(--dark-blue);
+}
+
+.sidenav-category-button {
+  display: block;
+  width: 100%;
+  border: none;
+  background: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  line-height: 1.6rem;
+}
+
+.sidenav-category-button:hover {
+  background-color: #f0f0f0;
+}
+
+.sidenav-item-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.sidenav-chevron {
+  flex-shrink: 0;
+  margin-left: 0.5rem;
+  transition: transform 0.2s ease;
+}
+
+.sidenav-chevron--expanded {
+  transform: rotate(180deg);
 }

--- a/packages/static-site/components/SideNav.tsx
+++ b/packages/static-site/components/SideNav.tsx
@@ -3,8 +3,13 @@
  *
  * Supports up to three levels: top-level items, child links, and grandchild
  * links. Active state is indicated via the `isCurrent` flag on each item.
+ * Top-level items with children render as expandable sections.
  */
 
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
 import { LocalizedLink } from "@/components/landing/LocalizedLink";
 import type { ContentLink } from "@/domain/content/messageTypes";
 
@@ -71,41 +76,89 @@ export interface SideNavProps {
  * ```
  */
 export const SideNav = ({ ariaLabel, items }: SideNavProps) => {
+  const [expandedKeys, setExpandedKeys] = useState<ReadonlySet<string>>(() => {
+    const initial = new Set<string>();
+    for (const item of items) {
+      if (item.isCurrent && item.children && item.children.length > 0) {
+        initial.add(item.link.href);
+      }
+    }
+    return initial;
+  });
+
+  const toggleExpanded = (key: string) => {
+    setExpandedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
   return (
     <nav aria-label={ariaLabel}>
       <ul className="usa-sidenav">
-        {items.map((item) => (
-          <li key={item.link.href} className="usa-sidenav__item">
-            <LocalizedLink
-              link={item.link}
-              className={item.isCurrent ? "usa-current" : undefined}
-            />
-            {item.children && item.children.length > 0 && (
-              <ul className="usa-sidenav__sublist">
-                {item.children.map((child) => (
-                  <li key={child.link.href} className="usa-sidenav__item">
-                    <LocalizedLink
-                      link={child.link}
-                      className={child.isCurrent ? "usa-current" : undefined}
+        {items.map((item) => {
+          const hasChildren = item.children && item.children.length > 0;
+          const isExpanded = expandedKeys.has(item.link.href);
+
+          return (
+            <li key={item.link.href} className="usa-sidenav__item">
+              {hasChildren ? (
+                <button
+                  type="button"
+                  className={`sidenav-category-button${item.isCurrent ? " usa-current" : ""}`}
+                  aria-expanded={isExpanded}
+                  onClick={() => toggleExpanded(item.link.href)}
+                >
+                  <span className="sidenav-item-label">
+                    {item.link.label}
+                    <Image
+                      src="/img/chevron-down.svg"
+                      alt=""
+                      width={16}
+                      height={16}
+                      className={`sidenav-chevron${isExpanded ? " sidenav-chevron--expanded" : ""}`}
+                      aria-hidden="true"
                     />
-                    {child.children && child.children.length > 0 && (
-                      <ul className="usa-sidenav__sublist">
-                        {child.children.map((grandchild) => (
-                          <li key={grandchild.link.href} className="usa-sidenav__item">
-                            <LocalizedLink
-                              link={grandchild.link}
-                              className={grandchild.isCurrent ? "usa-current" : undefined}
-                            />
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </li>
-        ))}
+                  </span>
+                </button>
+              ) : (
+                <LocalizedLink
+                  link={item.link}
+                  className={item.isCurrent ? "usa-current" : undefined}
+                />
+              )}
+              {hasChildren && isExpanded && (
+                <ul className="usa-sidenav__sublist">
+                  {item.children.map((child) => (
+                    <li key={child.link.href} className="usa-sidenav__item">
+                      <LocalizedLink
+                        link={child.link}
+                        className={child.isCurrent ? "usa-current" : undefined}
+                      />
+                      {child.children && child.children.length > 0 && (
+                        <ul className="usa-sidenav__sublist">
+                          {child.children.map((grandchild) => (
+                            <li key={grandchild.link.href} className="usa-sidenav__item">
+                              <LocalizedLink
+                                link={grandchild.link}
+                                className={grandchild.isCurrent ? "usa-current" : undefined}
+                              />
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          );
+        })}
       </ul>
     </nav>
   );

--- a/packages/static-site/components/learn/LearnSideNav.test.tsx
+++ b/packages/static-site/components/learn/LearnSideNav.test.tsx
@@ -1,22 +1,53 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LearnSideNav } from "@/components/learn/LearnSideNav";
+import { CATEGORY_HIERARCHY } from "@/domain/categories";
 import { getApplicationMessages } from "@/domain/i18n/messages";
 
 vi.mock("next/navigation", async (importOriginal) => ({
   ...(await importOriginal<typeof import("next/navigation")>()),
-  useSelectedLayoutSegment: vi.fn(),
+  usePathname: vi.fn(),
 }));
 
 const messages = await getApplicationMessages({ locale: "en-US" });
+
+const categoryChildren = Object.fromEntries(
+  messages.learn.categories.map((category) => {
+    const pages = (CATEGORY_HIERARCHY[category.key]?.children ?? [])
+      .filter((page) => page.hideFromCategoryPage !== "true")
+      .map((page) => ({
+        link: {
+          label: page.name,
+          href: `/pages/${page.slug}`,
+          isInternal: true,
+          opensInNewTab: false,
+        },
+      }));
+
+    const introItem = {
+      link: {
+        label: messages.learn.sideNav.learnCategory.title,
+        href: category.link.href,
+        isInternal: true,
+        opensInNewTab: false,
+      },
+    };
+
+    return [category.key, [introItem, ...pages]];
+  }),
+);
 
 describe("LearnSideNav", () => {
   describe("nav item order", () => {
     let navItems: HTMLElement[];
 
     beforeEach(async () => {
-      render(<LearnSideNav content={messages.learn} />);
-      navItems = screen.getAllByRole("listitem");
+      const { usePathname } = vi.mocked(await import("next/navigation"));
+      usePathname.mockReturnValue("/en-US/learn");
+
+      render(<LearnSideNav content={messages.learn} categoryChildren={categoryChildren} />);
+      const topList = screen.getByRole("navigation").querySelector(":scope > .usa-sidenav");
+      if (topList) navItems = Array.from(topList.querySelectorAll(":scope > .usa-sidenav__item"));
     });
 
     it("first item is Introduction linking to /learn", () => {
@@ -25,57 +56,70 @@ describe("LearnSideNav", () => {
       expect(link?.getAttribute("href")).toBe("/learn");
     });
 
-    it("second item is Plan linking to /plan", () => {
-      const link = navItems[1].querySelector("a");
-      expect(link?.textContent).toBe("Plan");
-      expect(link?.getAttribute("href")).toBe("/plan");
+    it("second item is Plan as an expandable button", () => {
+      const button = navItems[1].querySelector("button");
+      expect(button?.textContent).toContain("Plan");
+      expect(button).toHaveAttribute("aria-expanded", "false");
     });
 
-    it("third item is Start linking to /start", () => {
-      const link = navItems[2].querySelector("a");
-      expect(link?.textContent).toBe("Start");
-      expect(link?.getAttribute("href")).toBe("/start");
+    it("third item is Start as an expandable button", () => {
+      const button = navItems[2].querySelector("button");
+      expect(button?.textContent).toContain("Start");
     });
 
-    it("fourth item is Operate linking to /operate", () => {
-      const link = navItems[3].querySelector("a");
-      expect(link?.textContent).toBe("Operate");
-      expect(link?.getAttribute("href")).toBe("/operate");
+    it("fourth item is Operate as an expandable button", () => {
+      const button = navItems[3].querySelector("button");
+      expect(button?.textContent).toContain("Operate");
     });
 
-    it("fifth item is Grow linking to /grow", () => {
-      const link = navItems[4].querySelector("a");
-      expect(link?.textContent).toBe("Grow");
-      expect(link?.getAttribute("href")).toBe("/grow");
+    it("fifth item is Grow as an expandable button", () => {
+      const button = navItems[4].querySelector("button");
+      expect(button?.textContent).toContain("Grow");
     });
   });
 
-  describe("isCurrent is set based on active route segment", () => {
-    it("marks Introduction as current when segment is null", async () => {
-      const { useSelectedLayoutSegment } = vi.mocked(await import("next/navigation"));
-      useSelectedLayoutSegment.mockReturnValue(null);
+  describe("isCurrent is set based on active route", () => {
+    it("marks Introduction as current when on /learn", async () => {
+      const { usePathname } = vi.mocked(await import("next/navigation"));
+      usePathname.mockReturnValue("/en-US/learn");
 
-      render(<LearnSideNav content={messages.learn} />);
+      render(<LearnSideNav content={messages.learn} categoryChildren={categoryChildren} />);
 
       expect(screen.getByRole("link", { name: "Introduction" })).toHaveClass("usa-current");
     });
 
-    it("marks Plan as current when segment is 'plan'", async () => {
-      const { useSelectedLayoutSegment } = vi.mocked(await import("next/navigation"));
-      useSelectedLayoutSegment.mockReturnValue("plan");
+    it("marks Plan as current when on /plan", async () => {
+      const { usePathname } = vi.mocked(await import("next/navigation"));
+      usePathname.mockReturnValue("/en-US/plan");
 
-      render(<LearnSideNav content={messages.learn} />);
+      render(<LearnSideNav content={messages.learn} categoryChildren={categoryChildren} />);
 
-      expect(screen.getByRole("link", { name: "Plan" })).toHaveClass("usa-current");
+      expect(screen.getByRole("button", { name: /Plan/ })).toHaveClass("usa-current");
     });
 
-    it("does not mark Introduction as current when segment is 'plan'", async () => {
-      const { useSelectedLayoutSegment } = vi.mocked(await import("next/navigation"));
-      useSelectedLayoutSegment.mockReturnValue("plan");
+    it("does not mark top-level Introduction as current when on /plan", async () => {
+      const { usePathname } = vi.mocked(await import("next/navigation"));
+      usePathname.mockReturnValue("/en-US/plan");
 
-      render(<LearnSideNav content={messages.learn} />);
+      render(<LearnSideNav content={messages.learn} categoryChildren={categoryChildren} />);
 
-      expect(screen.getByRole("link", { name: "Introduction" })).not.toHaveClass("usa-current");
+      const introLinks = screen.getAllByRole("link", { name: "Introduction" });
+      const topLevelIntro = introLinks.find((link) => link.getAttribute("href") === "/learn");
+      expect(topLevelIntro).not.toHaveClass("usa-current");
+    });
+
+    it("marks both category and child as current when on a sub-page", async () => {
+      const { usePathname } = vi.mocked(await import("next/navigation"));
+      const startChildren = categoryChildren.start;
+      const firstChildPage = startChildren[1];
+      usePathname.mockReturnValue(`/en-US${firstChildPage.link.href}`);
+
+      render(<LearnSideNav content={messages.learn} categoryChildren={categoryChildren} />);
+
+      expect(screen.getByRole("button", { name: /Start/ })).toHaveClass("usa-current");
+      expect(screen.getByRole("link", { name: firstChildPage.link.label })).toHaveClass(
+        "usa-current",
+      );
     });
   });
 });

--- a/packages/static-site/components/learn/LearnSideNav.tsx
+++ b/packages/static-site/components/learn/LearnSideNav.tsx
@@ -5,7 +5,8 @@
 
 "use client";
 
-import { useSelectedLayoutSegment } from "next/navigation";
+import { usePathname } from "next/navigation";
+import type { SideNavChildItem } from "@/components/SideNav";
 import { SideNav } from "@/components/SideNav";
 import type { LearnPageContent } from "@/domain/content/messageTypes";
 
@@ -15,6 +16,8 @@ import type { LearnPageContent } from "@/domain/content/messageTypes";
 export interface LearnSideNavProps {
   /** Ordered list of pages to render in the side navigation. */
   readonly content: LearnPageContent;
+  /** Pre-computed child items keyed by category key. */
+  readonly categoryChildren: Readonly<Record<string, readonly SideNavChildItem[]>>;
 }
 
 /**
@@ -25,17 +28,35 @@ export interface LearnSideNavProps {
  * @param props.pages Ordered nav pages sourced from localized messages.
  * @returns A side navigation element with the current item highlighted.
  */
-export const LearnSideNav = ({ content }: LearnSideNavProps) => {
-  const pathSegment = useSelectedLayoutSegment();
-  const activeKey = pathSegment ?? "learn";
+export const LearnSideNav = ({ content, categoryChildren }: LearnSideNavProps) => {
+  const pathname = usePathname();
+  const pathWithoutLocale = pathname.replace(/^\/[^/]+/, "");
 
   const sideNavCategories = [content.sideNav.learnCategory, ...content.categories];
+  const items = sideNavCategories.map((category) => {
+    const children = categoryChildren[category.key] ?? [];
 
-  const items = sideNavCategories.map((category) => ({
-    link: { ...category.link, label: category.title },
-    isCurrent: category.key === activeKey,
-    children: [],
-  }));
+    const currentChildIndex = children.findIndex((child) => child.link.href === pathWithoutLocale);
+    const hasCurrentChild = currentChildIndex !== -1;
+
+    const isCategoryCurrent =
+      (pathWithoutLocale === "/learn" && category.key === "learn") ||
+      (pathWithoutLocale === category.link.href && !hasCurrentChild) ||
+      hasCurrentChild;
+
+    const childrenWithCurrent = hasCurrentChild
+      ? children.map((child, i) => ({
+          ...child,
+          isCurrent: i === currentChildIndex,
+        }))
+      : children;
+
+    return {
+      link: { ...category.link, label: category.title },
+      isCurrent: isCategoryCurrent,
+      children: childrenWithCurrent,
+    };
+  });
 
   return <SideNav ariaLabel={content.sideNav.ariaLabel} items={items} />;
 };

--- a/packages/static-site/public/img/chevron-down.svg
+++ b/packages/static-site/public/img/chevron-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <path d="M4 6L8 10L12 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Description

Add expandable category dropdowns to the Learn side navigation in the static site. Categories (Plan, Start, Operate, Grow) now render as collapsible buttons that reveal their child pages when clicked, replacing the previous plain link behavior.

### Ticket

This pull request resolves [#17710](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17710).

### Approach

- Converted `SideNav` to a client component with expand/collapse state for items that have children
- Added a chevron icon that rotates on expand
- Pre-computed category children in the layout server component and passed them as props
- Added CSS for the expandable buttons and sticky positioning
- Updated tests to reflect the new button-based category items

### Steps to Test

1. Navigate to the Learn section of the static site
2. Verify Introduction link still works as before
3. Click on Plan/Start/Operate/Grow category buttons — they should expand to show child pages with a chevron rotation animation
4. Click again to collapse
5. Verify the side nav is sticky on scroll (desktop)

### Notes

The `SideNav` component is now a client component (`"use client"`) to support the interactive expand/collapse state.

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [ ] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews