### PR TITLE
feat: [AB#17826] skip login modal for non-required task checkboxes

### DIFF
--- a/web/src/components/Task.tsx
+++ b/web/src/components/Task.tsx
@@ -62,6 +62,7 @@ export const Task = (props: Props): ReactElement => {
               <TaskProgressCheckbox
                 taskId={props.task.id}
                 disabledTooltipText={getDisabledTooltipText(props.task.id, taskProgress)}
+                needsAccount={props.task.required}
               />
             ) : (
               TaskProgressTagLookup[taskProgress]

--- a/web/src/components/TaskHeader.tsx
+++ b/web/src/components/TaskHeader.tsx
@@ -8,7 +8,7 @@ import {
   getModifiedTaskBooleanUndefined,
   getModifiedTaskContent,
 } from "@/lib/utils/roadmap-helpers";
-import { TaskProgress, isFormationTask } from "@businessnjgovnavigator/shared";
+import { isFormationTask, TaskProgress } from "@businessnjgovnavigator/shared";
 import { Task } from "@businessnjgovnavigator/shared/types";
 import { ReactElement } from "react";
 
@@ -65,7 +65,11 @@ export const TaskHeader = (props: Props): ReactElement => {
           data-testid="taskProgress"
         >
           <div className="margin-right-105 margin-bottom-1">
-            <TaskProgressCheckbox taskId={props.task.id} disabledTooltipText={getDisabledText()} />
+            <TaskProgressCheckbox
+              taskId={props.task.id}
+              disabledTooltipText={getDisabledText()}
+              needsAccount={props.task.required}
+            />
           </div>
           {getModifiedTaskBooleanUndefined(roadmap, props.task, "required") === true && (
             <span className={`${getTextColorClass()} display-inline-block margin-bottom-1`}>

--- a/web/src/components/TaskProgressCheckbox.test.tsx
+++ b/web/src/components/TaskProgressCheckbox.test.tsx
@@ -33,7 +33,9 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 jest.mock("next/compat/router", () => ({ useRouter: jest.fn() }));
 jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
 jest.mock("@/lib/data-hooks/useRoadmap", () => ({ useRoadmap: jest.fn() }));
-jest.mock("@/lib/roadmap/buildUserRoadmap", () => ({ buildUserRoadmap: jest.fn() }));
+jest.mock("@/lib/roadmap/buildUserRoadmap", () => ({
+  buildUserRoadmap: jest.fn(),
+}));
 
 const Config = getMergedConfig();
 let setShowNeedsAccountModal: jest.Mock;
@@ -64,11 +66,14 @@ describe("<TaskProgressCheckbox />", () => {
       withNeedsAccountContext(
         <MunicipalitiesContext.Provider value={{ municipalities: [] }}>
           <WithStatefulUserData initialUserData={generateUserDataForBusiness(initialBusiness)}>
-            <TaskProgressCheckbox taskId={taskId} disabledTooltipText={undefined} />
+            <TaskProgressCheckbox taskId={taskId} disabledTooltipText={undefined} needsAccount />
           </WithStatefulUserData>
         </MunicipalitiesContext.Provider>,
         IsAuthenticated.FALSE,
-        { showNeedsAccountModal: false, setShowNeedsAccountModal: setShowNeedsAccountModal },
+        {
+          showNeedsAccountModal: false,
+          setShowNeedsAccountModal: setShowNeedsAccountModal,
+        },
       ),
     );
   };
@@ -90,7 +95,9 @@ describe("<TaskProgressCheckbox />", () => {
 
   it("updates task status when progress checkbox is clicked", async () => {
     const taskId = "123";
-    const taskProgress: Record<string, TaskProgress> = { "some-id": "COMPLETED" };
+    const taskProgress: Record<string, TaskProgress> = {
+      "some-id": "COMPLETED",
+    };
 
     renderTaskCheckbox(taskId, generateBusiness({ taskProgress }));
 
@@ -224,7 +231,9 @@ describe("<TaskProgressCheckbox />", () => {
     it("updates status and date of formation, and redirects user on save", async () => {
       jest.useFakeTimers();
       const id = formationTaskId;
-      const startingPersonaForRoadmapUrl = generateProfileData({ businessPersona: "STARTING" });
+      const startingPersonaForRoadmapUrl = generateProfileData({
+        businessPersona: "STARTING",
+      });
       renderTaskCheckbox(
         formationTaskId,
         generateBusiness({ profileData: startingPersonaForRoadmapUrl }),

--- a/web/src/components/TaskProgressCheckbox.tsx
+++ b/web/src/components/TaskProgressCheckbox.tsx
@@ -2,10 +2,10 @@ import { ArrowTooltip } from "@/components/ArrowTooltip";
 import { Content } from "@/components/Content";
 import { FormationDateModal } from "@/components/FormationDateModal";
 import { ModalTwoButton } from "@/components/ModalTwoButton";
+import { Icon } from "@/components/njwds/Icon";
 import { TaskProgressTagLookup } from "@/components/TaskProgressTagLookup";
 import { TaskStatusChangeSnackbar } from "@/components/TaskStatusChangeSnackbar";
 import { TaskStatusTaxRegistrationSnackbar } from "@/components/TaskStatusTaxRegistrationSnackbar";
-import { Icon } from "@/components/njwds/Icon";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
@@ -22,6 +22,7 @@ import { ReactElement, ReactNode, useContext, useEffect, useState } from "react"
 
 interface Props {
   taskId: string;
+  needsAccount?: boolean;
   disabledTooltipText: string | undefined;
   STORYBOOK_ONLY_currentTaskProgress?: TaskProgress;
 }
@@ -69,7 +70,7 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
   const setToNextStatus = (config?: { redirectOnSuccess: boolean }): void => {
     if (!updateQueue) return;
     let redirectOnSuccess = config?.redirectOnSuccess;
-    if (isAuthenticated === IsAuthenticated.FALSE) {
+    if (props.needsAccount && isAuthenticated === IsAuthenticated.FALSE) {
       setShowNeedsAccountModal(true);
       return;
     }
@@ -86,7 +87,9 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
         return;
       }
       if (currentOpenModal === "formation-unset") {
-        updateQueue.queueProfileData({ dateOfFormation: emptyProfileData.dateOfFormation });
+        updateQueue.queueProfileData({
+          dateOfFormation: emptyProfileData.dateOfFormation,
+        });
       }
     }
 
@@ -134,7 +137,12 @@ export const TaskProgressCheckbox = (props: Props): ReactElement => {
     }
   };
 
-  const getStyles = (): { border: string; bg: string; textColor: string; hover: string } => {
+  const getStyles = (): {
+    border: string;
+    bg: string;
+    textColor: string;
+    hover: string;
+  } => {
     switch (currentTaskProgress) {
       case "TO_DO":
         if (isDisabled) {


### PR DESCRIPTION
## Description

Remove the login modal trigger from task progress checkboxes for non-required tasks. 

Previously, all checkbox clicks by unauthenticated users would show the login modal. Now, only required tasks prompt the user to log in.

### Ticket

This pull request resolves [#17826](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17826).

### Approach

- Added a `needsAccount` prop to `TaskProgressCheckbox` that controls whether the login modal is shown for unauthenticated users.
- Pass `task.required` as the value from both `Task.tsx` and `TaskHeader.tsx`.
- Updated the authentication check to be conditional on `props.needsAccount`.

### Steps to Test

1. Onboard as a new business (make sure you are not logged in).
2. Once on the dashboard, click the checkbox on a **non-required** task — it should toggle without showing the login modal.
3. Click the checkbox on a **required** task — the login modal should appear.

### Notes

Formatting-only changes in the test file and component are from Prettier alignment; no logic changes beyond the new prop.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews