### PR TITLE
fix: update Cloudwatch alarm for`lambda-excessive-executions`

### DIFF
--- a/api/cdk/lib/monitoringStack.ts
+++ b/api/cdk/lib/monitoringStack.ts
@@ -1,18 +1,18 @@
-import { RemovalPolicy, Stack, StackProps, Duration } from "aws-cdk-lib";
-import { Construct } from "constructs";
-import * as logs from "aws-cdk-lib/aws-logs";
-import * as sns from "aws-cdk-lib/aws-sns";
+import { Duration, RemovalPolicy, Stack, StackProps } from "aws-cdk-lib";
 import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
 import * as cloudwatch_actions from "aws-cdk-lib/aws-cloudwatch-actions";
+import * as logs from "aws-cdk-lib/aws-logs";
+import * as sns from "aws-cdk-lib/aws-sns";
+import { Construct } from "constructs";
 import {
+  BUSINESSES_TABLE,
+  ECS_CLUSTER_NAME,
+  ECS_SERVICE_NAME,
+  HEALTH_CHECK_ENDPOINTS,
   HEALTH_CHECK_SERVICE,
   NAVIGATOR_DB_CLIENT,
   NAVIGATOR_WEBSERVICE,
-  HEALTH_CHECK_ENDPOINTS,
   USERS_TABLE,
-  BUSINESSES_TABLE,
-  ECS_SERVICE_NAME,
-  ECS_CLUSTER_NAME,
 } from "./constants";
 
 export interface MonitoringStackProps extends StackProps {
@@ -479,7 +479,8 @@ export class MonitoringStack extends Stack {
       const lambdaAnomalyAlarm = new cloudwatch.CfnAlarm(this, "LambdaAnomalyAlarm", {
         alarmName: `${props.stage}-bfs-navigator-lambda-excessive-executions`,
         comparisonOperator: "GreaterThanUpperThreshold",
-        evaluationPeriods: 1,
+        evaluationPeriods: 3,
+        datapointsToAlarm: 2,
         thresholdMetricId: "ad1",
         treatMissingData: "notBreaching",
 
@@ -504,7 +505,7 @@ export class MonitoringStack extends Stack {
           },
           {
             id: "ad1",
-            expression: "ANOMALY_DETECTION_BAND(m1, 2)",
+            expression: "ANOMALY_DETECTION_BAND(m1, 3)",
             label: "Expected Invocations",
             returnData: true,
           },


### PR DESCRIPTION
Currently this alarm is too sensitive and is causing false positives. This updates the alarm to:
- evaluate over 15 minute periods instead of 5
- require 2 datapoints to trigger an alarm (instead of 1)
- increase the acceptable range of executions to be slightly wider

<!-- Please complete the following sections as necessary. -->

## Description

See Ade's investigation into the issue [here](https://docs.google.com/document/d/1bSqjC0imO5scHCiAxSNCGKZJrBB9tZCmowAt-OmHjXo/edit?tab=t.0).

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#17817](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17817)