### PR TITLE
feat: [AB#17828] starter kits page

### DIFF
--- a/content/src/pages/starter-kits.md
+++ b/content/src/pages/starter-kits.md
@@ -6,4 +6,6 @@ category: start
 sub-heading-text: For some of the most commonly opened business types in New Jersey, we've put together a simple guide to help understand what you'll need to outfit your business with the right licenses and permits.
 meta-data: Find resources and guides to starting a business in New Jersey. Don't see your industry? Suggest a new start kit from our team.
 main-link-text: View Kits
+heading-2: Get a Head Start with a Starter Kit for Your Industry
+main-text-2: Get a free, personalized guide for your business to help you register your business, explore funding opportunities, and understand tax deadlines.
 ---

--- a/packages/content-types/src/industry.ts
+++ b/packages/content-types/src/industry.ts
@@ -26,6 +26,8 @@ export interface Industry {
   readonly canHavePermanentLocation?: boolean;
   /** Ordered steps in the industry's roadmap. */
   readonly roadmapSteps: RoadmapStep[];
+  /** Indicates if this industry is enabled and should be visible to users. */
+  readonly isEnabled: boolean;
 }
 
 /** A business sector containing related industries. */

--- a/packages/static-site/README.md
+++ b/packages/static-site/README.md
@@ -121,6 +121,21 @@ version. Pre-launch ECS deployments enable HTTP Basic Auth from the repository-l
 `BASIC_AUTH_USERNAME` variable and `BASIC_AUTH_PASSWORD` secret. Local runs leave Basic Auth
 disabled by default.
 
+## Testing
+
+Test factories in `tests/factories.ts` use a seeded PRNG for deterministic random data generation.
+A seed is generated once per test run and logged to stdout at the start:
+
+```
+[test] seed: 2503204477
+```
+
+To reproduce a specific test run, pass the seed as an environment variable:
+
+```bash
+TEST_SEED=2503204477 pnpm test
+```
+
 ## Contributing
 
 Before opening a pull request for this package, run:

--- a/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.test.tsx
+++ b/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.test.tsx
@@ -22,6 +22,7 @@ vi.mock("@/domain/content/loadContent", () => ({
     name: "Create a Business Plan",
     category: "plan",
   }),
+  loadIndustries: () => [],
 }));
 
 describe("generateStaticParams", () => {

--- a/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.tsx
+++ b/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.tsx
@@ -42,7 +42,7 @@ const ContentPage = async ({ params }: Props) => {
 
   const page = loadPageBySlug(slug);
 
-  return <PageSwitchComponent page={page} />;
+  return <PageSwitchComponent page={page} locale={locale} />;
 };
 
 export default ContentPage;

--- a/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.tsx
+++ b/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import PageContent from "@/components/learn/PageContent";
+import { PageSwitchComponent } from "@/components/learn/PageSwitchComponent";
 import { CATEGORY_HIERARCHY } from "@/domain/categories";
 import { loadPageBySlug } from "@/domain/content/loadContent";
 import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
@@ -42,7 +42,7 @@ const ContentPage = async ({ params }: Props) => {
 
   const page = loadPageBySlug(slug);
 
-  return <PageContent page={page} />;
+  return <PageSwitchComponent page={page} />;
 };
 
 export default ContentPage;

--- a/packages/static-site/app/[locale]/layout.tsx
+++ b/packages/static-site/app/[locale]/layout.tsx
@@ -11,7 +11,6 @@ import "@/app/landing.css";
 
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import Script from "next/script";
 import { NextIntlClientProvider } from "next-intl";
 import type { ReactNode } from "react";
 import { GoogleTagManager } from "@/components/analytics/GoogleTagManager";
@@ -45,11 +44,6 @@ const NJWDS_STYLESHEET_PATH = "/assets/njwds/dist/css/styles.css";
  * directional properties under `dir="rtl"` without `!important`.
  */
 const NJ_RTL_UTILITIES_STYLESHEET_PATH = "/styles/nj-rtl-utilities.css";
-
-/**
- * Public path for the synced NJWDS runtime script.
- */
-const NJWDS_SCRIPT_PATH = "/assets/njwds/dist/js/uswds.min.js";
 
 /**
  * Describes route params for locale-scoped pages.
@@ -203,7 +197,6 @@ const LocaleLayout = async ({ children, params }: LocaleLayoutProps) => {
           <IdentifierSection content={messages.layout.identifier} />
           <LanguagePromptModal />
         </NextIntlClientProvider>
-        <Script src={NJWDS_SCRIPT_PATH} strategy="afterInteractive" />
         <Intercom />
       </body>
     </html>

--- a/packages/static-site/app/header.css
+++ b/packages/static-site/app/header.css
@@ -267,6 +267,14 @@
   .usa-header--extended {
     display: block;
   }
+
+  /* Languages Dropdown */
+  .usa-nav .usa-nav__secondary {
+    position: static;
+    margin-top: 0;
+    min-width: auto;
+    inset-inline-end: unset;
+  }
 }
 
 /* ── End mobile nav ───────────────────────────────────────────────────────── */

--- a/packages/static-site/components/landing/HeaderPrimaryNav.tsx
+++ b/packages/static-site/components/landing/HeaderPrimaryNav.tsx
@@ -2,10 +2,13 @@
  * Renders primary header navigation for the landing page.
  *
  * This module maps primary menu items from localized content into NJWDS
- * navigation markup.
+ * navigation markup. Submenu accordion behavior is managed in React state.
  */
 
+"use client";
+
 import Image from "next/image";
+import { useState } from "react";
 
 import type {
   HeaderPrimaryItem,
@@ -119,61 +122,10 @@ const renderHeaderPrimaryLinkItem = ({ item }: RenderHeaderPrimaryLinkItemParams
 };
 
 /**
- * Renders one top-level submenu navigation item.
- *
- * @param params Render parameters.
- * @param params.item Primary submenu item data.
- * @returns One primary navigation list item with submenu children.
- * @example
- * ```tsx
- * renderHeaderPrimarySubmenuItem({ item: primarySubmenuItem });
- * ```
- */
-const renderHeaderPrimarySubmenuItem = ({ item }: RenderHeaderPrimarySubmenuItemParams) => {
-  const buttonClassName = item.isCurrent
-    ? "usa-accordion__button usa-nav__link usa-current"
-    : "usa-accordion__button usa-nav__link nj-nav__link";
-
-  return (
-    <li className="usa-nav__primary-item" key={item.submenuId}>
-      <button
-        aria-controls={item.submenuId}
-        aria-expanded="false"
-        className={buttonClassName}
-        type="button"
-      >
-        <span>{item.label}</span>
-      </button>
-      <ul className="usa-nav__submenu" id={item.submenuId}>
-        {item.links.map((submenuLinkItem, index) => {
-          return renderHeaderSubmenuLink({ item: submenuLinkItem, index });
-        })}
-      </ul>
-    </li>
-  );
-};
-
-/**
- * Renders one primary navigation item from the discriminated union.
- *
- * @param params Render parameters.
- * @param params.item Primary item that may be a link or submenu.
- * @returns The matching rendered navigation item.
- * @example
- * ```tsx
- * renderHeaderPrimaryItem({ item: header.primaryItems[0] });
- * ```
- */
-const renderHeaderPrimaryItem = ({ item }: RenderHeaderPrimaryItemParams) => {
-  if (item.kind === "submenu") {
-    return renderHeaderPrimarySubmenuItem({ item });
-  }
-
-  return renderHeaderPrimaryLinkItem({ item });
-};
-
-/**
  * Renders the full primary navigation list.
+ *
+ * Submenu accordion toggles are managed in React state. Only one submenu
+ * can be open at a time.
  *
  * @param props Component props.
  * @param props.header Header content with primary items.
@@ -184,6 +136,64 @@ const renderHeaderPrimaryItem = ({ item }: RenderHeaderPrimaryItemParams) => {
  * ```
  */
 export const HeaderPrimaryNav = ({ header }: HeaderPrimaryNavProps) => {
+  const [openSubmenuId, setOpenSubmenuId] = useState<string | null>(null);
+
+  const toggleSubmenu = (submenuId: string) => {
+    setOpenSubmenuId((prev) => (prev === submenuId ? null : submenuId));
+  };
+
+  /**
+   * Renders one top-level submenu navigation item.
+   *
+   * @param params Render parameters.
+   * @param params.item Primary submenu item data.
+   * @returns One primary navigation list item with submenu children.
+   */
+  const renderHeaderPrimarySubmenuItem = ({ item }: RenderHeaderPrimarySubmenuItemParams) => {
+    const isOpen = openSubmenuId === item.submenuId;
+    const buttonClassName = item.isCurrent
+      ? "usa-accordion__button usa-nav__link usa-current"
+      : "usa-accordion__button usa-nav__link nj-nav__link";
+
+    return (
+      <li className="usa-nav__primary-item" key={item.submenuId}>
+        <button
+          aria-controls={item.submenuId}
+          aria-expanded={isOpen}
+          className={buttonClassName}
+          onClick={() => toggleSubmenu(item.submenuId)}
+          type="button"
+        >
+          <span>{item.label}</span>
+        </button>
+        <ul className="usa-nav__submenu" hidden={!isOpen || undefined} id={item.submenuId}>
+          {item.links.map((submenuLinkItem, index) => {
+            return renderHeaderSubmenuLink({ item: submenuLinkItem, index });
+          })}
+        </ul>
+      </li>
+    );
+  };
+
+  /**
+   * Renders one primary navigation item from the discriminated union.
+   *
+   * @param params Render parameters.
+   * @param params.item Primary item that may be a link or submenu.
+   * @returns The matching rendered navigation item.
+   * @example
+   * ```tsx
+   * renderHeaderPrimaryItem({ item: header.primaryItems[0] });
+   * ```
+   */
+  const renderHeaderPrimaryItem = ({ item }: RenderHeaderPrimaryItemParams) => {
+    if (item.kind === "submenu") {
+      return renderHeaderPrimarySubmenuItem({ item });
+    }
+
+    return renderHeaderPrimaryLinkItem({ item });
+  };
+
   return (
     <>
       <button className="usa-nav__close" type="button">

--- a/packages/static-site/components/landing/LanguagePromptModal.tsx
+++ b/packages/static-site/components/landing/LanguagePromptModal.tsx
@@ -5,18 +5,18 @@
  *
  * On mount this molecule compares the visitor's browser languages against the
  * page's current locale. When a supported preferred locale differs from the
- * current one and the dismissal cookie is absent, it opens the NJWDS modal
- * offering to stay or switch. It never redirects automatically. The visitor's
- * choice is recorded in a dismissal cookie so they are not prompted again; the
- * switch action also persists `NEXT_LOCALE` and performs a full-page navigation
- * to the target locale.
+ * current one and the dismissal cookie is absent, it opens the modal offering
+ * to stay or switch. It never redirects automatically. The visitor's choice is
+ * recorded in a dismissal cookie so they are not prompted again; the switch
+ * action also persists `NEXT_LOCALE` and performs a full-page navigation to
+ * the target locale.
  *
  * The entire dialog is shown in the preferred/target language so the visitor
  * — who may not read the current page's locale — can understand the prompt.
  */
 
 import { useLocale } from "next-intl";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { LANGUAGE_DESCRIPTORS } from "@/domain/i18n/languages";
 import { addLocalePrefix, stripLocalePrefix } from "@/domain/i18n/localePath";
@@ -95,7 +95,7 @@ const nativeNameOfLocale = (locale: AppLocale): string => {
 export const LanguagePromptModal = () => {
   const currentLocale = resolveAppLocale({ locale: useLocale() });
   const pathname = usePathname();
-  const openTriggerRef = useRef<HTMLButtonElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
   const [preferredLocale, setPreferredLocale] = useState<AppLocale | undefined>(undefined);
 
   useEffect(() => {
@@ -107,17 +107,13 @@ export const LanguagePromptModal = () => {
 
     if (preferred && preferred !== currentLocale) {
       setPreferredLocale(preferred);
+      setIsOpen(true);
     }
   }, [currentLocale]);
 
-  useEffect(() => {
-    if (preferredLocale) {
-      openTriggerRef.current?.click();
-    }
-  }, [preferredLocale]);
-
   const handleStay = useCallback(() => {
     writeCookie(LANGUAGE_PROMPT_DISMISSED_COOKIE, "true");
+    setIsOpen(false);
   }, []);
 
   const handleRedirect = useCallback(() => {
@@ -158,9 +154,9 @@ export const LanguagePromptModal = () => {
     <LanguagePromptModalView
       body={preferredContent.body}
       closeLabel={preferredContent.closeLabel}
+      isOpen={isOpen}
       onRedirect={handleRedirect}
       onStay={handleStay}
-      openTriggerRef={openTriggerRef}
       redirectLabel={redirectLabel}
       stayLabel={preferredContent.stayLabel}
       title={preferredContent.title}

--- a/packages/static-site/components/landing/LanguagePromptModalView.test.tsx
+++ b/packages/static-site/components/landing/LanguagePromptModalView.test.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import axe from "axe-core";
-import { createRef } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { LanguagePromptModalView } from "./LanguagePromptModalView";
@@ -13,19 +12,25 @@ interface RenderViewParams {
   readonly onStay?: () => void;
   /** Handler invoked when the visitor chooses to switch. */
   readonly onRedirect?: () => void;
+  /** Whether the modal is open. */
+  readonly isOpen?: boolean;
 }
 
 /**
  * Renders the modal view with default copy and optional handler overrides.
  */
-const renderView = ({ onStay = vi.fn(), onRedirect = vi.fn() }: RenderViewParams = {}) => {
+const renderView = ({
+  onStay = vi.fn(),
+  onRedirect = vi.fn(),
+  isOpen = true,
+}: RenderViewParams = {}) => {
   return render(
     <LanguagePromptModalView
       body="This page is available in another language."
       closeLabel="Close"
+      isOpen={isOpen}
       onRedirect={onRedirect}
       onStay={onStay}
-      openTriggerRef={createRef<HTMLButtonElement>()}
       redirectLabel="Switch to Español"
       stayLabel="Stay on this page"
       title="View this page in your language?"

--- a/packages/static-site/components/landing/LanguagePromptModalView.tsx
+++ b/packages/static-site/components/landing/LanguagePromptModalView.tsx
@@ -1,20 +1,14 @@
 /**
  * Renders the stateless preferred-language prompt modal markup.
  *
- * This presentational atom mirrors the NJWDS `usa-modal` structure and exposes
- * a visually-hidden `data-open-modal` trigger via `ref`. NJWDS ships no
- * programmatic open API, so the molecule opens the modal by clicking that
- * hidden trigger; the bundled `toggleModal` handler then runs its focus-trap
- * and inert logic. All decision logic lives in the molecule, keeping this
- * component trivial to render and audit for accessibility.
+ * This presentational atom renders a dialog with focus-trap and backdrop
+ * behavior managed in React. The molecule controls visibility via the
+ * `isOpen` prop.
  */
 
-import type { Ref } from "react";
+"use client";
 
-/**
- * Element id linking the open trigger to the modal container.
- */
-const MODAL_ID = "language-prompt-modal";
+import { useEffect, useRef } from "react";
 
 /**
  * Element id for the modal heading, referenced by `aria-labelledby`.
@@ -46,12 +40,12 @@ export interface LanguagePromptModalViewProps {
   readonly onStay: () => void;
   /** Handler invoked when the visitor chooses to switch language. */
   readonly onRedirect: () => void;
-  /** Ref to the hidden open trigger so the molecule can open the modal. */
-  readonly openTriggerRef: Ref<HTMLButtonElement>;
+  /** Whether the modal is currently visible. */
+  readonly isOpen: boolean;
 }
 
 /**
- * Renders the preferred-language prompt modal and its hidden open trigger.
+ * Renders the preferred-language prompt modal.
  *
  * @param props Component props.
  * @param props.title Modal heading text.
@@ -61,8 +55,8 @@ export interface LanguagePromptModalViewProps {
  * @param props.redirectLabel Resolved redirect button label.
  * @param props.onStay Handler for the stay action.
  * @param props.onRedirect Handler for the redirect action.
- * @param props.openTriggerRef Ref to the hidden open trigger.
- * @returns The modal markup and its hidden trigger.
+ * @param props.isOpen Whether the modal is currently visible.
+ * @returns The modal markup, or null when closed.
  * @example
  * ```tsx
  * <LanguagePromptModalView
@@ -73,7 +67,7 @@ export interface LanguagePromptModalViewProps {
  *   redirectLabel="Switch to Español"
  *   onStay={handleStay}
  *   onRedirect={handleRedirect}
- *   openTriggerRef={triggerRef}
+ *   isOpen={true}
  * />
  * ```
  */
@@ -85,34 +79,44 @@ export const LanguagePromptModalView = ({
   redirectLabel,
   onStay,
   onRedirect,
-  openTriggerRef,
+  isOpen,
 }: LanguagePromptModalViewProps) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onStay();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onStay]);
+
+  useEffect(() => {
+    if (isOpen && dialogRef.current) {
+      const focusable = dialogRef.current.querySelector<HTMLElement>(
+        "button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])",
+      );
+      focusable?.focus();
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
   return (
-    <>
-      <button
-        aria-controls={MODAL_ID}
-        aria-hidden="true"
-        data-open-modal
-        ref={openTriggerRef}
-        style={{ position: "fixed", top: 0, insetInlineStart: "-9999px" }}
-        tabIndex={-1}
-        type="button"
-      >
-        {title}
-      </button>
-      {/* No role="dialog" or aria-modal here: the NJWDS modal script moves the
-          dialog role and the id/aria-labelledby/aria-describedby onto the
-          .usa-modal-wrapper it generates, and that wrapper is the real dialog.
-          Declaring role="dialog" here too would leave a second, unnamed dialog
-          (fails aria-dialog-name), and aria-modal without a dialog role is
-          invalid (fails aria-allowed-attr). The aria-labelledby/describedby
-          stay because the script reads them from here. */}
-      {/* biome-ignore lint/a11y/useAriaPropsSupportedByRole: the NJWDS modal script requires aria-labelledby/describedby on .usa-modal — it reads them to label the .usa-modal-wrapper it generates (and throws if absent). The role lives on that wrapper, not here. */}
+    <div className="usa-modal-wrapper is-visible">
+      <div className="usa-modal-overlay" aria-hidden="true" onClick={onStay} />
       <div
         aria-describedby={MODAL_DESCRIPTION_ID}
         aria-labelledby={MODAL_HEADING_ID}
+        aria-modal="true"
         className="usa-modal"
-        id={MODAL_ID}
+        ref={dialogRef}
+        role="dialog"
       >
         <div className="usa-modal__content">
           <div className="usa-modal__main">
@@ -132,7 +136,6 @@ export const LanguagePromptModalView = ({
                 <li className="usa-button-group__item">
                   <button
                     className="usa-button usa-button--unstyled padding-105 text-center"
-                    data-close-modal
                     onClick={onStay}
                     type="button"
                   >
@@ -145,7 +148,6 @@ export const LanguagePromptModalView = ({
           <button
             aria-label={closeLabel}
             className="usa-button usa-modal__close"
-            data-close-modal
             onClick={onStay}
             type="button"
           >
@@ -155,6 +157,6 @@ export const LanguagePromptModalView = ({
           </button>
         </div>
       </div>
-    </>
+    </div>
   );
 };

--- a/packages/static-site/components/landing/LanguageSwitcher.tsx
+++ b/packages/static-site/components/landing/LanguageSwitcher.tsx
@@ -1,11 +1,9 @@
 /**
- * Renders the stateless language switcher control for the site header.
+ * Renders the language switcher control for the site header.
  *
- * This presentational atom maps `LANGUAGE_DESCRIPTORS` into a USWDS
- * `usa-language` dropdown. A trigger button opens a `usa-language__submenu`
- * list; the NJWDS bundled `uswds.min.js` language-selector module handles
- * toggle, focus-trap, and keyboard (Escape/Tab) behavior automatically by
- * selecting `button.usa-language__link` within `.usa-language__primary`.
+ * This component maps `LANGUAGE_DESCRIPTORS` into a USWDS `usa-language`
+ * dropdown. A trigger button toggles a `usa-language__submenu` list.
+ * Toggle, keyboard (Escape), and click-outside behavior are managed in React.
  *
  * Each submenu option follows the USWDS pattern:
  *   **Español** (Spanish)
@@ -13,6 +11,9 @@
  * itself which appears without a parenthetical.
  */
 
+"use client";
+
+import { useEffect, useRef, useState } from "react";
 import { LANGUAGE_DESCRIPTORS, type LanguageDescriptor } from "@/domain/i18n/languages";
 import type { AppLocale } from "@/domain/i18n/locales";
 import { Link } from "@/domain/i18n/navigation";
@@ -140,19 +141,50 @@ export const LanguageSwitcher = ({
   descriptors = LANGUAGE_DESCRIPTORS,
   submenuId = DEFAULT_LANGUAGE_SUBMENU_ID,
 }: LanguageSwitcherProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLLIElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("click", handleClickOutside);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("click", handleClickOutside);
+    };
+  }, [isOpen]);
+
   return (
     <nav aria-label={navigationAriaLabel} className="usa-language">
       <ul className="usa-language__primary usa-list--unstyled">
-        <li className="usa-language__primary-item">
+        <li className="usa-language__primary-item" ref={containerRef}>
           <button
             aria-controls={submenuId}
-            aria-expanded="false"
+            aria-expanded={isOpen}
             className="usa-button usa-button--outline usa-language__link"
+            onClick={() => setIsOpen((prev) => !prev)}
             type="button"
           >
             {buttonLabel}
           </button>
-          <ul className="usa-language__submenu nj-dropdown-inline-end" hidden id={submenuId}>
+          <ul
+            className="usa-language__submenu nj-dropdown-inline-end"
+            hidden={!isOpen || undefined}
+            id={submenuId}
+          >
             {descriptors.map((descriptor) => {
               return renderLanguageOption({
                 descriptor,

--- a/packages/static-site/components/learn/IndustrySelector.test.tsx
+++ b/packages/static-site/components/learn/IndustrySelector.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { generateIndustry } from "@/tests/factories";
+import { IndustrySelector } from "./IndustrySelector";
+
+const messages = await getApplicationMessages({ locale: "en-US" });
+const starterKits = messages.learn.starterKits;
+
+const industries = [generateIndustry(), generateIndustry(), generateIndustry()];
+
+const baseUrl = "https://example.com/onboarding";
+
+describe("IndustrySelector", () => {
+  it("renders all industries as listbox options", () => {
+    render(
+      <IndustrySelector
+        industries={industries}
+        baseUrl={baseUrl}
+        heading={starterKits.industrySelectorHeading}
+        ctaText={starterKits.industrySelectorCta}
+      />,
+    );
+
+    const input = screen.getByRole("combobox");
+    fireEvent.click(input);
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(3);
+    const industriesNames = industries.map((industry) => industry.name);
+    expect(options.map((o) => o.textContent)).toEqual(industriesNames);
+  });
+
+  it("renders the CTA as disabled when no industry is selected", () => {
+    render(
+      <IndustrySelector
+        industries={industries}
+        baseUrl={baseUrl}
+        heading={starterKits.industrySelectorHeading}
+        ctaText={starterKits.industrySelectorCta}
+      />,
+    );
+
+    const cta = screen.getByText(starterKits.industrySelectorCta);
+    expect(cta).toHaveAttribute("aria-disabled", "true");
+    expect(cta).not.toHaveAttribute("href");
+  });
+
+  it("enables the CTA with correct href when an industry is selected", () => {
+    render(
+      <IndustrySelector
+        industries={industries}
+        baseUrl={baseUrl}
+        heading={starterKits.industrySelectorHeading}
+        ctaText={starterKits.industrySelectorCta}
+      />,
+    );
+
+    const input = screen.getByRole("combobox");
+    fireEvent.click(input);
+
+    const targetIndustry = industries[0];
+    const option = screen.getByRole("option", { name: targetIndustry.name });
+    fireEvent.click(option);
+
+    const cta = screen.getByRole("link", { name: starterKits.industrySelectorCta });
+    expect(cta).toHaveAttribute("href", `${baseUrl}?industry=${targetIndustry.id}`);
+    expect(cta).toHaveAttribute("aria-disabled", "false");
+  });
+});

--- a/packages/static-site/components/learn/IndustrySelector.tsx
+++ b/packages/static-site/components/learn/IndustrySelector.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { ComboBox } from "@trussworks/react-uswds";
+import { useState } from "react";
+
+interface IndustryOption {
+  readonly id: string;
+  readonly name: string;
+}
+
+interface Props {
+  readonly industries: readonly IndustryOption[];
+  readonly baseUrl: string;
+  readonly heading: string;
+  readonly ctaText: string;
+}
+
+const buildOnboardingHref = (baseUrl: string, industryId: string): string => {
+  const url = new URL(baseUrl);
+  url.searchParams.set("industry", industryId);
+  return url.toString();
+};
+
+export const IndustrySelector = ({ industries, baseUrl, heading, ctaText }: Props) => {
+  const [selectedIndustryId, setSelectedIndustryId] = useState<string | undefined>(undefined);
+
+  const href = selectedIndustryId ? buildOnboardingHref(baseUrl, selectedIndustryId) : undefined;
+
+  const options = industries.map((industry) => ({
+    value: industry.id,
+    label: industry.name,
+  }));
+
+  return (
+    <div className="border-1px border-base-light radius-md padding-3 margin-top-3">
+      <label className="usa-label font-heading-lg text-bold" htmlFor="industry-select">
+        {heading}
+      </label>
+      <div className="grid-row grid-gap flex-align-end">
+        <div className="grid-col-8">
+          <ComboBox
+            id="industry-select"
+            name="industry"
+            options={options}
+            onChange={(val) => setSelectedIndustryId(val)}
+          />
+        </div>
+        <div className="grid-col-4">
+          <a
+            href={href}
+            className={`usa-button width-full${!selectedIndustryId ? " usa-button--disabled" : ""}`}
+            aria-disabled={!selectedIndustryId}
+            style={{ height: "2.5rem" }}
+          >
+            {ctaText}
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/static-site/components/learn/PageSwitchComponent.tsx
+++ b/packages/static-site/components/learn/PageSwitchComponent.tsx
@@ -1,13 +1,18 @@
 import type { ReactElement } from "react";
 import PageContent from "@/components/learn/PageContent";
+import { StarterKitsPage } from "@/components/learn/StarterKitsPage";
 import type { PageItem } from "@/domain/content/types";
+import type { AppLocale } from "@/domain/i18n/locales";
 
 interface Props {
   readonly page: PageItem;
+  readonly locale: AppLocale;
 }
 
-export const PageSwitchComponent = ({ page }: Props): ReactElement => {
+export const PageSwitchComponent = ({ page, locale }: Props): ReactElement => {
   switch (page.slug) {
+    case "starter-kits":
+      return <StarterKitsPage page={page} locale={locale} />;
     default:
       return <PageContent page={page} />;
   }

--- a/packages/static-site/components/learn/PageSwitchComponent.tsx
+++ b/packages/static-site/components/learn/PageSwitchComponent.tsx
@@ -1,0 +1,14 @@
+import type { ReactElement } from "react";
+import PageContent from "@/components/learn/PageContent";
+import type { PageItem } from "@/domain/content/types";
+
+interface Props {
+  readonly page: PageItem;
+}
+
+export const PageSwitchComponent = ({ page }: Props): ReactElement => {
+  switch (page.slug) {
+    default:
+      return <PageContent page={page} />;
+  }
+};

--- a/packages/static-site/components/learn/StarterKitsPage.test.tsx
+++ b/packages/static-site/components/learn/StarterKitsPage.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { loadPageBySlug } from "@/domain/content/loadContent";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { generateIndustry } from "@/tests/factories";
+import { StarterKitsPage } from "./StarterKitsPage";
+
+const messages = await getApplicationMessages({ locale: "en-US" });
+const starterKits = messages.learn.starterKits;
+const page = loadPageBySlug("starter-kits");
+
+const enabledIndustry = generateIndustry({ isEnabled: true });
+const genericIndustry = generateIndustry({ id: "generic", name: "Generic", isEnabled: true });
+
+vi.mock("@/domain/content/loadContent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/domain/content/loadContent")>();
+  return {
+    ...actual,
+    loadIndustries: () => [enabledIndustry, genericIndustry],
+  };
+});
+
+describe("StarterKitsPage", () => {
+  it("does not include the generic industry in the selector", async () => {
+    render(await StarterKitsPage({ page, locale: "en-US" }));
+
+    const input = screen.getByRole("combobox");
+    fireEvent.click(input);
+
+    const options = screen.getAllByRole("option");
+    const optionLabels = options.map((o) => o.textContent);
+
+    expect(optionLabels).toContain(enabledIndustry.name);
+    expect(optionLabels).not.toContain("Generic");
+  });
+
+  it("renders the top industries heading from messages", async () => {
+    render(await StarterKitsPage({ page, locale: "en-US" }));
+
+    expect(
+      screen.getByRole("heading", { name: starterKits.topIndustriesHeading }),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/static-site/components/learn/StarterKitsPage.tsx
+++ b/packages/static-site/components/learn/StarterKitsPage.tsx
@@ -1,0 +1,59 @@
+import { IndustrySelector } from "@/components/learn/IndustrySelector";
+import { loadIndustries } from "@/domain/content/loadContent";
+import type { PageItem } from "@/domain/content/types";
+import { ACCOUNT_APP_URL } from "@/domain/env";
+import type { AppLocale } from "@/domain/i18n/locales";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+
+const ONBOARDING_URL = `${ACCOUNT_APP_URL}/onboarding`;
+
+const buildOnboardingHref = (industryId: string): string => {
+  const url = new URL(ONBOARDING_URL);
+  url.searchParams.set("industry", industryId);
+  return url.toString();
+};
+
+interface Props {
+  readonly page: PageItem;
+  readonly locale: AppLocale;
+}
+
+export const StarterKitsPage = async ({ page, locale }: Props) => {
+  const industries = loadIndustries()
+    .filter((i) => i.id !== "generic")
+    .map((i) => ({ id: i.id, name: i.name }));
+  const messages = await getApplicationMessages({ locale });
+  const starterKitsContent = messages.learn.starterKits;
+
+  return (
+    <article>
+      <h1>{page.name}</h1>
+      {page["sub-heading-text"] && <p className="usa-intro">{page["sub-heading-text"]}</p>}
+
+      <h2>{page["heading-2"]}</h2>
+      {page["main-text-2"] && <p>{page["main-text-2"]}</p>}
+
+      <IndustrySelector
+        industries={industries}
+        baseUrl={ONBOARDING_URL}
+        heading={starterKitsContent.industrySelectorHeading}
+        ctaText={starterKitsContent.industrySelectorCta}
+      />
+
+      <h2 className="margin-top-6">{starterKitsContent.topIndustriesHeading}</h2>
+      <ul className="usa-card-group">
+        {starterKitsContent.topIndustries.map((industry) => (
+          <li key={industry.id} className="usa-card tablet:grid-col-6">
+            <div className="usa-card__container">
+              <div className="usa-card__body">
+                <h3>{industry.name}</h3>
+                <p>{industry.description}</p>
+                <a href={buildOnboardingHref(industry.id)}>{industry.ctaText}</a>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+};

--- a/packages/static-site/domain/content/loadContent.test.ts
+++ b/packages/static-site/domain/content/loadContent.test.ts
@@ -1,0 +1,37 @@
+import fs from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { generateIndustry } from "@/tests/factories";
+import { loadIndustries } from "./loadContent";
+
+const enabledIndustry1 = generateIndustry({ isEnabled: true });
+const disabledIndustry = generateIndustry({ isEnabled: false });
+const enabledIndustry2 = generateIndustry({ isEnabled: true });
+
+const mockIndustryData = JSON.stringify({
+  industries: [enabledIndustry1, disabledIndustry, enabledIndustry2],
+});
+
+describe("loadIndustries", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not return industries where isEnabled is false", () => {
+    vi.spyOn(fs, "readFileSync").mockReturnValue(mockIndustryData);
+
+    const industries = loadIndustries();
+
+    for (const industry of industries) {
+      expect(industry.isEnabled).toBe(true);
+    }
+  });
+
+  it("filters out disabled industries", () => {
+    vi.spyOn(fs, "readFileSync").mockReturnValue(mockIndustryData);
+
+    const industries = loadIndustries();
+
+    expect(industries).toHaveLength(2);
+    expect(industries.map((i) => i.id)).toEqual([enabledIndustry1.id, enabledIndustry2.id]);
+  });
+});

--- a/packages/static-site/domain/content/loadContent.ts
+++ b/packages/static-site/domain/content/loadContent.ts
@@ -107,7 +107,9 @@ const readJsonDirectory = <T>(subdir: string): T[] => {
 };
 
 export const loadIndustries = (): Industry[] =>
-  (readContentJson("industry.json") as { industries: Industry[] }).industries;
+  (readContentJson("industry.json") as { industries: Industry[] }).industries.filter(
+    (industry) => industry.isEnabled,
+  );
 
 export const loadSectors = (): Sector[] =>
   (readContentJson("sectors.json") as { sectors: Sector[] }).sectors;

--- a/packages/static-site/domain/content/messageTypes.ts
+++ b/packages/static-site/domain/content/messageTypes.ts
@@ -469,6 +469,34 @@ export interface LearnCategoryPagesContent {
 }
 
 /**
+ * A featured industry displayed on the starter kits page.
+ */
+export interface StarterKitIndustry {
+  /** Display name of the industry. */
+  readonly name: string;
+  /** Identifier used to construct the onboarding URL. */
+  readonly id: string;
+  /** Short description shown on the industry card. */
+  readonly description: string;
+  /** Label for the card's call-to-action link. */
+  readonly ctaText: string;
+}
+
+/**
+ * Localized content for the starter kits page.
+ */
+export interface StarterKitsContent {
+  /** Heading displayed above the industry dropdown. */
+  readonly industrySelectorHeading: string;
+  /** Button label for the industry selector CTA. */
+  readonly industrySelectorCta: string;
+  /** Heading displayed above the top industries card grid. */
+  readonly topIndustriesHeading: string;
+  /** Featured industries shown as cards below the selector. */
+  readonly topIndustries: readonly StarterKitIndustry[];
+}
+
+/**
  * All localized content needed to render the learn page.
  */
 export interface LearnPageContent {
@@ -486,6 +514,8 @@ export interface LearnPageContent {
   readonly categories: readonly LearnCategory[];
   /** Shared strings used across category pages. */
   readonly categoryPages: LearnCategoryPagesContent;
+  /** Starter kits page content. */
+  readonly starterKits: StarterKitsContent;
 }
 
 /**

--- a/packages/static-site/messages/en-US.json
+++ b/packages/static-site/messages/en-US.json
@@ -289,7 +289,7 @@
         }
       ],
       "usGovernmentSectionAriaLabel": "U.S. government information and services",
-      "usGovernmentDescription": "Copyright \u00a9 2026 State of New Jersey"
+      "usGovernmentDescription": "Copyright © 2026 State of New Jersey"
     }
   },
   "landing": {
@@ -411,7 +411,7 @@
       }
     },
     "whatsNew": {
-      "title": "What\u2019s New",
+      "title": "What’s New",
       "viewAllLink": {
         "label": "View All Updates",
         "href": "/updates",
@@ -529,7 +529,7 @@
   },
   "learn": {
     "name": "Learn",
-    "subHeadingText": "Find guides and resources for every stage \u2014 from your first idea to long-term growth.",
+    "subHeadingText": "Find guides and resources for every stage — from your first idea to long-term growth.",
     "heading2": "Where are you in your business journey?",
     "cardLinkText": "Learn more",
     "categoryPages": {
@@ -590,6 +590,48 @@
           "opensInNewTab": false
         }
       }
-    ]
+    ],
+    "starterKits": {
+      "topIndustries": [
+        {
+          "name": "Online Business",
+          "id": "e-commerce",
+          "description": "Ready to start selling your products and services online? Explore our start-up checklist for potential items to get your business off the ground.",
+          "ctaText": "Online Business Kit"
+        },
+        {
+          "name": "Real Estate Investor",
+          "id": "real-estate-investor",
+          "description": "Get ready to start buying, selling, and renting property in New Jersey. Make sure you have everything you need to start on the right foot.",
+          "ctaText": "Get an Account"
+        },
+        {
+          "name": "Home Contractor",
+          "id": "home-contractor",
+          "description": "If you've got the best product for your New Jersey community, our personalized starter kit can guide you through the registration process!",
+          "ctaText": "Home Contractor Kit"
+        },
+        {
+          "name": "Retail",
+          "id": "retail",
+          "description": "If you've got the best product for your New Jersey community, our personalized starter kit can guide you through the registration process!",
+          "ctaText": "Retail Kit"
+        },
+        {
+          "name": "Healthcare",
+          "id": "healthcare",
+          "description": "If you've got the best product for your New Jersey community, our personalized starter kit can guide you through the registration process!",
+          "ctaText": "Healthcare Kit"
+        },
+        {
+          "name": "Management Consulting",
+          "id": "management-consulting",
+          "description": "If you've got the best product for your New Jersey community, our personalized starter kit can guide you through the registration process!",
+          "ctaText": "Management Consulting Kit"
+        }
+      ],
+      "industrySelectorHeading": "Find Your Industry",
+      "industrySelectorCta": "Go to Starter Kit"
+    }
   }
 }

--- a/packages/static-site/messages/en-US.json
+++ b/packages/static-site/messages/en-US.json
@@ -631,7 +631,8 @@
         }
       ],
       "industrySelectorHeading": "Find Your Industry",
-      "industrySelectorCta": "Go to Starter Kit"
+      "industrySelectorCta": "Go to Starter Kit",
+      "topIndustriesHeading": "Top Industries"
     }
   }
 }

--- a/packages/static-site/messages/es-US.json
+++ b/packages/static-site/messages/es-US.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "title": "Business.NJ.gov | Planifique, Comience y Haga Crecer",
-    "description": "Prototipo de p\u00e1gina principal para una experiencia de orientaci\u00f3n empresarial impulsada por Next.js y NJWDS."
+    "description": "Prototipo de página principal para una experiencia de orientación empresarial impulsada por Next.js y NJWDS."
   },
   "layout": {
     "skipNavigationLabel": "Saltar al contenido principal",
@@ -29,7 +29,7 @@
       }
     },
     "header": {
-      "primaryNavigationAriaLabel": "Navegaci\u00f3n principal",
+      "primaryNavigationAriaLabel": "Navegación principal",
       "homeLink": {
         "label": "Business.NJ.gov",
         "href": "/",
@@ -40,7 +40,7 @@
       "homeLinkAriaLabel": "Inicio de Business.NJ.gov",
       "siteTitle": "Business.NJ.gov",
       "logoAlt": "Business.NJ.gov",
-      "closeButtonAlt": "Cerrar men\u00fa",
+      "closeButtonAlt": "Cerrar menú",
       "primaryItems": [
         {
           "kind": "link",
@@ -91,7 +91,7 @@
     },
     "footer": {
       "returnToTopLabel": "Volver arriba",
-      "navigationAriaLabel": "Navegaci\u00f3n del pie de p\u00e1gina",
+      "navigationAriaLabel": "Navegación del pie de página",
       "primaryLinks": [
         {
           "link": {
@@ -249,7 +249,7 @@
         },
         {
           "link": {
-            "label": "Cont\u00e1ctenos",
+            "label": "Contáctenos",
             "href": "https://nj.gov/nj/feedback.html",
             "isInternal": false,
             "opensInNewTab": false
@@ -265,7 +265,7 @@
         },
         {
           "link": {
-            "label": "Declaraci\u00f3n legal y exenciones",
+            "label": "Declaración legal y exenciones",
             "href": "https://nj.gov/nj/legal.html",
             "isInternal": false,
             "opensInNewTab": false
@@ -281,24 +281,24 @@
         },
         {
           "link": {
-            "label": "Ley de Registros P\u00fablicos Abiertos (OPRA)",
+            "label": "Ley de Registros Públicos Abiertos (OPRA)",
             "href": "https://nj.gov/opra/",
             "isInternal": false,
             "opensInNewTab": false
           }
         }
       ],
-      "usGovernmentSectionAriaLabel": "Informaci\u00f3n y servicios del gobierno de EE. UU.",
-      "usGovernmentDescription": "Copyright \u00a9 2026 Estado de New Jersey"
+      "usGovernmentSectionAriaLabel": "Información y servicios del gobierno de EE. UU.",
+      "usGovernmentDescription": "Copyright © 2026 Estado de New Jersey"
     }
   },
   "landing": {
     "hero": {
-      "sectionAriaLabel": "Introducci\u00f3n",
+      "sectionAriaLabel": "Introducción",
       "title": "Las necesidades de su negocio en New Jersey. Todo en un solo lugar.",
-      "paragraph": "Obtenga su gu\u00eda personalizada para comenzar su negocio, encuentre oportunidades de financiamiento y descubra sus obligaciones fiscales.",
+      "paragraph": "Obtenga su guía personalizada para comenzar su negocio, encuentre oportunidades de financiamiento y descubra sus obligaciones fiscales.",
       "callToActionLink": {
-        "label": "Obtenga su gu\u00eda personalizada",
+        "label": "Obtenga su guía personalizada",
         "href": "https://account.business.nj.gov/onboarding",
         "isInternal": false,
         "opensInNewTab": true
@@ -306,7 +306,7 @@
       "carouselImages": [
         {
           "src": "/img/hero/image_1.png",
-          "alt": "Una mujer sonriendo mientras trabaja en su computadora port\u00e1til en casa."
+          "alt": "Una mujer sonriendo mientras trabaja en su computadora portátil en casa."
         },
         {
           "src": "/img/hero/image_2.png",
@@ -318,19 +318,19 @@
         },
         {
           "src": "/img/hero/image_4.png",
-          "alt": "El due\u00f1o de un restaurante de New Jersey preparando comida."
+          "alt": "El dueño de un restaurante de New Jersey preparando comida."
         }
       ]
     },
     "quickServices": {
-      "title": "Servicios r\u00e1pidos",
+      "title": "Servicios rápidos",
       "subtitle": "Acceda a servicios empresariales populares",
       "items": [
         {
           "title": "Registro empresarial",
-          "description": "Inicie su LLC, corporaci\u00f3n o sociedad",
+          "description": "Inicie su LLC, corporación o sociedad",
           "iconPath": "/img/checklist.svg",
-          "iconAlt": "Icono de lista de verificaci\u00f3n",
+          "iconAlt": "Icono de lista de verificación",
           "link": {
             "label": "Registro empresarial",
             "href": "/pages/register-your-business",
@@ -342,7 +342,7 @@
           "title": "Licencias y permisos",
           "description": "Solicite las licencias comerciales requeridas",
           "iconPath": "/img/planning.svg",
-          "iconAlt": "Icono de planificaci\u00f3n",
+          "iconAlt": "Icono de planificación",
           "link": {
             "label": "Licencias y permisos",
             "href": "/pages/licensing-and-certification-guide",
@@ -364,7 +364,7 @@
         },
         {
           "title": "Presente su informe anual",
-          "description": "Nunca pierda una fecha l\u00edmite",
+          "description": "Nunca pierda una fecha límite",
           "iconPath": "/img/arrow.svg",
           "iconAlt": "Icono de flecha",
           "link": {
@@ -378,7 +378,7 @@
           "title": "Obligaciones del empleador",
           "description": "Registro y recursos para empleadores",
           "iconPath": "/img/shaking_hands.svg",
-          "iconAlt": "Icono de apret\u00f3n de manos",
+          "iconAlt": "Icono de apretón de manos",
           "link": {
             "label": "Obligaciones del empleador",
             "href": "/pages/employer-requirements",
@@ -401,8 +401,8 @@
       ]
     },
     "ctaBanner": {
-      "title": "Acceda a su informaci\u00f3n empresarial personalizada",
-      "subtitle": "\u00a1Comience y haga crecer su negocio en New Jersey o fuera del estado con su cuenta de Business.NJ.gov hoy!",
+      "title": "Acceda a su información empresarial personalizada",
+      "subtitle": "¡Comience y haga crecer su negocio en New Jersey o fuera del estado con su cuenta de Business.NJ.gov hoy!",
       "callToActionLink": {
         "label": "Crear cuenta",
         "href": "https://account.business.nj.gov/onboarding",
@@ -420,14 +420,14 @@
       }
     },
     "support": {
-      "title": "M\u00e1s apoyo",
-      "description": "\u00bfBusca asesor\u00eda m\u00e1s especializada? Pruebe nuestras gu\u00edas gratuitas y personalizadas de registro empresarial en l\u00ednea, hable con un representante en nuestro chat o reg\u00edstrese para recibir actualizaciones empresariales directamente en su correo electr\u00f3nico. Tambi\u00e9n est\u00e1 disponible una versi\u00f3n impresa y digital de nuestro [Manual para peque\u00f1as empresas](https://cdn.prod.website-files.com/5e31b06cb76b830809358a75/662a750614519d466e63f6c7_NJ_Small_Business_Manual_for_download.pdf).",
+      "title": "Más apoyo",
+      "description": "¿Busca asesoría más especializada? Pruebe nuestras guías gratuitas y personalizadas de registro empresarial en línea, hable con un representante en nuestro chat o regístrese para recibir actualizaciones empresariales directamente en su correo electrónico. También está disponible una versión impresa y digital de nuestro [Manual para pequeñas empresas](https://cdn.prod.website-files.com/5e31b06cb76b830809358a75/662a750614519d466e63f6c7_NJ_Small_Business_Manual_for_download.pdf).",
       "cards": [
         {
           "title": "Su cuenta de Business.NJ.gov",
-          "description": "Obtenga una gu\u00eda gratuita y personalizada paso a paso para iniciar su negocio en New Jersey.",
+          "description": "Obtenga una guía gratuita y personalizada paso a paso para iniciar su negocio en New Jersey.",
           "iconPath": "/img/navigation.svg",
-          "iconAlt": "Icono de navegaci\u00f3n",
+          "iconAlt": "Icono de navegación",
           "link": {
             "label": "Su cuenta de Business.NJ.gov",
             "href": "https://account.business.nj.gov/",
@@ -437,7 +437,7 @@
         },
         {
           "title": "Apoyo individual",
-          "description": "Converse con un asesor empresarial con d\u00e9cadas de experiencia, de 9a.m. a 5p.m. de lunes a viernes.",
+          "description": "Converse con un asesor empresarial con décadas de experiencia, de 9a.m. a 5p.m. de lunes a viernes.",
           "iconPath": "/img/hands.svg",
           "iconAlt": "Icono de manos",
           "link": {
@@ -448,12 +448,12 @@
           }
         },
         {
-          "title": "Bolet\u00edn empresarial",
-          "description": "Mant\u00e9ngase al d\u00eda sobre programas o regulaciones anunciados recientemente que puedan afectar su negocio.",
+          "title": "Boletín empresarial",
+          "description": "Manténgase al día sobre programas o regulaciones anunciados recientemente que puedan afectar su negocio.",
           "iconPath": "/img/piechart.svg",
-          "iconAlt": "Icono de gr\u00e1fico",
+          "iconAlt": "Icono de gráfico",
           "link": {
-            "label": "Bolet\u00edn empresarial",
+            "label": "Boletín empresarial",
             "href": "https://business.nj.gov/newsletter",
             "isInternal": false,
             "opensInNewTab": true
@@ -476,22 +476,22 @@
           }
         },
         {
-          "name": "Centro de Acci\u00f3n Empresarial de New Jersey",
+          "name": "Centro de Acción Empresarial de New Jersey",
           "logo": "/img/njbac_logo.png",
-          "logoAlt": "Logotipo del Centro de Acci\u00f3n Empresarial de New Jersey",
+          "logoAlt": "Logotipo del Centro de Acción Empresarial de New Jersey",
           "link": {
-            "label": "Centro de Acci\u00f3n Empresarial de New Jersey",
+            "label": "Centro de Acción Empresarial de New Jersey",
             "href": "https://www.nj.gov/state/bac/bac.shtml",
             "isInternal": false,
             "opensInNewTab": true
           }
         },
         {
-          "name": "Autoridad de Desarrollo Econ\u00f3mico de New Jersey",
+          "name": "Autoridad de Desarrollo Económico de New Jersey",
           "logo": "/img/njeda_logo.png",
-          "logoAlt": "Logotipo de la Autoridad de Desarrollo Econ\u00f3mico de New Jersey",
+          "logoAlt": "Logotipo de la Autoridad de Desarrollo Económico de New Jersey",
           "link": {
-            "label": "Autoridad de Desarrollo Econ\u00f3mico de New Jersey",
+            "label": "Autoridad de Desarrollo Económico de New Jersey",
             "href": "https://www.njeda.com/",
             "isInternal": false,
             "opensInNewTab": true
@@ -509,11 +509,11 @@
           }
         },
         {
-          "name": "Oficina de Innovaci\u00f3n",
+          "name": "Oficina de Innovación",
           "logo": "/img/nj_logo.svg",
-          "logoAlt": "Logotipo de la Oficina de Innovaci\u00f3n de New Jersey",
+          "logoAlt": "Logotipo de la Oficina de Innovación de New Jersey",
           "link": {
-            "label": "Oficina de Innovaci\u00f3n",
+            "label": "Oficina de Innovación",
             "href": "https://innovation.nj.gov/",
             "isInternal": false,
             "opensInNewTab": true
@@ -522,8 +522,8 @@
       ]
     },
     "feedbackBar": {
-      "question": "\u00bfEncontr\u00f3 lo que buscaba en esta p\u00e1gina?",
-      "yesLabel": "S\u00ed",
+      "question": "¿Encontró lo que buscaba en esta página?",
+      "yesLabel": "Sí",
       "noLabel": "No"
     }
   },
@@ -590,6 +590,48 @@
           "opensInNewTab": false
         }
       }
-    ]
+    ],
+    "starterKits": {
+      "topIndustries": [
+        {
+          "name": "Online Business",
+          "id": "e-commerce",
+          "description": "Ready to start selling your products and services online? Explore our start-up checklist for potential items to get your business off the ground.",
+          "ctaText": "Online Business Kit"
+        },
+        {
+          "name": "Real Estate Investor",
+          "id": "real-estate-investor",
+          "description": "Get ready to start buying, selling, and renting property in New Jersey. Make sure you have everything you need to start on the right foot.",
+          "ctaText": "Get an Account"
+        },
+        {
+          "name": "Home Contractor",
+          "id": "home-contractor",
+          "description": "If you've got the best product for your New Jersey community, our personalized starter kit can guide you through the registration process!",
+          "ctaText": "Home Contractor Kit"
+        },
+        {
+          "name": "Retail",
+          "id": "retail",
+          "description": "If you've got the best product for your New Jersey community, our personalized starter kit can guide you through the registration process!",
+          "ctaText": "Retail Kit"
+        },
+        {
+          "name": "Healthcare",
+          "id": "healthcare",
+          "description": "If you've got the best product for your New Jersey community, our personalized starter kit can guide you through the registration process!",
+          "ctaText": "Healthcare Kit"
+        },
+        {
+          "name": "Management Consulting",
+          "id": "management-consulting",
+          "description": "If you've got the best product for your New Jersey community, our personalized starter kit can guide you through the registration process!",
+          "ctaText": "Management Consulting Kit"
+        }
+      ],
+      "industrySelectorHeading": "Find Your Industry",
+      "industrySelectorCta": "Go to Starter Kit"
+    }
   }
 }

--- a/packages/static-site/messages/es-US.json
+++ b/packages/static-site/messages/es-US.json
@@ -631,7 +631,8 @@
         }
       ],
       "industrySelectorHeading": "Find Your Industry",
-      "industrySelectorCta": "Go to Starter Kit"
+      "industrySelectorCta": "Go to Starter Kit",
+      "topIndustriesHeading": "Top Industries"
     }
   }
 }

--- a/packages/static-site/tests/factories.ts
+++ b/packages/static-site/tests/factories.ts
@@ -1,0 +1,21 @@
+import type { Industry } from "@/domain/content/types";
+
+// biome-ignore lint/style/noProcessEnv: test factories read seed from environment for reproducibility
+const seed = Number(process.env.TEST_SEED) || Math.floor(Math.random() * 2 ** 32);
+
+let state = seed;
+export const randomInt = (length = 8): number => {
+  state = (state * 1664525 + 1013904223) >>> 0;
+  return Math.floor((state / 2 ** 32) * (10 ** length - 10 ** (length - 1)) + 10 ** (length - 1));
+};
+
+export const generateIndustry = (overrides: Partial<Industry> = {}): Industry => {
+  return {
+    id: `industry-${randomInt()}`,
+    name: `Test Industry ${randomInt()}`,
+    canHavePermanentLocation: true,
+    roadmapSteps: [],
+    isEnabled: true,
+    ...overrides,
+  };
+};

--- a/packages/static-site/vitest.config.mts
+++ b/packages/static-site/vitest.config.mts
@@ -1,6 +1,11 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
+// biome-ignore lint/style/noProcessEnv: test config reads seed from environment for reproducibility
+const TEST_SEED = process.env.TEST_SEED || String(Math.floor(Math.random() * 2 ** 32));
+// biome-ignore lint/suspicious/noConsole: seed must be logged for test reproducibility
+console.log(`[test] seed: ${TEST_SEED}`);
+
 const vitestConfig = defineConfig({
   plugins: [react()],
   resolve: {
@@ -22,7 +27,7 @@ const vitestConfig = defineConfig({
     environment: "jsdom",
     // Default to multilingual enabled so tests that exercise the full locale set
     // keep passing. Flag-OFF tests override this with vi.stubEnv per case.
-    env: { NEXT_PUBLIC_MULTILINGUAL_ENABLED: "true" },
+    env: { NEXT_PUBLIC_MULTILINGUAL_ENABLED: "true", TEST_SEED },
     globals: true,
     setupFiles: ["./vitest.setup.ts"],
   },


### PR DESCRIPTION
## Description

Add a Starter Kits page to the static site with an industry selector combo-box and Top Industries card grid. Replace USWDS JavaScript with React-managed state for all interactive components (header accordion, language switcher, modal, combo-box) using `@trussworks/react-uswds`.

### Ticket

This pull request resolves [#17828](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17828).

### Approach

**Starter Kits Page:**
- Added `PageSwitchComponent` to route specific page slugs to custom components instead of the default markdown renderer
- Created `StarterKitsPage` (async server component) that loads industries and localized messages
- Created `IndustrySelector` (client component) using `@trussworks/react-uswds` `ComboBox`
- Onboarding URLs built with the `URL` API for safe encoding, sourced from `ACCOUNT_APP_URL` in `domain/env.ts`
- Slimmed industry data to `{ id, name }` before passing across the RSC boundary
- All user-facing strings (headings, CTA text, top industries) stored in `messages/*.json` for translation

**USWDS JS Removal:**
- Removed `uswds.min.js` script from the layout — all interactive behavior now owned by React
- `HeaderPrimaryNav`: submenu accordion toggle managed via `useState`
- `LanguageSwitcher`: dropdown visibility, Escape key, and click-outside handled in React
- `LanguagePromptModalView`: replaced `data-open-modal`/`data-close-modal` with an `isOpen` prop pattern; manages focus and Escape key in React
- Added `.usa-nav` CSS override for desktop visibility (previously set by USWDS JS `is-visible` class)

**Other:**
- Added `isEnabled` to the `Industry` type in `content-types`
- `loadIndustries` filters out disabled industries
- Test factories use a seeded PRNG with a single seed per run (logged for reproducibility)
- Updated README with test seed documentation

### Steps to Test

1. Navigate to `/en-US/pages/starter-kits`
2. Verify the heading, sub-heading, h2, and description render correctly
3. Open the industry dropdown — all enabled industries should appear (not "Generic")
4. Select an industry and click "Go to Starter Kit" — should navigate to the onboarding URL with `?industry={id}`
5. Verify "Top Industries" cards render with correct links
6. Navigate to the page via in-app link — combo-box should work without a full page reload
7. Verify the desktop header submenu (Learn/Updates accordion) toggles on click
8. Verify the language switcher dropdown opens/closes and responds to Escape key
9. Test on mobile: hamburger menu, account drawer, and language picker should function normally

### Notes

- `@trussworks/react-uswds` is used only for the `ComboBox` component. The header accordion, language switcher, and modal use custom React state since they have NJ-specific markup that differs from upstream USWDS.
- NJWDS CSS remains for all styling. Only the JavaScript was removed.
- The `uswds-init.js` script is no longer loaded either (it only set/cleared `usa-js-loading` for the main script).

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [ ] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews