### PR TITLE
fix: restore automated content environment deploys

### DIFF
--- a/.github/workflows/merge-content.yml
+++ b/.github/workflows/merge-content.yml
@@ -35,3 +35,11 @@ jobs:
 
       - name: Push merged branch
         run: git push origin content-repo
+
+  deploy-content:
+    needs: merge-content
+    uses: newjersey/navigator.business.nj.gov/.github/workflows/deploy-content-environment.yml@main
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write


### PR DESCRIPTION
## Description

Content environment deployments (`content.account.business.nj.gov`, `content.api.account.business.nj.gov`, `content.next.business.nj.gov`) have been silently broken since 2025-12-17 — no automated content deploy has run since 2026-06-05.

### Approach

**Root cause:** `merge-content.yml` pushes to `content-repo` using the default `GITHUB_TOKEN`. GitHub does not trigger new workflow runs from `GITHUB_TOKEN` pushes (loop prevention), so `build-and-test.yml`'s `deploy-content` job — which depends on a `content-repo` push event — never fires automatically.

The fix restores the `deploy-content` job directly inside `merge-content.yml` as a second job (`needs: merge-content`). This was the original working design before commit `5580ffa31` removed it. Now the content deploy runs in the same workflow as the merge, requiring no additional trigger.

The `deploy-content` job in `build-and-test.yml` remains but is effectively dead code (its trigger path still doesn't work) — it can be cleaned up in a follow-up.

### Steps to Test

After merging, the next commit to `main` will trigger `merge-content.yml`. Confirm:
1. The `deploy-content` job appears as a second job in the `merge-content.yml` run.
2. All three content sites are redeployed successfully.
3. \`gh api "repos/newjersey/navigator.business.nj.gov/deployments?per_page=3&environment=content" --jq '.[].created_at'\` shows a new deployment timestamp.

### Notes

- Manual pushes to `content-repo` (e.g. from a PR merged directly into that branch) continue to work via `build-and-test.yml` as they always have.
- The static site deploy step has been present in `deploy-content-environment.yml` since `e79965df7` (2026-05-14) — this fix simply ensures it now gets called.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in \`userData\` (including \`profileData\`, \`formationData\` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and \`cmsCollections.ts\` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant \`.env\` values in \`.env-template\`, in Bitwarden, and in our workspaces
- [x] I have added the \`pr-show\` or \`pr-review\` label on GitHub to show or request reviews