### PR TITLE
chore: preserve expiring DB backups in CI pipeline

### DIFF
--- a/.github/actions/deploy-cdk/action.yml
+++ b/.github/actions/deploy-cdk/action.yml
@@ -62,3 +62,65 @@ runs:
           --verbose \
           --region us-east-1 \
           --require-approval never
+
+    - name: Preserve expiring backup recovery points
+      shell: bash
+      run: |
+        VAULT_NAME="BizX_dynamodb_backups"
+        CUTOFF_DATE=$(date -u -d "+30 days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v+30d +%Y-%m-%dT%H:%M:%SZ)
+
+        echo "Removing deletion deadline from recovery points expiring before $CUTOFF_DATE"
+
+        ARNS=$(aws backup list-recovery-points-by-backup-vault \
+          --backup-vault-name "$VAULT_NAME" \
+          --region us-east-1 \
+          --query "RecoveryPoints[?Lifecycle.DeleteAt<='${CUTOFF_DATE}'].RecoveryPointArn" \
+          --output text)
+
+        if [ -z "$ARNS" ] || [ "$ARNS" = "None" ]; then
+          echo "No recovery points expiring within 30 days."
+          exit 0
+        fi
+
+        for ARN in $ARNS; do
+          echo "Extending: $ARN"
+          aws backup update-recovery-point-lifecycle \
+            --backup-vault-name "$VAULT_NAME" \
+            --recovery-point-arn "$ARN" \
+            --lifecycle '{"MoveToColdStorageAfterDays": 14}' \
+            --region us-east-1
+        done
+
+        echo "Done. Extended $(echo "$ARNS" | wc -w | tr -d ' ') recovery points."
+
+    # Uncomment the step below to reapply the 6-month deletion policy to
+    # recovery points that were previously set to retain forever.
+    #
+    # - name: Reapply 6-month retention to preserved recovery points
+    #   shell: bash
+    #   run: |
+    #     VAULT_NAME="BizX_dynamodb_backups"
+    #
+    #     echo "Reapplying 180-day retention to recovery points with no deletion date"
+    #
+    #     ARNS=$(aws backup list-recovery-points-by-backup-vault \
+    #       --backup-vault-name "$VAULT_NAME" \
+    #       --region us-east-1 \
+    #       --query "RecoveryPoints[?!Lifecycle.DeleteAt].RecoveryPointArn" \
+    #       --output text)
+    #
+    #     if [ -z "$ARNS" ] || [ "$ARNS" = "None" ]; then
+    #       echo "No recovery points without a deletion date."
+    #       exit 0
+    #     fi
+    #
+    #     for ARN in $ARNS; do
+    #       echo "Reapplying retention: $ARN"
+    #       aws backup update-recovery-point-lifecycle \
+    #         --backup-vault-name "$VAULT_NAME" \
+    #         --recovery-point-arn "$ARN" \
+    #         --lifecycle '{"MoveToColdStorageAfterDays": 14, "DeleteAfterDays": 180}' \
+    #         --region us-east-1
+    #     done
+    #
+    #     echo "Done. Updated $(echo "$ARNS" | wc -w | tr -d ' ') recovery points."


### PR DESCRIPTION
## Description

Adds a post-CDK-deploy pipeline step that removes the deletion deadline from DynamoDB backup recovery points expiring within 30 days. This preserves backups for an external processing workflow before they reach their 6-month retention limit. 

This is being done explicitly to preserve database backups that might otherwise be deleted so that they can be processed by the data warehouse.

Includes a commented-out step to reapply the 180-day retention policy when ready to revert this change.

### Ticket

This pull request resolves [#0000](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/0000).

### Approach

- Added a new step to `.github/actions/deploy-cdk/action.yml` that runs after CDK deploy
- Uses `aws backup list-recovery-points-by-backup-vault` to find recovery points with a `DeleteAt` within 30 days
- Calls `update-recovery-point-lifecycle` to remove the deletion date while keeping the 14-day cold storage transition
- Commented-out reverse step queries for recovery points with no deletion date and reapplies 180-day retention

### Steps to Test

1. Trigger a deploy on a non-prod environment with the BackupStack enabled
2. Verify the step runs and reports the number of recovery points extended (or "No recovery points expiring within 30 days")
3. Confirm in the AWS console that affected recovery points no longer have a deletion date

### Notes

- The backup plan rule in `backupStack.ts` still retains the 180-day `deleteAfter` — new backups continue to get a deadline, but the pipeline step catches them before deletion
- When the external workflow is complete, uncomment the reapply step and remove the preserve step
- Requires the pipeline's IAM role to have `backup:ListRecoveryPointsByBackupVault` and `backup:UpdateRecoveryPointLifecycle` permissions

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [X] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews