### PR TITLE
feat: [AB#17822] add funding page to static site

### DIFF
--- a/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.test.tsx
+++ b/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
 import { describe, expect, it, vi } from "vitest";
+import { getApplicationMessages } from "@/domain/i18n/messages";
 import ContentPage, { generateStaticParams } from "./page";
 
 vi.mock("@/domain/categories", () => ({
@@ -19,10 +21,14 @@ vi.mock("@/domain/categories", () => ({
 vi.mock("@/domain/content/loadContent", () => ({
   loadPageBySlug: (slug: string) => ({
     slug,
-    name: "Create a Business Plan",
-    category: "plan",
+    name: slug === "funding" ? "Funding" : "Create a Business Plan",
+    category: slug === "funding" ? "grow" : "plan",
+    "sub-heading-text":
+      slug === "funding" ? "Whether you're looking for startup capital..." : undefined,
   }),
   loadIndustries: () => [],
+  loadFundings: () => [],
+  loadSectors: () => [],
 }));
 
 describe("generateStaticParams", () => {
@@ -52,5 +58,22 @@ describe("ContentPage", () => {
     expect(
       screen.getByRole("heading", { level: 1, name: "Create a Business Plan" }),
     ).toBeInTheDocument();
+  });
+});
+
+describe("ContentPage — funding slug", () => {
+  it("renders FundingPageContent for the funding slug", async () => {
+    const page = await ContentPage({
+      params: Promise.resolve({
+        locale: "en-US",
+        slug: "funding",
+      }),
+    });
+    render(
+      <NextIntlClientProvider locale="en-US" messages={getApplicationMessages({ locale: "en-US" })}>
+        {page}
+      </NextIntlClientProvider>,
+    );
+    expect(screen.getByRole("heading", { level: 1, name: "Funding" })).toBeInTheDocument();
   });
 });

--- a/packages/static-site/app/[locale]/layout.tsx
+++ b/packages/static-site/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@
 import "@/app/globals.css";
 import "@/app/header.css";
 import "@/app/landing.css";
+import "@/app/funding.css";
 
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";

--- a/packages/static-site/app/funding.css
+++ b/packages/static-site/app/funding.css
@@ -1,0 +1,104 @@
+/* Establishes a block formatting context so the search input's margins are
+   contained within the field wrapper. */
+.funding-search-field {
+  display: flow-root;
+}
+
+/* USWDS's [type="search"] reset drops the input's inline-end border because it
+   assumes a search field sits flush against an attached submit button that
+   covers that edge. This is a standalone search field with no button, so its
+   right side looked open ("cut off"); restore the border to match the other
+   three sides. */
+#funding-search {
+  border-inline-end: 1px solid var(--color-base-dark);
+}
+
+.funding-layout {
+  display: flex;
+  flex-direction: column;
+}
+
+@media (min-width: 64em) {
+  .funding-layout {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    grid-template-areas:
+      "header filter"
+      "results filter";
+    column-gap: 2rem;
+    align-items: start;
+  }
+
+  .funding-header-col {
+    grid-area: header;
+  }
+  .funding-filter-col {
+    grid-area: filter;
+  }
+  .funding-results-col {
+    grid-area: results;
+  }
+}
+
+.funding-filtering-by {
+  background-color: #e1f3f8;
+  border-radius: 0.25rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.funding-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 0.15rem;
+  border: 1px solid var(--color-primary);
+  gap: 0.25rem;
+  color: var(--color-primary);
+  background-color: white;
+  padding: 0.125rem 0.5rem 0.125rem 0.75rem;
+  font-size: 0.875rem;
+}
+
+.funding-filter-chip__remove {
+  background: none;
+  border: 0;
+  color: var(--color-primary);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0 0.25rem;
+}
+
+.funding-filter-chip__remove:hover,
+.funding-filter-chip__remove:focus {
+  color: var(--color-primary);
+}
+
+/* Scrollable checkbox list. The inline-start padding (offset by a negative
+   margin to preserve alignment) keeps the focused checkbox's outline from being
+   clipped against the scroll container's inline-start overflow edge. */
+.funding-filter-options {
+  max-height: 240px;
+  overflow-y: auto;
+  padding-inline-start: 6px;
+  margin-inline-start: -6px;
+}
+
+.funding-search-highlight {
+  color: white;
+  background-color: var(--color-primary);
+}
+
+.funding-card__heading-link {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.funding-card__heading-link:hover,
+.funding-card__heading-link:focus {
+  cursor: pointer;
+}

--- a/packages/static-site/app/globals.css
+++ b/packages/static-site/app/globals.css
@@ -5,6 +5,7 @@
   --color-base-dark: #565c65; /* USWDS base-dark / gray-cool-60 */
   --color-base-lightest: #f0f0f0; /* USWDS base-lightest / gray-5 */
   --color-ink: #1b1b1b; /* USWDS ink / gray-90 */
+  --color-primary: #005ea2; /* Funding-scoped accent (chips, search highlight); per designs it contrasts the NJWDS "primary". Does not override NJWDS/USWDS theming, which is SCSS-compiled. */
   --color-primary-dark: #2c608a; /* NJ primary dark blue; USWDS primary-dark (NJ override) */
   --color-accent-cool-darkest: #38536f; /* NJ-specific; no exact USWDS palette match */
 }
@@ -29,6 +30,38 @@ p a,
 body {
   margin: 0;
   min-height: 100vh;
+}
+
+.grid-container:has(.layout-wide) {
+  max-width: 90rem;
+}
+
+/*
+ * Wide pages need more room for content (e.g. a right-rail filter), so the
+ * side-nav gives up space: 4/8 becomes 3/9. Gated at 64em — narrower than
+ * that, the three-column inner layout doesn't have room to breathe and the
+ * site side-nav gets squeezed. Overridden in CSS rather than conditionally
+ * in `(learn)/layout.tsx` because the layout can't see which child route
+ * is rendering.
+ */
+@media (min-width: 64em) {
+  .grid-row:has(.layout-wide) > .tablet\:grid-col-4 {
+    width: 25%;
+  }
+  .grid-row:has(.layout-wide) > .tablet\:grid-col-8 {
+    width: 75%;
+  }
+}
+
+/*
+ * Widen the header to line up with the wider content on `.layout-wide` pages.
+ * The header (`.usa-nav__inner`) is a sibling of `<main>` — not an ancestor of
+ * `.layout-wide` — so it's scoped via `body:has(.layout-wide)` rather than the
+ * `.grid-container`/`.grid-row` scoping used for the in-page columns above.
+ * `!important` overrides the USWDS-compiled `.usa-nav__inner` max-width.
+ */
+body:has(.layout-wide) .usa-nav__inner {
+  max-width: 80rem !important;
 }
 
 .grid-container p {
@@ -58,6 +91,23 @@ body {
   margin-top: 0;
 }
 
+.usa-pagination .usa-current {
+  text-decoration: none;
+}
+
+.usa-pagination .usa-pagination__button:not(.usa-current) {
+  background-color: white;
+  text-decoration: underline;
+}
+
+.usa-pagination__previous-page,
+.usa-pagination__next-page {
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0;
+}
+
 .usa-header--extended .usa-nav__secondary-links a,
 .usa-header--extended .usa-nav__secondary-links a:visited {
   color: var(--color-base-lighter);
@@ -73,7 +123,14 @@ ul.usa-card-group {
 }
 
 div.usa-card__container {
-  margin-inline: 0.75rem;
+  margin-inline: 0;
+}
+
+/* The header's full-width bottom border already divides the header from the
+   content below it. Drop the side-nav's own bottom border so it doesn't stack
+   a second, near-parallel hairline just under that rule. */
+.learn-side-nav .usa-sidenav {
+  border-bottom: none;
 }
 
 @media (min-width: 40em) {

--- a/packages/static-site/components/landing/SiteHeader.tsx
+++ b/packages/static-site/components/landing/SiteHeader.tsx
@@ -33,7 +33,7 @@ export const SiteHeader = ({ content, languageSwitcher }: SiteHeaderProps) => {
         onAccountOpen={() => setIsAccountOpen(true)}
         onNavOpen={() => setIsNavOpen(true)}
       />
-      <header className="usa-header usa-header--extended">
+      <header className="usa-header usa-header--extended border-bottom-1px border-base-lighter">
         <nav aria-label={content.primaryNavigationAriaLabel} className="usa-nav">
           <div className="usa-nav__inner">
             <HeaderPrimaryNav header={content} />

--- a/packages/static-site/components/learn/FundingCard.test.tsx
+++ b/packages/static-site/components/learn/FundingCard.test.tsx
@@ -1,0 +1,163 @@
+import { render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { describe, expect, it } from "vitest";
+import type { FundingPageMessages } from "@/domain/content/messageTypes";
+import type { Funding } from "@/domain/content/types";
+import FundingCard from "./FundingCard";
+
+const cardMessages = {
+  cardDueLabel: "Due:",
+  cardEligibilityHeading: "Eligibility",
+  cardBenefitsHeading: "Benefits",
+} as FundingPageMessages;
+
+const renderCard = (props: Omit<ComponentProps<typeof FundingCard>, "messages">) =>
+  render(<FundingCard messages={cardMessages} {...props} />);
+
+const funding = (overrides: Partial<Funding> = {}): Funding =>
+  ({
+    id: "test-funding",
+    filename: "test-funding",
+    name: "Test Funding Program",
+    urlSlug: "test-funding",
+    callToActionLink: "https://example.com",
+    callToActionText: "Learn more",
+    sidebarCardBodyText: "A short description.",
+    summaryDescriptionMd: "Summary text.",
+    contentMd: `## Eligibility\n\n- Must be NJ registered\n\n:::largeCallout{ showHeader="true" headerText="Benefits:" calloutType="conditional" }\n\nThe benefit is great.\n\n:::`,
+    fundingType: "grant",
+    agency: ["njeda"],
+    publishStageArchive: "",
+    openDate: "",
+    dueDate: "",
+    status: "rolling application",
+    programFrequency: "ongoing",
+    businessStage: "both",
+    employeesRequired: "n/a",
+    homeBased: "unknown",
+    certifications: [],
+    preferenceForOpportunityZone: "no",
+    county: ["All"],
+    sector: [],
+    programPurpose: "",
+    agencyContact: "",
+    isNonprofitOnly: false,
+    minEmployeesRequired: 0,
+    maxEmployeesRequired: 0,
+    priority: false,
+    ...overrides,
+  }) as Funding;
+
+describe("FundingCard", () => {
+  it("renders the funding name as a heading", () => {
+    renderCard({ funding: funding() });
+    expect(screen.getByRole("heading", { name: "Test Funding Program" })).toBeInTheDocument();
+  });
+
+  it("renders status badge uppercased", () => {
+    renderCard({ funding: funding({ status: "rolling application" }) });
+    expect(screen.getByText("ROLLING APPLICATION")).toBeInTheDocument();
+  });
+
+  it("renders funding type badge uppercased", () => {
+    renderCard({ funding: funding({ fundingType: "grant" }) });
+    expect(screen.getByText("GRANT")).toBeInTheDocument();
+  });
+
+  it("renders eligibility bullet from contentMd", () => {
+    renderCard({ funding: funding() });
+    expect(screen.getByText(/Must be NJ registered/)).toBeInTheDocument();
+  });
+
+  it("renders benefits callout from contentMd", () => {
+    renderCard({ funding: funding() });
+    expect(screen.getByText(/The benefit is great/)).toBeInTheDocument();
+  });
+
+  it("renders Benefits heading on the callout box", () => {
+    renderCard({ funding: funding() });
+    expect(screen.getByRole("heading", { name: "Benefits" })).toBeInTheDocument();
+  });
+
+  it("does not render status badge when status is empty", () => {
+    renderCard({
+      funding: funding({ status: undefined as unknown as "rolling application" }),
+    });
+    expect(screen.queryByText("ROLLING APPLICATION")).not.toBeInTheDocument();
+  });
+
+  it("renders due date when present", () => {
+    renderCard({ funding: funding({ dueDate: "2026-12-31" }) });
+    expect(screen.getByText(/2026-12-31/)).toBeInTheDocument();
+  });
+
+  it("highlights a query match in the funding name", () => {
+    renderCard({ funding: funding({ name: "Grant Program" }), query: "grant" });
+    const heading = screen.getByRole("heading", { name: "Grant Program" });
+    const mark = heading.querySelector("mark.funding-search-highlight");
+    expect(mark).not.toBeNull();
+    expect(mark).toHaveTextContent("Grant");
+  });
+
+  it("highlights a query match in the eligibility body", () => {
+    const { container } = renderCard({ funding: funding(), query: "registered" });
+    const marks = container.querySelectorAll("mark.funding-search-highlight");
+    expect([...marks].some((m) => m.textContent === "registered")).toBe(true);
+  });
+
+  it("highlights a query match in the benefits body", () => {
+    const { container } = renderCard({ funding: funding(), query: "benefit" });
+    const marks = container.querySelectorAll("mark.funding-search-highlight");
+    expect([...marks].some((m) => m.textContent === "benefit")).toBe(true);
+  });
+
+  it("preserves markdown list structure in benefits when a query is active", () => {
+    const withList = funding({
+      contentMd: `## Eligibility\n\n- Must be NJ registered\n\n:::largeCallout{ showHeader="true" headerText="Benefits:" calloutType="conditional" }\n\n- Benefit one\n- Benefit two\n\n:::`,
+    });
+    const { container } = renderCard({ funding: withList, query: "benefit" });
+    const benefitsBox = container.querySelector('[role="note"]');
+    expect(benefitsBox?.querySelector("ul")).not.toBeNull();
+  });
+
+  it("renders no highlight marks when no query is given", () => {
+    const { container } = renderCard({ funding: funding() });
+    expect(container.querySelector("mark.funding-search-highlight")).toBeNull();
+  });
+
+  it("keeps markdown rendering for a whitespace-only query", () => {
+    const { container } = renderCard({ funding: funding(), query: "   " });
+    // A whitespace-only query matches and highlights nothing, so the
+    // Eligibility section should stay in its <Markdown> rendering (a list)
+    // rather than the plain-text fallback used while actively searching.
+    expect(container.querySelector("ul")).not.toBeNull();
+    expect(container.querySelector("mark.funding-search-highlight")).toBeNull();
+  });
+});
+
+describe("FundingCard callToActionLink", () => {
+  it("links the funding name to callToActionLink in a new tab", () => {
+    renderCard({ funding: funding({ callToActionLink: "https://example.com/apply" }) });
+    const link = screen.getByRole("link", { name: "Test Funding Program" });
+    expect(link).toHaveAttribute("href", "https://example.com/apply");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noreferrer");
+  });
+
+  it("renders the funding name as plain text when callToActionLink is empty", () => {
+    renderCard({ funding: funding({ callToActionLink: "" }) });
+    expect(screen.getByRole("heading", { name: "Test Funding Program" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Test Funding Program" })).not.toBeInTheDocument();
+  });
+
+  it("highlights a query match inside the linked funding name", () => {
+    renderCard({
+      funding: funding({ name: "Grant Program", callToActionLink: "https://example.com" }),
+      query: "grant",
+    });
+    const link = screen.getByRole("link", { name: "Grant Program" });
+    const mark = link.querySelector("mark.funding-search-highlight");
+    expect(mark).not.toBeNull();
+    expect(mark).toHaveTextContent("Grant");
+  });
+});

--- a/packages/static-site/components/learn/FundingCard.tsx
+++ b/packages/static-site/components/learn/FundingCard.tsx
@@ -1,0 +1,96 @@
+import type { Element, ElementContent, Parents, Root, Text } from "hast";
+import Markdown from "react-markdown";
+import type { Node } from "unist";
+import { visitParents } from "unist-util-visit-parents";
+import type { FundingPageMessages } from "@/domain/content/messageTypes";
+import type { Funding } from "@/domain/content/types";
+import { HighlightedText, splitHighlight } from "./highlightMatches";
+import { parseFundingContent } from "./parseFundingContent";
+
+interface Props {
+  readonly funding: Funding;
+  readonly messages: FundingPageMessages;
+  readonly query?: string;
+}
+
+const makeHighlightPlugin = (query: string) => () => (tree: Root) => {
+  visitParents(tree as Node, "text", (node: Text, ancestors) => {
+    const parent = ancestors.at(-1) as Parents | undefined;
+    if (parent === undefined) return;
+    const index = parent.children.indexOf(node);
+    const segments = splitHighlight(node.value, query);
+    if (segments.length === 1 && !segments[0].match) return;
+
+    const replacement: ElementContent[] = segments.map((seg) =>
+      seg.match
+        ? {
+            type: "element",
+            tagName: "mark",
+            properties: { className: ["funding-search-highlight"] },
+            children: [{ type: "text", value: seg.text }],
+          }
+        : { type: "text", value: seg.text },
+    );
+
+    (parent as Element).children.splice(index, 1, ...replacement);
+  });
+};
+
+const FundingCard = ({ funding, messages, query = "" }: Props) => {
+  const { eligibility, benefits } = parseFundingContent(funding.contentMd ?? "");
+  const rehypePlugins = query.trim() ? [makeHighlightPlugin(query)] : [];
+
+  return (
+    <div className="usa-card__container margin-bottom-3">
+      <div className="usa-card__header">
+        <h3 className="usa-card__heading">
+          {funding.callToActionLink ? (
+            <a
+              className="funding-card__heading-link"
+              href={funding.callToActionLink}
+              rel="noreferrer"
+              target="_blank"
+            >
+              <HighlightedText text={funding.name} query={query} />
+            </a>
+          ) : (
+            <HighlightedText text={funding.name} query={query} />
+          )}
+        </h3>
+        <div className="margin-top-1">
+          {funding.status && (
+            <span className="usa-tag margin-right-1">{funding.status.toUpperCase()}</span>
+          )}
+          {funding.fundingType && (
+            <span className="usa-tag">{funding.fundingType.toUpperCase()}</span>
+          )}
+        </div>
+      </div>
+      <div className="usa-card__body">
+        {funding.dueDate && (
+          <p className="text-base margin-bottom-1">
+            <strong>{messages.cardDueLabel}</strong> {funding.dueDate}
+          </p>
+        )}
+        {eligibility && (
+          <div className="margin-bottom-2">
+            <p className="text-bold margin-bottom-1">{messages.cardEligibilityHeading}</p>
+            <Markdown rehypePlugins={rehypePlugins}>{eligibility}</Markdown>
+          </div>
+        )}
+        {benefits && (
+          <div className="usa-alert usa-alert--info usa-alert--no-icon" role="note">
+            <div className="usa-alert__body">
+              <h4 className="usa-alert__heading">{messages.cardBenefitsHeading}</h4>
+              <div className="usa-alert__text">
+                <Markdown rehypePlugins={rehypePlugins}>{benefits}</Markdown>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FundingCard;

--- a/packages/static-site/components/learn/FundingPage.tsx
+++ b/packages/static-site/components/learn/FundingPage.tsx
@@ -1,0 +1,20 @@
+import FundingPageContent from "@/components/learn/FundingPageContent";
+import { loadFundings, loadSectors } from "@/domain/content/loadContent";
+import type { PageItem } from "@/domain/content/types";
+import type { AppLocale } from "@/domain/i18n/locales";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+
+interface Props {
+  readonly page: PageItem;
+  readonly locale: AppLocale;
+}
+
+export const FundingPage = ({ page, locale }: Props) => {
+  const fundings = loadFundings().sort((a, b) => a.name.localeCompare(b.name));
+  const sectors = loadSectors();
+  const { funding: messages } = getApplicationMessages({ locale });
+
+  return (
+    <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />
+  );
+};

--- a/packages/static-site/components/learn/FundingPageContent.test.tsx
+++ b/packages/static-site/components/learn/FundingPageContent.test.tsx
@@ -1,0 +1,428 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import type { ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+import type { FundingPageMessages } from "@/domain/content/messageTypes";
+import type { Funding, PageItem, Sector } from "@/domain/content/types";
+import FundingPageContent from "./FundingPageContent";
+
+const messages: FundingPageMessages = {
+  title: "Funding",
+  ctaHeading: "Find Funding Fit for Your Business",
+  ctaBody: "Answers just a few questions.",
+  ctaButton: "Create Account",
+  filterHeading: "Filter All Funding Options",
+  filterSearch: "Search",
+  filterIndustry: "Industry",
+  filterFundingType: "Funding Type",
+  fundingTypeLabels: {
+    grant: "Grant",
+    loan: "Loan",
+    "tax credit": "Tax Credit",
+    "tax exemption": "Tax Exemption",
+    "technical assistance": "Technical Assistance",
+    "hiring and employee training support": "Hiring & Employee Training Support",
+  },
+  filterClear: "Clear",
+  filterShowResults: "Show {count} Results",
+  filterReset: "Reset",
+  resultCount: "Showing <bold>{filtered}</bold> results of {total} items",
+  filteringByLabel: "Filtering by:",
+  filterSearchChip: 'Search: "{query}"',
+  filterRemoveLabel: "Remove {filter} filter",
+  paginationPrevious: "Previous",
+  paginationNext: "Next",
+  paginationLabel: "Pagination",
+  paginationPageLabel: "Page {page}",
+  cardDueLabel: "Due:",
+  cardEligibilityHeading: "Eligibility",
+  cardBenefitsHeading: "Benefits",
+};
+
+const renderWithIntl = (ui: ReactElement) =>
+  render(
+    <NextIntlClientProvider locale="en-US" messages={{ funding: messages }}>
+      {ui}
+    </NextIntlClientProvider>,
+  );
+
+const page: PageItem = {
+  name: "Funding",
+  slug: "funding",
+  "sub-heading-text": "Whether you're looking for startup capital...",
+};
+
+const makeFunding = (name: string, overrides: Partial<Funding> = {}): Funding =>
+  ({
+    id: name,
+    filename: name,
+    name,
+    urlSlug: name,
+    callToActionLink: "",
+    callToActionText: "",
+    sidebarCardBodyText: "",
+    summaryDescriptionMd: "",
+    contentMd: `## Eligibility\n\n- Eligible\n\n:::largeCallout{ showHeader="true" headerText="Benefits:" calloutType="conditional" }\n\nBenefit text.\n\n:::`,
+    fundingType: "grant",
+    agency: [],
+    publishStageArchive: null,
+    openDate: "",
+    dueDate: "",
+    status: "rolling application",
+    programFrequency: "ongoing",
+    businessStage: "both",
+    employeesRequired: "n/a",
+    homeBased: "unknown",
+    certifications: [],
+    preferenceForOpportunityZone: "no",
+    county: [],
+    sector: [],
+    programPurpose: "",
+    agencyContact: "",
+    isNonprofitOnly: false,
+    minEmployeesRequired: 0,
+    maxEmployeesRequired: 0,
+    priority: false,
+    ...overrides,
+  }) as Funding;
+
+const sectors: Sector[] = [
+  { id: "technology", name: "Technology", nonEssentialQuestionsIds: [], industries: [] },
+  { id: "retail-trade", name: "Retail Trade", nonEssentialQuestionsIds: [], industries: [] },
+];
+
+const makeFundings = (count: number): Funding[] =>
+  Array.from({ length: count }, (_, i) => makeFunding(`Funding ${String(i + 1).padStart(2, "0")}`));
+
+describe("FundingPageContent", () => {
+  it("renders the page title", () => {
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={[]} sectors={sectors} />,
+    );
+    expect(screen.getByRole("heading", { level: 1, name: "Funding" })).toBeInTheDocument();
+  });
+
+  it("renders intro text from page sub-heading-text", () => {
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={[]} sectors={sectors} />,
+    );
+    expect(screen.getByText("Whether you're looking for startup capital...")).toBeInTheDocument();
+  });
+
+  it("renders CTA heading and button", () => {
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={[]} sectors={sectors} />,
+    );
+    expect(screen.getByText("Find Funding Fit for Your Business")).toBeInTheDocument();
+    const button = screen.getByRole("link", { name: "Create Account" });
+    expect(button).toHaveAttribute("href", "https://account.business.nj.gov/");
+  });
+
+  it("renders result count with total fundings", () => {
+    const fundings = makeFundings(5);
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+    const countLine = screen.getByText(/Showing/).closest("p");
+    expect(countLine).toHaveTextContent("Showing 5 results of 5 items");
+    expect(countLine?.querySelector("strong")).toHaveTextContent("5");
+  });
+
+  it("renders up to 10 cards on the first page", () => {
+    const fundings = makeFundings(15);
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+    expect(screen.getAllByRole("heading", { level: 3 })).toHaveLength(10);
+  });
+
+  it("renders next page of cards when Next is clicked", async () => {
+    const fundings = makeFundings(15);
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getAllByRole("heading", { level: 3 })).toHaveLength(5);
+  });
+
+  it("Previous button is disabled on first page", () => {
+    const fundings = makeFundings(15);
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+    expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
+  });
+
+  it("Next button is disabled on last page", async () => {
+    const fundings = makeFundings(15);
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+  });
+
+  it("renders filter sidebar heading", () => {
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={[]} sectors={sectors} />,
+    );
+    expect(screen.getByText("Filter All Funding Options")).toBeInTheDocument();
+  });
+
+  it("renders sector as industry checkbox", () => {
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={[]} sectors={sectors} />,
+    );
+    expect(screen.getByLabelText("Technology")).toBeInTheDocument();
+  });
+
+  it("filters by funding type only after Show Results is clicked", async () => {
+    const user = userEvent.setup();
+    const fundings = [
+      makeFunding("Grant A", { fundingType: "grant" }),
+      makeFunding("Loan B", { fundingType: "loan" }),
+    ];
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+
+    // Before Show Results: both cards visible
+    expect(screen.getByText("Grant A")).toBeInTheDocument();
+    expect(screen.getByText("Loan B")).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Grant"));
+
+    // Pending: still both visible; button count reflects pending = 1
+    expect(screen.getByText("Loan B")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show 1 Results" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Show 1 Results" }));
+
+    // Applied: only Grant A visible
+    expect(screen.getByText("Grant A")).toBeInTheDocument();
+    expect(screen.queryByText("Loan B")).not.toBeInTheDocument();
+  });
+
+  it("shows a Filtering by chip for each applied filter", async () => {
+    const user = userEvent.setup();
+    const fundings = [makeFunding("Grant A", { fundingType: "grant" })];
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+
+    // No chips before any filter applied
+    expect(screen.queryByText("Filtering by:")).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Grant"));
+    await user.click(screen.getByRole("button", { name: "Show 1 Results" }));
+
+    expect(screen.getByText("Filtering by:")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove Grant filter" })).toBeInTheDocument();
+  });
+
+  it("filters by specific industry sector", async () => {
+    const user = userEvent.setup();
+    const fundings = [
+      makeFunding("Tech Funding", { sector: ["technology"] }),
+      makeFunding("Retail Funding", { sector: ["retail-trade"] }),
+    ];
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+
+    await user.click(screen.getByLabelText("Technology"));
+    await user.click(screen.getByRole("button", { name: "Show 1 Results" }));
+
+    expect(screen.getByText("Tech Funding")).toBeInTheDocument();
+    expect(screen.queryByText("Retail Funding")).not.toBeInTheDocument();
+  });
+
+  it("removing a chip removes the filter immediately", async () => {
+    const user = userEvent.setup();
+    const fundings = [
+      makeFunding("Grant A", { fundingType: "grant" }),
+      makeFunding("Loan B", { fundingType: "loan" }),
+    ];
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+
+    await user.click(screen.getByLabelText("Grant"));
+    await user.click(screen.getByRole("button", { name: "Show 1 Results" }));
+    expect(screen.queryByText("Loan B")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Remove Grant filter" }));
+
+    // Chip removed
+    expect(screen.queryByRole("button", { name: "Remove Grant filter" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Filtering by:")).not.toBeInTheDocument();
+    // Both cards visible again
+    expect(screen.getByText("Grant A")).toBeInTheDocument();
+    expect(screen.getByText("Loan B")).toBeInTheDocument();
+    // Grant checkbox unticked
+    expect((screen.getByLabelText("Grant") as HTMLInputElement).checked).toBe(false);
+  });
+
+  it("Show Results button label uses the pending filtered count", async () => {
+    const user = userEvent.setup();
+    const fundings = [
+      makeFunding("Grant A", { fundingType: "grant" }),
+      makeFunding("Grant B", { fundingType: "grant" }),
+      makeFunding("Loan C", { fundingType: "loan" }),
+    ];
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Show 3 Results" })).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Grant"));
+    expect(screen.getByRole("button", { name: "Show 2 Results" })).toBeInTheDocument();
+  });
+
+  it("Show Results button count reflects the active search query", async () => {
+    const user = userEvent.setup();
+    const fundings = [
+      makeFunding("Grant Alpha", { fundingType: "grant" }),
+      makeFunding("Grant Beta", { fundingType: "grant" }),
+      makeFunding("Loan Alpha", { fundingType: "loan" }),
+    ];
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Show 3 Results" })).toBeInTheDocument();
+
+    await user.type(screen.getByRole("searchbox"), "alpha");
+
+    // Only "Grant Alpha" and "Loan Alpha" match the query.
+    expect(screen.getByRole("button", { name: "Show 2 Results" })).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Grant"));
+
+    // grant AND "alpha" -> only "Grant Alpha".
+    expect(screen.getByRole("button", { name: "Show 1 Results" })).toBeInTheDocument();
+  });
+
+  it("Reset clears all pending, applied, and search filters", async () => {
+    const user = userEvent.setup();
+    const fundings = [
+      makeFunding("Grant A", { fundingType: "grant" }),
+      makeFunding("Loan B", { fundingType: "loan" }),
+    ];
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+
+    await user.click(screen.getByLabelText("Grant"));
+    await user.click(screen.getByRole("button", { name: "Show 1 Results" }));
+    await user.type(screen.getByRole("searchbox"), "grant");
+    expect(screen.queryByText("Loan B")).not.toBeInTheDocument();
+    expect(screen.getByText('Search: "grant"')).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Reset" }));
+
+    expect(screen.getByText("Loan B")).toBeInTheDocument();
+    expect(screen.queryByText("Filtering by:")).not.toBeInTheDocument();
+    expect((screen.getByLabelText("Grant") as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByRole("searchbox") as HTMLInputElement).value).toBe("");
+  });
+
+  it("Clear inside the Industry fieldset clears pending only, not applied", async () => {
+    const user = userEvent.setup();
+    const fundings = [
+      makeFunding("Tech Funding", { sector: ["technology"] }),
+      makeFunding("Retail Funding", { sector: ["retail-trade"] }),
+    ];
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+
+    // Apply Technology
+    await user.click(screen.getByLabelText("Technology"));
+    await user.click(screen.getByRole("button", { name: "Show 1 Results" }));
+    expect(screen.queryByText("Retail Funding")).not.toBeInTheDocument();
+
+    // Click Industry fieldset's Clear button (first of two Clear buttons in DOM order)
+    const clearButtons = screen.getAllByRole("button", { name: "Clear" });
+    await user.click(clearButtons[0]);
+
+    // Applied results unchanged
+    expect(screen.queryByText("Retail Funding")).not.toBeInTheDocument();
+    // Chip still present (applied state untouched)
+    expect(screen.getByRole("button", { name: "Remove Technology filter" })).toBeInTheDocument();
+    // Technology checkbox unticked (pending state cleared)
+    expect((screen.getByLabelText("Technology") as HTMLInputElement).checked).toBe(false);
+  });
+
+  it("filters cards live by name as the user types, without clicking a button", async () => {
+    const user = userEvent.setup();
+    const fundings = [makeFunding("Grant Alpha"), makeFunding("Loan Beta")];
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+
+    await user.type(screen.getByRole("searchbox"), "alpha");
+
+    expect(screen.getByRole("heading", { name: "Grant Alpha" })).toBeInTheDocument();
+    expect(screen.queryByText("Loan Beta")).not.toBeInTheDocument();
+  });
+
+  it("matches case-insensitively against the funding body text", async () => {
+    const user = userEvent.setup();
+    const fundings = [
+      makeFunding("Alpha", {
+        contentMd: `## Eligibility\n\n- Must be WIDGET maker\n\n:::largeCallout{ showHeader="true" headerText="Benefits:" calloutType="conditional" }\n\nGreat benefit.\n\n:::`,
+      }),
+      makeFunding("Beta"),
+    ];
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+
+    await user.type(screen.getByRole("searchbox"), "widget");
+
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.queryByText("Beta")).not.toBeInTheDocument();
+  });
+
+  it("shows a removable search chip whose x clears the query", async () => {
+    const user = userEvent.setup();
+    const fundings = [makeFunding("Grant Alpha"), makeFunding("Loan Beta")];
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+
+    await user.type(screen.getByRole("searchbox"), "alpha");
+    expect(screen.getByText('Search: "alpha"')).toBeInTheDocument();
+    expect(screen.queryByText("Loan Beta")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: 'Remove Search: "alpha" filter' }));
+
+    expect(screen.queryByText('Search: "alpha"')).not.toBeInTheDocument();
+    expect(screen.getByText("Loan Beta")).toBeInTheDocument();
+    expect((screen.getByRole("searchbox") as HTMLInputElement).value).toBe("");
+  });
+
+  it("AND-combines the search query with applied checkbox filters", async () => {
+    const user = userEvent.setup();
+    const fundings = [
+      makeFunding("Grant Alpha", { fundingType: "grant" }),
+      makeFunding("Grant Beta", { fundingType: "grant" }),
+      makeFunding("Loan Alpha", { fundingType: "loan" }),
+    ];
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+
+    await user.click(screen.getByLabelText("Grant"));
+    await user.click(screen.getByRole("button", { name: "Show 2 Results" }));
+    await user.type(screen.getByRole("searchbox"), "alpha");
+
+    // grant AND "alpha" -> only "Grant Alpha"
+    expect(screen.getByRole("heading", { name: "Grant Alpha" })).toBeInTheDocument();
+    expect(screen.queryByText("Grant Beta")).not.toBeInTheDocument();
+    expect(screen.queryByText("Loan Alpha")).not.toBeInTheDocument();
+  });
+});

--- a/packages/static-site/components/learn/FundingPageContent.tsx
+++ b/packages/static-site/components/learn/FundingPageContent.tsx
@@ -1,0 +1,495 @@
+"use client";
+
+import { Fragment, type ReactNode, useMemo, useState } from "react";
+import type { FundingPageMessages } from "@/domain/content/messageTypes";
+import type { Funding, FundingType, PageItem, Sector } from "@/domain/content/types";
+import FundingCard from "./FundingCard";
+import { parseFundingContent } from "./parseFundingContent";
+
+const ITEMS_PER_PAGE = 10;
+
+const fundingTypes = (messages: FundingPageMessages): readonly FundingType[] =>
+  Object.keys(messages.fundingTypeLabels) as FundingType[];
+
+interface ResultCountParams {
+  readonly template: string;
+  readonly filtered: number;
+  readonly total: number;
+}
+
+/**
+ * Renders the result-count template, substituting `{total}` as text and the
+ * `<bold>…</bold>`-wrapped `{filtered}` count as a `<strong>` element. Keeping
+ * the whole sentence in one message (rather than splitting it in the component)
+ * lets translators control word order around the bolded count.
+ */
+const renderResultCount = ({ template, filtered, total }: ResultCountParams): ReactNode => {
+  const withTotal = template.replace("{total}", String(total));
+  return withTotal.split(/(<bold>.*?<\/bold>)/).map((part, index) => {
+    const boldMatch = part.match(/^<bold>(.*?)<\/bold>$/);
+    if (boldMatch === null) {
+      // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional and stable per render
+      return <Fragment key={index}>{part}</Fragment>;
+    }
+    return (
+      // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional and stable per render
+      <strong key={index}>{boldMatch[1].replace("{filtered}", String(filtered))}</strong>
+    );
+  });
+};
+
+interface Props {
+  readonly messages: FundingPageMessages;
+  readonly page: PageItem;
+  readonly fundings: readonly Funding[];
+  readonly sectors: readonly Sector[];
+}
+
+interface AppliedFilters {
+  readonly industries: ReadonlySet<string>;
+  readonly fundingTypes: ReadonlySet<FundingType>;
+}
+
+const matchesFilters = (funding: Funding, filters: AppliedFilters): boolean => {
+  const typeMatch =
+    filters.fundingTypes.size === 0 || filters.fundingTypes.has(funding.fundingType);
+  const industryMatch =
+    filters.industries.size === 0 || funding.sector.some((id) => filters.industries.has(id));
+  return typeMatch && industryMatch;
+};
+
+const fundingSearchableText = (funding: Funding): string => {
+  const { eligibility, benefits } = parseFundingContent(funding.contentMd ?? "");
+  return `${funding.name} ${eligibility} ${benefits}`.toLowerCase();
+};
+
+const matchesQuery = (searchableText: string, normalizedQuery: string): boolean =>
+  normalizedQuery === "" || searchableText.includes(normalizedQuery);
+
+interface FilterChipProps {
+  readonly label: string;
+  readonly removeLabel: string;
+  readonly onRemove: () => void;
+}
+
+const FilterChip = ({ label, removeLabel, onRemove }: FilterChipProps) => (
+  <span className="funding-filter-chip">
+    {label}
+    <button
+      type="button"
+      className="funding-filter-chip__remove"
+      aria-label={removeLabel}
+      onClick={onRemove}
+    >
+      <span aria-hidden="true">×</span>
+    </button>
+  </span>
+);
+
+interface FilteringByBarProps {
+  readonly messages: FundingPageMessages;
+  readonly sectors: readonly Sector[];
+  readonly applied: AppliedFilters;
+  readonly query: string;
+  readonly onRemoveIndustry: (id: string) => void;
+  readonly onRemoveFundingType: (id: FundingType) => void;
+  readonly onRemoveQuery: () => void;
+}
+
+const FilteringByBar = ({
+  messages,
+  sectors,
+  applied,
+  query,
+  onRemoveIndustry,
+  onRemoveFundingType,
+  onRemoveQuery,
+}: FilteringByBarProps) => {
+  if (applied.industries.size === 0 && applied.fundingTypes.size === 0 && query.trim() === "") {
+    return null;
+  }
+
+  const industryLabel = (id: string): string => sectors.find((s) => s.id === id)?.name ?? id;
+
+  const removeLabel = (filterName: string): string =>
+    messages.filterRemoveLabel.replace("{filter}", filterName);
+
+  return (
+    <section
+      aria-label={messages.filteringByLabel}
+      className="funding-filtering-by margin-bottom-2 padding-2 radius-md bg-primary-lightest border-1px border-primary"
+    >
+      <span className="margin-right-1">{messages.filteringByLabel}</span>
+      {query.trim() !== "" && (
+        <FilterChip
+          key="search"
+          label={messages.filterSearchChip.replace("{query}", query)}
+          removeLabel={removeLabel(messages.filterSearchChip.replace("{query}", query))}
+          onRemove={onRemoveQuery}
+        />
+      )}
+      {sectors
+        .map((s) => s.id)
+        .filter((id) => applied.industries.has(id))
+        .map((id) => {
+          const label = industryLabel(id);
+          return (
+            <FilterChip
+              key={`industry-${id}`}
+              label={label}
+              removeLabel={removeLabel(label)}
+              onRemove={() => onRemoveIndustry(id)}
+            />
+          );
+        })}
+      {fundingTypes(messages)
+        .filter((id) => applied.fundingTypes.has(id))
+        .map((id) => {
+          const label = messages.fundingTypeLabels[id];
+          return (
+            <FilterChip
+              key={`type-${id}`}
+              label={label}
+              removeLabel={removeLabel(label)}
+              onRemove={() => onRemoveFundingType(id)}
+            />
+          );
+        })}
+    </section>
+  );
+};
+
+const FundingPageContent = ({ messages, page, fundings, sectors }: Props) => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pendingIndustries, setPendingIndustries] = useState<ReadonlySet<string>>(new Set());
+  const [pendingFundingTypes, setPendingFundingTypes] = useState<ReadonlySet<FundingType>>(
+    new Set(),
+  );
+  const [applied, setApplied] = useState<AppliedFilters>({
+    industries: new Set(),
+    fundingTypes: new Set(),
+  });
+  const [query, setQuery] = useState("");
+
+  const searchableEntries = useMemo(
+    () => fundings.map((funding) => ({ funding, searchableText: fundingSearchableText(funding) })),
+    [fundings],
+  );
+
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const filteredFundings = useMemo(
+    () =>
+      searchableEntries
+        .filter(
+          ({ funding, searchableText }) =>
+            matchesFilters(funding, applied) && matchesQuery(searchableText, normalizedQuery),
+        )
+        .map(({ funding }) => funding),
+    [searchableEntries, applied, normalizedQuery],
+  );
+
+  const pendingFiltered = useMemo(
+    () =>
+      searchableEntries.filter(
+        ({ funding, searchableText }) =>
+          matchesFilters(funding, {
+            industries: pendingIndustries,
+            fundingTypes: pendingFundingTypes,
+          }) && matchesQuery(searchableText, normalizedQuery),
+      ),
+    [searchableEntries, pendingIndustries, pendingFundingTypes, normalizedQuery],
+  );
+
+  const totalPages = Math.max(1, Math.ceil(filteredFundings.length / ITEMS_PER_PAGE));
+  const pageNumbers = Array.from({ length: totalPages }, (_, i) => i + 1);
+  const safePage = Math.min(currentPage, totalPages);
+  const pageSlice = filteredFundings.slice(
+    (safePage - 1) * ITEMS_PER_PAGE,
+    safePage * ITEMS_PER_PAGE,
+  );
+
+  const resultCount = renderResultCount({
+    template: messages.resultCount,
+    filtered: filteredFundings.length,
+    total: fundings.length,
+  });
+  const showResultsLabel = messages.filterShowResults.replace(
+    "{count}",
+    String(pendingFiltered.length),
+  );
+
+  const toggleIndustry = (id: string): void => {
+    setPendingIndustries((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const toggleFundingType = (id: FundingType): void => {
+    setPendingFundingTypes((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const applyPending = (): void => {
+    setApplied({
+      industries: new Set(pendingIndustries),
+      fundingTypes: new Set(pendingFundingTypes),
+    });
+    setCurrentPage(1);
+  };
+
+  const removeIndustry = (id: string): void => {
+    setApplied((prev) => {
+      const next = new Set(prev.industries);
+      next.delete(id);
+      return { ...prev, industries: next };
+    });
+    setPendingIndustries((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+    setCurrentPage(1);
+  };
+
+  const removeFundingType = (id: FundingType): void => {
+    setApplied((prev) => {
+      const next = new Set(prev.fundingTypes);
+      next.delete(id);
+      return { ...prev, fundingTypes: next };
+    });
+    setPendingFundingTypes((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+    setCurrentPage(1);
+  };
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    setQuery(event.target.value);
+    setCurrentPage(1);
+  };
+
+  const removeQuery = (): void => {
+    setQuery("");
+    setCurrentPage(1);
+  };
+
+  const clearPendingIndustries = (): void => {
+    setPendingIndustries(new Set());
+  };
+
+  const clearPendingFundingTypes = (): void => {
+    setPendingFundingTypes(new Set());
+  };
+
+  const resetAll = (): void => {
+    setPendingIndustries(new Set());
+    setPendingFundingTypes(new Set());
+    setApplied({ industries: new Set(), fundingTypes: new Set() });
+    setQuery("");
+    setCurrentPage(1);
+  };
+
+  return (
+    <div className="funding-layout layout-wide">
+      <div className="funding-header-col">
+        <h1>{messages.title}</h1>
+        {page["sub-heading-text"] && <p className="usa-intro">{page["sub-heading-text"]}</p>}
+
+        <div className="padding-3 margin-bottom-3 radius-lg border-2px border-base-lighter">
+          <h2 className="margin-top-0">{messages.ctaHeading}</h2>
+          <p>{messages.ctaBody}</p>
+          <a href="https://account.business.nj.gov/" className="usa-button">
+            {messages.ctaButton}
+          </a>
+        </div>
+      </div>
+
+      <aside className="border-1px border-base-lighter padding-3 radius-lg funding-filter-col">
+        <h2>{messages.filterHeading}</h2>
+
+        <div className="margin-y-3 funding-search-field">
+          <label className="usa-label text-bold margin-bottom-1" htmlFor="funding-search">
+            {messages.filterSearch}
+          </label>
+          <input
+            id="funding-search"
+            className="usa-input"
+            type="search"
+            value={query}
+            onChange={handleSearchChange}
+          />
+        </div>
+
+        <hr className="border-base-lighter border-top-1px margin-y-2" />
+        <fieldset className="usa-fieldset margin-bottom-2">
+          <legend className="usa-legend text-bold display-flex flex-justify flex-align-center width-full margin-bottom-1">
+            {messages.filterIndustry}
+            <button
+              type="button"
+              className="usa-button usa-button--unstyled font-sans-xs"
+              onClick={clearPendingIndustries}
+            >
+              {messages.filterClear}
+            </button>
+          </legend>
+          <div className="funding-filter-options">
+            {sectors.map((sector) => (
+              <div key={sector.id} className="usa-checkbox">
+                <input
+                  className="usa-checkbox__input"
+                  id={`industry-${sector.id}`}
+                  type="checkbox"
+                  checked={pendingIndustries.has(sector.id)}
+                  onChange={() => toggleIndustry(sector.id)}
+                />
+                <label className="usa-checkbox__label" htmlFor={`industry-${sector.id}`}>
+                  {sector.name}
+                </label>
+              </div>
+            ))}
+          </div>
+        </fieldset>
+
+        <hr className="border-base-lighter border-top-1px margin-y-2" />
+
+        <fieldset className="usa-fieldset margin-bottom-3">
+          <legend className="usa-legend text-bold display-flex flex-justify flex-align-center width-full margin-bottom-1">
+            {messages.filterFundingType}
+            <button
+              type="button"
+              className="usa-button usa-button--unstyled font-sans-xs"
+              onClick={clearPendingFundingTypes}
+            >
+              {messages.filterClear}
+            </button>
+          </legend>
+          <div className="funding-filter-options">
+            {fundingTypes(messages).map((type) => {
+              const inputId = `type-${type.replace(/\s+/g, "-")}`;
+              return (
+                <div key={type} className="usa-checkbox">
+                  <input
+                    className="usa-checkbox__input"
+                    id={inputId}
+                    type="checkbox"
+                    checked={pendingFundingTypes.has(type)}
+                    onChange={() => toggleFundingType(type)}
+                  />
+                  <label className="usa-checkbox__label" htmlFor={inputId}>
+                    {messages.fundingTypeLabels[type]}
+                  </label>
+                </div>
+              );
+            })}
+          </div>
+        </fieldset>
+
+        <hr className="border-base-lighter border-top-1px margin-y-2" />
+
+        <div className="display-flex flex-justify">
+          <button type="button" className="usa-button width-full" onClick={applyPending}>
+            {showResultsLabel}
+          </button>
+          <button
+            type="button"
+            className="usa-button usa-button--outline margin-right-0"
+            onClick={resetAll}
+          >
+            {messages.filterReset}
+          </button>
+        </div>
+      </aside>
+
+      <div className="funding-results-col">
+        <FilteringByBar
+          messages={messages}
+          sectors={sectors}
+          applied={applied}
+          query={query}
+          onRemoveIndustry={removeIndustry}
+          onRemoveFundingType={removeFundingType}
+          onRemoveQuery={removeQuery}
+        />
+
+        <p className="margin-bottom-2" role="status" aria-live="polite">
+          {resultCount}
+        </p>
+
+        {pageSlice.map((funding) => (
+          <FundingCard key={funding.id} funding={funding} messages={messages} query={query} />
+        ))}
+
+        {totalPages > 1 && (
+          <nav aria-label={messages.paginationLabel} className="usa-pagination">
+            <ul className="usa-pagination__list">
+              <li className="usa-pagination__item usa-pagination__arrow">
+                <button
+                  type="button"
+                  className="usa-pagination__link usa-pagination__previous-page"
+                  onClick={() => setCurrentPage(safePage - 1)}
+                  disabled={safePage === 1}
+                  aria-label={messages.paginationPrevious}
+                >
+                  <svg className="usa-icon" aria-hidden="true" focusable="false" role="img">
+                    <use href="/assets/njwds/dist/img/sprite.svg#navigate_before" />
+                  </svg>
+                  <span className="usa-pagination__link-text">{messages.paginationPrevious}</span>
+                </button>
+              </li>
+              {pageNumbers.map((pageNumber) => (
+                <li
+                  key={`page-${pageNumber}`}
+                  className="usa-pagination__item usa-pagination__page-no"
+                >
+                  <button
+                    type="button"
+                    className={`usa-pagination__button${
+                      safePage === pageNumber ? " usa-current" : ""
+                    }`}
+                    onClick={() => setCurrentPage(pageNumber)}
+                    aria-label={messages.paginationPageLabel.replace("{page}", String(pageNumber))}
+                    aria-current={safePage === pageNumber ? "page" : undefined}
+                  >
+                    {pageNumber}
+                  </button>
+                </li>
+              ))}
+              <li className="usa-pagination__item usa-pagination__arrow">
+                <button
+                  type="button"
+                  className="usa-pagination__link usa-pagination__next-page"
+                  onClick={() => setCurrentPage(safePage + 1)}
+                  disabled={safePage === totalPages}
+                  aria-label={messages.paginationNext}
+                >
+                  <span className="usa-pagination__link-text">{messages.paginationNext}</span>
+                  <svg className="usa-icon" aria-hidden="true" focusable="false" role="img">
+                    <use href="/assets/njwds/dist/img/sprite.svg#navigate_next" />
+                  </svg>
+                </button>
+              </li>
+            </ul>
+          </nav>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FundingPageContent;

--- a/packages/static-site/components/learn/PageSwitchComponent.tsx
+++ b/packages/static-site/components/learn/PageSwitchComponent.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { FundingPage } from "@/components/learn/FundingPage";
 import PageContent from "@/components/learn/PageContent";
 import { StarterKitsPage } from "@/components/learn/StarterKitsPage";
 import type { PageItem } from "@/domain/content/types";
@@ -11,6 +12,8 @@ interface Props {
 
 export const PageSwitchComponent = ({ page, locale }: Props): ReactElement => {
   switch (page.slug) {
+    case "funding":
+      return <FundingPage page={page} locale={locale} />;
     case "starter-kits":
       return <StarterKitsPage page={page} locale={locale} />;
     default:

--- a/packages/static-site/components/learn/highlightMatches.test.tsx
+++ b/packages/static-site/components/learn/highlightMatches.test.tsx
@@ -1,0 +1,63 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { HighlightedText, splitHighlight } from "./highlightMatches";
+
+describe("splitHighlight", () => {
+  it("returns the whole string as one non-match segment for an empty query", () => {
+    expect(splitHighlight("Hello world", "")).toEqual([{ text: "Hello world", match: false }]);
+  });
+
+  it("returns the whole string as one non-match segment for a whitespace query", () => {
+    expect(splitHighlight("Hello world", "   ")).toEqual([{ text: "Hello world", match: false }]);
+  });
+
+  it("returns a single non-match segment when there is no match", () => {
+    expect(splitHighlight("Hello world", "xyz")).toEqual([{ text: "Hello world", match: false }]);
+  });
+
+  it("splits around a single match", () => {
+    expect(splitHighlight("Hello world", "world")).toEqual([
+      { text: "Hello ", match: false },
+      { text: "world", match: true },
+    ]);
+  });
+
+  it("matches case-insensitively while preserving the original casing", () => {
+    expect(splitHighlight("Grant Program", "grant")).toEqual([
+      { text: "Grant", match: true },
+      { text: " Program", match: false },
+    ]);
+  });
+
+  it("splits around multiple matches", () => {
+    expect(splitHighlight("aXaXa", "x")).toEqual([
+      { text: "a", match: false },
+      { text: "X", match: true },
+      { text: "a", match: false },
+      { text: "X", match: true },
+      { text: "a", match: false },
+    ]);
+  });
+
+  it("handles adjacent matches", () => {
+    expect(splitHighlight("aa", "a")).toEqual([
+      { text: "a", match: true },
+      { text: "a", match: true },
+    ]);
+  });
+});
+
+describe("HighlightedText", () => {
+  it("wraps matched text in a mark with the highlight class", () => {
+    const { container } = render(<HighlightedText text="Grant Program" query="grant" />);
+    const mark = container.querySelector("mark.funding-search-highlight");
+    expect(mark).not.toBeNull();
+    expect(mark).toHaveTextContent("Grant");
+  });
+
+  it("renders plain text with no mark when the query is empty", () => {
+    const { container } = render(<HighlightedText text="Grant Program" query="" />);
+    expect(container.querySelector("mark")).toBeNull();
+    expect(container).toHaveTextContent("Grant Program");
+  });
+});

--- a/packages/static-site/components/learn/highlightMatches.tsx
+++ b/packages/static-site/components/learn/highlightMatches.tsx
@@ -1,0 +1,56 @@
+import { Fragment, type ReactElement } from "react";
+
+export interface HighlightSegment {
+  readonly text: string;
+  readonly match: boolean;
+}
+
+export const splitHighlight = (text: string, query: string): HighlightSegment[] => {
+  const needle = query.trim().toLowerCase();
+  if (needle === "") {
+    return [{ text, match: false }];
+  }
+
+  const segments: HighlightSegment[] = [];
+  const haystack = text.toLowerCase();
+  let cursor = 0;
+
+  for (;;) {
+    const index = haystack.indexOf(needle, cursor);
+    if (index === -1) {
+      break;
+    }
+    if (index > cursor) {
+      segments.push({ text: text.slice(cursor, index), match: false });
+    }
+    segments.push({ text: text.slice(index, index + needle.length), match: true });
+    cursor = index + needle.length;
+  }
+
+  if (cursor < text.length) {
+    segments.push({ text: text.slice(cursor), match: false });
+  }
+
+  return segments;
+};
+
+interface HighlightedTextProps {
+  readonly text: string;
+  readonly query: string;
+}
+
+export const HighlightedText = ({ text, query }: HighlightedTextProps): ReactElement => (
+  <>
+    {splitHighlight(text, query).map((segment, index) =>
+      segment.match ? (
+        // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional and stable per render
+        <mark key={index} className="funding-search-highlight">
+          {segment.text}
+        </mark>
+      ) : (
+        // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional and stable per render
+        <Fragment key={index}>{segment.text}</Fragment>
+      ),
+    )}
+  </>
+);

--- a/packages/static-site/components/learn/parseFundingContent.test.ts
+++ b/packages/static-site/components/learn/parseFundingContent.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { parseFundingContent } from "./parseFundingContent";
+
+const SAMPLE_CONTENT_MD = `
+## Eligibility
+
+- Your business must be registered in New Jersey
+- Enroll at least 1 apprentice in your program
+
+:::largeCallout{ showHeader="true" headerText="Benefits:" calloutType="conditional" }
+
+The tax credit ranges from $5,000 to $10,000.
+
+:::
+`;
+
+describe("parseFundingContent", () => {
+  it("extracts eligibility bullets", () => {
+    const { eligibility } = parseFundingContent(SAMPLE_CONTENT_MD);
+    expect(eligibility).toContain("Your business must be registered in New Jersey");
+    expect(eligibility).toContain("Enroll at least 1 apprentice in your program");
+  });
+
+  it("extracts benefits text", () => {
+    const { benefits } = parseFundingContent(SAMPLE_CONTENT_MD);
+    expect(benefits).toContain("The tax credit ranges from $5,000 to $10,000.");
+  });
+
+  it("extracts the section under a non-Eligibility heading", () => {
+    const content = `## Eligible Expenses
+
+- Electric vehicles and EV charging stations
+- Program development and operation
+
+:::largeCallout{ showHeader="true" headerText="Benefits" calloutType="conditional" }
+
+Previous awards have ranged between $100K to $8M.
+
+:::`;
+    const { eligibility, benefits } = parseFundingContent(content);
+    expect(eligibility).toContain("Electric vehicles and EV charging stations");
+    expect(eligibility).not.toContain("Eligible Expenses");
+    expect(benefits).toContain("Previous awards have ranged between $100K to $8M.");
+  });
+
+  it("returns empty strings when there is no heading or callout", () => {
+    const { eligibility, benefits } = parseFundingContent("No sections here.");
+    expect(eligibility).toBe("");
+    expect(benefits).toBe("");
+  });
+
+  it("trims whitespace from extracted sections", () => {
+    const { eligibility, benefits } = parseFundingContent(SAMPLE_CONTENT_MD);
+    expect(eligibility).toBe(eligibility.trim());
+    expect(benefits).toBe(benefits.trim());
+  });
+
+  it("strips the |id suffix from inline code contextual info links", () => {
+    const content = `## Eligibility\n\n- Must use a \`Qualified Incentive Track|qit-njeda\` designation\n\n:::largeCallout{ showHeader="true" headerText="Benefits:" calloutType="conditional" }\n\nSee \`program terms|some-id\` for details.\n\n:::`;
+    const { eligibility, benefits } = parseFundingContent(content);
+    expect(eligibility).toContain("Qualified Incentive Track");
+    expect(eligibility).not.toContain("|qit-njeda");
+    expect(benefits).toContain("program terms");
+    expect(benefits).not.toContain("|some-id");
+  });
+});

--- a/packages/static-site/components/learn/parseFundingContent.ts
+++ b/packages/static-site/components/learn/parseFundingContent.ts
@@ -1,0 +1,38 @@
+export interface FundingContentSections {
+  readonly eligibility: string;
+  readonly benefits: string;
+}
+
+export const parseFundingContent = (contentMd: string): FundingContentSections => {
+  const calloutMarker = ":::largeCallout";
+  const calloutEnd = ":::";
+
+  const calloutStart = contentMd.indexOf(calloutMarker);
+
+  // Match the first level-2 heading regardless of its text (content files vary
+  // between "## Eligibility" and headings like "## Eligible Expenses"). The
+  // heading itself is rendered from the message file; we extract only the body
+  // beneath it, up to the callout when one is present.
+  const headingMatch = contentMd.match(/^##[^\n#][^\n]*$/m);
+  const headingStart = headingMatch?.index ?? -1;
+
+  const stripContextualInfoIds = (text: string): string => text.replace(/`([^`|]+)\|[^`]+`/g, "$1");
+
+  let eligibility = "";
+  if (headingStart !== -1) {
+    const bodyStart = contentMd.indexOf("\n", headingStart) + 1;
+    const bodyEnd = calloutStart === -1 ? contentMd.length : calloutStart;
+    eligibility = stripContextualInfoIds(contentMd.slice(bodyStart, bodyEnd).trim());
+  }
+
+  let benefits = "";
+  if (calloutStart !== -1) {
+    const benefitsBodyStart = contentMd.indexOf("\n", calloutStart) + 1;
+    const calloutEndIndex = contentMd.indexOf(calloutEnd, calloutStart + calloutMarker.length);
+    if (calloutEndIndex !== -1) {
+      benefits = stripContextualInfoIds(contentMd.slice(benefitsBodyStart, calloutEndIndex).trim());
+    }
+  }
+
+  return { eligibility, benefits };
+};

--- a/packages/static-site/domain/content/messageTypes.ts
+++ b/packages/static-site/domain/content/messageTypes.ts
@@ -5,6 +5,8 @@
  * and rendered UI sections.
  */
 
+import type { FundingType } from "./types";
+
 /**
  * A localized link used by landing-page components.
  */
@@ -519,6 +521,58 @@ export interface LearnPageContent {
 }
 
 /**
+ * Localized content for the funding page.
+ */
+export interface FundingPageMessages {
+  /** Page H1 title. */
+  readonly title: string;
+  /** Heading inside the "Find Funding Fit" CTA box. */
+  readonly ctaHeading: string;
+  /** Body text inside the "Find Funding Fit" CTA box. */
+  readonly ctaBody: string;
+  /** Label for the "Create Account" CTA button. */
+  readonly ctaButton: string;
+  /** Heading for the filter sidebar. */
+  readonly filterHeading: string;
+  /** Label for the search input. */
+  readonly filterSearch: string;
+  /** Label for the industry filter group. */
+  readonly filterIndustry: string;
+  /** Label for the funding type filter group. */
+  readonly filterFundingType: string;
+  /** Display labels for each funding type, keyed by its content value. */
+  readonly fundingTypeLabels: Record<FundingType, string>;
+  /** Label for the "Clear" button inside each filter fieldset. */
+  readonly filterClear: string;
+  /** Label for the "Show Results" button; {count} is replaced at runtime. */
+  readonly filterShowResults: string;
+  /** Label for the "Reset" button. */
+  readonly filterReset: string;
+  /** Result count line; {filtered} (wrapped in <bold>) and {total} are substituted at runtime via t.rich. */
+  readonly resultCount: string;
+  /** Label preceding the filter chips ("Filtering by:"). */
+  readonly filteringByLabel: string;
+  /** Chip label for the active search query; {query} is replaced at runtime. */
+  readonly filterSearchChip: string;
+  /** aria-label template for chip remove buttons; {filter} is replaced at runtime. */
+  readonly filterRemoveLabel: string;
+  /** Label for pagination "Previous" control. */
+  readonly paginationPrevious: string;
+  /** Label for pagination "Next" control. */
+  readonly paginationNext: string;
+  /** aria-label for the pagination navigation landmark. */
+  readonly paginationLabel: string;
+  /** aria-label template for a numbered page button; {page} is replaced at runtime. */
+  readonly paginationPageLabel: string;
+  /** Prefix label for a funding's due date on the card. */
+  readonly cardDueLabel: string;
+  /** Heading for the eligibility section on a funding card. */
+  readonly cardEligibilityHeading: string;
+  /** Heading for the benefits callout on a funding card. */
+  readonly cardBenefitsHeading: string;
+}
+
+/**
  * Complete localized message payload for one locale.
  */
 export interface ApplicationMessages {
@@ -530,4 +584,6 @@ export interface ApplicationMessages {
   readonly landing: LandingPageContent;
   /** Learn page content strings and links. */
   readonly learn: LearnPageContent;
+  /** Funding page content strings. */
+  readonly funding: FundingPageMessages;
 }

--- a/packages/static-site/messages/en-US.json
+++ b/packages/static-site/messages/en-US.json
@@ -634,5 +634,37 @@
       "industrySelectorCta": "Go to Starter Kit",
       "topIndustriesHeading": "Top Industries"
     }
+  },
+  "funding": {
+    "title": "Funding",
+    "ctaHeading": "Find Funding Fit for Your Business",
+    "ctaBody": "Answers just a few questions, and we'll find programs you may be eligible for.",
+    "ctaButton": "Create Account",
+    "filterHeading": "Filter All Funding Options",
+    "filterSearch": "Search",
+    "filterIndustry": "Industry",
+    "filterFundingType": "Funding Type",
+    "fundingTypeLabels": {
+      "grant": "Grant",
+      "loan": "Loan",
+      "tax credit": "Tax Credit",
+      "tax exemption": "Tax Exemption",
+      "technical assistance": "Technical Assistance",
+      "hiring and employee training support": "Hiring & Employee Training Support"
+    },
+    "filterClear": "Clear",
+    "filterShowResults": "Show {count} Results",
+    "filterReset": "Reset",
+    "resultCount": "Showing <bold>{filtered}</bold> results of {total} items",
+    "filteringByLabel": "Filtering by:",
+    "filterSearchChip": "Search: \"{query}\"",
+    "filterRemoveLabel": "Remove {filter} filter",
+    "paginationPrevious": "Previous",
+    "paginationNext": "Next",
+    "paginationLabel": "Pagination",
+    "paginationPageLabel": "Page {page}",
+    "cardDueLabel": "Due:",
+    "cardEligibilityHeading": "Eligibility",
+    "cardBenefitsHeading": "Benefits"
   }
 }

--- a/packages/static-site/messages/es-US.json
+++ b/packages/static-site/messages/es-US.json
@@ -634,5 +634,37 @@
       "industrySelectorCta": "Go to Starter Kit",
       "topIndustriesHeading": "Top Industries"
     }
+  },
+  "funding": {
+    "title": "Financiamiento",
+    "ctaHeading": "Encuentre el financiamiento adecuado para su negocio",
+    "ctaBody": "Responda solo unas pocas preguntas y encontraremos programas para los que podría ser elegible.",
+    "ctaButton": "Crear cuenta",
+    "filterHeading": "Filtrar todas las opciones de financiamiento",
+    "filterSearch": "Buscar",
+    "filterIndustry": "Industria",
+    "filterFundingType": "Tipo de financiamiento",
+    "fundingTypeLabels": {
+      "grant": "Subvención",
+      "loan": "Préstamo",
+      "tax credit": "Crédito fiscal",
+      "tax exemption": "Exención fiscal",
+      "technical assistance": "Asistencia técnica",
+      "hiring and employee training support": "Apoyo para contratación y capacitación de empleados"
+    },
+    "filterClear": "Borrar",
+    "filterShowResults": "Mostrar {count} resultados",
+    "filterReset": "Restablecer",
+    "resultCount": "Mostrando <bold>{filtered}</bold> resultados de {total} elementos",
+    "filteringByLabel": "Filtrando por:",
+    "filterSearchChip": "Búsqueda: \"{query}\"",
+    "filterRemoveLabel": "Quitar el filtro {filter}",
+    "paginationPrevious": "Anterior",
+    "paginationNext": "Siguiente",
+    "paginationLabel": "Paginación",
+    "paginationPageLabel": "Página {page}",
+    "cardDueLabel": "Fecha límite:",
+    "cardEligibilityHeading": "Elegibilidad",
+    "cardBenefitsHeading": "Beneficios"
   }
 }

--- a/packages/static-site/package.json
+++ b/packages/static-site/package.json
@@ -54,9 +54,12 @@
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/hast": "^3.0.4",
     "@types/node": "25.9.3",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
+    "@types/unist": "^3.0.3",
     "@vitejs/plugin-react": "6.0.2",
     "axe-core": "4.12.1",
     "babel-plugin-react-compiler": "1.0.0",
@@ -83,6 +86,7 @@
     "next-intl": "4.13.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "unist-util-visit-parents": "^6.0.2"
   }
 }

--- a/packages/static-site/pnpm-lock.yaml
+++ b/packages/static-site/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
+      unist-util-visit-parents:
+        specifier: ^6.0.2
+        version: 6.0.2
     devDependencies:
       '@axe-core/playwright':
         specifier: 4.11.3
@@ -54,6 +57,12 @@ importers:
       '@testing-library/react':
         specifier: 16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@types/node':
         specifier: 25.9.3
         version: 25.9.3
@@ -63,6 +72,9 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@types/unist':
+        specifier: ^3.0.3
+        version: 3.0.3
       '@vitejs/plugin-react':
         specifier: 6.0.2
         version: 6.0.2(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
@@ -933,6 +945,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@trussworks/react-uswds@11.1.0':
     resolution: {integrity: sha512-trvTYjbokohPKUPWbhMxEHIfuW/MEnQUuaMeOqV7XPBTv6OYvZsv6/jI5ul0YSRd/VyT0m8L8Fj0cRTCQx4GoQ==}
@@ -2636,6 +2654,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@trussworks/react-uswds@11.1.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@uswds/uswds@3.10.0)(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:


### PR DESCRIPTION
## Description

Adds the `/pages/funding` page with a fully wired up filter sidebar.

### Ticket

- This pull request resolves [#17822](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17822).
- Figma designs [here](https://www.figma.com/design/pk0neG436QNTm805O603Vp/96-100-Business-Experience-Sprint-Designs?node-id=68436-4347&t=eRz2yk2qGqjSzK5a-0).

### Approach

Before squashing things down prior to merging, commits were sequentially program down into 4 general groupings of commits:

1. The funding page, cards, and content
2. Industry/funding-type filters with a "Filtering by" chip bar and result count
3. Basic search with case-insensitive literal matching on each card's title and visible body
4. Follow-up fixes, design tweaks, bugs in self-review, gaps from AC, etc

### Steps to Test

1. `cd packages/static-sit && pnpm dev`
5. Open `http://localhost:4000/pages/funding`.
6. **Search:** type `tax credit` in the Search box. Results filter live as you type, the count updates (e.g. "Showing 10 results of 63 items"), matches are highlighted in card titles and bodies, and a removable `Search: "tax credit"` chip appears in the "Filtering by" bar. Clicking the chip's X (or clearing the search box) restores all results.
7. **Combine with filters:** with a search active, check an Industry or Funding Type box and click "Show Results" — results match the filters and the search together.
8. **Case-insensitivity:** confirm `TAX CREDIT` and `tax credit` return the same results.

### Notes

- The search highlight uses `--color-primary` instead of the original guidacne of `--color-primary-lighter`, which would fail WCAG contrast guidelines for highlighted text that shows up in the info alert box components. This was validated with design

### Screenshots

<details>
<summary>With An Active Search Query</summary>

**Filtering with an exact match (case-insensitive) search query**
Part 1
<img width="1512" height="806" alt="funding-search-1" src="https://github.com/user-attachments/assets/b51a29b9-a420-4abd-bb9d-6461f5efe549" />

Part 2
<img width="1512" height="806" alt="funding-search-2" src="https://github.com/user-attachments/assets/5186f287-33c1-493c-be75-86c236b65adf" />

</details>


<details>

<summary>Full Page Screenshot (no active filters)</summary>
<img width="1512" height="6958" alt="funding-fullpage" src="https://github.com/user-attachments/assets/8cdeb465-df38-48d5-a001-2ebd51e5f977" />

</details>

<details>
<summary>Full Page Screenshot (with active filters + search query)</summary>
<img width="1512" height="3624" alt="funding-filtered-fullpage" src="https://github.com/user-attachments/assets/851ae4af-041e-4681-bb5d-06ba5bc174ec" />

</details>

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [ ] ~~I have created and/or updated relevant documentation on the engineering documentation website~~ N/A
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [ ] ~~If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file~~ N/A
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] ~~I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces~~ N/A
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
