### PR TITLE
feat: [AB#17710] add show/hide toggle to mobile side nav

### DIFF
--- a/packages/static-site/app/globals.css
+++ b/packages/static-site/app/globals.css
@@ -100,3 +100,37 @@ li {
 .sidenav-chevron--expanded {
   transform: rotate(180deg);
 }
+
+.sidenav-toggle-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  width: 100%;
+}
+
+.sidenav-toggle-button img {
+  /* equates to #005ea2 */
+  filter: invert(19%) sepia(89%) saturate(1981%) hue-rotate(187deg) brightness(103%) contrast(101%);
+}
+
+@media (max-width: 39.99em) {
+  .sidenav-collapsible-item {
+    overflow: hidden;
+    /* This height could limit the number of visible items in SideNav,
+    but is necessary for animating open/close. Should be adequate. */
+    max-height: 500px;
+    opacity: 1;
+    transition:
+      max-height 0.3s ease,
+      opacity 0.3s ease,
+      margin 0.3s ease;
+  }
+
+  .sidenav--collapsed .sidenav-collapsible-item {
+    max-height: 0;
+    opacity: 0;
+    margin: 0;
+  }
+}

--- a/packages/static-site/components/SideNav.test.tsx
+++ b/packages/static-site/components/SideNav.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SideNav } from "@/components/SideNav";
+
+describe("SideNav", () => {
+  describe("onItemSelect", () => {
+    const items = [
+      {
+        link: { label: "Category", href: "/category", isInternal: true, opensInNewTab: false },
+        isCurrent: true,
+        children: [
+          {
+            link: { label: "Child A", href: "/child-a", isInternal: true, opensInNewTab: false },
+          },
+          {
+            link: { label: "Child B", href: "/child-b", isInternal: true, opensInNewTab: false },
+          },
+        ],
+      },
+    ];
+
+    it("calls onItemSelect when a child item is clicked", () => {
+      const onItemSelect = vi.fn();
+      render(<SideNav ariaLabel="Test nav" items={items} onItemSelect={onItemSelect} />);
+
+      fireEvent.click(screen.getByRole("link", { name: "Child A" }));
+      expect(onItemSelect).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/static-site/components/SideNav.tsx
+++ b/packages/static-site/components/SideNav.tsx
@@ -33,6 +33,8 @@ export interface SideNavChildItem {
   readonly isCurrent?: boolean;
   /** Optional grandchild links rendered as a nested sublist. */
   readonly children?: readonly SideNavGrandchildItem[];
+  /** When true, this item can be hidden in collapsed mobile mode. */
+  readonly isCollapsible?: boolean;
 }
 
 /**
@@ -45,6 +47,8 @@ export interface SideNavItem {
   readonly isCurrent?: boolean;
   /** Optional child links rendered as a nested sublist. */
   readonly children?: readonly SideNavChildItem[];
+  /** When true, this item can be hidden in collapsed mobile mode. */
+  readonly isCollapsible?: boolean;
 }
 
 /**
@@ -55,6 +59,8 @@ export interface SideNavProps {
   readonly ariaLabel: string;
   /** Top-level navigation items to render. */
   readonly items: readonly SideNavItem[];
+  /** Called when a navigation item is selected. */
+  readonly onItemSelect?: () => void;
 }
 
 /**
@@ -75,7 +81,7 @@ export interface SideNavProps {
  * />
  * ```
  */
-export const SideNav = ({ ariaLabel, items }: SideNavProps) => {
+export const SideNav = ({ ariaLabel, items, onItemSelect }: SideNavProps) => {
   const [expandedKeys, setExpandedKeys] = useState<ReadonlySet<string>>(() => {
     const initial = new Set<string>();
     for (const item of items) {
@@ -106,7 +112,10 @@ export const SideNav = ({ ariaLabel, items }: SideNavProps) => {
           const isExpanded = expandedKeys.has(item.link.href);
 
           return (
-            <li key={item.link.href} className="usa-sidenav__item">
+            <li
+              key={item.link.href}
+              className={`usa-sidenav__item${item.isCollapsible ? " sidenav-collapsible-item" : ""}`}
+            >
               {hasChildren ? (
                 <button
                   type="button"
@@ -135,7 +144,12 @@ export const SideNav = ({ ariaLabel, items }: SideNavProps) => {
               {hasChildren && isExpanded && (
                 <ul className="usa-sidenav__sublist">
                   {item.children.map((child) => (
-                    <li key={child.link.href} className="usa-sidenav__item">
+                    // biome-ignore lint/a11y/useKeyWithClickEvents: Because these are links, the browser will fire an onClick for "enter". Key event hook is redundant.
+                    <li
+                      key={child.link.href}
+                      className={`usa-sidenav__item${child.isCollapsible ? " sidenav-collapsible-item" : ""}`}
+                      onClick={onItemSelect}
+                    >
                       <LocalizedLink
                         link={child.link}
                         className={child.isCurrent ? "usa-current" : undefined}

--- a/packages/static-site/components/learn/LearnSideNav.test.tsx
+++ b/packages/static-site/components/learn/LearnSideNav.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LearnSideNav } from "@/components/learn/LearnSideNav";
 import { CATEGORY_HIERARCHY } from "@/domain/categories";
@@ -37,6 +37,7 @@ const categoryChildren = Object.fromEntries(
   }),
 );
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: test suite
 describe("LearnSideNav", () => {
   describe("nav item order", () => {
     let navItems: HTMLElement[];
@@ -120,6 +121,64 @@ describe("LearnSideNav", () => {
       expect(screen.getByRole("link", { name: firstChildPage.link.label })).toHaveClass(
         "usa-current",
       );
+    });
+  });
+
+  describe("mobile - show/hide full menu toggle", () => {
+    const { showFullMenuLabel, hideFullMenuLabel } = messages.learn.sideNav;
+
+    beforeEach(async () => {
+      const { usePathname } = vi.mocked(await import("next/navigation"));
+      usePathname.mockReturnValue("/en-US/plan");
+    });
+
+    it("renders show full menu button by default", () => {
+      render(<LearnSideNav content={messages.learn} categoryChildren={categoryChildren} />);
+      expect(screen.getByRole("button", { name: showFullMenuLabel })).toBeInTheDocument();
+    });
+
+    it("marks non-current categories as collapsible", () => {
+      const { container } = render(
+        <LearnSideNav content={messages.learn} categoryChildren={categoryChildren} />,
+      );
+      const collapsibleItems = container.querySelectorAll(".sidenav-collapsible-item");
+      expect(collapsibleItems.length).toBeGreaterThan(0);
+
+      const currentButton = container.querySelector(".usa-current");
+      expect(currentButton?.closest(".sidenav-collapsible-item")).toBeNull();
+    });
+
+    it("wraps nav in sidenav--collapsed class by default", () => {
+      const { container } = render(
+        <LearnSideNav content={messages.learn} categoryChildren={categoryChildren} />,
+      );
+      expect(container.querySelector(".sidenav--collapsed")).toBeInTheDocument();
+    });
+
+    it("removes collapsed class and shows hide full menu after clicking toggle", () => {
+      const { container } = render(
+        <LearnSideNav content={messages.learn} categoryChildren={categoryChildren} />,
+      );
+      const toggleButton = screen.getByRole("button", { name: showFullMenuLabel });
+      fireEvent.click(toggleButton);
+
+      expect(container.querySelector(".sidenav--collapsed")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: hideFullMenuLabel })).toBeInTheDocument();
+    });
+
+    it("collapses menu when a child nav item is clicked", () => {
+      const { container } = render(
+        <LearnSideNav content={messages.learn} categoryChildren={categoryChildren} />,
+      );
+      const toggleButton = screen.getByRole("button", { name: showFullMenuLabel });
+      fireEvent.click(toggleButton);
+      expect(container.querySelector(".sidenav--collapsed")).not.toBeInTheDocument();
+
+      const sublist = container.querySelector(".usa-sidenav__sublist");
+      const childLink = sublist?.querySelector("a");
+      // biome-ignore lint/style/noNonNullAssertion: Needed for the test
+      fireEvent.click(childLink!);
+      expect(container.querySelector(".sidenav--collapsed")).toBeInTheDocument();
     });
   });
 });

--- a/packages/static-site/components/learn/LearnSideNav.tsx
+++ b/packages/static-site/components/learn/LearnSideNav.tsx
@@ -5,7 +5,9 @@
 
 "use client";
 
+import Image from "next/image";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
 import type { SideNavChildItem } from "@/components/SideNav";
 import { SideNav } from "@/components/SideNav";
 import type { LearnPageContent } from "@/domain/content/messageTypes";
@@ -20,6 +22,9 @@ export interface LearnSideNavProps {
   readonly categoryChildren: Readonly<Record<string, readonly SideNavChildItem[]>>;
 }
 
+const VISIBILITY_ICON = "/assets/njwds/dist/img/usa-icons/visibility.svg";
+const VISIBILITY_OFF_ICON = "/assets/njwds/dist/img/usa-icons/visibility_off.svg";
+
 /**
  * Renders a side navigation for the learn section, marking the current page
  * based on the active route segment below the learn layout.
@@ -30,6 +35,7 @@ export interface LearnSideNavProps {
  */
 export const LearnSideNav = ({ content, categoryChildren }: LearnSideNavProps) => {
   const pathname = usePathname();
+  const [showFullMenu, setShowFullMenu] = useState(false);
   const pathWithoutLocale = pathname.replace(/^\/[^/]+/, "");
 
   const sideNavCategories = [content.sideNav.learnCategory, ...content.categories];
@@ -44,19 +50,42 @@ export const LearnSideNav = ({ content, categoryChildren }: LearnSideNavProps) =
       (pathWithoutLocale === category.link.href && !hasCurrentChild) ||
       hasCurrentChild;
 
-    const childrenWithCurrent = hasCurrentChild
-      ? children.map((child, i) => ({
-          ...child,
-          isCurrent: i === currentChildIndex,
-        }))
-      : children;
+    const childrenWithCurrent = children.map((child, i) => ({
+      ...child,
+      isCurrent: hasCurrentChild && i === currentChildIndex,
+      isCollapsible: !hasCurrentChild || i !== currentChildIndex,
+    }));
 
     return {
       link: { ...category.link, label: category.title },
       isCurrent: isCategoryCurrent,
       children: childrenWithCurrent,
+      isCollapsible: !isCategoryCurrent,
     };
   });
 
-  return <SideNav ariaLabel={content.sideNav.ariaLabel} items={items} />;
+  return (
+    <div className={showFullMenu ? "" : "sidenav--collapsed"}>
+      <SideNav
+        ariaLabel={content.sideNav.ariaLabel}
+        items={items}
+        onItemSelect={() => setShowFullMenu(false)}
+      />
+      <button
+        type="button"
+        className="usa-button usa-button--outline sidenav-toggle-button tablet:display-none"
+        aria-expanded={showFullMenu}
+        onClick={() => setShowFullMenu((prev) => !prev)}
+      >
+        <Image
+          src={showFullMenu ? VISIBILITY_OFF_ICON : VISIBILITY_ICON}
+          alt=""
+          width={20}
+          height={20}
+          aria-hidden="true"
+        />
+        {showFullMenu ? content.sideNav.hideFullMenuLabel : content.sideNav.showFullMenuLabel}
+      </button>
+    </div>
+  );
 };

--- a/packages/static-site/domain/content/messageTypes.ts
+++ b/packages/static-site/domain/content/messageTypes.ts
@@ -382,6 +382,10 @@ export interface LandingMetadataContent {
 export interface LearnSideNav {
   /** Accessible name for the section. */
   readonly ariaLabel: string;
+  /** Label for the button that reveals all categories. */
+  readonly showFullMenuLabel: string;
+  /** Label for the button that hides non-current categories. */
+  readonly hideFullMenuLabel: string;
   /** The top-level "Introduction" entry linking to /learn. */
   readonly learnCategory: LearnCategory;
 }

--- a/packages/static-site/messages/en-US.json
+++ b/packages/static-site/messages/en-US.json
@@ -516,6 +516,8 @@
     },
     "sideNav": {
       "ariaLabel": "Side navigation",
+      "showFullMenuLabel": "Show Full Menu",
+      "hideFullMenuLabel": "Hide Full Menu",
       "learnCategory": {
         "key": "learn",
         "title": "Introduction",

--- a/packages/static-site/messages/es-US.json
+++ b/packages/static-site/messages/es-US.json
@@ -516,6 +516,8 @@
     },
     "sideNav": {
       "ariaLabel": "Side navigation",
+      "showFullMenuLabel": "Mostrar menú completo",
+      "hideFullMenuLabel": "Ocultar menú completo",
       "learnCategory": {
         "key": "learn",
         "title": "Introduction",


### PR DESCRIPTION
## Description

Adds a "Show Full Menu" / "Hide Full Menu" toggle button to the Learn section side navigation on mobile. In collapsed state (default), only the current category and active child page are visible. Clicking the toggle reveals all categories with animated transitions. On tablet+, the full menu is always visible and the toggle is hidden.

### Ticket

This pull request resolves [#17710](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17710).

### Approach

- Added `isCollapsible` flag to `SideNavItem` and `SideNavChildItem` interfaces in `SideNav.tsx`, rendered as a `sidenav-collapsible-item` CSS class
- `LearnSideNav` manages `showFullMenu` state and wraps SideNav in a `sidenav--collapsed` div
- Toggle button uses USWDS `usa-button--outline` with NJWDS visibility/visibility_off icons
- CSS animation (max-height + opacity) scoped to mobile via `@media (max-width: 39.99em)`
- Added `onItemSelect` callback to SideNav so menu collapses on link click
- i18n strings added to both en-US and es-US message files

### Steps to Test

1. Run `pnpm dev` in `packages/static-site`
2. Navigate to any Learn category page (e.g. /en-US/start)
3. On mobile viewport: verify only the current category is shown with a "Show Full Menu" button
4. Click "Show Full Menu" — all categories animate in, button changes to "Hide Full Menu"
5. Click a nav link — menu collapses back
6. On tablet+ viewport: verify full menu is always visible with no toggle button
7. Test in es-US locale for Spanish labels

### Notes

- Toggle button is hidden on tablet+ using USWDS utility class `tablet:display-none`
- Animation uses `max-height: 500px` technique — adequate for current category sizes

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [ ] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews