### PR TITLE
feat: add language picker + RTL foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ report-industries-and-non-essential-questions.csv
 # testing
 /coverage
 coverage/
+.playwright-mcp/
 
 # next.js
 web/.next/

--- a/packages/static-site/app/[locale]/(learn)/[category]/page.tsx
+++ b/packages/static-site/app/[locale]/(learn)/[category]/page.tsx
@@ -1,5 +1,7 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { CATEGORY_HIERARCHY } from "@/domain/categories";
+import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
 import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
 
@@ -11,6 +13,19 @@ interface PageParams {
 interface Props {
   readonly params: Promise<PageParams>;
 }
+
+/**
+ * Generates metadata advertising hreflang alternates for a category page.
+ *
+ * @param props Route props provided by Next.js.
+ * @param props.params Async route params including the category segment.
+ * @returns Metadata containing canonical and alternate-language links.
+ */
+export const generateMetadata = async ({ params }: Props): Promise<Metadata> => {
+  const { category } = await params;
+
+  return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: `/${category}` }) };
+};
 
 /**
  * Returns the list of category segments to pre-render at build time.

--- a/packages/static-site/app/[locale]/(learn)/learn/page.tsx
+++ b/packages/static-site/app/[locale]/(learn)/learn/page.tsx
@@ -1,5 +1,7 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
+import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
 import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
 
@@ -10,6 +12,15 @@ interface PageParams {
 interface Props {
   readonly params: Promise<PageParams>;
 }
+
+/**
+ * Generates metadata advertising hreflang alternates for the learn page.
+ *
+ * @returns Metadata containing canonical and alternate-language links.
+ */
+export const generateMetadata = (): Metadata => {
+  return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: "/learn" }) };
+};
 
 const LearnPage = async ({ params }: Props) => {
   const { locale } = await params;

--- a/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.tsx
+++ b/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.tsx
@@ -1,7 +1,9 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import PageContent from "@/components/learn/PageContent";
 import { CATEGORY_HIERARCHY } from "@/domain/categories";
 import { loadPageBySlug } from "@/domain/content/loadContent";
+import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
 import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
 
 interface PageParams {
@@ -12,6 +14,19 @@ interface PageParams {
 interface Props {
   readonly params: Promise<PageParams>;
 }
+
+/**
+ * Generates metadata advertising hreflang alternates for a content page.
+ *
+ * @param props Route props provided by Next.js.
+ * @param props.params Async route params including the slug segment.
+ * @returns Metadata containing canonical and alternate-language links.
+ */
+export const generateMetadata = async ({ params }: Props): Promise<Metadata> => {
+  const { slug } = await params;
+
+  return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: `/pages/${slug}` }) };
+};
 
 export const generateStaticParams = () => {
   const allChildren = Object.values(CATEGORY_HIERARCHY).flatMap((category) => category.children);

--- a/packages/static-site/app/[locale]/language-switcher-harness/page.tsx
+++ b/packages/static-site/app/[locale]/language-switcher-harness/page.tsx
@@ -1,0 +1,109 @@
+/**
+ * Test-only harness that renders the language switcher with a controlled
+ * number of options so e2e tests can assert scroll behavior at specific counts.
+ *
+ * This route is gated out of production builds via `notFound()`, so it never
+ * ships to real users. It exists solely to bridge the "inject a specific option
+ * count" need with a real browser, where scrollHeight/clientHeight are
+ * meaningful (jsdom has no layout engine).
+ */
+
+import { notFound } from "next/navigation";
+
+import { LanguageSwitcher } from "@/components/landing/LanguageSwitcher";
+import type { LanguageDescriptor } from "@/domain/i18n/languages";
+import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+
+/** Upper bound on synthetic options, generous enough to exercise scrolling. */
+const MAX_SYNTHETIC_OPTIONS = 20;
+
+/**
+ * Describes route params and query for the harness page.
+ */
+interface HarnessPageProps {
+  /** Async locale route params provided by Next.js. */
+  readonly params: Promise<{ readonly locale: string }>;
+  /** Async query params; `count` selects how many languages to render. */
+  readonly searchParams: Promise<{ readonly count?: string }>;
+}
+
+/**
+ * Clamps the requested option count into the supported synthetic range.
+ *
+ * @param rawCount Raw `count` query value, possibly undefined or invalid.
+ * @returns A count between 1 and {@link MAX_SYNTHETIC_OPTIONS}.
+ */
+const resolveCount = (rawCount: string | undefined): number => {
+  const parsed = Number.parseInt(rawCount ?? "", 10);
+
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return MAX_SYNTHETIC_OPTIONS;
+  }
+
+  return Math.min(parsed, MAX_SYNTHETIC_OPTIONS);
+};
+
+/**
+ * Builds a list of synthetic language descriptors for scroll measurement.
+ *
+ * The switcher is stateless, so its scroll behavior depends only on how many
+ * options it renders, not on the app's real language set. Generating options
+ * here keeps the scroll e2e tests independent of the supported locales. The
+ * synthetic `locale` values are display-only (the harness never navigates), so
+ * they are cast to {@link AppLocale} to satisfy the descriptor type.
+ *
+ * @param count How many synthetic options to produce.
+ * @returns A descriptor list of the requested length.
+ */
+const buildSyntheticDescriptors = (count: number): readonly LanguageDescriptor[] => {
+  return Array.from({ length: count }, (_unused, index) => {
+    return {
+      locale: `synthetic-${index}` as AppLocale,
+      nativeName: `Language ${index + 1}`,
+      englishName: `Language ${index + 1}`,
+      regionName: "United States",
+      textDirection: "ltr",
+    } satisfies LanguageDescriptor;
+  });
+};
+
+/**
+ * Renders the language switcher with a controlled number of options.
+ *
+ * @param props Route props with locale params and `count` query.
+ * @returns The harness markup, or `notFound()` in production / for bad locales.
+ */
+const LanguageSwitcherHarnessPage = async ({ params, searchParams }: HarnessPageProps) => {
+  // biome-ignore lint/style/noProcessEnv: gate this test-only route out of production builds.
+  if (process.env.NODE_ENV === "production") {
+    notFound();
+  }
+
+  const { locale } = await params;
+
+  if (!hasAppLocale(locale)) {
+    notFound();
+  }
+
+  const { count } = await searchParams;
+  const descriptors = buildSyntheticDescriptors(resolveCount(count));
+  const messages = getApplicationMessages({ locale });
+
+  return (
+    <div className="grid-container usa-section">
+      <h1>Language switcher harness</h1>
+      <LanguageSwitcher
+        buttonLabel={messages.layout.languageSwitcher.buttonLabel}
+        currentLanguageLabel={messages.layout.languageSwitcher.currentLanguageLabel}
+        currentLocale={locale}
+        descriptors={descriptors}
+        navigationAriaLabel={messages.layout.languageSwitcher.navigationAriaLabel}
+        pathname="/language-switcher-harness"
+        submenuId="harness-language-switcher-submenu"
+      />
+    </div>
+  );
+};
+
+export default LanguageSwitcherHarnessPage;

--- a/packages/static-site/app/[locale]/layout.tsx
+++ b/packages/static-site/app/[locale]/layout.tsx
@@ -17,11 +17,14 @@ import { GoogleTagManager } from "@/components/analytics/GoogleTagManager";
 import { Intercom } from "@/components/analytics/Intercom";
 import { GovBanner } from "@/components/landing/GovBanner";
 import { IdentifierSection } from "@/components/landing/IdentifierSection";
+import { LanguagePromptModal } from "@/components/landing/LanguagePromptModal";
 import { SiteFooter } from "@/components/landing/SiteFooter";
 import { SiteHeader } from "@/components/landing/SiteHeader";
 import { SkipNav } from "@/components/landing/SkipNav";
+import { textDirectionForLocale } from "@/domain/i18n/languages";
 import { APP_LOCALES, hasAppLocale } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
+import { SITE_BASE_URL } from "@/domain/siteConfig";
 
 /**
  * Stores the logo path used in metadata icons and social previews.
@@ -29,14 +32,18 @@ import { getApplicationMessages } from "@/domain/i18n/messages";
 const NJ_LOGO_IMAGE_PATH = "/assets/njwds/dist/img/nj-logo-gray-20.png";
 
 /**
- * Stores the canonical production URL for metadata URL resolution.
- */
-const METADATA_BASE_URL = "https://next.business.nj.gov";
-
-/**
  * Public path for the synced NJWDS stylesheet.
  */
 const NJWDS_STYLESHEET_PATH = "/assets/njwds/dist/css/styles.css";
+
+/**
+ * Public path for our flow-relative (RTL-aware) utility classes.
+ *
+ * Loaded immediately after the NJWDS stylesheet so these utilities win on
+ * source order at equal specificity, letting them flip NJWDS's physical
+ * directional properties under `dir="rtl"` without `!important`.
+ */
+const NJ_RTL_UTILITIES_STYLESHEET_PATH = "/styles/nj-rtl-utilities.css";
 
 /**
  * Public path for the synced NJWDS runtime script.
@@ -116,7 +123,7 @@ export const generateMetadata = async ({ params }: GenerateMetadataProps): Promi
   return {
     title: messages.metadata.title,
     description: messages.metadata.description,
-    metadataBase: new URL(METADATA_BASE_URL),
+    metadataBase: new URL(SITE_BASE_URL),
     icons: {
       icon: NJ_LOGO_IMAGE_PATH,
       shortcut: NJ_LOGO_IMAGE_PATH,
@@ -170,9 +177,10 @@ const LocaleLayout = async ({ children, params }: LocaleLayoutProps) => {
   const messages = getApplicationMessages({ locale });
 
   return (
-    <html lang={locale}>
+    <html dir={textDirectionForLocale(locale)} lang={locale}>
       <head>
         <link href={NJWDS_STYLESHEET_PATH} rel="stylesheet" />
+        <link href={NJ_RTL_UTILITIES_STYLESHEET_PATH} rel="stylesheet" />
       </head>
       <body>
         <GoogleTagManager />
@@ -182,13 +190,17 @@ const LocaleLayout = async ({ children, params }: LocaleLayoutProps) => {
             mainContentId={messages.layout.mainContentId}
           />
           <GovBanner content={messages.layout.banner} />
-          <SiteHeader content={messages.layout.header} />
+          <SiteHeader
+            content={messages.layout.header}
+            languageSwitcher={messages.layout.languageSwitcher}
+          />
           <main id={messages.layout.mainContentId}>{children}</main>
           <SiteFooter
             content={messages.layout.footer}
             mainContentId={messages.layout.mainContentId}
           />
           <IdentifierSection content={messages.layout.identifier} />
+          <LanguagePromptModal />
         </NextIntlClientProvider>
         <Script src={NJWDS_SCRIPT_PATH} strategy="afterInteractive" />
         <Intercom />

--- a/packages/static-site/app/[locale]/page.tsx
+++ b/packages/static-site/app/[locale]/page.tsx
@@ -5,8 +5,10 @@
  * and renders the landing page component.
  */
 
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Script from "next/script";
+
 import { BroughtToYouBySection } from "@/components/landing/BroughtToYouBySection";
 import { CtaBannerSection } from "@/components/landing/CtaBannerSection";
 import { FeedbackBar } from "@/components/landing/FeedbackBar";
@@ -15,6 +17,7 @@ import { QuickServicesSection } from "@/components/landing/QuickServicesSection"
 import { SupportSection } from "@/components/landing/SupportSection";
 import { WhatsNewSection } from "@/components/landing/WhatsNewSection";
 import { loadRecents } from "@/domain/content/loadContent";
+import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
 import { hasAppLocale } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
 
@@ -37,6 +40,19 @@ interface LocalizedPageProps {
   /** Asynchronous route parameters provided by Next.js. */
   readonly params: Promise<LocalePageParams>;
 }
+
+/**
+ * Generates metadata advertising hreflang alternates for the landing page.
+ *
+ * @returns Metadata containing canonical and alternate-language links.
+ * @example
+ * ```ts
+ * const metadata = generateMetadata();
+ * ```
+ */
+export const generateMetadata = (): Metadata => {
+  return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: "/" }) };
+};
 
 /**
  * Renders the localized landing page route.

--- a/packages/static-site/app/globals.css
+++ b/packages/static-site/app/globals.css
@@ -12,6 +12,15 @@ body a {
   text-decoration: none;
 }
 
+/* Inline links inside running text must stay distinguishable without relying on
+   color alone (WCAG 1.4.1), so restore their underline. Block/standalone links
+   such as cards and nav items keep the underline-free treatment above. */
+p a,
+.usa-prose a,
+.usa-identifier__identity-disclaimer a {
+  text-decoration: underline;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
@@ -19,6 +28,21 @@ body {
 
 .grid-container p {
   max-width: unset;
+}
+
+/* Flow-relative spacing/alignment utilities. NJWDS/USWDS ship only physical
+   utilities (margin-right-*, text-right), which do not flip under dir="rtl".
+   These logical equivalents auto-flip, keeping our approach class-based. */
+.nj-margin-inline-end-1 {
+  margin-inline-end: 1rem;
+}
+
+.nj-margin-inline-end-05 {
+  margin-inline-end: 0.5rem;
+}
+
+.nj-text-align-end {
+  text-align: end;
 }
 
 .nj-banner__inner ul {
@@ -40,13 +64,11 @@ body {
 }
 
 ul.usa-card-group {
-  margin-left: -0.75rem;
-  margin-right: -0.75rem;
+  margin-inline: -0.75rem;
 }
 
 div.usa-card__container {
-  margin-left: 0.75rem;
-  margin-right: 0.75rem;
+  margin-inline: 0.75rem;
 }
 
 @media (min-width: 40em) {
@@ -56,7 +78,7 @@ div.usa-card__container {
   }
 
   .learn-side-nav nav {
-    margin-right: 48px;
+    margin-inline-end: 48px;
     position: sticky;
     top: 20px;
   }
@@ -93,7 +115,7 @@ li {
 
 .sidenav-chevron {
   flex-shrink: 0;
-  margin-left: 0.5rem;
+  margin-inline-start: 0.5rem;
   transition: transform 0.2s ease;
 }
 
@@ -133,4 +155,17 @@ li {
     opacity: 0;
     margin: 0;
   }
+}
+
+/* Show at most six language options before scrolling, per USWDS language-selector spec. */
+.usa-language__submenu {
+  max-height: 13.5rem;
+  overflow-y: auto;
+}
+
+/* Drop the USWDS default divider line between options, per Figma design.
+   Scoped under .usa-language__submenu to outrank the single-class NJWDS rule
+   on specificity, independent of stylesheet load order. */
+.usa-language__submenu .usa-language__submenu-item {
+  border-top: none;
 }

--- a/packages/static-site/app/sitemap.ts
+++ b/packages/static-site/app/sitemap.ts
@@ -1,0 +1,74 @@
+/**
+ * Generates the XML sitemap with hreflang alternates for every route.
+ *
+ * Each entry lists its absolute default-locale URL plus a `languages` map so
+ * search engines treat the localized variants as linked. Routes are enumerated
+ * from the same content sources the pages render from, so the sitemap stays in
+ * sync with the actual route tree.
+ */
+
+import type { MetadataRoute } from "next";
+
+import { CATEGORY_HIERARCHY } from "@/domain/categories";
+import { addLocalePrefix } from "@/domain/i18n/localePath";
+import { APP_LOCALES } from "@/domain/i18n/locales";
+import { SITE_BASE_URL } from "@/domain/siteConfig";
+
+/**
+ * Builds an absolute URL for a locale-prefixed pathname.
+ *
+ * @param pathnameWithoutLocale Unprefixed pathname starting with `/`.
+ * @param locale Locale to apply before resolving against the site origin.
+ * @returns The absolute URL for the locale variant.
+ */
+const toAbsoluteUrl = (pathnameWithoutLocale: string, locale: (typeof APP_LOCALES)[number]) => {
+  return new URL(addLocalePrefix({ pathnameWithoutLocale, locale }), SITE_BASE_URL).toString();
+};
+
+/**
+ * Builds one sitemap entry with per-locale alternate URLs.
+ *
+ * @param pathnameWithoutLocale Unprefixed pathname for the route.
+ * @returns A sitemap entry for the default-locale URL plus language alternates.
+ */
+const buildSitemapEntry = (pathnameWithoutLocale: string): MetadataRoute.Sitemap[number] => {
+  const languages: Record<string, string> = {};
+
+  for (const locale of APP_LOCALES) {
+    languages[locale] = toAbsoluteUrl(pathnameWithoutLocale, locale);
+  }
+
+  return {
+    url: toAbsoluteUrl(pathnameWithoutLocale, "en-US"),
+    alternates: { languages },
+  };
+};
+
+/**
+ * Lists every unprefixed pathname the site exposes.
+ *
+ * @returns Unprefixed pathnames for the home, learn, category, and content pages.
+ */
+const collectRoutePathnames = (): readonly string[] => {
+  const categoryPathnames = Object.keys(CATEGORY_HIERARCHY).map((category) => `/${category}`);
+  const contentPathnames = Object.values(CATEGORY_HIERARCHY).flatMap((category) => {
+    return category.children.map((page) => `/pages/${page.slug}`);
+  });
+
+  return ["/", "/learn", ...categoryPathnames, ...contentPathnames];
+};
+
+/**
+ * Generates the localized sitemap for the static site.
+ *
+ * @returns The sitemap with hreflang alternates for every route.
+ * @example
+ * ```ts
+ * const entries = sitemap();
+ * ```
+ */
+const sitemap = (): MetadataRoute.Sitemap => {
+  return collectRoutePathnames().map(buildSitemapEntry);
+};
+
+export default sitemap;

--- a/packages/static-site/components/landing/FeedbackBar.tsx
+++ b/packages/static-site/components/landing/FeedbackBar.tsx
@@ -12,9 +12,9 @@ export const FeedbackBar = ({ content }: FeedbackBarProps) => {
           <div className="tablet:grid-col-8">
             <p className="margin-y-0 font-body-md">{content.question}</p>
           </div>
-          <div className="tablet:grid-col-4 text-right">
+          <div className="tablet:grid-col-4 nj-text-align-end">
             <button
-              className="usa-button usa-button--outline usa-button--inverse margin-right-1"
+              className="usa-button usa-button--outline usa-button--inverse nj-margin-inline-end-1"
               type="button"
             >
               {content.yesLabel}

--- a/packages/static-site/components/landing/GovBanner.tsx
+++ b/packages/static-site/components/landing/GovBanner.tsx
@@ -46,7 +46,7 @@ export const GovBanner = ({ content }: GovBannerProps) => {
             <div className="grid-col-auto">
               <Image
                 alt={content.stateSealAlt}
-                className="margin-right-1"
+                className="nj-margin-inline-end-1"
                 height={36}
                 src="/state-seal-2px.png"
                 width={36}
@@ -55,9 +55,11 @@ export const GovBanner = ({ content }: GovBannerProps) => {
             <div className="grid-col-fill">
               <LocalizedLink link={content.stateSiteLink} />
             </div>
-            <ul className="grid-col-auto display-flex flex-align-center">
+            <ul className="grid-col-auto display-flex flex-align-center nj-inline-separators">
               <li>
-                <LocalizedLink link={content.governorIdentityLink} />
+                <LocalizedLink link={content.governorIdentityLink}>
+                  <bdi dir="ltr">{content.governorIdentityLink.label}</bdi>
+                </LocalizedLink>
               </li>
               <li className="grid-col-auto">
                 <LocalizedLink
@@ -66,7 +68,7 @@ export const GovBanner = ({ content }: GovBannerProps) => {
                 >
                   <svg
                     aria-hidden="true"
-                    className="usa-icon usa-icon--size-3 nj-banner__mail-icon margin-right-05"
+                    className="usa-icon usa-icon--size-3 nj-banner__mail-icon nj-margin-inline-end-05"
                     focusable="false"
                   >
                     <use xlinkHref={`${NJWDS_SPRITE_PATH}#mail`} />

--- a/packages/static-site/components/landing/HeaderLanguageSwitcher.test.tsx
+++ b/packages/static-site/components/landing/HeaderLanguageSwitcher.test.tsx
@@ -1,0 +1,46 @@
+import { render } from "@testing-library/react";
+import { useLocale } from "next-intl";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { usePathname } from "@/domain/i18n/navigation";
+import { HeaderLanguageSwitcher } from "./HeaderLanguageSwitcher";
+
+vi.mock("next-intl", () => {
+  return { useLocale: vi.fn() };
+});
+
+const mockedUseLocale = vi.mocked(useLocale);
+const mockedUsePathname = vi.mocked(usePathname);
+
+describe("HeaderLanguageSwitcher", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes the resolved locale and pathname through to the atom", () => {
+    mockedUseLocale.mockReturnValue("es-US");
+    mockedUsePathname.mockReturnValue("/learn");
+
+    const content = getApplicationMessages({ locale: "es-US" }).layout.languageSwitcher;
+    render(<HeaderLanguageSwitcher content={content} />);
+
+    const activeLink = document.querySelector('a[aria-current="true"]');
+    expect(activeLink).not.toBeNull();
+
+    expect(activeLink).toHaveAttribute("hreflang", "es-US");
+    expect(activeLink).toHaveAttribute("href", "/learn");
+  });
+
+  it("defaults unknown locale values to the default locale", () => {
+    mockedUseLocale.mockReturnValue("fr-FR");
+    mockedUsePathname.mockReturnValue("/");
+
+    const content = getApplicationMessages({ locale: "en-US" }).layout.languageSwitcher;
+    render(<HeaderLanguageSwitcher content={content} />);
+
+    const activeLink = document.querySelector('a[aria-current="true"]');
+    expect(activeLink).not.toBeNull();
+
+    expect(activeLink).toHaveAttribute("hreflang", "en-US");
+  });
+});

--- a/packages/static-site/components/landing/HeaderLanguageSwitcher.tsx
+++ b/packages/static-site/components/landing/HeaderLanguageSwitcher.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+/**
+ * Supplies live locale and pathname values to the language switcher atom.
+ *
+ * This thin client molecule isolates the `next-intl` hooks the stateless
+ * `LanguageSwitcher` cannot call itself, then delegates all rendering to it.
+ */
+
+import { useLocale } from "next-intl";
+
+import type { LayoutLanguageSwitcherContent } from "@/domain/content/messageTypes";
+import { resolveAppLocale } from "@/domain/i18n/locales";
+import { usePathname } from "@/domain/i18n/navigation";
+import { LanguageSwitcher } from "./LanguageSwitcher";
+
+/**
+ * Describes props accepted by the header language switcher molecule.
+ *
+ * This type defines a stable shape for related data.
+ */
+export interface HeaderLanguageSwitcherProps {
+  /** Localized switcher chrome shown in the current language. */
+  readonly content: LayoutLanguageSwitcherContent;
+}
+
+/**
+ * Renders the language switcher wired to the current locale and pathname.
+ *
+ * @param props Component props.
+ * @param props.content Localized switcher chrome content.
+ * @returns The language switcher for the header utility area.
+ * @example
+ * ```tsx
+ * <HeaderLanguageSwitcher content={messages.layout.languageSwitcher} />
+ * ```
+ */
+export const HeaderLanguageSwitcher = ({ content }: HeaderLanguageSwitcherProps) => {
+  const pathname = usePathname();
+  const currentLocale = resolveAppLocale({ locale: useLocale() });
+
+  return (
+    <LanguageSwitcher
+      buttonLabel={content.buttonLabel}
+      currentLanguageLabel={content.currentLanguageLabel}
+      currentLocale={currentLocale}
+      navigationAriaLabel={content.navigationAriaLabel}
+      pathname={pathname}
+    />
+  );
+};

--- a/packages/static-site/components/landing/IdentifierSection.tsx
+++ b/packages/static-site/components/landing/IdentifierSection.tsx
@@ -93,7 +93,9 @@ export const IdentifierSection = ({ content }: IdentifierSectionProps) => {
             </a>
           </div>
           <div className="usa-identifier__identity">
-            <p className="usa-identifier__identity-domain">{content.domain}</p>
+            <p className="usa-identifier__identity-domain">
+              <bdi dir="ltr">{content.domain}</bdi>
+            </p>
             <p className="usa-identifier__identity-disclaimer">
               {content.disclaimerPrefix} <LocalizedLink link={content.disclaimerLink} />
             </p>

--- a/packages/static-site/components/landing/LanguagePromptModal.test.tsx
+++ b/packages/static-site/components/landing/LanguagePromptModal.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react";
+import { useLocale } from "next-intl";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { usePathname, useRouter } from "@/domain/i18n/navigation";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+import { LanguagePromptModal } from "./LanguagePromptModal";
+
+vi.mock("next-intl", () => {
+  return { useLocale: vi.fn() };
+});
+
+const mockedUseLocale = vi.mocked(useLocale);
+const mockedUsePathname = vi.mocked(usePathname);
+const mockedUseRouter = vi.mocked(useRouter);
+const replaceMock = vi.fn();
+
+/**
+ * Overrides the browser's reported language preferences for one test.
+ */
+const setBrowserLanguages = (languages: readonly string[]): void => {
+  Object.defineProperty(window.navigator, "languages", {
+    value: languages,
+    configurable: true,
+  });
+};
+
+const renderModal = () => render(<LanguagePromptModal />);
+
+describe("LanguagePromptModal", () => {
+  beforeEach(() => {
+    mockedUsePathname.mockReturnValue("/learn");
+    mockedUseRouter.mockReturnValue({
+      replace: replaceMock,
+    } as unknown as ReturnType<typeof useRouter>);
+    document.cookie = `${LANGUAGE_PROMPT_DISMISSED_COOKIE}=; max-age=0; path=/`;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    document.cookie = `${LANGUAGE_PROMPT_DISMISSED_COOKIE}=; max-age=0; path=/`;
+  });
+
+  it("prompts when browser language differs from current locale", () => {
+    mockedUseLocale.mockReturnValue("en-US");
+    setBrowserLanguages(["es-US"]);
+
+    renderModal();
+
+    // Entire dialog is in the preferred (es-US) language.
+    expect(screen.getByRole("heading", { name: /su idioma/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Español/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Permanecer/i })).toBeInTheDocument();
+  });
+
+  it("does not prompt when browser language matches current locale", () => {
+    mockedUseLocale.mockReturnValue("en-US");
+    setBrowserLanguages(["en-US"]);
+
+    renderModal();
+
+    expect(screen.queryByRole("heading", { name: /language/i })).not.toBeInTheDocument();
+  });
+
+  it("does not prompt when the dismissal cookie is present", () => {
+    mockedUseLocale.mockReturnValue("en-US");
+    setBrowserLanguages(["es-US"]);
+    document.cookie = `${LANGUAGE_PROMPT_DISMISSED_COOKIE}=true; path=/`;
+
+    renderModal();
+
+    expect(screen.queryByRole("heading", { name: /language/i })).not.toBeInTheDocument();
+  });
+
+  it("sets the dismissal cookie without navigating when staying", () => {
+    mockedUseLocale.mockReturnValue("en-US");
+    setBrowserLanguages(["es-US"]);
+
+    renderModal();
+    screen.getByRole("button", { name: /Permanecer/i }).click();
+
+    expect(document.cookie).toContain(`${LANGUAGE_PROMPT_DISMISSED_COOKIE}=true`);
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("navigates to the preferred locale and sets the dismissal cookie when switching", () => {
+    mockedUseLocale.mockReturnValue("en-US");
+    setBrowserLanguages(["es-US"]);
+
+    renderModal();
+    screen.getByRole("button", { name: /Español/ }).click();
+
+    expect(document.cookie).toContain(`${LANGUAGE_PROMPT_DISMISSED_COOKIE}=true`);
+    expect(replaceMock).toHaveBeenCalledWith("/learn", { locale: "es-US" });
+  });
+});

--- a/packages/static-site/components/landing/LanguagePromptModal.tsx
+++ b/packages/static-site/components/landing/LanguagePromptModal.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+/**
+ * Detects a preferred-language mismatch and prompts the visitor to switch.
+ *
+ * On mount this molecule compares the visitor's browser languages against the
+ * page's current locale. When a supported preferred locale differs from the
+ * current one and the dismissal cookie is absent, it opens the NJWDS modal
+ * offering to stay or switch. It never redirects automatically. The visitor's
+ * choice is recorded in a dismissal cookie so they are not prompted again; the
+ * switch action also persists `NEXT_LOCALE` via the next-intl router.
+ *
+ * The entire dialog is shown in the preferred/target language so the visitor
+ * — who may not read the current page's locale — can understand the prompt.
+ */
+
+import { useLocale } from "next-intl";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { LANGUAGE_DESCRIPTORS } from "@/domain/i18n/languages";
+import { addLocalePrefix, stripLocalePrefix } from "@/domain/i18n/localePath";
+import { type AppLocale, resolveAppLocale } from "@/domain/i18n/locales";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { usePathname, useRouter } from "@/domain/i18n/navigation";
+import { resolvePreferredLocale } from "@/domain/i18n/preferredLocale";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+import { LanguagePromptModalView } from "./LanguagePromptModalView";
+
+/**
+ * One year, in seconds, used as the dismissal cookie lifetime.
+ */
+const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
+
+/**
+ * Reads the browser's ordered language preferences, if available.
+ *
+ * @returns Ordered browser language tags, or an empty list outside a browser.
+ */
+const readBrowserLanguages = (): readonly string[] => {
+  if (typeof navigator === "undefined") {
+    return [];
+  }
+
+  return navigator.languages ?? [];
+};
+
+/**
+ * Checks whether the dismissal cookie is present.
+ *
+ * @returns `true` when the visitor already dismissed the prompt.
+ */
+const hasDismissalCookie = (): boolean => {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  return document.cookie
+    .split(";")
+    .some((entry) => entry.trim().startsWith(`${LANGUAGE_PROMPT_DISMISSED_COOKIE}=`));
+};
+
+/**
+ * Writes a session-persistent cookie scoped to the whole site.
+ *
+ * @param name Cookie name to set.
+ * @param value Cookie value to store.
+ */
+const writeCookie = (name: string, value: string): void => {
+  document.cookie = `${name}=${value}; path=/; max-age=${ONE_YEAR_IN_SECONDS}; samesite=lax`;
+};
+
+/**
+ * Resolves the autonym for a locale from the descriptor table.
+ *
+ * @param locale Locale whose native name is needed.
+ * @returns The locale's native name, or the locale tag as a fallback.
+ */
+const nativeNameOfLocale = (locale: AppLocale): string => {
+  return (
+    LANGUAGE_DESCRIPTORS.find((descriptor) => descriptor.locale === locale)?.nativeName ?? locale
+  );
+};
+
+/**
+ * Renders the preferred-language prompt when the browser language mismatches.
+ *
+ * @returns The prompt modal, or `null` when no prompt is warranted.
+ * @example
+ * ```tsx
+ * <LanguagePromptModal />
+ * ```
+ */
+export const LanguagePromptModal = () => {
+  const currentLocale = resolveAppLocale({ locale: useLocale() });
+  const pathname = usePathname();
+  const router = useRouter();
+  const openTriggerRef = useRef<HTMLButtonElement>(null);
+  const [preferredLocale, setPreferredLocale] = useState<AppLocale | undefined>(undefined);
+
+  useEffect(() => {
+    if (hasDismissalCookie()) {
+      return;
+    }
+
+    const preferred = resolvePreferredLocale({ browserLanguages: readBrowserLanguages() });
+
+    if (preferred && preferred !== currentLocale) {
+      setPreferredLocale(preferred);
+    }
+  }, [currentLocale]);
+
+  useEffect(() => {
+    if (preferredLocale) {
+      openTriggerRef.current?.click();
+    }
+  }, [preferredLocale]);
+
+  const handleStay = useCallback(() => {
+    writeCookie(LANGUAGE_PROMPT_DISMISSED_COOKIE, "true");
+  }, []);
+
+  const handleRedirect = useCallback(() => {
+    if (!preferredLocale) {
+      return;
+    }
+
+    writeCookie(LANGUAGE_PROMPT_DISMISSED_COOKIE, "true");
+
+    const targetPathname = stripLocalePrefix(pathname);
+
+    try {
+      router.replace(targetPathname, { locale: preferredLocale });
+    } catch {
+      window.location.assign(
+        addLocalePrefix({ pathnameWithoutLocale: targetPathname, locale: preferredLocale }),
+      );
+    }
+  }, [pathname, preferredLocale, router]);
+
+  if (!preferredLocale) {
+    return null;
+  }
+
+  // Show the entire dialog in the preferred language — the visitor may not read
+  // the current page locale, so the prompt must speak to them in their language.
+  const preferredContent = getApplicationMessages({ locale: preferredLocale }).layout
+    .languagePrompt;
+  const redirectLabel = preferredContent.redirectLabel.replace(
+    "{language}",
+    nativeNameOfLocale(preferredLocale),
+  );
+
+  return (
+    <LanguagePromptModalView
+      body={preferredContent.body}
+      closeLabel={preferredContent.closeLabel}
+      onRedirect={handleRedirect}
+      onStay={handleStay}
+      openTriggerRef={openTriggerRef}
+      redirectLabel={redirectLabel}
+      stayLabel={preferredContent.stayLabel}
+      title={preferredContent.title}
+    />
+  );
+};

--- a/packages/static-site/components/landing/LanguagePromptModalView.test.tsx
+++ b/packages/static-site/components/landing/LanguagePromptModalView.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import axe from "axe-core";
+import { createRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { LanguagePromptModalView } from "./LanguagePromptModalView";
+
+/**
+ * Describes overrides for rendering the modal view in tests.
+ */
+interface RenderViewParams {
+  /** Handler invoked when the visitor chooses to stay. */
+  readonly onStay?: () => void;
+  /** Handler invoked when the visitor chooses to switch. */
+  readonly onRedirect?: () => void;
+}
+
+/**
+ * Renders the modal view with default copy and optional handler overrides.
+ */
+const renderView = ({ onStay = vi.fn(), onRedirect = vi.fn() }: RenderViewParams = {}) => {
+  return render(
+    <LanguagePromptModalView
+      body="This page is available in another language."
+      closeLabel="Close"
+      onRedirect={onRedirect}
+      onStay={onStay}
+      openTriggerRef={createRef<HTMLButtonElement>()}
+      redirectLabel="Switch to Español"
+      stayLabel="Stay on this page"
+      title="View this page in your language?"
+    />,
+  );
+};
+
+describe("LanguagePromptModalView", () => {
+  it("renders the title, body, and both action buttons", () => {
+    renderView();
+
+    expect(
+      screen.getByRole("heading", { name: "View this page in your language?" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("This page is available in another language.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Switch to Español" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Stay on this page" })).toBeInTheDocument();
+  });
+
+  it("labels the close control", () => {
+    renderView();
+
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+  });
+
+  it("fires onRedirect when the switch button is clicked", () => {
+    const onRedirect = vi.fn();
+    renderView({ onRedirect });
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to Español" }));
+
+    expect(onRedirect).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onStay when the stay button is clicked", () => {
+    const onStay = vi.fn();
+    renderView({ onStay });
+
+    fireEvent.click(screen.getByRole("button", { name: "Stay on this page" }));
+
+    expect(onStay).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes automated accessibility checks", async () => {
+    const view = renderView();
+
+    const results = await axe.run(view.container, {
+      rules: { "color-contrast": { enabled: false } },
+    });
+
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/packages/static-site/components/landing/LanguagePromptModalView.tsx
+++ b/packages/static-site/components/landing/LanguagePromptModalView.tsx
@@ -1,0 +1,160 @@
+/**
+ * Renders the stateless preferred-language prompt modal markup.
+ *
+ * This presentational atom mirrors the NJWDS `usa-modal` structure and exposes
+ * a visually-hidden `data-open-modal` trigger via `ref`. NJWDS ships no
+ * programmatic open API, so the molecule opens the modal by clicking that
+ * hidden trigger; the bundled `toggleModal` handler then runs its focus-trap
+ * and inert logic. All decision logic lives in the molecule, keeping this
+ * component trivial to render and audit for accessibility.
+ */
+
+import type { Ref } from "react";
+
+/**
+ * Element id linking the open trigger to the modal container.
+ */
+const MODAL_ID = "language-prompt-modal";
+
+/**
+ * Element id for the modal heading, referenced by `aria-labelledby`.
+ */
+const MODAL_HEADING_ID = "language-prompt-modal-heading";
+
+/**
+ * Element id for the modal body, referenced by `aria-describedby`.
+ */
+const MODAL_DESCRIPTION_ID = "language-prompt-modal-description";
+
+/**
+ * Describes props accepted by the language prompt modal view.
+ *
+ * This type defines a stable shape for related data.
+ */
+export interface LanguagePromptModalViewProps {
+  /** Modal heading text. */
+  readonly title: string;
+  /** Body text describing the offered language choice. */
+  readonly body: string;
+  /** Label for the button that keeps the visitor on the current page. */
+  readonly stayLabel: string;
+  /** Accessible label for the close control. */
+  readonly closeLabel: string;
+  /** Resolved redirect button label including the target language name. */
+  readonly redirectLabel: string;
+  /** Handler invoked when the visitor chooses to stay on the page. */
+  readonly onStay: () => void;
+  /** Handler invoked when the visitor chooses to switch language. */
+  readonly onRedirect: () => void;
+  /** Ref to the hidden open trigger so the molecule can open the modal. */
+  readonly openTriggerRef: Ref<HTMLButtonElement>;
+}
+
+/**
+ * Renders the preferred-language prompt modal and its hidden open trigger.
+ *
+ * @param props Component props.
+ * @param props.title Modal heading text.
+ * @param props.body Body text describing the choice.
+ * @param props.stayLabel Label for the stay button.
+ * @param props.closeLabel Accessible label for the close control.
+ * @param props.redirectLabel Resolved redirect button label.
+ * @param props.onStay Handler for the stay action.
+ * @param props.onRedirect Handler for the redirect action.
+ * @param props.openTriggerRef Ref to the hidden open trigger.
+ * @returns The modal markup and its hidden trigger.
+ * @example
+ * ```tsx
+ * <LanguagePromptModalView
+ *   title="View this page in your language?"
+ *   body="..."
+ *   stayLabel="Stay"
+ *   closeLabel="Close"
+ *   redirectLabel="Switch to Español"
+ *   onStay={handleStay}
+ *   onRedirect={handleRedirect}
+ *   openTriggerRef={triggerRef}
+ * />
+ * ```
+ */
+export const LanguagePromptModalView = ({
+  title,
+  body,
+  stayLabel,
+  closeLabel,
+  redirectLabel,
+  onStay,
+  onRedirect,
+  openTriggerRef,
+}: LanguagePromptModalViewProps) => {
+  return (
+    <>
+      <button
+        aria-controls={MODAL_ID}
+        aria-hidden="true"
+        data-open-modal
+        ref={openTriggerRef}
+        style={{ position: "fixed", top: 0, insetInlineStart: "-9999px" }}
+        tabIndex={-1}
+        type="button"
+      >
+        {title}
+      </button>
+      {/* No role="dialog" or aria-modal here: the NJWDS modal script moves the
+          dialog role and the id/aria-labelledby/aria-describedby onto the
+          .usa-modal-wrapper it generates, and that wrapper is the real dialog.
+          Declaring role="dialog" here too would leave a second, unnamed dialog
+          (fails aria-dialog-name), and aria-modal without a dialog role is
+          invalid (fails aria-allowed-attr). The aria-labelledby/describedby
+          stay because the script reads them from here. */}
+      {/* biome-ignore lint/a11y/useAriaPropsSupportedByRole: the NJWDS modal script requires aria-labelledby/describedby on .usa-modal — it reads them to label the .usa-modal-wrapper it generates (and throws if absent). The role lives on that wrapper, not here. */}
+      <div
+        aria-describedby={MODAL_DESCRIPTION_ID}
+        aria-labelledby={MODAL_HEADING_ID}
+        className="usa-modal"
+        id={MODAL_ID}
+      >
+        <div className="usa-modal__content">
+          <div className="usa-modal__main">
+            <h2 className="usa-modal__heading" id={MODAL_HEADING_ID}>
+              {title}
+            </h2>
+            <div className="usa-prose">
+              <p id={MODAL_DESCRIPTION_ID}>{body}</p>
+            </div>
+            <div className="usa-modal__footer">
+              <ul className="usa-button-group">
+                <li className="usa-button-group__item">
+                  <button className="usa-button" onClick={onRedirect} type="button">
+                    {redirectLabel}
+                  </button>
+                </li>
+                <li className="usa-button-group__item">
+                  <button
+                    className="usa-button usa-button--unstyled padding-105 text-center"
+                    data-close-modal
+                    onClick={onStay}
+                    type="button"
+                  >
+                    {stayLabel}
+                  </button>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <button
+            aria-label={closeLabel}
+            className="usa-button usa-modal__close"
+            data-close-modal
+            onClick={onStay}
+            type="button"
+          >
+            <svg aria-hidden="true" className="usa-icon" focusable="false" role="img">
+              <use xlinkHref="/assets/njwds/dist/img/sprite.svg#close" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/packages/static-site/components/landing/LanguageSwitcher.test.tsx
+++ b/packages/static-site/components/landing/LanguageSwitcher.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen, within } from "@testing-library/react";
+import axe from "axe-core";
+import { describe, expect, it } from "vitest";
+
+import { LANGUAGE_DESCRIPTORS, type LanguageDescriptor } from "@/domain/i18n/languages";
+import type { AppLocale } from "@/domain/i18n/locales";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { LanguageSwitcher } from "./LanguageSwitcher";
+
+/**
+ * Describes input for rendering the switcher in a given locale context.
+ */
+interface RenderSwitcherParams {
+  /** Locale used to source switcher chrome and mark the active option. */
+  readonly currentLocale: AppLocale;
+  /** Pathname the options should re-target. */
+  readonly pathname: string;
+  /** Optional override for the languages offered, for count-specific tests. */
+  readonly descriptors?: readonly LanguageDescriptor[];
+}
+
+/**
+ * Builds a list of synthetic descriptors of a given length.
+ *
+ * The switcher is stateless and renders whatever descriptors it is given, so
+ * count/order behavior can be tested independently of the app's real language
+ * set. The synthetic `locale` values are display-only here, so they are cast to
+ * satisfy the descriptor type.
+ */
+const buildSyntheticDescriptors = (count: number): readonly LanguageDescriptor[] => {
+  return Array.from({ length: count }, (_unused, index) => {
+    return {
+      locale: `synthetic-${index}` as AppLocale,
+      nativeName: `Language ${index + 1}`,
+      englishName: `Language ${index + 1}`,
+      regionName: "United States",
+      textDirection: "ltr",
+    } satisfies LanguageDescriptor;
+  });
+};
+
+/**
+ * Renders the language switcher with localized chrome for one locale.
+ */
+const renderSwitcher = ({ currentLocale, pathname, descriptors }: RenderSwitcherParams) => {
+  const messages = getApplicationMessages({ locale: currentLocale });
+
+  return render(
+    <LanguageSwitcher
+      buttonLabel={messages.layout.languageSwitcher.buttonLabel}
+      currentLanguageLabel={messages.layout.languageSwitcher.currentLanguageLabel}
+      currentLocale={currentLocale}
+      descriptors={descriptors}
+      navigationAriaLabel={messages.layout.languageSwitcher.navigationAriaLabel}
+      pathname={pathname}
+    />,
+  );
+};
+
+describe("LanguageSwitcher", () => {
+  it("renders the trigger button with the button label", () => {
+    renderSwitcher({ currentLocale: "en-US", pathname: "/learn" });
+
+    expect(screen.getByRole("button", { name: "Languages" })).toBeInTheDocument();
+  });
+
+  it("renders one link per descriptor in the submenu", () => {
+    const { container } = renderSwitcher({ currentLocale: "es-US", pathname: "/learn" });
+
+    const links = container.querySelectorAll(".usa-language__submenu a");
+
+    expect(links).toHaveLength(LANGUAGE_DESCRIPTORS.length);
+    for (const link of links) {
+      expect(link).toHaveAttribute("href", "/learn");
+    }
+  });
+
+  it("marks the active locale option with aria-current and a hidden label", () => {
+    const { currentLanguageLabel } = getApplicationMessages({
+      locale: "es-US",
+    }).layout.languageSwitcher;
+    const { container } = renderSwitcher({ currentLocale: "es-US", pathname: "/learn" });
+
+    const activeLink = container.querySelector('a[aria-current="true"]');
+
+    expect(activeLink).not.toBeNull();
+    expect(activeLink).toHaveAttribute("hreflang", "es-US");
+    expect(
+      within(activeLink as HTMLElement).getByText(currentLanguageLabel, { exact: false }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows native name in bold and English name in parentheses for non-English locales", () => {
+    const { container } = renderSwitcher({ currentLocale: "en-US", pathname: "/learn" });
+
+    const spanishLink = container.querySelector('a[hreflang="es-US"]');
+    expect(spanishLink).not.toBeNull();
+    expect(spanishLink?.querySelector("strong")?.textContent).toBe("Español");
+    expect(spanishLink?.textContent).toContain("(Spanish)");
+  });
+
+  it("scopes the lang attribute to the native-name span, not the whole link", () => {
+    // WCAG H58: only the foreign-language native name is marked with lang.
+    const { container } = renderSwitcher({ currentLocale: "en-US", pathname: "/learn" });
+
+    const spanishLink = container.querySelector('a[hreflang="es-US"]');
+    expect(spanishLink).not.toBeNull();
+    expect(spanishLink).not.toHaveAttribute("lang");
+    expect(spanishLink?.querySelector("strong")).toHaveAttribute("lang", "es-US");
+  });
+
+  it("renders options ordered alphabetically by native name", () => {
+    const { container } = renderSwitcher({ currentLocale: "en-US", pathname: "/learn" });
+
+    const renderedNatives = Array.from(
+      container.querySelectorAll(".usa-language__submenu a strong"),
+    ).map((strong) => strong.textContent);
+    const expectedOrder = LANGUAGE_DESCRIPTORS.map((descriptor) => descriptor.nativeName);
+
+    expect(renderedNatives).toEqual(expectedOrder);
+  });
+
+  describe("option counts", () => {
+    // jsdom has no layout engine, so scrollbar presence is asserted in the e2e
+    // suite; here we only verify the correct options render for each count.
+    // Counts use synthetic descriptors so they stay independent of the app's
+    // actual supported languages.
+    it("renders exactly two options when given two descriptors", () => {
+      const twoLanguages = buildSyntheticDescriptors(2);
+      const { container } = renderSwitcher({
+        currentLocale: "en-US",
+        pathname: "/learn",
+        descriptors: twoLanguages,
+      });
+
+      const links = container.querySelectorAll(".usa-language__submenu a");
+
+      expect(links).toHaveLength(2);
+      for (const descriptor of twoLanguages) {
+        expect(container.querySelector(`a[hreflang="${descriptor.locale}"]`)).not.toBeNull();
+      }
+    });
+
+    it("renders exactly six options when given six descriptors", () => {
+      const sixLanguages = buildSyntheticDescriptors(6);
+      const { container } = renderSwitcher({
+        currentLocale: "en-US",
+        pathname: "/learn",
+        descriptors: sixLanguages,
+      });
+
+      const links = container.querySelectorAll(".usa-language__submenu a");
+
+      expect(links).toHaveLength(6);
+      for (const descriptor of sixLanguages) {
+        expect(container.querySelector(`a[hreflang="${descriptor.locale}"]`)).not.toBeNull();
+      }
+    });
+
+    it("renders one option per descriptor when given more than six", () => {
+      const manyLanguages = buildSyntheticDescriptors(8);
+      const { container } = renderSwitcher({
+        currentLocale: "en-US",
+        pathname: "/learn",
+        descriptors: manyLanguages,
+      });
+
+      const links = container.querySelectorAll(".usa-language__submenu a");
+
+      expect(links.length).toBeGreaterThan(6);
+      expect(links).toHaveLength(manyLanguages.length);
+    });
+  });
+
+  it("passes automated accessibility checks for both locales", async () => {
+    const englishView = renderSwitcher({ currentLocale: "en-US", pathname: "/learn" });
+    const englishResults = await axe.run(englishView.container, {
+      rules: { "color-contrast": { enabled: false } },
+    });
+    expect(englishResults.violations).toHaveLength(0);
+    englishView.unmount();
+
+    const spanishView = renderSwitcher({ currentLocale: "es-US", pathname: "/learn" });
+    const spanishResults = await axe.run(spanishView.container, {
+      rules: { "color-contrast": { enabled: false } },
+    });
+    expect(spanishResults.violations).toHaveLength(0);
+  });
+});

--- a/packages/static-site/components/landing/LanguageSwitcher.tsx
+++ b/packages/static-site/components/landing/LanguageSwitcher.tsx
@@ -1,0 +1,169 @@
+/**
+ * Renders the stateless language switcher control for the site header.
+ *
+ * This presentational atom maps `LANGUAGE_DESCRIPTORS` into a USWDS
+ * `usa-language` dropdown. A trigger button opens a `usa-language__submenu`
+ * list; the NJWDS bundled `uswds.min.js` language-selector module handles
+ * toggle, focus-trap, and keyboard (Escape/Tab) behavior automatically by
+ * selecting `button.usa-language__link` within `.usa-language__primary`.
+ *
+ * Each submenu option follows the USWDS pattern:
+ *   **Español** (Spanish)
+ * — native name in bold, English name in parentheses — except for English
+ * itself which appears without a parenthetical.
+ */
+
+import { LANGUAGE_DESCRIPTORS, type LanguageDescriptor } from "@/domain/i18n/languages";
+import type { AppLocale } from "@/domain/i18n/locales";
+import { Link } from "@/domain/i18n/navigation";
+
+/**
+ * Default element id linking the trigger button to the submenu list.
+ *
+ * Override via the `submenuId` prop when more than one switcher renders on a
+ * page, so each trigger's `aria-controls` points at its own submenu.
+ */
+const DEFAULT_LANGUAGE_SUBMENU_ID = "language-switcher-submenu";
+
+/**
+ * Describes props accepted by the language switcher atom.
+ *
+ * This type defines a stable shape for related data.
+ */
+export interface LanguageSwitcherProps {
+  /** Accessible label for the language navigation region. */
+  readonly navigationAriaLabel: string;
+  /** Label shown on the dropdown trigger button. */
+  readonly buttonLabel: string;
+  /** Visually-hidden suffix marking the active language option. */
+  readonly currentLanguageLabel: string;
+  /** Locale currently shown to the visitor. */
+  readonly currentLocale: AppLocale;
+  /** Current page pathname without a locale prefix, used as the link target. */
+  readonly pathname: string;
+  /**
+   * Languages to offer, in display order. Defaults to the full app list;
+   * accepts an override so tests can exercise specific option counts.
+   */
+  readonly descriptors?: readonly LanguageDescriptor[];
+  /**
+   * Element id linking the trigger to its submenu. Override when more than one
+   * switcher appears on a page so each `aria-controls` stays unique.
+   */
+  readonly submenuId?: string;
+}
+
+/**
+ * Describes input for rendering one language option in the submenu.
+ *
+ * This type defines a stable shape for related data.
+ */
+interface RenderLanguageOptionParams {
+  /** Language metadata for the option. */
+  readonly descriptor: LanguageDescriptor;
+  /** Visually-hidden suffix marking the active language option. */
+  readonly currentLanguageLabel: string;
+  /** Locale currently shown to the visitor. */
+  readonly currentLocale: AppLocale;
+  /** Current page pathname without a locale prefix. */
+  readonly pathname: string;
+}
+
+/**
+ * Renders one selectable language option inside the dropdown submenu.
+ *
+ * @param params Render parameters.
+ * @param params.descriptor Language metadata for the option.
+ * @param params.currentLanguageLabel Visually-hidden active-state suffix.
+ * @param params.currentLocale Locale currently shown to the visitor.
+ * @param params.pathname Current page pathname without a locale prefix.
+ * @returns One submenu list item.
+ * @example
+ * ```tsx
+ * renderLanguageOption({ descriptor, currentLanguageLabel, currentLocale, pathname });
+ * ```
+ */
+const renderLanguageOption = ({
+  descriptor,
+  currentLanguageLabel,
+  currentLocale,
+  pathname,
+}: RenderLanguageOptionParams) => {
+  const isCurrent = descriptor.locale === currentLocale;
+  const isEnglish = descriptor.englishName === descriptor.nativeName;
+
+  return (
+    <li className="usa-language__submenu-item" key={descriptor.locale}>
+      <Link
+        aria-current={isCurrent ? "true" : undefined}
+        href={pathname}
+        hrefLang={descriptor.locale}
+        locale={descriptor.locale}
+      >
+        {/* Per WCAG H58, only the native-name text is in a foreign language, so
+            the lang attribute scopes to it rather than the whole link. */}
+        <strong lang={descriptor.locale}>{descriptor.nativeName}</strong>
+        {isEnglish ? null : ` (${descriptor.englishName})`}
+        {isCurrent ? <span className="usa-sr-only">{` ${currentLanguageLabel}`}</span> : null}
+      </Link>
+    </li>
+  );
+};
+
+/**
+ * Renders the language switcher dropdown in the site header.
+ *
+ * @param props Component props.
+ * @param props.navigationAriaLabel Accessible label for the nav region.
+ * @param props.buttonLabel Label shown on the trigger button.
+ * @param props.currentLanguageLabel Visually-hidden active-state suffix.
+ * @param props.currentLocale Locale currently shown to the visitor.
+ * @param props.pathname Current page pathname without a locale prefix.
+ * @returns The language switcher nav with dropdown markup.
+ * @example
+ * ```tsx
+ * <LanguageSwitcher
+ *   navigationAriaLabel="Language"
+ *   buttonLabel="Languages"
+ *   currentLanguageLabel="Current language"
+ *   currentLocale="en-US"
+ *   pathname="/learn"
+ * />
+ * ```
+ */
+export const LanguageSwitcher = ({
+  navigationAriaLabel,
+  buttonLabel,
+  currentLanguageLabel,
+  currentLocale,
+  pathname,
+  descriptors = LANGUAGE_DESCRIPTORS,
+  submenuId = DEFAULT_LANGUAGE_SUBMENU_ID,
+}: LanguageSwitcherProps) => {
+  return (
+    <nav aria-label={navigationAriaLabel} className="usa-language">
+      <ul className="usa-language__primary usa-list--unstyled">
+        <li className="usa-language__primary-item">
+          <button
+            aria-controls={submenuId}
+            aria-expanded="false"
+            className="usa-button usa-button--outline usa-language__link"
+            type="button"
+          >
+            {buttonLabel}
+          </button>
+          <ul className="usa-language__submenu nj-dropdown-inline-end" hidden id={submenuId}>
+            {descriptors.map((descriptor) => {
+              return renderLanguageOption({
+                descriptor,
+                currentLanguageLabel,
+                currentLocale,
+                pathname,
+              });
+            })}
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  );
+};

--- a/packages/static-site/components/landing/SiteHeader.tsx
+++ b/packages/static-site/components/landing/SiteHeader.tsx
@@ -5,7 +5,11 @@
  * dedicated navigation subcomponents.
  */
 
-import type { LayoutHeaderContent } from "@/domain/content/messageTypes";
+import type {
+  LayoutHeaderContent,
+  LayoutLanguageSwitcherContent,
+} from "@/domain/content/messageTypes";
+import { HeaderLanguageSwitcher } from "./HeaderLanguageSwitcher";
 import { HeaderPrimaryNav } from "./HeaderPrimaryNav";
 import { HeaderSecondaryNav } from "./HeaderSecondaryNav";
 import { LocalizedLink } from "./LocalizedLink";
@@ -18,6 +22,8 @@ import { LocalizedLink } from "./LocalizedLink";
 export interface SiteHeaderProps {
   /** Localized content used by header subcomponents. */
   readonly content: LayoutHeaderContent;
+  /** Localized language switcher chrome shown in the utility area. */
+  readonly languageSwitcher: LayoutLanguageSwitcherContent;
 }
 
 /**
@@ -25,13 +31,14 @@ export interface SiteHeaderProps {
  *
  * @param props Component props.
  * @param props.content Localized header content.
+ * @param props.languageSwitcher Localized language switcher chrome.
  * @returns The full extended header markup.
  * @example
  * ```tsx
- * <SiteHeader content={landing.header} />
+ * <SiteHeader content={landing.header} languageSwitcher={landing.languageSwitcher} />
  * ```
  */
-export const SiteHeader = ({ content }: SiteHeaderProps) => {
+export const SiteHeader = ({ content, languageSwitcher }: SiteHeaderProps) => {
   return (
     <>
       <div className="usa-overlay" />
@@ -44,7 +51,7 @@ export const SiteHeader = ({ content }: SiteHeaderProps) => {
                 link={content.homeLink}
                 title={content.homeLinkTitle}
               >
-                {content.siteTitle}
+                <bdi dir="ltr">{content.siteTitle}</bdi>
               </LocalizedLink>
             </em>
           </div>
@@ -56,6 +63,9 @@ export const SiteHeader = ({ content }: SiteHeaderProps) => {
           <div className="usa-nav__inner">
             <HeaderPrimaryNav header={content} />
             <HeaderSecondaryNav header={content} />
+            <div className="usa-nav__secondary nj-inset-inline-end-2">
+              <HeaderLanguageSwitcher content={languageSwitcher} />
+            </div>
           </div>
         </nav>
       </header>

--- a/packages/static-site/domain/content/messageTypes.ts
+++ b/packages/static-site/domain/content/messageTypes.ts
@@ -215,6 +215,40 @@ export interface LayoutIdentifierContent {
 }
 
 /**
+ * Localized chrome for the header language switcher control.
+ *
+ * Shown in the viewer's current language. Language option labels themselves are
+ * autonyms drawn from `LANGUAGE_DESCRIPTORS`, not from this content.
+ */
+export interface LayoutLanguageSwitcherContent {
+  /** Accessible label for the language navigation region. */
+  readonly navigationAriaLabel: string;
+  /** Label shown on the dropdown trigger button. */
+  readonly buttonLabel: string;
+  /** Visually-hidden suffix marking the currently active language option. */
+  readonly currentLanguageLabel: string;
+}
+
+/**
+ * Localized copy for the preferred-language prompt modal.
+ *
+ * Shown in the page's current language; `redirectLabel` is a template whose
+ * `{language}` placeholder is filled with the target language's autonym.
+ */
+export interface LayoutLanguagePromptContent {
+  /** Modal heading text. */
+  readonly title: string;
+  /** Body text explaining the language choice offered. */
+  readonly body: string;
+  /** Label for the button that keeps the visitor on the current page. */
+  readonly stayLabel: string;
+  /** Accessible label for the modal close control. */
+  readonly closeLabel: string;
+  /** Redirect button template containing a `{language}` placeholder. */
+  readonly redirectLabel: string;
+}
+
+/**
  * Shared localized content rendered on every page of the site.
  */
 export interface LayoutContent {
@@ -226,6 +260,10 @@ export interface LayoutContent {
   readonly banner: LayoutBannerContent;
   /** Header section content. */
   readonly header: LayoutHeaderContent;
+  /** Language switcher chrome content. */
+  readonly languageSwitcher: LayoutLanguageSwitcherContent;
+  /** Preferred-language prompt modal content. */
+  readonly languagePrompt: LayoutLanguagePromptContent;
   /** Footer section content. */
   readonly footer: LayoutFooterContent;
   /** Identifier section content. */

--- a/packages/static-site/domain/i18n/alternateLanguages.test.ts
+++ b/packages/static-site/domain/i18n/alternateLanguages.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAlternateLanguages } from "./alternateLanguages";
+
+describe("alternateLanguages", () => {
+  describe("buildAlternateLanguages", () => {
+    it("builds canonical and hreflang entries for the root path", () => {
+      const alternates = buildAlternateLanguages({ pathnameWithoutLocale: "/" });
+
+      expect(alternates.canonical).toBe("/");
+      expect(alternates.languages).toEqual({
+        "en-US": "/",
+        "es-US": "/es-US",
+        "x-default": "/",
+      });
+    });
+
+    it("builds canonical and hreflang entries for a nested path", () => {
+      const alternates = buildAlternateLanguages({ pathnameWithoutLocale: "/pages/foo" });
+
+      expect(alternates.canonical).toBe("/pages/foo");
+      expect(alternates.languages).toEqual({
+        "en-US": "/pages/foo",
+        "es-US": "/es-US/pages/foo",
+        "x-default": "/pages/foo",
+      });
+    });
+  });
+});

--- a/packages/static-site/domain/i18n/alternateLanguages.ts
+++ b/packages/static-site/domain/i18n/alternateLanguages.ts
@@ -1,0 +1,55 @@
+/**
+ * Builds hreflang alternate metadata linking a page's locale variants.
+ *
+ * Search engines treat localized pages as linked variants when each page
+ * advertises `<link rel="alternate" hreflang>` entries (and an `x-default`).
+ * This pure helper produces the Next.js `Metadata["alternates"]` shape from a
+ * single unprefixed pathname; relative paths resolve against `metadataBase`.
+ */
+
+import type { Metadata } from "next";
+
+import { addLocalePrefix } from "./localePath";
+import { APP_LOCALES } from "./locales";
+
+/**
+ * Describes input for building alternate-language metadata.
+ *
+ * This type defines a stable shape for related data.
+ */
+export interface BuildAlternateLanguagesParams {
+  /** Page pathname without any locale prefix, starting with `/`. */
+  readonly pathnameWithoutLocale: string;
+}
+
+/**
+ * Builds canonical and hreflang alternate metadata for a page.
+ *
+ * The canonical URL points at the unprefixed (default-locale) path. Each
+ * supported locale gets an entry keyed by its BCP-47 tag, plus an `x-default`
+ * pointing at the unprefixed path.
+ *
+ * @param params Build input.
+ * @param params.pathnameWithoutLocale Unprefixed page pathname.
+ * @returns Alternate metadata for the page `<head>`.
+ * @example
+ * ```ts
+ * buildAlternateLanguages({ pathnameWithoutLocale: "/learn" });
+ * // { canonical: "/learn", languages: { "en-US": "/learn", "es-US": "/es-US/learn", "x-default": "/learn" } }
+ * ```
+ */
+export const buildAlternateLanguages = ({
+  pathnameWithoutLocale,
+}: BuildAlternateLanguagesParams): NonNullable<Metadata["alternates"]> => {
+  const canonical = addLocalePrefix({ pathnameWithoutLocale, locale: "en-US" });
+
+  const languages: Record<string, string> = {};
+
+  for (const locale of APP_LOCALES) {
+    languages[locale] = addLocalePrefix({ pathnameWithoutLocale, locale });
+  }
+
+  languages["x-default"] = canonical;
+
+  return { canonical, languages };
+};

--- a/packages/static-site/domain/i18n/languages.test.ts
+++ b/packages/static-site/domain/i18n/languages.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { LANGUAGE_DESCRIPTORS, textDirectionForLocale } from "./languages";
+import type { AppLocale } from "./locales";
+
+describe("languages", () => {
+  describe("LANGUAGE_DESCRIPTORS ordering", () => {
+    it("is ordered alphabetically by native name", () => {
+      const nativeNames = LANGUAGE_DESCRIPTORS.map((descriptor) => descriptor.nativeName);
+      const sorted = [...nativeNames].sort((a, b) => a.localeCompare(b));
+
+      expect(nativeNames).toEqual(sorted);
+    });
+  });
+
+  describe("textDirectionForLocale", () => {
+    // Skipped while only LTR locales (en/es) ship. Restore by adding an RTL
+    // language back to APP_LOCALES + LANGUAGE_DESCRIPTORS; the RTL plumbing it
+    // exercises is still in place.
+    it.skip("returns rtl for Arabic", () => {
+      expect(textDirectionForLocale("ar-US" as AppLocale)).toBe("rtl");
+    });
+
+    it("returns ltr for English", () => {
+      expect(textDirectionForLocale("en-US")).toBe("ltr");
+    });
+
+    it("returns the declared direction for every descriptor", () => {
+      for (const descriptor of LANGUAGE_DESCRIPTORS) {
+        expect(textDirectionForLocale(descriptor.locale)).toBe(descriptor.textDirection);
+      }
+    });
+  });
+});

--- a/packages/static-site/domain/i18n/languages.ts
+++ b/packages/static-site/domain/i18n/languages.ts
@@ -1,0 +1,84 @@
+/**
+ * Describes display metadata for each supported locale.
+ *
+ * Autonyms (a language's name in its own language) are locale-independent, so
+ * they live here in config rather than in per-locale message files. This module
+ * is the single extension point when adding a new supported language.
+ */
+
+import { type AppLocale, DEFAULT_LOCALE } from "./locales";
+
+/**
+ * Display metadata for one selectable language.
+ *
+ * Add a new entry here (and a matching message file) to support another locale.
+ */
+export interface LanguageDescriptor {
+  /** Locale tag; also the BCP-47 value for `lang` and `hrefLang` attributes. */
+  readonly locale: AppLocale;
+  /** Language name written in its own language (autonym), e.g. "Español". */
+  readonly nativeName: string;
+  /** Language name written in English, e.g. "Spanish". Used for the submenu format "Español (Spanish)". */
+  readonly englishName: string;
+  /** Region name written in the language itself, e.g. "Estados Unidos". */
+  readonly regionName: string;
+  /** Writing direction for the language, used for the document `dir` attribute. */
+  readonly textDirection: "ltr" | "rtl";
+}
+
+/**
+ * Every selectable language, declared in a readable locale order.
+ *
+ * Display order is not taken from this array — `LANGUAGE_DESCRIPTORS` sorts it
+ * by native name. Extend this list to offer additional locales over time.
+ */
+const LANGUAGE_DESCRIPTORS_BY_LOCALE: readonly LanguageDescriptor[] = [
+  {
+    locale: "en-US",
+    nativeName: "English",
+    englishName: "English",
+    regionName: "United States",
+    textDirection: "ltr",
+  },
+  {
+    locale: "es-US",
+    nativeName: "Español",
+    englishName: "Spanish",
+    regionName: "Estados Unidos",
+    textDirection: "ltr",
+  },
+];
+
+/**
+ * Every selectable language, ordered alphabetically by native name.
+ *
+ * NJWDS specifies that a 3+ language selector orders options "alphabetically by
+ * the common, native language name", so the display order is derived here
+ * rather than hand-maintained. The order controls how options appear in the
+ * language switcher.
+ */
+export const LANGUAGE_DESCRIPTORS: readonly LanguageDescriptor[] = [
+  ...LANGUAGE_DESCRIPTORS_BY_LOCALE,
+].sort((a, b) => a.nativeName.localeCompare(b.nativeName));
+
+/**
+ * Resolves the writing direction for a locale from its descriptor.
+ *
+ * @param locale Locale whose writing direction is needed.
+ * @returns The locale's `dir` value, defaulting to the default locale's
+ *   direction when no descriptor matches.
+ * @example
+ * ```ts
+ * textDirectionForLocale("ar-US"); // "rtl"
+ * textDirectionForLocale("en-US"); // "ltr"
+ * ```
+ */
+export const textDirectionForLocale = (locale: AppLocale): "ltr" | "rtl" => {
+  const descriptor = LANGUAGE_DESCRIPTORS.find((entry) => entry.locale === locale);
+
+  return (
+    descriptor?.textDirection ??
+    LANGUAGE_DESCRIPTORS.find((entry) => entry.locale === DEFAULT_LOCALE)?.textDirection ??
+    "ltr"
+  );
+};

--- a/packages/static-site/domain/i18n/localePath.test.ts
+++ b/packages/static-site/domain/i18n/localePath.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { addLocalePrefix, localeOfPathname, stripLocalePrefix } from "./localePath";
+
+describe("localePath", () => {
+  describe("stripLocalePrefix", () => {
+    it("removes a non-default locale prefix", () => {
+      expect(stripLocalePrefix("/es-US/learn")).toBe("/learn");
+    });
+
+    it("reduces a bare locale prefix to root", () => {
+      expect(stripLocalePrefix("/es-US")).toBe("/");
+    });
+
+    it("leaves an unprefixed pathname unchanged", () => {
+      expect(stripLocalePrefix("/learn")).toBe("/learn");
+    });
+
+    it("leaves the default locale segment intact when it is real content", () => {
+      expect(stripLocalePrefix("/learn/plan")).toBe("/learn/plan");
+    });
+  });
+
+  describe("addLocalePrefix", () => {
+    it("keeps the default locale unprefixed", () => {
+      expect(addLocalePrefix({ pathnameWithoutLocale: "/learn", locale: "en-US" })).toBe("/learn");
+    });
+
+    it("prefixes a non-default locale", () => {
+      expect(addLocalePrefix({ pathnameWithoutLocale: "/learn", locale: "es-US" })).toBe(
+        "/es-US/learn",
+      );
+    });
+
+    it("prefixes the root path without a trailing slash", () => {
+      expect(addLocalePrefix({ pathnameWithoutLocale: "/", locale: "es-US" })).toBe("/es-US");
+    });
+  });
+
+  describe("round-trip", () => {
+    it("add after strip restores the non-default locale form", () => {
+      const external = "/es-US/learn/plan";
+      const restored = addLocalePrefix({
+        pathnameWithoutLocale: stripLocalePrefix(external),
+        locale: "es-US",
+      });
+
+      expect(restored).toBe(external);
+    });
+  });
+
+  describe("localeOfPathname", () => {
+    it("reads a non-default locale from the prefix", () => {
+      expect(localeOfPathname("/es-US/learn")).toBe("es-US");
+    });
+
+    it("defaults to en-US when unprefixed", () => {
+      expect(localeOfPathname("/learn")).toBe("en-US");
+    });
+  });
+});

--- a/packages/static-site/domain/i18n/localePath.ts
+++ b/packages/static-site/domain/i18n/localePath.ts
@@ -1,0 +1,107 @@
+/**
+ * Provides pure helpers for locale prefix math on pathnames.
+ *
+ * Under `as-needed` routing the default locale is unprefixed while other
+ * locales carry a leading `/<locale>` segment. These side-effect-free helpers
+ * convert between the prefixed (external) and unprefixed forms so components and
+ * the language switcher can re-target the current page at another locale.
+ */
+
+import { APP_LOCALES, type AppLocale, DEFAULT_LOCALE, hasAppLocale } from "./locales";
+
+/**
+ * Describes input for building a locale-prefixed pathname.
+ *
+ * This type defines a stable shape for related data.
+ */
+export interface AddLocalePrefixParams {
+  /** Pathname without any locale prefix, always starting with `/`. */
+  readonly pathnameWithoutLocale: string;
+  /** Target locale to prefix the pathname with. */
+  readonly locale: AppLocale;
+}
+
+/**
+ * Reads the leading path segment from a pathname.
+ *
+ * @param pathname Pathname that may begin with a locale segment.
+ * @returns The first non-empty segment, or `undefined` when none exists.
+ */
+const readLeadingSegment = (pathname: string): string | undefined => {
+  return pathname.split("/").find((segment) => segment.length > 0);
+};
+
+/**
+ * Removes a leading locale segment from a pathname.
+ *
+ * @param pathname External pathname that may include a locale prefix.
+ * @returns The pathname without its locale prefix, always starting with `/`.
+ * @example
+ * ```ts
+ * stripLocalePrefix("/es-US/learn"); // "/learn"
+ * stripLocalePrefix("/learn"); // "/learn"
+ * ```
+ */
+export const stripLocalePrefix = (pathname: string): string => {
+  const leadingSegment = readLeadingSegment(pathname);
+
+  if (leadingSegment && hasAppLocale(leadingSegment)) {
+    const remainder = pathname.slice(leadingSegment.length + 1);
+
+    return remainder.startsWith("/") ? remainder : `/${remainder}`;
+  }
+
+  return pathname;
+};
+
+/**
+ * Adds a locale prefix to an unprefixed pathname.
+ *
+ * The default locale stays unprefixed; every other locale is prefixed. This is
+ * the inverse of {@link stripLocalePrefix} and is idempotent when composed.
+ *
+ * @param params Prefixing input.
+ * @param params.pathnameWithoutLocale Pathname without any locale prefix.
+ * @param params.locale Target locale to apply.
+ * @returns The pathname for the target locale.
+ * @example
+ * ```ts
+ * addLocalePrefix({ pathnameWithoutLocale: "/learn", locale: "es-US" }); // "/es-US/learn"
+ * addLocalePrefix({ pathnameWithoutLocale: "/learn", locale: "en-US" }); // "/learn"
+ * ```
+ */
+export const addLocalePrefix = ({
+  pathnameWithoutLocale,
+  locale,
+}: AddLocalePrefixParams): string => {
+  if (locale === DEFAULT_LOCALE) {
+    return pathnameWithoutLocale;
+  }
+
+  if (pathnameWithoutLocale === "/") {
+    return `/${locale}`;
+  }
+
+  return `/${locale}${pathnameWithoutLocale}`;
+};
+
+/**
+ * Resolves the locale implied by a pathname's leading segment.
+ *
+ * @param pathname External pathname that may include a locale prefix.
+ * @returns The prefixed locale, or `DEFAULT_LOCALE` when unprefixed.
+ * @example
+ * ```ts
+ * localeOfPathname("/es-US/learn"); // "es-US"
+ * localeOfPathname("/learn"); // "en-US"
+ * ```
+ */
+export const localeOfPathname = (pathname: string): AppLocale => {
+  const leadingSegment = readLeadingSegment(pathname);
+
+  if (leadingSegment && APP_LOCALES.includes(leadingSegment as AppLocale)) {
+    return leadingSegment as AppLocale;
+  }
+
+  return DEFAULT_LOCALE;
+};

--- a/packages/static-site/domain/i18n/preferredLocale.test.ts
+++ b/packages/static-site/domain/i18n/preferredLocale.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { resolvePreferredLocale } from "./preferredLocale";
+
+describe("preferredLocale", () => {
+  describe("resolvePreferredLocale", () => {
+    it("maps a regional Spanish tag to es-US", () => {
+      expect(resolvePreferredLocale({ browserLanguages: ["es-US", "es"] })).toBe("es-US");
+    });
+
+    it("maps a bare Spanish subtag to es-US", () => {
+      expect(resolvePreferredLocale({ browserLanguages: ["es"] })).toBe("es-US");
+    });
+
+    it("maps a non-US English variant to en-US", () => {
+      expect(resolvePreferredLocale({ browserLanguages: ["en-GB"] })).toBe("en-US");
+    });
+
+    it("returns undefined for an unsupported language", () => {
+      expect(resolvePreferredLocale({ browserLanguages: ["fr"] })).toBeUndefined();
+    });
+
+    it("returns undefined for an empty list", () => {
+      expect(resolvePreferredLocale({ browserLanguages: [] })).toBeUndefined();
+    });
+
+    it("returns the first supported match over later entries", () => {
+      expect(resolvePreferredLocale({ browserLanguages: ["fr", "es", "en"] })).toBe("es-US");
+    });
+  });
+});

--- a/packages/static-site/domain/i18n/preferredLocale.ts
+++ b/packages/static-site/domain/i18n/preferredLocale.ts
@@ -1,0 +1,63 @@
+/**
+ * Matches a visitor's browser languages to a supported locale.
+ *
+ * This pure helper takes the already-ordered list of browser language tags
+ * (e.g. from `navigator.languages`) and returns the first one whose primary
+ * language subtag maps to a supported app locale. It performs no `navigator`
+ * access so it stays fully table-testable.
+ */
+
+import { APP_LOCALES, type AppLocale } from "./locales";
+
+/**
+ * Describes input for resolving a preferred locale.
+ *
+ * This type defines a stable shape for related data.
+ */
+export interface ResolvePreferredLocaleParams {
+  /** Browser language tags in descending priority order. */
+  readonly browserLanguages: readonly string[];
+}
+
+/**
+ * Maps a primary language subtag to a supported locale.
+ *
+ * @param languageSubtag Lowercased primary subtag, e.g. "es" or "en".
+ * @returns The supported locale sharing that subtag, or `undefined`.
+ */
+const matchLanguageSubtag = (languageSubtag: string): AppLocale | undefined => {
+  return APP_LOCALES.find((locale) => {
+    return locale.toLowerCase().split("-")[0] === languageSubtag;
+  });
+};
+
+/**
+ * Resolves the visitor's preferred supported locale.
+ *
+ * Walks `browserLanguages` in priority order and returns the first entry whose
+ * language subtag maps to a supported locale (e.g. `es-ES` and `es` both map to
+ * `es-US`). Returns `undefined` when no entry is supported.
+ *
+ * @param params Resolution input.
+ * @param params.browserLanguages Browser language tags in priority order.
+ * @returns The preferred supported locale, or `undefined` when none matches.
+ * @example
+ * ```ts
+ * resolvePreferredLocale({ browserLanguages: ["es-ES", "en"] }); // "es-US"
+ * resolvePreferredLocale({ browserLanguages: ["fr"] }); // undefined
+ * ```
+ */
+export const resolvePreferredLocale = ({
+  browserLanguages,
+}: ResolvePreferredLocaleParams): AppLocale | undefined => {
+  for (const browserLanguage of browserLanguages) {
+    const languageSubtag = browserLanguage.toLowerCase().split("-")[0];
+    const matchedLocale = matchLanguageSubtag(languageSubtag);
+
+    if (matchedLocale) {
+      return matchedLocale;
+    }
+  }
+
+  return undefined;
+};

--- a/packages/static-site/domain/i18n/routing.ts
+++ b/packages/static-site/domain/i18n/routing.ts
@@ -17,5 +17,10 @@ import { APP_LOCALES, DEFAULT_LOCALE } from "./locales";
 export const routing = defineRouting({
   locales: APP_LOCALES,
   defaultLocale: DEFAULT_LOCALE,
-  localePrefix: "always",
+  // `as-needed` leaves the default locale (en-US) unprefixed (`/page/x`) while
+  // prefixing every other locale (`/es-US/page/x`).
+  localePrefix: "as-needed",
+  // The preferred-language modal handles locale suggestion client-side, so the
+  // middleware must never silently redirect based on cookie or accept-language.
+  localeDetection: false,
 });

--- a/packages/static-site/domain/siteConfig.ts
+++ b/packages/static-site/domain/siteConfig.ts
@@ -1,0 +1,30 @@
+/**
+ * Centralizes site-wide configuration constants for the static site.
+ *
+ * Keeping these values in one module lets metadata, alternate-language helpers,
+ * the sitemap, and client components share a single source of truth instead of
+ * duplicating literals.
+ */
+
+/**
+ * Canonical production origin used to resolve absolute URLs.
+ *
+ * Metadata, hreflang alternates, and the sitemap all resolve relative paths
+ * against this origin so every emitted URL points at the same host.
+ */
+export const SITE_BASE_URL = "https://next.business.nj.gov";
+
+/**
+ * Cookie name recording that a visitor dismissed the language prompt.
+ *
+ * Once set, the preferred-language modal stays hidden so a returning visitor is
+ * not prompted again after choosing to stay or switch.
+ */
+export const LANGUAGE_PROMPT_DISMISSED_COOKIE = "njLanguagePromptDismissed";
+
+/**
+ * Cookie name that next-intl writes when a visitor explicitly picks a locale
+ * via a language link. When this cookie matches the current page locale the
+ * visitor deliberately chose that locale, so the language prompt is suppressed.
+ */
+export const NEXT_LOCALE_COOKIE_NAME = "NEXT_LOCALE";

--- a/packages/static-site/messages/ar-US.json
+++ b/packages/static-site/messages/ar-US.json
@@ -1,16 +1,16 @@
 {
   "metadata": {
-    "title": "Business.NJ.gov | Plan, Start, and Grow",
-    "description": "Landing page prototype for a Next.js and NJWDS-powered business guidance experience."
+    "title": "هذا من الصفحة النهائي مؤقت الصفحة",
+    "description": "من المنتج عربي النهائي اتجاه اتجاه النهائي عربي إلى نص عربي"
   },
   "layout": {
-    "skipNavigationLabel": "Skip to main content",
+    "skipNavigationLabel": "مؤقت المنتج لاحقا سيتم",
     "mainContentId": "main-content",
     "banner": {
-      "sectionAriaLabel": "Official government website",
-      "stateSealAlt": "New Jersey state seal",
+      "sectionAriaLabel": "عربي هذا في",
+      "stateSealAlt": "اتجاه من عربي حذفه",
       "stateSiteLink": {
-        "label": "Official Site of the State of New Jersey",
+        "label": "لاختبار نص سيتم سيتم من لاحقا لاحقا سيتم",
         "href": "https://nj.gov",
         "isInternal": false,
         "opensInNewTab": true
@@ -22,30 +22,30 @@
         "opensInNewTab": true
       },
       "updatesLink": {
-        "label": "Get Updates",
+        "label": "نص اليمين",
         "href": "https://nj.gov/subscribe/",
         "isInternal": false,
         "opensInNewTab": true
       }
     },
     "header": {
-      "primaryNavigationAriaLabel": "Primary navigation",
+      "primaryNavigationAriaLabel": "لاختبار المحتوى",
       "homeLink": {
         "label": "Business.NJ.gov",
         "href": "/",
         "isInternal": true,
         "opensInNewTab": false
       },
-      "homeLinkTitle": "Home",
-      "homeLinkAriaLabel": "Business.NJ.gov home",
+      "homeLinkTitle": "إلى",
+      "homeLinkAriaLabel": "من حذفه",
       "siteTitle": "Business.NJ.Gov",
-      "menuButtonLabel": "Menu",
-      "closeButtonAlt": "Close menu",
+      "menuButtonLabel": "من",
+      "closeButtonAlt": "من الصفحة",
       "primaryItems": [
         {
           "kind": "link",
           "link": {
-            "label": "Learn",
+            "label": "اتجاه",
             "href": "/learn",
             "isInternal": true,
             "opensInNewTab": false
@@ -55,7 +55,7 @@
         {
           "kind": "link",
           "link": {
-            "label": "Updates",
+            "label": "اليسار",
             "href": "/updates",
             "isInternal": true,
             "opensInNewTab": false
@@ -65,28 +65,28 @@
       ],
       "secondaryLinks": [],
       "searchAction": "/search",
-      "searchInputLabel": "Search site",
-      "searchSubmitIconAlt": "Search"
+      "searchInputLabel": "هذا إلى",
+      "searchSubmitIconAlt": "من"
     },
     "languageSwitcher": {
-      "navigationAriaLabel": "Language",
-      "buttonLabel": "Languages",
-      "currentLanguageLabel": "Current language"
+      "navigationAriaLabel": "لاحقا",
+      "buttonLabel": "هذا",
+      "currentLanguageLabel": "اليمين سيتم"
     },
     "languagePrompt": {
-      "title": "View this page in your language?",
-      "body": "This page is available in another language that matches your browser settings.",
-      "stayLabel": "Stay on this page",
-      "closeLabel": "Close",
-      "redirectLabel": "Switch to {language}"
+      "title": "هذا إلى هذا اتجاه عربي هذا",
+      "body": "الصفحة اليسار من اليسار عربي حذفه اتجاه تجريبي لاحقا هذا هذا المنتج",
+      "stayLabel": "الكتابة في إلى المحتوى",
+      "closeLabel": "مؤقت",
+      "redirectLabel": "اتجاه اتجاه هذا"
     },
     "footer": {
-      "returnToTopLabel": "Return to top",
-      "navigationAriaLabel": "Footer navigation",
+      "returnToTopLabel": "نص الكتابة حذفه",
+      "navigationAriaLabel": "حذفه اليسار",
       "primaryLinks": [
         {
           "link": {
-            "label": "Plan",
+            "label": "اليمين",
             "href": "/plan",
             "isInternal": true,
             "opensInNewTab": false
@@ -94,7 +94,7 @@
         },
         {
           "link": {
-            "label": "Start",
+            "label": "في",
             "href": "/start",
             "isInternal": true,
             "opensInNewTab": false
@@ -102,7 +102,7 @@
         },
         {
           "link": {
-            "label": "Operate",
+            "label": "الكتابة",
             "href": "/operate",
             "isInternal": true,
             "opensInNewTab": false
@@ -110,7 +110,7 @@
         },
         {
           "link": {
-            "label": "Grow",
+            "label": "من",
             "href": "/grow",
             "isInternal": true,
             "opensInNewTab": false
@@ -118,81 +118,81 @@
         },
         {
           "link": {
-            "label": "Support",
+            "label": "لاحقا",
             "href": "/support",
             "isInternal": true,
             "opensInNewTab": false
           }
         }
       ],
-      "agencyLogoAlt": "Business.NJ.gov logo",
+      "agencyLogoAlt": "الكتابة هذا",
       "agencyName": "Business.NJ.gov",
       "socialLinks": [
         {
           "modifier": "github",
           "link": {
-            "label": "GitHub",
+            "label": "عربي",
             "href": "https://github.com/newjersey/",
             "isInternal": false,
             "opensInNewTab": true
           },
-          "iconAlt": "GitHub",
+          "iconAlt": "من",
           "iconPath": "/assets/njwds/dist/img/usa-icons/github.svg"
         },
         {
           "modifier": "facebook",
           "link": {
-            "label": "Facebook",
+            "label": "مؤقت",
             "href": "https://www.facebook.com/BusinessNJgov",
             "isInternal": false,
             "opensInNewTab": true
           },
-          "iconAlt": "Facebook",
+          "iconAlt": "اليسار",
           "iconPath": "/assets/njwds/dist/img/usa-icons/facebook.svg"
         },
         {
           "modifier": "youtube",
           "link": {
-            "label": "YouTube",
+            "label": "لاختبار",
             "href": "https://www.youtube.com/@BusinessExperience-NJOOI",
             "isInternal": false,
             "opensInNewTab": true
           },
-          "iconAlt": "YouTube",
+          "iconAlt": "لاحقا",
           "iconPath": "/assets/njwds/dist/img/usa-icons/youtube.svg"
         }
       ],
-      "contactHeading": "Business.NJ.gov Contact Center",
+      "contactHeading": "من اتجاه اليسار",
       "phoneLink": {
-        "label": "(800) CALL-GOVT",
+        "label": "حذفه اليمين",
         "href": "tel:1-800-555-5555",
         "isInternal": false,
         "opensInNewTab": false
       },
       "emailLink": {
-        "label": "info@business.nj.gov",
+        "label": "نص",
         "href": "mailto:info@business.nj.gov",
         "isInternal": false,
         "opensInNewTab": false
       }
     },
     "identifier": {
-      "agencySectionAriaLabel": "Agency identifier",
-      "stateLogoAlt": "State of New Jersey logo",
-      "agencyLogoAlt": "Business.NJ.gov logo",
+      "agencySectionAriaLabel": "إلى تجريبي",
+      "stateLogoAlt": "النهائي الكتابة هذا هذا من",
+      "agencyLogoAlt": "سيتم النهائي",
       "domain": "business.nj.gov",
-      "disclaimerPrefix": "An official website of the",
+      "disclaimerPrefix": "الكتابة اتجاه في إلى حذفه",
       "disclaimerLink": {
-        "label": "State of New Jersey",
+        "label": "في المنتج حذفه في",
         "href": "https://nj.gov",
         "isInternal": false,
         "opensInNewTab": false
       },
-      "importantLinksAriaLabel": "Important links",
+      "importantLinksAriaLabel": "المنتج إلى",
       "requiredLinks": [
         {
           "link": {
-            "label": "Governor Mikie Sherrill",
+            "label": "هذا من اليسار",
             "href": "https://nj.gov/governor/admin/about/",
             "isInternal": false,
             "opensInNewTab": false
@@ -200,7 +200,7 @@
         },
         {
           "link": {
-            "label": "Lt. Governor Dr. Dale G. Caldwell",
+            "label": "اليمين سيتم من من لاختبار الكتابة",
             "href": "https://nj.gov/governor/admin/lt/",
             "isInternal": false,
             "opensInNewTab": false
@@ -208,7 +208,7 @@
         },
         {
           "link": {
-            "label": "NJ Home",
+            "label": "اليمين عربي",
             "href": "https://nj.gov/",
             "isInternal": false,
             "opensInNewTab": false
@@ -216,7 +216,7 @@
         },
         {
           "link": {
-            "label": "Services A to Z",
+            "label": "تجريبي المحتوى لاحقا اتجاه",
             "href": "https://nj.gov/nj/gov/njgov/alphaserv.html",
             "isInternal": false,
             "opensInNewTab": false
@@ -224,7 +224,7 @@
         },
         {
           "link": {
-            "label": "Departments/Agencies",
+            "label": "الصفحة",
             "href": "https://nj.gov/nj/gov/deptserv/",
             "isInternal": false,
             "opensInNewTab": false
@@ -232,7 +232,7 @@
         },
         {
           "link": {
-            "label": "FAQs",
+            "label": "الكتابة",
             "href": "https://nj.gov/faqs/",
             "isInternal": false,
             "opensInNewTab": false
@@ -240,7 +240,7 @@
         },
         {
           "link": {
-            "label": "Contact Us",
+            "label": "لاختبار هذا",
             "href": "https://nj.gov/nj/feedback.html",
             "isInternal": false,
             "opensInNewTab": false
@@ -248,7 +248,7 @@
         },
         {
           "link": {
-            "label": "Privacy Notice",
+            "label": "المحتوى المنتج",
             "href": "https://nj.gov/nj/privacy.html",
             "isInternal": false,
             "opensInNewTab": false
@@ -256,7 +256,7 @@
         },
         {
           "link": {
-            "label": "Legal Statement & Disclaimers",
+            "label": "المنتج الكتابة مؤقت تجريبي",
             "href": "https://nj.gov/nj/legal.html",
             "isInternal": false,
             "opensInNewTab": false
@@ -264,7 +264,7 @@
         },
         {
           "link": {
-            "label": "Accessibility",
+            "label": "لاحقا",
             "href": "https://nj.gov/nj/accessibility.html",
             "isInternal": false,
             "opensInNewTab": false
@@ -272,24 +272,24 @@
         },
         {
           "link": {
-            "label": "Open Public Records Act (OPRA)",
+            "label": "اليمين من مؤقت تجريبي لاحقا",
             "href": "https://nj.gov/opra/",
             "isInternal": false,
             "opensInNewTab": false
           }
         }
       ],
-      "usGovernmentSectionAriaLabel": "U.S. government information and services",
-      "usGovernmentDescription": "Copyright \u00a9 2026 State of New Jersey"
+      "usGovernmentSectionAriaLabel": "اليمين الكتابة هذا اليسار الصفحة",
+      "usGovernmentDescription": "المنتج اليسار النهائي عربي هذا المحتوى لاختبار"
     }
   },
   "landing": {
     "hero": {
-      "sectionAriaLabel": "Introduction",
-      "title": "Your New Jersey business needs. All in one place.",
-      "paragraph": "Get your personalized business starter kit, find funding opportunities, discover your tax obligations, and more.",
+      "sectionAriaLabel": "هذا",
+      "title": "حذفه هذا عربي من اليسار اليسار لاحقا سيتم لاختبار",
+      "paragraph": "من من تجريبي اتجاه عربي حذفه حذفه هذا نص إلى لاحقا اليسار لاختبار اتجاه لاختبار",
       "callToActionLink": {
-        "label": "Get Your Personalized Guide",
+        "label": "هذا هذا من المحتوى",
         "href": "https://account.business.nj.gov/onboarding",
         "isInternal": false,
         "opensInNewTab": true
@@ -297,93 +297,93 @@
       "carouselImages": [
         {
           "src": "/img/hero/image_1.png",
-          "alt": "A woman smiling while working on her laptop at home."
+          "alt": "تجريبي لاحقا تجريبي النهائي تجريبي الكتابة عربي مؤقت اليسار مؤقت"
         },
         {
           "src": "/img/hero/image_2.png",
-          "alt": "A tattoo artist working in his New Jersey shop."
+          "alt": "نص عربي نص تجريبي في عربي النهائي من لاختبار"
         },
         {
           "src": "/img/hero/image_3.png",
-          "alt": "A female entrepreneur reviewing documents in her business."
+          "alt": "اتجاه من اليسار في النهائي مؤقت هذا لاختبار"
         },
         {
           "src": "/img/hero/image_4.png",
-          "alt": "The owner of a New Jersey restaurant preparing food."
+          "alt": "الكتابة حذفه سيتم في عربي سيتم سيتم عربي تجريبي"
         }
       ]
     },
     "quickServices": {
-      "title": "Quick Services",
-      "subtitle": "Access popular business services",
+      "title": "من اتجاه",
+      "subtitle": "الكتابة المحتوى الصفحة لاحقا",
       "items": [
         {
-          "title": "Business Registration",
-          "description": "Start your LLC, corporation, or partnership",
+          "title": "الصفحة من",
+          "description": "في تجريبي المحتوى في الصفحة حذفه",
           "iconPath": "/img/checklist.svg",
-          "iconAlt": "Checklist icon",
+          "iconAlt": "النهائي المحتوى",
           "link": {
-            "label": "Business Registration",
+            "label": "مؤقت من",
             "href": "/pages/register-your-business",
             "isInternal": true,
             "opensInNewTab": false
           }
         },
         {
-          "title": "Licenses & Permits",
-          "description": "Apply for required business licenses",
+          "title": "من المنتج في",
+          "description": "من النهائي المنتج من الصفحة",
           "iconPath": "/img/planning.svg",
-          "iconAlt": "Planning icon",
+          "iconAlt": "نص مؤقت",
           "link": {
-            "label": "Licenses & Permits",
+            "label": "عربي هذا نص",
             "href": "/pages/licensing-and-certification-guide",
             "isInternal": true,
             "opensInNewTab": false
           }
         },
         {
-          "title": "Business Names",
-          "description": "Choose available names to represent your business",
+          "title": "النهائي نص",
+          "description": "لاحقا لاحقا نص اليسار تجريبي في عربي",
           "iconPath": "/img/paper.svg",
-          "iconAlt": "Stack of paper icon",
+          "iconAlt": "اليمين اتجاه إلى حذفه",
           "link": {
-            "label": "Business Names",
+            "label": "حذفه المنتج",
             "href": "/pages/business-names",
             "isInternal": true,
             "opensInNewTab": false
           }
         },
         {
-          "title": "File Your Annual Report",
-          "description": "Never miss a deadline",
+          "title": "اليمين لاحقا الصفحة في",
+          "description": "تجريبي هذا الصفحة عربي",
           "iconPath": "/img/arrow.svg",
-          "iconAlt": "Up arrow icon",
+          "iconAlt": "الكتابة نص لاختبار",
           "link": {
-            "label": "File Your Annual Report",
+            "label": "من من الصفحة النهائي",
             "href": "/pages/filings-and-accounting",
             "isInternal": true,
             "opensInNewTab": false
           }
         },
         {
-          "title": "Employer Obligations",
-          "description": "Employer registration and resources",
+          "title": "الصفحة هذا",
+          "description": "المنتج المنتج المنتج الصفحة",
           "iconPath": "/img/shaking_hands.svg",
-          "iconAlt": "Shaking hands icon",
+          "iconAlt": "سيتم عربي لاختبار",
           "link": {
-            "label": "Employer Obligations",
+            "label": "اليسار المنتج",
             "href": "/pages/employer-requirements",
             "isInternal": true,
             "opensInNewTab": false
           }
         },
         {
-          "title": "Business Support",
-          "description": "Access grants and assistance programs",
+          "title": "المحتوى نص",
+          "description": "اتجاه سيتم حذفه سيتم حذفه",
           "iconPath": "/img/finance.svg",
-          "iconAlt": "Finance icon",
+          "iconAlt": "إلى نص",
           "link": {
-            "label": "Business Support",
+            "label": "اتجاه مؤقت",
             "href": "/pages/business-support",
             "isInternal": true,
             "opensInNewTab": false
@@ -392,59 +392,59 @@
       ]
     },
     "ctaBanner": {
-      "title": "Access Your Personalized Business Information",
-      "subtitle": "Start and grow your New Jersey or out-of-state business with your Business.NJ.gov account today!",
+      "title": "مؤقت اليسار هذا اتجاه من",
+      "subtitle": "نص من المنتج تجريبي إلى اليمين حذفه من تجريبي اتجاه تجريبي مؤقت من في",
       "callToActionLink": {
-        "label": "Create Account",
+        "label": "النهائي الكتابة",
         "href": "https://account.business.nj.gov/onboarding",
         "isInternal": false,
         "opensInNewTab": true
       }
     },
     "whatsNew": {
-      "title": "What\u2019s New",
+      "title": "مؤقت النهائي",
       "viewAllLink": {
-        "label": "View All Updates",
+        "label": "النهائي المحتوى مؤقت",
         "href": "/updates",
         "isInternal": true,
         "opensInNewTab": false
       }
     },
     "support": {
-      "title": "For More Support",
-      "description": "Looking for more expert advice? Try our free, personalized online business registration guides, speak to a representative on our chat, or sign up for business updates straight to your email. A print version and digital file of our [Small Business Manual](https://cdn.prod.website-files.com/5e31b06cb76b830809358a75/662a750614519d466e63f6c7_NJ_Small_Business_Manual_for_download.pdf) is also available.",
+      "title": "هذا لاحقا المحتوى",
+      "description": "الصفحة حذفه في تجريبي الكتابة النهائي من النهائي المحتوى لاختبار المحتوى الكتابة النهائي المحتوى اتجاه المنتج في لاختبار سيتم نص نص اليمين مؤقت لاحقا تجريبي هذا هذا الصفحة لاختبار في اليمين لاختبار المحتوى من تجريبي تجريبي لاحقا في لاحقا من المنتج اتجاه النهائي اتجاه",
       "cards": [
         {
-          "title": "Your Business.NJ.gov Account",
-          "description": "Get a free, personalized step-by-step guide for starting your business in New Jersey.",
+          "title": "اليسار من هذا",
+          "description": "تجريبي عربي اليسار لاختبار النهائي المحتوى مؤقت عربي هذا اليسار اتجاه تجريبي المحتوى",
           "iconPath": "/img/navigation.svg",
-          "iconAlt": "Navigation icon",
+          "iconAlt": "عربي هذا",
           "link": {
-            "label": "Your Business.NJ.gov Account",
+            "label": "لاحقا المحتوى الصفحة",
             "href": "https://account.business.nj.gov/",
             "isInternal": false,
             "opensInNewTab": true
           }
         },
         {
-          "title": "One-on-One Support",
-          "description": "Chat with a business advocate with decades of experience, anytime from 9a.m. - 5p.m. Monday - Friday.",
+          "title": "تجريبي اتجاه",
+          "description": "تجريبي تجريبي نص نص الصفحة تجريبي اليسار نص المنتج لاختبار اليمين تجريبي النهائي سيتم نص اليسار لاحقا",
           "iconPath": "/img/hands.svg",
-          "iconAlt": "Helping hands icon",
+          "iconAlt": "لاختبار اتجاه المنتج",
           "link": {
-            "label": "One-on-One Support",
+            "label": "النهائي في",
             "href": "/support",
             "isInternal": true,
             "opensInNewTab": false
           }
         },
         {
-          "title": "Business Newsletter",
-          "description": "Stay up to date on recently announced programs or regulations likely to affect your business.",
+          "title": "سيتم هذا",
+          "description": "لاحقا مؤقت مؤقت اليمين حذفه لاختبار اليمين النهائي المنتج من لاختبار من الصفحة مؤقت إلى",
           "iconPath": "/img/piechart.svg",
-          "iconAlt": "Business chart icon",
+          "iconAlt": "مؤقت من هذا",
           "link": {
-            "label": "Business Newsletter",
+            "label": "من مؤقت",
             "href": "https://business.nj.gov/newsletter",
             "isInternal": false,
             "opensInNewTab": true
@@ -453,58 +453,58 @@
       ]
     },
     "broughtToYouBy": {
-      "title": "Brought to you by",
+      "title": "اليسار تجريبي المنتج إلى",
       "agencies": [
         {
-          "name": "Office of the Governor",
+          "name": "من تجريبي الكتابة سيتم",
           "logo": "/img/New_Jersey_state_seal.png",
-          "logoAlt": "State of New Jersey Seal",
+          "logoAlt": "من هذا المحتوى حذفه الكتابة",
           "link": {
-            "label": "Office of the Governor",
+            "label": "من الصفحة إلى نص",
             "href": "https://nj.gov/governor/",
             "isInternal": false,
             "opensInNewTab": true
           }
         },
         {
-          "name": "New Jersey Business Action Center",
+          "name": "الكتابة في اليمين مؤقت المنتج",
           "logo": "/img/njbac_logo.png",
-          "logoAlt": "New Jersey Business Action Center Logo",
+          "logoAlt": "من نص إلى نص من عربي",
           "link": {
-            "label": "New Jersey Business Action Center",
+            "label": "لاختبار سيتم لاختبار لاختبار هذا",
             "href": "https://www.nj.gov/state/bac/bac.shtml",
             "isInternal": false,
             "opensInNewTab": true
           }
         },
         {
-          "name": "New Jersey Economic Development Authority",
+          "name": "لاختبار المحتوى النهائي المنتج سيتم",
           "logo": "/img/njeda_logo.png",
-          "logoAlt": "New Jersey Economic Development Authority Logo",
+          "logoAlt": "اليمين هذا مؤقت المحتوى مؤقت سيتم",
           "link": {
-            "label": "New Jersey Economic Development Authority",
+            "label": "نص عربي نص إلى الكتابة",
             "href": "https://www.njeda.com/",
             "isInternal": false,
             "opensInNewTab": true
           }
         },
         {
-          "name": "Department of the Treasury",
+          "name": "المنتج من المنتج من",
           "logo": "/img/treasuryseal.webp",
-          "logoAlt": "New Jersey Department of Treasury Seal",
+          "logoAlt": "اليمين المحتوى لاختبار من المنتج سيتم",
           "link": {
-            "label": "Department of the Treasury",
+            "label": "الصفحة المحتوى في إلى",
             "href": "https://www.state.nj.us/treasury/",
             "isInternal": false,
             "opensInNewTab": true
           }
         },
         {
-          "name": "New Jersey Innovation Authority",
+          "name": "من اليمين النهائي نص",
           "logo": "/img/nj_logo.svg",
-          "logoAlt": "New Jersey Innovation Authority Logo",
+          "logoAlt": "إلى حذفه نص المنتج سيتم",
           "link": {
-            "label": "New Jersey Innovation Authority",
+            "label": "سيتم إلى عربي هذا",
             "href": "https://innovation.nj.gov/",
             "isInternal": false,
             "opensInNewTab": true
@@ -513,26 +513,24 @@
       ]
     },
     "feedbackBar": {
-      "question": "Did you find what you were looking for on this page?",
-      "yesLabel": "Yes",
-      "noLabel": "No"
+      "question": "اليسار تجريبي في لاختبار الكتابة لاحقا المنتج من لاختبار اتجاه عربي",
+      "yesLabel": "مؤقت",
+      "noLabel": "هذا"
     }
   },
   "learn": {
-    "name": "Learn",
-    "subHeadingText": "Find guides and resources for every stage \u2014 from your first idea to long-term growth.",
-    "heading2": "Where are you in your business journey?",
-    "cardLinkText": "Learn more",
+    "name": "مؤقت",
+    "subHeadingText": "اليمين الصفحة نص في الصفحة اليمين نص سيتم إلى لاختبار اليمين في من لاختبار اليمين",
+    "heading2": "اليمين سيتم من المحتوى اليسار من المنتج",
+    "cardLinkText": "تجريبي لاختبار",
     "categoryPages": {
-      "allTopics": "All Topics"
+      "allTopics": "حذفه الصفحة"
     },
     "sideNav": {
-      "ariaLabel": "Side navigation",
-      "showFullMenuLabel": "Show Full Menu",
-      "hideFullMenuLabel": "Hide Full Menu",
+      "ariaLabel": "مؤقت نص",
       "learnCategory": {
         "key": "learn",
-        "title": "Introduction",
+        "title": "اتجاه",
         "link": {
           "href": "/learn",
           "isInternal": true,
@@ -543,8 +541,8 @@
     "categories": [
       {
         "key": "plan",
-        "title": "Plan",
-        "subtitle": "Expand on your great idea to lay the foundation for a successful business.",
+        "title": "مؤقت",
+        "subtitle": "من حذفه هذا لاحقا الكتابة في اليمين المنتج حذفه مؤقت المنتج اليمين المحتوى",
         "link": {
           "href": "/plan",
           "isInternal": true,
@@ -553,8 +551,8 @@
       },
       {
         "key": "start",
-        "title": "Start",
-        "subtitle": "Learn what it means to be an employer in New Jersey and register your new business.",
+        "title": "اليسار",
+        "subtitle": "عربي لاختبار نص إلى سيتم المحتوى من المنتج حذفه حذفه الكتابة إلى هذا المحتوى نص سيتم",
         "link": {
           "href": "/start",
           "isInternal": true,
@@ -563,8 +561,8 @@
       },
       {
         "key": "operate",
-        "title": "Operate",
-        "subtitle": "Understand the requirements of keeping your business running smoothly.",
+        "title": "إلى",
+        "subtitle": "الكتابة الصفحة من تجريبي نص من إلى اليمين لاختبار",
         "link": {
           "href": "/operate",
           "isInternal": true,
@@ -573,8 +571,8 @@
       },
       {
         "key": "grow",
-        "title": "Grow",
-        "subtitle": "Expand your business and see it flourish with financing and new opportunities.",
+        "title": "تجريبي",
+        "subtitle": "في تجريبي من إلى إلى إلى مؤقت إلى الكتابة سيتم النهائي حذفه",
         "link": {
           "href": "/grow",
           "isInternal": true,

--- a/packages/static-site/messages/es-US.json
+++ b/packages/static-site/messages/es-US.json
@@ -45,7 +45,7 @@
         {
           "kind": "link",
           "link": {
-            "label": "Learn",
+            "label": "Aprender",
             "href": "/learn",
             "isInternal": true,
             "opensInNewTab": false
@@ -55,7 +55,7 @@
         {
           "kind": "link",
           "link": {
-            "label": "Updates",
+            "label": "Actualizaciones",
             "href": "/updates",
             "isInternal": true,
             "opensInNewTab": false
@@ -67,6 +67,18 @@
       "searchAction": "/search",
       "searchInputLabel": "Buscar en el sitio",
       "searchSubmitIconAlt": "Buscar"
+    },
+    "languageSwitcher": {
+      "navigationAriaLabel": "Idioma",
+      "buttonLabel": "Idiomas",
+      "currentLanguageLabel": "Idioma actual"
+    },
+    "languagePrompt": {
+      "title": "¿Ver esta página en su idioma?",
+      "body": "Esta página está disponible en otro idioma que coincide con la configuración de su navegador.",
+      "stayLabel": "Permanecer en esta página",
+      "closeLabel": "Cerrar",
+      "redirectLabel": "Cambiar a {language}"
     },
     "footer": {
       "returnToTopLabel": "Volver arriba",

--- a/packages/static-site/package.json
+++ b/packages/static-site/package.json
@@ -33,7 +33,9 @@
     "test:watch": "vitest",
     "pretest:accessibility": "pnpm sync:njwds-assets",
     "sync:njwds-assets": "tsx scripts/syncNjwdsAssets.ts",
-    "test:accessibility": "playwright test --config=playwright.a11y.config.ts"
+    "test:accessibility": "playwright test --config=playwright.a11y.config.ts",
+    "pretest:e2e": "pnpm sync:njwds-assets",
+    "test:e2e": "playwright test --config=playwright.e2e.config.ts"
   },
   "keywords": [],
   "author": {

--- a/packages/static-site/playwright.e2e.config.ts
+++ b/packages/static-site/playwright.e2e.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "@playwright/test";
+
+const SERVER_URL = "http://127.0.0.1:3100";
+
+/**
+ * Defines Playwright configuration for functional end-to-end tests.
+ *
+ * Kept separate from the accessibility config so behavior specs and a11y audits
+ * stay clearly named and can run independently. Uses a dedicated port to avoid
+ * clashing with the a11y suite's dev server.
+ */
+const playwrightE2eConfig = defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 120_000,
+  use: {
+    baseURL: SERVER_URL,
+    headless: true,
+  },
+  webServer: {
+    command: "pnpm dev --port 3100",
+    reuseExistingServer: true,
+    timeout: 120_000,
+    url: SERVER_URL,
+  },
+});
+
+export default playwrightE2eConfig;

--- a/packages/static-site/public/styles/nj-rtl-utilities.css
+++ b/packages/static-site/public/styles/nj-rtl-utilities.css
@@ -1,0 +1,60 @@
+/*
+ * Flow-relative (RTL-aware) utility classes that compose onto NJWDS components.
+ *
+ * NJWDS (a USWDS derivative) ships only physical directional properties
+ * (right / border-right / padding-left / …) and no RTL support, so its
+ * components do not mirror under dir="rtl". These single-purpose utilities use
+ * CSS logical properties to flip automatically with the document direction.
+ *
+ * This sheet is <link>ed AFTER the NJWDS stylesheet so that, at equal
+ * specificity, these utilities win on source order without needing !important —
+ * matching the USWDS "utilities are authoritative" convention. Each utility
+ * also resets the physical edge NJWDS set, so a single class is correct in both
+ * LTR and RTL. Every rule here corresponds to a documented NJWDS RTL gap
+ * (see docs/njwds-rtl-feedback.md).
+ */
+
+/* Anchors an absolutely-positioned block to the inline-end edge (flips under
+   RTL). Composes onto .usa-nav__secondary, whose NJWDS rule hard-codes
+   right: 2rem at the desktop breakpoint. */
+.nj-inset-inline-end-2 {
+  right: auto;
+  left: auto;
+  inset-inline-end: 2rem;
+}
+
+/* Inline-end separator for adjacent items: a border + spacing on the side
+   facing the next item, flipping under RTL. Opt-in on the list.
+
+   Split into two rules on purpose. The base rule neutralizes NJWDS's physical
+   right edge in both directions; the separator itself is a logical property
+   added per-item below so it flips with the document direction. Keeping the
+   reset and the separator in one block is unsafe: in LTR `border-inline-end`
+   resolves to `border-right`, so a `border-right` reset in the same block
+   would clobber the separator. */
+.nj-inline-separators > li {
+  margin-right: 0;
+  padding-right: 0;
+  border-right: 0;
+}
+
+/* The separator sits between adjacent items, so the final item is excluded.
+   The (0,2,1) specificity beats NJWDS's `.nj-banner__header li` (0,1,1), so the
+   logical border wins regardless of source order. */
+.nj-inline-separators > li:not(:last-child) {
+  margin-inline-end: 0.5rem;
+  padding-inline-end: 0.5rem;
+  border-inline-end: 1px solid currentcolor;
+}
+
+/* Opens an absolutely-positioned dropdown from the inline-end edge (flips under
+   RTL). Composes onto the language submenu, whose NJWDS rule hard-codes
+   right: 0. NJWDS targets it with a (0,3,0) selector
+   (.usa-language__primary-item:last-of-type .usa-language__submenu), so this
+   utility is qualified with the item + submenu classes to reach equal (0,3,0)
+   specificity and win on source order rather than fighting with !important. */
+.usa-language__primary-item .usa-language__submenu.nj-dropdown-inline-end {
+  right: auto;
+  left: auto;
+  inset-inline-end: 0;
+}

--- a/packages/static-site/scripts/syncNjwdsAssets.ts
+++ b/packages/static-site/scripts/syncNjwdsAssets.ts
@@ -200,6 +200,10 @@ const REQUIRED_NJWDS_ASSETS: readonly RequiredNjwdsAsset[] = [
     description: "NJWDS icon sprite",
   },
   {
+    relativePath: "img/us_flag_small.png",
+    description: "NJWDS US flag image",
+  },
+  {
     relativePath: "img/usa-icons/facebook.svg",
     description: "NJWDS Facebook icon",
   },

--- a/packages/static-site/tests/accessibility/homepage.a11y.spec.ts
+++ b/packages/static-site/tests/accessibility/homepage.a11y.spec.ts
@@ -1,9 +1,10 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test } from "@playwright/test";
-import type { Page } from "playwright";
+import type { BrowserContext, Page } from "playwright";
 import type { AppLocale } from "@/domain/i18n/locales";
 import { APP_LOCALES } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
 
 /**
  * Defines the test context provided by Playwright.
@@ -11,6 +12,8 @@ import { getApplicationMessages } from "@/domain/i18n/messages";
 interface AccessibilityTestContext {
   /** Browser page used by the test run. */
   readonly page: Page;
+  /** Browser context, used to seed cookies before navigation. */
+  readonly context: BrowserContext;
 }
 
 /**
@@ -25,8 +28,18 @@ interface CreateLocaleAccessibilityTestParams {
  * Creates a Playwright accessibility test for one locale.
  */
 const createLocaleAccessibilityTest = ({ locale }: CreateLocaleAccessibilityTestParams) => {
-  return async ({ page }: AccessibilityTestContext) => {
+  return async ({ page, context }: AccessibilityTestContext) => {
     const messages = await getApplicationMessages({ locale });
+
+    // Suppress the preferred-language prompt modal so its open/animation state
+    // cannot race with the axe scan, which made this audit flaky.
+    await context.addCookies([
+      {
+        name: LANGUAGE_PROMPT_DISMISSED_COOKIE,
+        value: "true",
+        url: "http://127.0.0.1:3000",
+      },
+    ]);
 
     await page.goto(`/${locale}`);
     await page.getByRole("heading", { level: 1, name: messages.landing.hero.title }).waitFor();

--- a/packages/static-site/tests/e2e/govBannerSeparator.e2e.spec.ts
+++ b/packages/static-site/tests/e2e/govBannerSeparator.e2e.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+
+/**
+ * Verifies the gov-banner item separator renders on the inline-end edge under
+ * LTR. The separator is a logical-property border (nj-rtl-utilities.css) that
+ * also resets NJWDS's physical right edge; an earlier version applied both in
+ * one rule and the reset clobbered the border in LTR, dropping the divider.
+ * Asserts computed styles in a real browser at the default (en-US) route.
+ */
+
+const SEPARATOR_ITEMS = ".nj-inline-separators > li";
+
+test.describe("gov banner separator", () => {
+  test.beforeEach(async ({ context }) => {
+    // Suppress the preferred-language prompt modal so its overlay never covers
+    // the banner these assertions read.
+    await context.addCookies([
+      {
+        name: LANGUAGE_PROMPT_DISMISSED_COOKIE,
+        value: "true",
+        url: "http://127.0.0.1:3100",
+      },
+    ]);
+  });
+
+  test("renders the separator on the inline-end edge under LTR", async ({ page }) => {
+    await page.setViewportSize({ width: 1200, height: 900 });
+    await page.goto("/learn");
+
+    const items = page.locator(SEPARATOR_ITEMS);
+    await expect(items.first()).toBeVisible();
+
+    // Non-final item: under LTR the inline-end edge is the physical right.
+    const firstBorder = await items.first().evaluate((el) => {
+      const style = getComputedStyle(el);
+      return { left: style.borderLeftWidth, right: style.borderRightWidth };
+    });
+    expect(firstBorder.right).toBe("1px");
+    expect(firstBorder.left).toBe("0px");
+
+    // Final item drops the separator on both edges.
+    const lastBorder = await items.last().evaluate((el) => {
+      const style = getComputedStyle(el);
+      return { left: style.borderLeftWidth, right: style.borderRightWidth };
+    });
+    expect(lastBorder.right).toBe("0px");
+    expect(lastBorder.left).toBe("0px");
+  });
+});

--- a/packages/static-site/tests/e2e/languageSwitcherAccessibility.e2e.spec.ts
+++ b/packages/static-site/tests/e2e/languageSwitcherAccessibility.e2e.spec.ts
@@ -1,0 +1,104 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+import { LANGUAGE_DESCRIPTORS } from "@/domain/i18n/languages";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+
+/**
+ * Verifies the screen-reader contract of the language switcher: the trigger
+ * advertises its expanded state, it points at the submenu it controls, each
+ * option carries its BCP-47 `lang`/`hreflang`, the active option is marked with
+ * `aria-current`, and the open dropdown has no automated WCAG violations.
+ */
+
+const TRIGGER = "nav.usa-language button.usa-language__link";
+const SUBMENU = "#language-switcher-submenu";
+
+test.describe("language switcher accessibility", () => {
+  test.beforeEach(async ({ context }) => {
+    // Suppress the preferred-language prompt modal, whose overlay would
+    // otherwise intercept clicks on the switcher when the browser locale
+    // differs from the page locale.
+    await context.addCookies([
+      {
+        name: LANGUAGE_PROMPT_DISMISSED_COOKIE,
+        value: "true",
+        url: "http://127.0.0.1:3100",
+      },
+    ]);
+  });
+
+  test("trigger exposes aria-controls pointing at the submenu", async ({ page }) => {
+    await page.goto("/learn");
+
+    const controls = await page.locator(TRIGGER).getAttribute("aria-controls");
+    expect(controls).toBe("language-switcher-submenu");
+    await expect(page.locator(`#${controls}`)).toHaveCount(1);
+  });
+
+  test("trigger toggles aria-expanded between collapsed and expanded", async ({ page }) => {
+    await page.goto("/learn");
+    const trigger = page.locator(TRIGGER);
+
+    await expect(trigger).toHaveAttribute("aria-expanded", "false");
+    await trigger.click();
+    await expect(trigger).toHaveAttribute("aria-expanded", "true");
+  });
+
+  test("the language navigation region has an accessible label", async ({ page }) => {
+    const { navigationAriaLabel } = getApplicationMessages({
+      locale: "en-US",
+    }).layout.languageSwitcher;
+
+    await page.goto("/learn");
+
+    await expect(page.locator("nav.usa-language")).toHaveAttribute(
+      "aria-label",
+      navigationAriaLabel,
+    );
+  });
+
+  test("each option declares hreflang on the link and lang on its native-name span", async ({
+    page,
+  }) => {
+    await page.goto("/learn");
+    await page.locator(TRIGGER).click();
+
+    for (const descriptor of LANGUAGE_DESCRIPTORS) {
+      const option = page.locator(`${SUBMENU} a[hreflang="${descriptor.locale}"]`);
+      await expect(option).toBeVisible();
+      // WCAG H58: lang scopes to the foreign-language native name, not the link.
+      await expect(option).not.toHaveAttribute("lang", /.+/);
+      await expect(option.locator("strong")).toHaveAttribute("lang", descriptor.locale);
+    }
+  });
+
+  test("orders options alphabetically by native name", async ({ page }) => {
+    await page.goto("/learn");
+    await page.locator(TRIGGER).click();
+
+    const renderedNatives = await page.locator(`${SUBMENU} a strong`).allTextContents();
+    const expectedOrder = LANGUAGE_DESCRIPTORS.map((descriptor) => descriptor.nativeName);
+
+    expect(renderedNatives).toEqual(expectedOrder);
+  });
+
+  test("marks the active locale option with aria-current", async ({ page }) => {
+    await page.goto("/es-US/learn");
+    await page.locator(TRIGGER).click();
+
+    const current = page.locator(`${SUBMENU} a[aria-current="true"]`);
+    await expect(current).toHaveCount(1);
+    await expect(current).toHaveAttribute("hreflang", "es-US");
+  });
+
+  test("open dropdown has no automated WCAG violations", async ({ page }) => {
+    await page.goto("/learn");
+    await page.locator(TRIGGER).click();
+    await expect(page.locator(SUBMENU)).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).include("nav.usa-language").analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/packages/static-site/tests/e2e/languageSwitcherRedirect.e2e.spec.ts
+++ b/packages/static-site/tests/e2e/languageSwitcherRedirect.e2e.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+
+/**
+ * Verifies that choosing a language re-targets the current page in that
+ * language: the locale prefix appears in the URL, the path is preserved, and
+ * the document `lang` (and `dir`, for RTL languages) plus visible content
+ * change to the destination locale.
+ */
+
+const TRIGGER = "nav.usa-language button.usa-language__link";
+const SUBMENU = "#language-switcher-submenu";
+
+const openSwitcherAndChoose = async (
+  page: import("@playwright/test").Page,
+  hrefLang: string,
+): Promise<void> => {
+  await page.locator(TRIGGER).click();
+  await expect(page.locator(SUBMENU)).toBeVisible();
+  await page.locator(`${SUBMENU} a[hreflang="${hrefLang}"]`).click();
+};
+
+test.describe("language switcher redirect", () => {
+  test.beforeEach(async ({ context }) => {
+    // Suppress the preferred-language prompt modal so its overlay never covers
+    // the post-switch page content this suite asserts on.
+    await context.addCookies([
+      {
+        name: LANGUAGE_PROMPT_DISMISSED_COOKIE,
+        value: "true",
+        url: "http://127.0.0.1:3100",
+      },
+    ]);
+  });
+
+  test("switches to Spanish: URL prefix, preserved path, lang and content change", async ({
+    page,
+  }) => {
+    const englishHero = getApplicationMessages({ locale: "en-US" }).landing.hero.title;
+    const spanishHero = getApplicationMessages({ locale: "es-US" }).landing.hero.title;
+
+    await page.goto("/");
+    await expect(page.getByRole("heading", { level: 1, name: englishHero })).toBeVisible();
+    await expect(page.locator("html")).toHaveAttribute("lang", "en-US");
+
+    await openSwitcherAndChoose(page, "es-US");
+
+    await expect(page).toHaveURL(/\/es-US$/);
+    await expect(page.locator("html")).toHaveAttribute("lang", "es-US");
+    await expect(page.getByRole("heading", { level: 1, name: spanishHero })).toBeVisible();
+  });
+
+  test("preserves a nested path when switching language", async ({ page }) => {
+    await page.goto("/learn");
+
+    await openSwitcherAndChoose(page, "es-US");
+
+    await expect(page).toHaveURL(/\/es-US\/learn$/);
+    await expect(page.locator("html")).toHaveAttribute("lang", "es-US");
+  });
+
+  // Skipped while no RTL locale ships. The switcher's dir-flip behavior is still
+  // wired (textDirectionForLocale + dir on <html>); restore this test by adding
+  // an RTL language such as ar-US back to APP_LOCALES and LANGUAGE_DESCRIPTORS.
+  test.skip("switches to Arabic and flips the document direction to rtl", async ({ page }) => {
+    await page.goto("/learn");
+    await expect(page.locator("html")).toHaveAttribute("dir", "ltr");
+
+    await openSwitcherAndChoose(page, "ar-US");
+
+    await expect(page).toHaveURL(/\/ar-US\/learn$/);
+    await expect(page.locator("html")).toHaveAttribute("lang", "ar-US");
+    await expect(page.locator("html")).toHaveAttribute("dir", "rtl");
+  });
+});

--- a/packages/static-site/tests/e2e/languageSwitcherScroll.e2e.spec.ts
+++ b/packages/static-site/tests/e2e/languageSwitcherScroll.e2e.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Verifies the language submenu only scrolls when more than six options exist.
+ *
+ * Uses the test-only harness route, which renders a single switcher with a
+ * controlled option count via `?count=`. Scroll presence is measured in a real
+ * browser (jsdom has no layout), comparing scrollHeight against clientHeight.
+ */
+
+const HARNESS_SUBMENU = "#harness-language-switcher-submenu";
+
+/**
+ * Opens the harness switcher at a given option count and returns scroll metrics.
+ */
+const measureSubmenuAtCount = async (
+  page: import("@playwright/test").Page,
+  count: number,
+): Promise<{ optionCount: number; isScrolling: boolean }> => {
+  await page.goto(`/language-switcher-harness?count=${count}`);
+  await page.locator("#main-content nav.usa-language button").click();
+
+  const submenu = page.locator(HARNESS_SUBMENU);
+  await expect(submenu).toBeVisible();
+
+  return submenu.evaluate((element) => {
+    return {
+      optionCount: element.querySelectorAll(".usa-language__submenu-item").length,
+      isScrolling: element.scrollHeight > element.clientHeight,
+    };
+  });
+};
+
+test.describe("language switcher scroll behavior", () => {
+  test("shows two options without a scrollbar", async ({ page }) => {
+    const { optionCount, isScrolling } = await measureSubmenuAtCount(page, 2);
+
+    expect(optionCount).toBe(2);
+    expect(isScrolling).toBe(false);
+  });
+
+  test("shows six options without a scrollbar", async ({ page }) => {
+    const { optionCount, isScrolling } = await measureSubmenuAtCount(page, 6);
+
+    expect(optionCount).toBe(6);
+    expect(isScrolling).toBe(false);
+  });
+
+  test("shows a scrollbar when more than six options are present", async ({ page }) => {
+    const { optionCount, isScrolling } = await measureSubmenuAtCount(page, 7);
+
+    expect(optionCount).toBe(7);
+    expect(isScrolling).toBe(true);
+  });
+});

--- a/packages/static-site/tests/e2e/languageSwitcherToggle.e2e.spec.ts
+++ b/packages/static-site/tests/e2e/languageSwitcherToggle.e2e.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Verifies the language dropdown opens on the trigger and closes again both
+ * when the trigger is re-clicked and when the visitor clicks outside it.
+ *
+ * Open/close is driven by the bundled NJWDS language-selector script, so this
+ * must run in a real browser rather than jsdom.
+ */
+
+const TRIGGER = "nav.usa-language button.usa-language__link";
+const SUBMENU = "#language-switcher-submenu";
+
+test.describe("language switcher open/close", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/learn");
+  });
+
+  test("opens the dropdown when the trigger is clicked", async ({ page }) => {
+    const trigger = page.locator(TRIGGER);
+    const submenu = page.locator(SUBMENU);
+
+    await expect(submenu).toBeHidden();
+    await expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+    await trigger.click();
+
+    await expect(submenu).toBeVisible();
+    await expect(trigger).toHaveAttribute("aria-expanded", "true");
+  });
+
+  test("closes the dropdown when the trigger is clicked again", async ({ page }) => {
+    const trigger = page.locator(TRIGGER);
+    const submenu = page.locator(SUBMENU);
+
+    await trigger.click();
+    await expect(submenu).toBeVisible();
+
+    await trigger.click();
+
+    await expect(submenu).toBeHidden();
+    await expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("closes the dropdown when clicking outside it", async ({ page }) => {
+    const trigger = page.locator(TRIGGER);
+    const submenu = page.locator(SUBMENU);
+
+    await trigger.click();
+    await expect(submenu).toBeVisible();
+
+    // Click a neutral region of the page away from the switcher.
+    await page.locator("#main-content").click({ position: { x: 5, y: 5 } });
+
+    await expect(submenu).toBeHidden();
+    await expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/packages/static-site/tests/e2e/rtlLayout.e2e.spec.ts
+++ b/packages/static-site/tests/e2e/rtlLayout.e2e.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "@playwright/test";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+
+/**
+ * Verifies that the RTL-aware utility classes correctly flip NJWDS's physical
+ * directional layout under `dir="rtl"`, and that inherently-Latin strings stay
+ * bidi-isolated. NJWDS ships no RTL support, so these flips come from our
+ * flow-relative utilities (public/styles/nj-rtl-utilities.css) composed onto
+ * the components. Assertions read computed styles in a real browser at the
+ * Arabic (`ar-US`) route.
+ */
+
+const RTL_ROUTE = "/ar-US";
+const TRIGGER = "nav.usa-language button.usa-language__link";
+const SUBMENU = "#language-switcher-submenu";
+
+// Skipped while no RTL locale ships: these assertions navigate to /ar-US, which
+// is not a route until an RTL language is added back to APP_LOCALES. The RTL
+// implementation they cover (the nj-rtl-utilities classes, bidi isolation, and
+// the placeholder messages/ar-US.json) is intentionally kept in the tree, so
+// re-enabling is just removing this `.skip` once ar-US is restored.
+const describeRtlLayout = test.describe.skip;
+
+describeRtlLayout("RTL layout", () => {
+  test.beforeEach(async ({ context }) => {
+    // Suppress the preferred-language prompt modal so its overlay never covers
+    // the elements these assertions target.
+    await context.addCookies([
+      {
+        name: LANGUAGE_PROMPT_DISMISSED_COOKIE,
+        value: "true",
+        url: "http://127.0.0.1:3100",
+      },
+    ]);
+  });
+
+  test("renders the document right-to-left", async ({ page }) => {
+    await page.setViewportSize({ width: 1200, height: 900 });
+    await page.goto(RTL_ROUTE);
+
+    await expect(page.locator("html")).toHaveAttribute("dir", "rtl");
+  });
+
+  test("anchors the secondary nav to the inline-end so it does not overlap the title", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1200, height: 900 });
+    await page.goto(RTL_ROUTE);
+
+    const overlap = await page.evaluate(() => {
+      const logo = document.querySelector(".usa-logo__text");
+      const langButton = document.querySelector(".usa-language__link");
+      if (!logo || !langButton) {
+        return { found: false, overlapping: true };
+      }
+      const a = logo.getBoundingClientRect();
+      const b = langButton.getBoundingClientRect();
+      const overlapping = !(a.right <= b.left || b.right <= a.left);
+      return { found: true, overlapping };
+    });
+
+    expect(overlap.found).toBe(true);
+    expect(overlap.overlapping).toBe(false);
+  });
+
+  test("flips the gov banner item separators to the inline-end", async ({ page }) => {
+    await page.setViewportSize({ width: 1200, height: 900 });
+    await page.goto(RTL_ROUTE);
+
+    const border = await page
+      .locator(".nj-inline-separators > li")
+      .first()
+      .evaluate((el) => {
+        const style = getComputedStyle(el);
+        return { left: style.borderLeftWidth, right: style.borderRightWidth };
+      });
+
+    // Under RTL the inline-end edge is the physical left.
+    expect(border.left).toBe("1px");
+    expect(border.right).toBe("0px");
+  });
+
+  test("opens the language submenu from the inline-end edge", async ({ page }) => {
+    await page.setViewportSize({ width: 1200, height: 900 });
+    await page.goto(RTL_ROUTE);
+    await page.locator(TRIGGER).click();
+    await expect(page.locator(SUBMENU)).toBeVisible();
+
+    const position = await page.locator(SUBMENU).evaluate((el) => {
+      const style = getComputedStyle(el);
+      return { left: style.left, insetInlineEnd: style.insetInlineEnd };
+    });
+
+    // inset-inline-end: 0 resolves to physical left: 0 under RTL (the browser
+    // then derives `right` from left + width, so only `left` is asserted).
+    expect(position.left).toBe("0px");
+    expect(position.insetInlineEnd).toBe("0px");
+  });
+
+  test("bidi-isolates inherently-Latin strings", async ({ page }) => {
+    await page.goto(RTL_ROUTE);
+
+    const siteTitle = page.locator(".usa-logo__text bdi");
+    await expect(siteTitle).toHaveAttribute("dir", "ltr");
+
+    const domain = page.locator(".usa-identifier__identity-domain bdi");
+    await expect(domain).toHaveAttribute("dir", "ltr");
+  });
+});

--- a/scripts/_install.sh
+++ b/scripts/_install.sh
@@ -387,6 +387,12 @@ yarn install && yarn build || { echo "Root install or build failed."; exit 1; }
 (
     cd packages/static-site
     pnpm install
+    # Playwright drives the static-site accessibility and e2e suites; install the
+    # browsers here (dev/CI only) rather than via a package postinstall, which
+    # would also pull Chromium into production Docker image builds. The headless
+    # shell is a separate download from full Chromium and is what the headless
+    # test runs actually launch.
+    pnpm exec playwright install chromium chromium-headless-shell
     pnpm build
 ) || {
     echo "Static-site install or build failed."


### PR DESCRIPTION
## Description

Adds a USWDS/NJWDS-based language picker to the locale-aware static site, then deliberately reduces the shipped locale set to English (US) and Spanish (US) while leaving the multilingual machinery — including right-to-left (RTL) support — intact and ready to switch back on.

The picker follows the USWDS language-selector "3+ languages" variant: a "Languages" dropdown where each option shows native + English name (`Español (Spanish)`), ordered alphabetically by native name, with no flags and a scrolling submenu past six languages. Accessibility was a primary constraint throughout (WCAG 2.1 AA): per-option `lang` (H58), `aria-current` for the active locale, `aria-expanded`/`aria-controls` on the trigger, and bidi-correct rendering of Latin proper nouns in either direction.

### Ticket

This pull request resolves [#17824](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17824).

### Approach

- **One locale source of truth.** `domain/i18n/locales.ts` declares `APP_LOCALES` (`as const`); `AppLocale` derives from it, so adding/removing a locale ripples through types, routing, sitemap, and message loading. `domain/i18n/languages.ts` holds the `LanguageDescriptor` records and **derives** display order by sorting on native name, so the "alphabetical" rule can't drift.
- **Stateless picker.** `LanguageSwitcher.tsx` is pure presentation rendering the `usa-language` markup; open/close/focus is driven by the bundled NJWDS `uswds.min.js` (no React state). A `descriptors` prop (defaulting to the real list) decouples it from the app's locale set so tests/harness can feed synthetic lists; a `submenuId` prop lets multiple instances coexist with unique `aria-controls`.
- **Clean URLs.** `next-intl` routing uses `localePrefix: "as-needed"` — the default locale is unprefixed (`/learn`), others prefixed (`/es-US/learn`). Pure, idempotent path helpers (`localePath.ts`) are reused by routing, the sitemap, and `hreflang`/`x-default` metadata. Switching language re-targets the same page rather than the home page.
- **RTL foundation.** The synced NJWDS stylesheet ships zero RTL support, so setting `dir="rtl"` flips text but repositions nothing. The fix is layered by code ownership: document `dir` from the descriptor; our own CSS converted to logical properties; a small composable `nj-rtl-utilities.css` (logical properties, loaded after NJWDS so source order wins without `!important`) for NJWDS's positional bugs; and `<bdi dir="ltr">` isolation for inherently-Latin strings. `docs/njwds-rtl-feedback.md` catalogues the upstream gaps.
- **RTL kept dormant, not deleted.** The locale set is reduced to en/es, but the RTL infra (utilities, `<bdi>`, placeholder `ar-US.json`, feedback doc) stays in the tree; `/ar-US`-dependent e2e tests are `.skip`'d with re-enable notes so reintroducing an RTL language is turnkey.

### Steps to Test

1. Run the static site (`pnpm dev` in `packages/static-site`).
2. Open the language picker in the header — confirm it's labeled "Languages", lists `English` and `Español (Spanish)`, and toggles open/closed via keyboard and mouse.
3. Select Español and confirm the URL gains an `/es-US` prefix, the page content switches, and you land on the same page (not the home page).
4. Confirm `<html lang>` updates and the language-prompt modal behaves.
5. Run `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm test:e2e`, `pnpm test:accessibility`, and `pnpm build` — all green.

### Notes

- A test-only harness route (`app/[locale]/language-switcher-harness`, `notFound()` in production) renders N synthetic options so the scroll-past-six behavior can be measured in a real browser, since jsdom has no layout engine.
- Playwright browsers install via `scripts/_install.sh` (dev/CI only), not a package `postinstall`, to keep ~150MB out of production Docker builds.
- Pre-existing, locale-independent a11y defects were fixed along the way: inline-link contrast (restored prose underlines), a duplicate unnamed `role="dialog"`, and an orphaned `aria-modal` on the NJWDS modal wrapper.
- To re-enable RTL later: restore an RTL locale to `APP_LOCALES` + a descriptor (`textDirection: "rtl"`), wire its messages, and remove the `.skip`s.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [x] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [ ] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
