### PR TITLE
feat: add GTM and Intercom to static site

### DIFF
--- a/packages/static-site/app/[locale]/layout.tsx
+++ b/packages/static-site/app/[locale]/layout.tsx
@@ -13,6 +13,8 @@ import { notFound } from "next/navigation";
 import Script from "next/script";
 import { NextIntlClientProvider } from "next-intl";
 import type { ReactNode } from "react";
+import { GoogleTagManager } from "@/components/analytics/GoogleTagManager";
+import { Intercom } from "@/components/analytics/Intercom";
 import { GovBanner } from "@/components/landing/GovBanner";
 import { IdentifierSection } from "@/components/landing/IdentifierSection";
 import { SiteFooter } from "@/components/landing/SiteFooter";
@@ -173,6 +175,7 @@ const LocaleLayout = async ({ children, params }: LocaleLayoutProps) => {
         <link href={NJWDS_STYLESHEET_PATH} rel="stylesheet" />
       </head>
       <body>
+        <GoogleTagManager />
         <NextIntlClientProvider locale={locale} messages={messages}>
           <SkipNav
             label={messages.layout.skipNavigationLabel}
@@ -188,6 +191,7 @@ const LocaleLayout = async ({ children, params }: LocaleLayoutProps) => {
           <IdentifierSection content={messages.layout.identifier} />
         </NextIntlClientProvider>
         <Script src={NJWDS_SCRIPT_PATH} strategy="afterInteractive" />
+        <Intercom />
       </body>
     </html>
   );

--- a/packages/static-site/components/analytics/GoogleTagManager.tsx
+++ b/packages/static-site/components/analytics/GoogleTagManager.tsx
@@ -1,0 +1,56 @@
+/**
+ * Loads Google Tag Manager on every page of the static site.
+ *
+ * This module injects the GTM bootstrap script that initializes the
+ * `dataLayer` and asynchronously loads the container, plus the `<noscript>`
+ * iframe fallback for clients with JavaScript disabled.
+ */
+
+import Script from "next/script";
+
+/**
+ * Google Tag Manager container ID for the static site.
+ *
+ * This is a public client-side identifier embedded in delivered HTML, so it
+ * lives here as a constant alongside the other site-wide asset references.
+ */
+const GTM_CONTAINER_ID = "GTM-MK9ZQD9";
+
+/**
+ * Renders the Google Tag Manager loader and `<noscript>` fallback.
+ *
+ * The inline loader runs with the `afterInteractive` strategy so the container
+ * loads as soon as the page is interactive without blocking first paint. The
+ * `<noscript>` iframe is rendered directly so it is present for clients that do
+ * not execute scripts.
+ *
+ * @returns The GTM loader script and `<noscript>` iframe fallback.
+ * @example
+ * ```tsx
+ * <body>
+ *   <GoogleTagManager />
+ * </body>
+ * ```
+ */
+export const GoogleTagManager = () => {
+  return (
+    <>
+      <Script id="google-tag-manager" strategy="afterInteractive">
+        {`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${GTM_CONTAINER_ID}');`}
+      </Script>
+      <noscript>
+        <iframe
+          title="Google Tag Manager"
+          src={`https://www.googletagmanager.com/ns.html?id=${GTM_CONTAINER_ID}`}
+          height="0"
+          width="0"
+          style={{ display: "none", visibility: "hidden" }}
+        />
+      </noscript>
+    </>
+  );
+};

--- a/packages/static-site/components/analytics/Intercom.tsx
+++ b/packages/static-site/components/analytics/Intercom.tsx
@@ -1,0 +1,58 @@
+/**
+ * Loads the Intercom messenger on every page of the static site.
+ *
+ * This module defines the `window.intercomSettings` configuration and injects
+ * the Intercom widget loader, which attaches the messenger once the page has
+ * loaded.
+ */
+
+import Script from "next/script";
+
+/**
+ * Intercom workspace (app) ID for the static site.
+ *
+ * This is a public client-side identifier embedded in delivered HTML, so it
+ * lives here as a constant alongside the other site-wide asset references.
+ */
+const INTERCOM_APP_ID = "ozxx8n5h";
+
+/**
+ * Intercom widget ID used to fetch the messenger loader script.
+ */
+const INTERCOM_WIDGET_ID = "td643jax";
+
+/**
+ * CSS selector for elements that should open the Intercom messenger on click.
+ */
+const INTERCOM_LAUNCHER_SELECTOR = ".intercomlaunch";
+
+/**
+ * Renders the Intercom settings and widget loader scripts.
+ *
+ * The settings script defines `window.intercomSettings` before the loader runs
+ * so the messenger boots with the correct workspace and launcher selector. Both
+ * scripts use the `afterInteractive` strategy so they do not block first paint.
+ *
+ * @returns The Intercom settings and loader scripts.
+ * @example
+ * ```tsx
+ * <body>
+ *   <Intercom />
+ * </body>
+ * ```
+ */
+export const Intercom = () => {
+  return (
+    <>
+      <Script id="intercom-settings" strategy="afterInteractive">
+        {`window.intercomSettings = {
+  app_id: "${INTERCOM_APP_ID}",
+  custom_launcher_selector: "${INTERCOM_LAUNCHER_SELECTOR}"
+};`}
+      </Script>
+      <Script id="intercom-widget" strategy="afterInteractive">
+        {`(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/${INTERCOM_WIDGET_ID}';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();`}
+      </Script>
+    </>
+  );
+};


### PR DESCRIPTION
## Description

Adds site-wide Google Tag Manager and Intercom integration to the new static site (`packages/static-site`) so both load on every page.

Two new presentation components inject the scripts via `next/script` (`afterInteractive`), following the existing NJWDS/SurveyMonkey pattern:

- `GoogleTagManager` — GTM bootstrap loader plus the `<noscript>` iframe fallback (with a `title` for accessibility).
- `Intercom` — `window.intercomSettings` config and the widget loader.

Both are rendered from the locale root layout (`app/[locale]/layout.tsx`): GTM right after `<body>` (so the noscript fallback sits near the top), Intercom alongside the existing NJWDS script.

### Ticket

This pull request resolves [#17843](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17843).

### Approach

No new dependencies or migrations. The GTM container ID (`GTM-MK9ZQD9`), Intercom app ID (`ozxx8n5h`), and widget ID (`td643jax`) are public client-side identifiers, so they live as named constants in their components — matching how the site handles other site-wide values (`METADATA_BASE_URL`, NJWDS paths).

### Steps to Test

1. From `packages/static-site`, run `pnpm dev` and open `http://localhost:4000/en-US`.
2. Confirm the page source contains the GTM loader (`googletagmanager.com/gtm.js`) and the `<noscript>` iframe (`googletagmanager.com/ns.html`).
3. Confirm the Intercom messenger loads (app ID `ozxx8n5h`, widget `td643jax`).
4. Repeat for the `es-US` locale and a learn page to confirm site-wide delivery.

### Notes

The support page copy still says "We have not implemented Intercom yet" (`app/[locale]/support/page.tsx`) — left unchanged in this PR; can update separately if desired.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews