### PR TITLE
fix: language modal switch crashes destination page

### DIFF
--- a/packages/static-site/components/landing/LanguagePromptModal.test.tsx
+++ b/packages/static-site/components/landing/LanguagePromptModal.test.tsx
@@ -1,8 +1,9 @@
+/** biome-ignore-all lint/suspicious/noDocumentCookie: tests set and clear cookies directly to drive the modal's dismissal state. */
 import { render, screen } from "@testing-library/react";
 import { useLocale } from "next-intl";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { usePathname, useRouter } from "@/domain/i18n/navigation";
-import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+import { usePathname } from "@/domain/i18n/navigation";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE, NEXT_LOCALE_COOKIE_NAME } from "@/domain/siteConfig";
 import { LanguagePromptModal } from "./LanguagePromptModal";
 
 vi.mock("next-intl", () => {
@@ -11,8 +12,7 @@ vi.mock("next-intl", () => {
 
 const mockedUseLocale = vi.mocked(useLocale);
 const mockedUsePathname = vi.mocked(usePathname);
-const mockedUseRouter = vi.mocked(useRouter);
-const replaceMock = vi.fn();
+const assignMock = vi.fn();
 
 /**
  * Overrides the browser's reported language preferences for one test.
@@ -29,10 +29,12 @@ const renderModal = () => render(<LanguagePromptModal />);
 describe("LanguagePromptModal", () => {
   beforeEach(() => {
     mockedUsePathname.mockReturnValue("/learn");
-    mockedUseRouter.mockReturnValue({
-      replace: replaceMock,
-    } as unknown as ReturnType<typeof useRouter>);
+    Object.defineProperty(window, "location", {
+      value: { assign: assignMock },
+      writable: true,
+    });
     document.cookie = `${LANGUAGE_PROMPT_DISMISSED_COOKIE}=; max-age=0; path=/`;
+    document.cookie = `${NEXT_LOCALE_COOKIE_NAME}=; max-age=0; path=/`;
   });
 
   afterEach(() => {
@@ -79,10 +81,10 @@ describe("LanguagePromptModal", () => {
     screen.getByRole("button", { name: /Permanecer/i }).click();
 
     expect(document.cookie).toContain(`${LANGUAGE_PROMPT_DISMISSED_COOKIE}=true`);
-    expect(replaceMock).not.toHaveBeenCalled();
+    expect(assignMock).not.toHaveBeenCalled();
   });
 
-  it("navigates to the preferred locale and sets the dismissal cookie when switching", () => {
+  it("navigates to the preferred locale and sets the cookies when switching", () => {
     mockedUseLocale.mockReturnValue("en-US");
     setBrowserLanguages(["es-US"]);
 
@@ -90,6 +92,7 @@ describe("LanguagePromptModal", () => {
     screen.getByRole("button", { name: /Español/ }).click();
 
     expect(document.cookie).toContain(`${LANGUAGE_PROMPT_DISMISSED_COOKIE}=true`);
-    expect(replaceMock).toHaveBeenCalledWith("/learn", { locale: "es-US" });
+    expect(document.cookie).toContain(`${NEXT_LOCALE_COOKIE_NAME}=es-US`);
+    expect(assignMock).toHaveBeenCalledWith("/es-US/learn");
   });
 });

--- a/packages/static-site/components/landing/LanguagePromptModal.tsx
+++ b/packages/static-site/components/landing/LanguagePromptModal.tsx
@@ -8,7 +8,8 @@
  * current one and the dismissal cookie is absent, it opens the NJWDS modal
  * offering to stay or switch. It never redirects automatically. The visitor's
  * choice is recorded in a dismissal cookie so they are not prompted again; the
- * switch action also persists `NEXT_LOCALE` via the next-intl router.
+ * switch action also persists `NEXT_LOCALE` and performs a full-page navigation
+ * to the target locale.
  *
  * The entire dialog is shown in the preferred/target language so the visitor
  * — who may not read the current page's locale — can understand the prompt.
@@ -21,9 +22,9 @@ import { LANGUAGE_DESCRIPTORS } from "@/domain/i18n/languages";
 import { addLocalePrefix, stripLocalePrefix } from "@/domain/i18n/localePath";
 import { type AppLocale, resolveAppLocale } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
-import { usePathname, useRouter } from "@/domain/i18n/navigation";
+import { usePathname } from "@/domain/i18n/navigation";
 import { resolvePreferredLocale } from "@/domain/i18n/preferredLocale";
-import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE, NEXT_LOCALE_COOKIE_NAME } from "@/domain/siteConfig";
 import { LanguagePromptModalView } from "./LanguagePromptModalView";
 
 /**
@@ -66,6 +67,7 @@ const hasDismissalCookie = (): boolean => {
  * @param value Cookie value to store.
  */
 const writeCookie = (name: string, value: string): void => {
+  // biome-ignore lint/suspicious/noDocumentCookie: a synchronous write is required here; the async Cookie Store API would let navigation race ahead of the cookie persisting.
   document.cookie = `${name}=${value}; path=/; max-age=${ONE_YEAR_IN_SECONDS}; samesite=lax`;
 };
 
@@ -93,7 +95,6 @@ const nativeNameOfLocale = (locale: AppLocale): string => {
 export const LanguagePromptModal = () => {
   const currentLocale = resolveAppLocale({ locale: useLocale() });
   const pathname = usePathname();
-  const router = useRouter();
   const openTriggerRef = useRef<HTMLButtonElement>(null);
   const [preferredLocale, setPreferredLocale] = useState<AppLocale | undefined>(undefined);
 
@@ -125,17 +126,20 @@ export const LanguagePromptModal = () => {
     }
 
     writeCookie(LANGUAGE_PROMPT_DISMISSED_COOKIE, "true");
+    writeCookie(NEXT_LOCALE_COOKIE_NAME, preferredLocale);
 
-    const targetPathname = stripLocalePrefix(pathname);
-
-    try {
-      router.replace(targetPathname, { locale: preferredLocale });
-    } catch {
-      window.location.assign(
-        addLocalePrefix({ pathnameWithoutLocale: targetPathname, locale: preferredLocale }),
-      );
-    }
-  }, [pathname, preferredLocale, router]);
+    // Use a full-page navigation rather than a client-side router transition.
+    // The open NJWDS modal hoists its DOM node out of React's tree into a
+    // body-level wrapper; a client-side re-render then tries to unmount a node
+    // React no longer owns, throwing a `removeChild` NotFoundError that trips
+    // the framework error boundary.
+    window.location.assign(
+      addLocalePrefix({
+        pathnameWithoutLocale: stripLocalePrefix(pathname),
+        locale: preferredLocale,
+      }),
+    );
+  }, [pathname, preferredLocale]);
 
   if (!preferredLocale) {
     return null;

--- a/packages/static-site/components/landing/LanguageSwitcher.test.tsx
+++ b/packages/static-site/components/landing/LanguageSwitcher.test.tsx
@@ -57,6 +57,7 @@ const renderSwitcher = ({ currentLocale, pathname, descriptors }: RenderSwitcher
   );
 };
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: test suite
 describe("LanguageSwitcher", () => {
   it("renders the trigger button with the button label", () => {
     renderSwitcher({ currentLocale: "en-US", pathname: "/learn" });

--- a/packages/static-site/components/learn/PageContent.test.tsx
+++ b/packages/static-site/components/learn/PageContent.test.tsx
@@ -1,4 +1,4 @@
-/** biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: <explanation> */
+/** biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: test suite */
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { PageItem } from "@/domain/content/types";

--- a/packages/static-site/tests/e2e/languagePromptModalRedirect.e2e.spec.ts
+++ b/packages/static-site/tests/e2e/languagePromptModalRedirect.e2e.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Verifies that switching language from the preferred-language *modal* loads the
+ * destination page cleanly. The modal-driven switch is a distinct code path from
+ * the header switcher: the open NJWDS modal hoists its DOM node to <body>, so a
+ * client-side router transition would unmount a node React no longer owns and
+ * trip the framework error boundary. This suite guards against that regression
+ * by asserting the destination renders real content, not the error screen.
+ */
+
+const MODAL = "#language-prompt-modal";
+
+// Force a browser language that differs from the visited (es-US) page so the
+// preferred-language modal opens on load.
+test.use({ locale: "en-US" });
+
+test.describe("language prompt modal redirect", () => {
+  test("switching to English from the modal loads the page without an error boundary", async ({
+    page,
+  }) => {
+    await page.goto("/es-US/plan");
+
+    await expect(page.locator(MODAL)).toBeVisible();
+    await page.locator(`${MODAL} button`, { hasText: "Switch to English" }).click();
+
+    await expect(page).toHaveURL(/\/plan$/);
+    await expect(page.locator("html")).toHaveAttribute("lang", "en-US");
+    await expect(page.getByRole("heading", { level: 1, name: "Plan" })).toBeVisible();
+    await expect(page.getByText(/couldn’t load/i)).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Description

The preferred-language modal (shown when a visitor's browser language differs from the page locale) crashed the destination page when clicking "Switch to English/Español". The browser navigated to the target URL but rendered Next.js's bare error screen ("This page couldn't load") with no CSS, instead of the page.

Root cause: the modal's switch used a **client-side** `router.replace`. The NJWDS runtime (`uswds.min.js`) initializes the modal by physically moving its DOM node out of React's tree into a `.usa-modal-wrapper` appended to `<body>`. The client-side transition then unmounts the modal's subtree, React calls `removeChild` on the relocated node, and throws `DOMException: NotFoundError`. That uncaught commit-phase error trips Next's default error boundary, which renders outside the locale layout — hence the missing CSS.

The fix replaces the client-side transition with a full-page `window.location.assign`, so React never reconciles the hoisted node out of a live tree. The `NEXT_LOCALE` cookie is set explicitly to preserve the locale preference `router.replace` used to persist.

### Approach

- `LanguagePromptModal.tsx`: `handleRedirect` now writes the `NEXT_LOCALE` cookie (via existing `NEXT_LOCALE_COOKIE_NAME`) and navigates with `window.location.assign(addLocalePrefix(...))`, reusing the existing `localePath` helpers. Removed the now-dead `useRouter`/`try-catch` (the exception was thrown async in React's commit phase, so the catch never fired).
- Updated unit tests to assert on `window.location.assign` + cookie state.
- Added `tests/e2e/languagePromptModalRedirect.e2e.spec.ts` driving the **modal** path (forcing `locale: "en-US"` so the modal opens on `/es-US/plan`) and asserting the destination renders real content, not the error boundary. The existing switcher e2e suite suppressed the modal via cookie, which is why this regression slipped through.

### Steps to Test

1. `pnpm dev` in `packages/static-site` (browser language = English).
2. Visit `/es-US/plan` → the modal auto-opens; click "Switch to English".
3. Confirm: lands on `/plan`, English content, CSS present, no error screen, no `NotFoundError` in the console.
4. Reverse direction (Spanish browser → `/plan` → "Cambiar a Español") works too.

### Notes

- A full reload on language switch is acceptable (arguably preferable) here. The SPA-preserving alternative would require stopping NJWDS from hoisting the node (React portal or tearing down the NJWDS modal instance before navigating) — a larger change.
- `pnpm lint`, `pnpm typecheck`, `pnpm test` (99 pass/1 skip), and both e2e specs pass.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
