### PR TITLE
Add the "Licensing and Certifications Guide" page to the static site

### DIFF
--- a/content/build.test.ts
+++ b/content/build.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import path from "path";
 import matter from "gray-matter";
 import fs from "fs";
+import { loadAllLicenses } from "@businessnjgovnavigator/shared/static/loadAllLicenses";
 import {
   type FileSystemPort,
   type BuildConfig,
@@ -13,7 +14,8 @@ import {
   buildSectors,
   buildAndWriteSectors,
   buildAndWriteContent,
-  contentConfigs,
+  getContentConfigs,
+  toIndustryNamesById,
   executeBuild,
   createBuildConfig,
   logBuildResults,
@@ -24,6 +26,7 @@ import {
   extractItemsFromObject,
   buildChecklistItemTaskMap,
   buildAndWriteChecklistItemTasks,
+  toLicenseCard,
 } from "./build";
 
 // ============================================================================
@@ -206,6 +209,19 @@ describe("Domain Layer", () => {
 
       const industries = buildIndustries(mockFs, "/industries");
       expect(industries).toHaveLength(0);
+    });
+
+    it("should build an industryId to name lookup map", () => {
+      const industries = [
+        { id: "ind1", name: "Industry 1" },
+        { id: "ind2", name: "Industry 2" },
+      ];
+
+      const industryNamesById = toIndustryNamesById(industries);
+
+      expect(industryNamesById.get("ind1")).toBe("Industry 1");
+      expect(industryNamesById.get("ind2")).toBe("Industry 2");
+      expect(industryNamesById.get("unknown")).toBeUndefined();
     });
   });
 
@@ -556,7 +572,8 @@ describe("Application Layer", () => {
 
   describe("Content Configuration", () => {
     it("should have configuration for all content types", () => {
-      expect(contentConfigs).toHaveLength(7); // 7 content types (excluding industries)
+      const contentConfigs = getContentConfigs(new Map());
+      expect(contentConfigs).toHaveLength(8); // 8 content types (excluding industries)
 
       const fileNames = contentConfigs.map((c) => c.outputFileName);
       expect(fileNames).toContain("tasks");
@@ -564,11 +581,13 @@ describe("Application Layer", () => {
       expect(fileNames).toContain("certifications");
       expect(fileNames).toContain("filings");
       expect(fileNames).toContain("fundings");
+      expect(fileNames).toContain("licenses");
       expect(fileNames).toContain("license-calendar-events");
       expect(fileNames).toContain("license-reinstatements");
     });
 
     it("should have valid loader functions", () => {
+      const contentConfigs = getContentConfigs(new Map());
       for (const config of contentConfigs) {
         expect(typeof config.loader).toBe("function");
         const result = config.loader();
@@ -583,10 +602,12 @@ describe("Application Layer", () => {
         "certificationsCount",
         "filingsCount",
         "fundingsCount",
+        "licensesCount",
         "licenseCalendarEventsCount",
         "licenseReinstatementsCount",
       ];
 
+      const contentConfigs = getContentConfigs(new Map());
       const resultKeys = contentConfigs.map((c) => c.resultKey);
       expect(resultKeys).toEqual(expectedKeys);
     });
@@ -708,5 +729,125 @@ describe("Integration Tests", () => {
     expect(fs.existsSync("lib/tasks.json")).toBe(true);
 
     consoleSpy.mockRestore();
+  });
+});
+
+// ============================================================================
+// toLicenseCard MAPPER TESTS
+// ============================================================================
+
+describe("toLicenseCard", () => {
+  it("resolves industry, falling back to webflowIndustry, and maps agency fields", () => {
+    const [first] = loadAllLicenses();
+    const card = toLicenseCard(first, new Map());
+    expect(card.name).toBe(first.webflowName || first.name || "");
+    expect(card.urlSlug).toBe(first.urlSlug);
+    // industry present either via industryId or webflowIndustry
+    expect(typeof card.industry === "string" || card.industry === undefined).toBe(true);
+  });
+
+  it("resolves the industry name from the provided industryNamesById map", () => {
+    const card = toLicenseCard(
+      {
+        id: "x",
+        filename: "x",
+        urlSlug: "x",
+        name: "X",
+        industryId: "restaurant",
+        licenseCertificationClassification: "LICENSE",
+        contentMd: "",
+      },
+      new Map([["restaurant", "Restaurant"]]),
+    );
+    expect(card.industry).toBe("Restaurant");
+  });
+
+  it("falls back to webflowIndustry when industryId is unmatched in the map", () => {
+    const card = toLicenseCard(
+      {
+        id: "x",
+        filename: "x",
+        urlSlug: "x",
+        name: "X",
+        industryId: "unknown-industry",
+        webflowIndustry: "General",
+        licenseCertificationClassification: "LICENSE",
+        contentMd: "",
+      },
+      new Map([["restaurant", "Restaurant"]]),
+    );
+    expect(card.industry).toBe("General");
+  });
+
+  it("falls back to webflowName for the card title when name is absent", () => {
+    // Most webflow-license source files carry only `webflowName`, not `name`;
+    // the card title must fall back to it so titles are never blank.
+    const card = toLicenseCard(
+      {
+        id: "x",
+        filename: "x",
+        urlSlug: "x",
+        name: undefined as unknown as string,
+        webflowName: "Adoption Agency",
+        licenseCertificationClassification: "LICENSE",
+        contentMd: "",
+      },
+      new Map(),
+    );
+    expect(card.name).toBe("Adoption Agency");
+  });
+
+  it("carries webflowType through for the classification label", () => {
+    const card = toLicenseCard(
+      {
+        id: "x",
+        filename: "x",
+        urlSlug: "x",
+        name: "X",
+        webflowType: "business-license",
+        licenseCertificationClassification: "LICENSE",
+        contentMd: "",
+      },
+      new Map(),
+    );
+    expect(card.webflowType).toBe("business-license");
+  });
+
+  it("prefers webflowName over name when both are present", () => {
+    // Roadmap license-task files carry an imperative `name` ("Apply for Your
+    // Food Truck License") alongside the Webflow catalog `webflowName` ("Food
+    // Truck License"). The licensing directory must show the catalog name, matching
+    // what the Webflow-published pages display.
+    const card = toLicenseCard(
+      {
+        id: "food-truck",
+        filename: "apply-for-food-truck-license",
+        urlSlug: "food-truck",
+        name: "Apply for Your Food Truck License",
+        webflowName: "Food Truck License",
+        licenseCertificationClassification: "LICENSE",
+        contentMd: "",
+      },
+      new Map(),
+    );
+    expect(card.name).toBe("Food Truck License");
+  });
+
+  it("falls back to webflowName when name is an empty string (not just missing)", () => {
+    // e.g. veterinarian.md has `name: ""` with a real webflowName — `??` would
+    // keep the empty string and produce a blank (a11y empty-heading) title.
+    const card = toLicenseCard(
+      {
+        id: "veterinarian",
+        filename: "veterinarian",
+        urlSlug: "veterinarian",
+        name: "",
+        webflowName: "Veterinarian",
+        licenseCertificationClassification: "REGISTRATION/LICENSE",
+        contentMd: "",
+      },
+      new Map(),
+    );
+    expect(card.name).toBe("Veterinarian");
   });
 });

--- a/content/build.ts
+++ b/content/build.ts
@@ -36,7 +36,13 @@ import { loadAllCertifications } from "@businessnjgovnavigator/shared/static/loa
 import { loadAllFilings } from "@businessnjgovnavigator/shared/static/loadFilings";
 import { loadAllFundings } from "@businessnjgovnavigator/shared/static/loadFundings";
 import { loadAllLicenseCalendarEvents } from "@businessnjgovnavigator/shared/static/loadLicenseCalendarEvents";
+import {
+  loadAllLicenses,
+  type WebflowLicenseCard,
+} from "@businessnjgovnavigator/shared/static/loadAllLicenses";
+import { LookupTaskAgencyById } from "@businessnjgovnavigator/shared/taskAgency";
 import { loadAllTasks } from "@businessnjgovnavigator/shared/static/loadTasks";
+import type { License } from "@businessnjgovnavigator/content-types";
 
 // ============================================================================
 // DOMAIN TYPES
@@ -60,6 +66,8 @@ export interface BuildResult {
   filingsCount: number;
   /** Number of fundings built */
   fundingsCount: number;
+  /** Number of licenses built */
+  licensesCount: number;
   /** Number of license calendar events built */
   licenseCalendarEventsCount: number;
   /** Number of license reinstatements built */
@@ -92,6 +100,46 @@ export interface FileSystemPort {
   /** Writes data to file as pretty-printed JSON with 2-space indentation */
   writePrettyJsonFile: (filePath: string, data: unknown) => void;
 }
+
+// ============================================================================
+// DOMAIN MAPPERS
+// ============================================================================
+
+/**
+ * Converts a raw WebflowLicenseCard (from shared loader) to a display-ready License card.
+ * Resolves agencyId → agency name and industryId → industry name, falling back to webflowIndustry.
+ *
+ * Takes industryNamesById rather than importing @businessnjgovnavigator/shared/industry directly:
+ * that module reads content's own build output (content/lib/industry.json), which does not exist
+ * yet on a cold build when content builds itself. Industries are built earlier in the same
+ * process (see executeBuild), so its in-memory result is passed in here instead.
+ */
+export const toLicenseCard = (
+  license: WebflowLicenseCard,
+  industryNamesById: ReadonlyMap<string, string>,
+): License => ({
+  // Prefer webflowName: it is the Webflow-canonical catalog title shown on the
+  // published license pages. Roadmap license-task files carry an imperative
+  // `name` ("Apply for Your Food Truck License") that reads wrong on a license
+  // directory, so it is only the fallback. Truthiness (not `??`) also skips the
+  // empty `name:` some source files carry, avoiding blank card titles.
+  name: license.webflowName || license.name || "",
+  urlSlug: license.urlSlug,
+  webflowId: license.webflowId,
+  webflowName: license.webflowName,
+  licenseCertificationClassification: license.licenseCertificationClassification,
+  webflowType: license.webflowType,
+  // Prefer the resolved industry name, but fall back to webflowIndustry when the
+  // industryId is missing or unmatched.
+  industry:
+    (license.industryId && industryNamesById.get(license.industryId)) || license.webflowIndustry,
+  summaryDescriptionMd: license.summaryDescriptionMd,
+  agency: license.agencyId ? LookupTaskAgencyById(license.agencyId).name : undefined,
+  division: license.agencyAdditionalContext,
+  divisionPhone: license.divisionPhone,
+  callToActionText: license.callToActionText,
+  callToActionLink: license.callToActionLink,
+});
 
 // ============================================================================
 // INFRASTRUCTURE LAYER - File System Port
@@ -224,6 +272,14 @@ interface IndustryData {
   readonly naicsCodes?: string;
   readonly defaultSectorId?: string;
 }
+
+/**
+ * Builds an industryId → name lookup from the in-memory industries built earlier in the
+ * same process. Used by the licenses loader below instead of importing
+ * @businessnjgovnavigator/shared/industry, which reads content's own build output.
+ */
+export const toIndustryNamesById = (industries: unknown[]): Map<string, string> =>
+  new Map((industries as IndustryData[]).map((industry) => [industry.id, industry.name]));
 
 /**
  * Sector structure from sectors.json.
@@ -556,7 +612,7 @@ export interface ContentConfig {
 }
 
 /**
- * Configuration array defining all content types to build.
+ * Builds the configuration array defining all content types to build.
  *
  * This is the metaprogramming approach that replaces 7 individual build functions.
  * Each entry defines how to build a specific content type (tasks, actions, etc.).
@@ -568,9 +624,13 @@ export interface ContentConfig {
  * 4. No other code changes needed!
  *
  * Note: Industries are handled separately (buildAndWriteIndustries) because they
- * use a custom file-based loader instead of the shared package loaders.
+ * use a custom file-based loader instead of the shared package loaders. This function
+ * takes the built industries so the licenses loader can resolve industry names without
+ * a circular dependency on content's own build output.
  */
-export const contentConfigs: ContentConfig[] = [
+export const getContentConfigs = (
+  industryNamesById: ReadonlyMap<string, string>,
+): ContentConfig[] => [
   {
     loader: () => loadAllTasks(false),
     outputFileName: "tasks",
@@ -600,6 +660,12 @@ export const contentConfigs: ContentConfig[] = [
     outputFileName: "fundings",
     dataKey: "fundings",
     resultKey: "fundingsCount",
+  },
+  {
+    loader: () => loadAllLicenses().map((license) => toLicenseCard(license, industryNamesById)),
+    outputFileName: "licenses",
+    dataKey: "licenses",
+    resultKey: "licensesCount",
   },
   {
     loader: () => loadAllLicenseCalendarEvents(),
@@ -647,6 +713,8 @@ export const executeBuild = (fileSystem: FileSystemPort, config: BuildConfig): B
     industriesCount: industries.length,
     sectorsCount: sectors.length,
   };
+
+  const contentConfigs = getContentConfigs(toIndustryNamesById(industries));
 
   // Loop through each content type config and build it
   for (const contentConfig of contentConfigs) {
@@ -697,6 +765,7 @@ export const logBuildResults = (result: BuildResult): void => {
   console.log(`✓ Built certifications.json with ${result.certificationsCount} certifications`);
   console.log(`✓ Built filings.json with ${result.filingsCount} filings`);
   console.log(`✓ Built fundings.json with ${result.fundingsCount} fundings`);
+  console.log(`✓ Built licenses.json with ${result.licensesCount} licenses`);
   console.log(
     `✓ Built license-calendar-events.json with ${result.licenseCalendarEventsCount} license-related calendar events`,
   );

--- a/content/package.json
+++ b/content/package.json
@@ -18,6 +18,7 @@
     "gray-matter": "4.0.3"
   },
   "devDependencies": {
+    "@businessnjgovnavigator/content-types": "*",
     "@businessnjgovnavigator/shared": "*",
     "@types/node": "24.12.2",
     "@vitest/coverage-v8": "4.1.9",

--- a/packages/content-types/src/index.ts
+++ b/packages/content-types/src/index.ts
@@ -5,4 +5,5 @@ export * from "./task";
 export * from "./filing";
 export * from "./anytime-action";
 export * from "./license-event";
+export * from "./license";
 export * from "./industry";

--- a/packages/content-types/src/license.ts
+++ b/packages/content-types/src/license.ts
@@ -1,0 +1,33 @@
+/** A license/certification card on the Licensing & Certification Guide page. */
+export interface License {
+  /** Card title. */
+  name: string;
+  /** URL-friendly slug. */
+  urlSlug: string;
+  /** Legacy Webflow CMS identifier. */
+  webflowId?: string;
+  /** Webflow display name (may differ from `name`). */
+  webflowName?: string;
+  /** "Who it's for" classification, e.g. "LICENSE" or "CERTIFICATION". */
+  licenseCertificationClassification?: string;
+  /**
+   * Clean classification key from Webflow (`business-license`,
+   * `individual-license`, `object-vehicle`, `school-course`). Drives the
+   * "Who it's for" label; prefer this over `licenseCertificationClassification`.
+   */
+  webflowType?: string;
+  /** Resolved industry display name. */
+  industry?: string;
+  /** Summary description markdown rendered in the card body. */
+  summaryDescriptionMd?: string;
+  /** Resolved agency display name (no URL — TaskAgency has no link field). */
+  agency?: string;
+  /** Agency division / additional context. */
+  division?: string;
+  /** Division phone number. */
+  divisionPhone?: string;
+  /** Primary CTA button label. */
+  callToActionText?: string;
+  /** Primary CTA button link. */
+  callToActionLink?: string;
+}

--- a/packages/static-site/app/[locale]/(learn)/layout.tsx
+++ b/packages/static-site/app/[locale]/(learn)/layout.tsx
@@ -60,14 +60,16 @@ const PageLayout = async ({ children, params }: PageLayoutProps) => {
   );
 
   return (
-    <main className="grid-container usa-section">
+    // A `div`, not `main`: the app shell (locale layout) already provides the
+    // top-level `<main>` landmark, so this inner wrapper must not be a second one.
+    <div className="grid-container usa-section">
       <div className="grid-row grid-gap">
         <div className="tablet:grid-col-4 learn-side-nav">
           <LearnSideNav content={messages.learn} categoryChildren={categoryChildren} />
         </div>
         <div className="tablet:grid-col-8">{children}</div>
       </div>
-    </main>
+    </div>
   );
 };
 

--- a/packages/static-site/app/funding.css
+++ b/packages/static-site/app/funding.css
@@ -4,13 +4,24 @@
   display: flow-root;
 }
 
-/* USWDS's [type="search"] reset drops the input's inline-end border because it
-   assumes a search field sits flush against an attached submit button that
-   covers that edge. This is a standalone search field with no button, so its
-   right side looked open ("cut off"); restore the border to match the other
-   three sides. */
-#funding-search {
+/* NJWDS strips the inline-end border off `[type="search"]` inputs because its
+   search pattern seams the field against an attached button. Our filter search
+   fields stand alone, so restore the border to close the box.
+
+   `.usa-input` also caps width at 30rem, which leaves the search field short of
+   the filter aside on single-column widths; drop the cap so it fills the aside
+   like the checkbox rows do. */
+.funding-filter-col .usa-input[type="search"] {
   border-inline-end: 1px solid var(--color-base-dark);
+  max-width: none;
+}
+
+/* `.usa-legend` shares the same 30rem cap, which would leave each filter
+   group's "Clear" button short of the aside edge that the search input,
+   dividers, and checkbox rows all fill. Drop the cap so the legend row spans
+   the full width and the Clear buttons align with everything else. */
+.funding-filter-col .usa-legend {
+  max-width: none;
 }
 
 .funding-layout {
@@ -21,7 +32,11 @@
 @media (min-width: 64em) {
   .funding-layout {
     display: grid;
-    grid-template-columns: 2fr 1fr;
+    /* `minmax(0, …)` lets the tracks shrink below their content's min-content,
+       so a wide grid item (e.g. a long card or the filter list) can't force a
+       column past its fraction and overflow the layout at narrow desktop
+       widths. */
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
     grid-template-areas:
       "header filter"
       "results filter";
@@ -101,4 +116,12 @@
 .funding-card__heading-link:hover,
 .funding-card__heading-link:focus {
   cursor: pointer;
+}
+
+/* Keeps a leading inline icon from shrinking in a flex row and aligns it with
+   the cap height of the first text line (the 1em icon otherwise sits slightly
+   above the text top). */
+.nj-icon-text-top {
+  flex-shrink: 0;
+  margin-top: 0.2em;
 }

--- a/packages/static-site/components/learn/FundingCard.test.tsx
+++ b/packages/static-site/components/learn/FundingCard.test.tsx
@@ -59,6 +59,15 @@ describe("FundingCard", () => {
     expect(screen.getByText("ROLLING APPLICATION")).toBeInTheDocument();
   });
 
+  it("renders a base-light divider between the card header and body", () => {
+    const { container } = renderCard({ funding: funding() });
+    const divider = container.querySelector("hr.border-base-light");
+    expect(divider).not.toBeNull();
+    // The divider sits between the header and the body.
+    expect(divider?.previousElementSibling?.classList.contains("usa-card__header")).toBe(true);
+    expect(divider?.nextElementSibling?.classList.contains("usa-card__body")).toBe(true);
+  });
+
   it("renders funding type badge uppercased", () => {
     renderCard({ funding: funding({ fundingType: "grant" }) });
     expect(screen.getByText("GRANT")).toBeInTheDocument();

--- a/packages/static-site/components/learn/FundingCard.tsx
+++ b/packages/static-site/components/learn/FundingCard.tsx
@@ -1,10 +1,7 @@
-import type { Element, ElementContent, Parents, Root, Text } from "hast";
 import Markdown from "react-markdown";
-import type { Node } from "unist";
-import { visitParents } from "unist-util-visit-parents";
 import type { FundingPageMessages } from "@/domain/content/messageTypes";
 import type { Funding } from "@/domain/content/types";
-import { HighlightedText, splitHighlight } from "./highlightMatches";
+import { HighlightedText, makeHighlightPlugin } from "./highlightMatches";
 import { parseFundingContent } from "./parseFundingContent";
 
 interface Props {
@@ -12,29 +9,6 @@ interface Props {
   readonly messages: FundingPageMessages;
   readonly query?: string;
 }
-
-const makeHighlightPlugin = (query: string) => () => (tree: Root) => {
-  visitParents(tree as Node, "text", (node: Text, ancestors) => {
-    const parent = ancestors.at(-1) as Parents | undefined;
-    if (parent === undefined) return;
-    const index = parent.children.indexOf(node);
-    const segments = splitHighlight(node.value, query);
-    if (segments.length === 1 && !segments[0].match) return;
-
-    const replacement: ElementContent[] = segments.map((seg) =>
-      seg.match
-        ? {
-            type: "element",
-            tagName: "mark",
-            properties: { className: ["funding-search-highlight"] },
-            children: [{ type: "text", value: seg.text }],
-          }
-        : { type: "text", value: seg.text },
-    );
-
-    (parent as Element).children.splice(index, 1, ...replacement);
-  });
-};
 
 const FundingCard = ({ funding, messages, query = "" }: Props) => {
   const { eligibility, benefits } = parseFundingContent(funding.contentMd ?? "");
@@ -66,6 +40,7 @@ const FundingCard = ({ funding, messages, query = "" }: Props) => {
           )}
         </div>
       </div>
+      <hr className="border-base-light border-top-1px margin-x-3 margin-y-1" />
       <div className="usa-card__body">
         {funding.dueDate && (
           <p className="text-base margin-bottom-1">

--- a/packages/static-site/components/learn/FundingPageContent.test.tsx
+++ b/packages/static-site/components/learn/FundingPageContent.test.tsx
@@ -27,7 +27,10 @@ const messages: FundingPageMessages = {
   filterClear: "Clear",
   filterShowResults: "Show {count} Results",
   filterReset: "Reset",
-  resultCount: "Showing <bold>{filtered}</bold> results of {total} items",
+  resultCountShowing: "Showing <bold>{start}–{end}</bold> of {total} items",
+  resultCountFiltered:
+    "Showing <bold>{start}–{end}</bold> of {filtered} matching items (of {total} total)",
+  resultCountFilteredEmpty: "0 matching items (of {total} total)",
   filteringByLabel: "Filtering by:",
   filterSearchChip: 'Search: "{query}"',
   filterRemoveLabel: "Remove {filter} filter",
@@ -125,8 +128,26 @@ describe("FundingPageContent", () => {
       <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
     );
     const countLine = screen.getByText(/Showing/).closest("p");
-    expect(countLine).toHaveTextContent("Showing 5 results of 5 items");
-    expect(countLine?.querySelector("strong")).toHaveTextContent("5");
+    expect(countLine).toHaveTextContent("Showing 1–5 of 5 items");
+    expect(countLine?.querySelector("strong")).toHaveTextContent("1–5");
+  });
+
+  it("renders paginated and filtered result count with the grand total", async () => {
+    const user = userEvent.setup();
+    // 11 names contain "alpha" (spanning two pages); 4 do not.
+    const fundings = [
+      ...Array.from({ length: 11 }, (_, i) => makeFunding(`Alpha ${String(i + 1)}`)),
+      ...Array.from({ length: 4 }, (_, i) => makeFunding(`Beta ${String(i + 1)}`)),
+    ];
+    renderWithIntl(
+      <FundingPageContent messages={messages} page={page} fundings={fundings} sectors={sectors} />,
+    );
+
+    await user.type(screen.getByRole("searchbox"), "alpha");
+
+    const countLine = screen.getByText(/Showing/).closest("p");
+    expect(countLine).toHaveTextContent("Showing 1–10 of 11 matching items (of 15 total)");
+    expect(countLine?.querySelector("strong")).toHaveTextContent("1–10");
   });
 
   it("renders up to 10 cards on the first page", () => {

--- a/packages/static-site/components/learn/FundingPageContent.tsx
+++ b/packages/static-site/components/learn/FundingPageContent.tsx
@@ -1,42 +1,18 @@
 "use client";
 
-import { Fragment, type ReactNode, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import type { FundingPageMessages } from "@/domain/content/messageTypes";
 import type { Funding, FundingType, PageItem, Sector } from "@/domain/content/types";
 import FundingCard from "./FundingCard";
+import Pagination from "./Pagination";
 import { parseFundingContent } from "./parseFundingContent";
+import { renderResultCount } from "./renderResultCount";
+import { usePaginatedScroll } from "./usePaginatedScroll";
 
 const ITEMS_PER_PAGE = 10;
 
 const fundingTypes = (messages: FundingPageMessages): readonly FundingType[] =>
   Object.keys(messages.fundingTypeLabels) as FundingType[];
-
-interface ResultCountParams {
-  readonly template: string;
-  readonly filtered: number;
-  readonly total: number;
-}
-
-/**
- * Renders the result-count template, substituting `{total}` as text and the
- * `<bold>…</bold>`-wrapped `{filtered}` count as a `<strong>` element. Keeping
- * the whole sentence in one message (rather than splitting it in the component)
- * lets translators control word order around the bolded count.
- */
-const renderResultCount = ({ template, filtered, total }: ResultCountParams): ReactNode => {
-  const withTotal = template.replace("{total}", String(total));
-  return withTotal.split(/(<bold>.*?<\/bold>)/).map((part, index) => {
-    const boldMatch = part.match(/^<bold>(.*?)<\/bold>$/);
-    if (boldMatch === null) {
-      // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional and stable per render
-      return <Fragment key={index}>{part}</Fragment>;
-    }
-    return (
-      // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional and stable per render
-      <strong key={index}>{boldMatch[1].replace("{filtered}", String(filtered))}</strong>
-    );
-  });
-};
 
 interface Props {
   readonly messages: FundingPageMessages;
@@ -170,6 +146,7 @@ const FundingPageContent = ({ messages, page, fundings, sectors }: Props) => {
     fundingTypes: new Set(),
   });
   const [query, setQuery] = useState("");
+  const { resultsRef, handlePageChange } = usePaginatedScroll(setCurrentPage);
 
   const searchableEntries = useMemo(
     () => fundings.map((funding) => ({ funding, searchableText: fundingSearchableText(funding) })),
@@ -202,17 +179,17 @@ const FundingPageContent = ({ messages, page, fundings, sectors }: Props) => {
   );
 
   const totalPages = Math.max(1, Math.ceil(filteredFundings.length / ITEMS_PER_PAGE));
-  const pageNumbers = Array.from({ length: totalPages }, (_, i) => i + 1);
   const safePage = Math.min(currentPage, totalPages);
-  const pageSlice = filteredFundings.slice(
-    (safePage - 1) * ITEMS_PER_PAGE,
-    safePage * ITEMS_PER_PAGE,
-  );
+  const pageStartIndex = (safePage - 1) * ITEMS_PER_PAGE;
+  const pageSlice = filteredFundings.slice(pageStartIndex, safePage * ITEMS_PER_PAGE);
 
   const resultCount = renderResultCount({
-    template: messages.resultCount,
-    filtered: filteredFundings.length,
-    total: fundings.length,
+    start: pageStartIndex + 1,
+    end: pageStartIndex + pageSlice.length,
+    shownCount: pageSlice.length,
+    filteredCount: filteredFundings.length,
+    totalCount: fundings.length,
+    messages,
   });
   const showResultsLabel = messages.filterShowResults.replace(
     "{count}",
@@ -416,7 +393,12 @@ const FundingPageContent = ({ messages, page, fundings, sectors }: Props) => {
         </div>
       </aside>
 
-      <div className="funding-results-col">
+      <section
+        ref={resultsRef}
+        tabIndex={-1}
+        aria-label={messages.title}
+        className="funding-results-col"
+      >
         <FilteringByBar
           messages={messages}
           sectors={sectors}
@@ -435,59 +417,13 @@ const FundingPageContent = ({ messages, page, fundings, sectors }: Props) => {
           <FundingCard key={funding.id} funding={funding} messages={messages} query={query} />
         ))}
 
-        {totalPages > 1 && (
-          <nav aria-label={messages.paginationLabel} className="usa-pagination">
-            <ul className="usa-pagination__list">
-              <li className="usa-pagination__item usa-pagination__arrow">
-                <button
-                  type="button"
-                  className="usa-pagination__link usa-pagination__previous-page"
-                  onClick={() => setCurrentPage(safePage - 1)}
-                  disabled={safePage === 1}
-                  aria-label={messages.paginationPrevious}
-                >
-                  <svg className="usa-icon" aria-hidden="true" focusable="false" role="img">
-                    <use href="/assets/njwds/dist/img/sprite.svg#navigate_before" />
-                  </svg>
-                  <span className="usa-pagination__link-text">{messages.paginationPrevious}</span>
-                </button>
-              </li>
-              {pageNumbers.map((pageNumber) => (
-                <li
-                  key={`page-${pageNumber}`}
-                  className="usa-pagination__item usa-pagination__page-no"
-                >
-                  <button
-                    type="button"
-                    className={`usa-pagination__button${
-                      safePage === pageNumber ? " usa-current" : ""
-                    }`}
-                    onClick={() => setCurrentPage(pageNumber)}
-                    aria-label={messages.paginationPageLabel.replace("{page}", String(pageNumber))}
-                    aria-current={safePage === pageNumber ? "page" : undefined}
-                  >
-                    {pageNumber}
-                  </button>
-                </li>
-              ))}
-              <li className="usa-pagination__item usa-pagination__arrow">
-                <button
-                  type="button"
-                  className="usa-pagination__link usa-pagination__next-page"
-                  onClick={() => setCurrentPage(safePage + 1)}
-                  disabled={safePage === totalPages}
-                  aria-label={messages.paginationNext}
-                >
-                  <span className="usa-pagination__link-text">{messages.paginationNext}</span>
-                  <svg className="usa-icon" aria-hidden="true" focusable="false" role="img">
-                    <use href="/assets/njwds/dist/img/sprite.svg#navigate_next" />
-                  </svg>
-                </button>
-              </li>
-            </ul>
-          </nav>
-        )}
-      </div>
+        <Pagination
+          messages={messages}
+          currentPage={safePage}
+          totalPages={totalPages}
+          onPageChange={handlePageChange}
+        />
+      </section>
     </div>
   );
 };

--- a/packages/static-site/components/learn/LicenseCard.test.tsx
+++ b/packages/static-site/components/learn/LicenseCard.test.tsx
@@ -1,0 +1,209 @@
+import { render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { describe, expect, it } from "vitest";
+import type { LicensingGuidePageMessages } from "@/domain/content/messageTypes";
+import type { License } from "@/domain/content/types";
+import LicenseCard from "./LicenseCard";
+
+const messages = {
+  cardWhoForLabel: "Who it's for:",
+  cardIndustryLabel: "Industry:",
+  cardAgencyLabel: "Agency:",
+  cardPhoneLabel: "Phone:",
+  whoItsForLabels: {
+    "business-license": "Businesses",
+    "individual-license": "Individuals",
+    "object-vehicle": "Object/Vehicle",
+  },
+  // Only the card-relevant fields are supplied; the bridge cast marks this as a
+  // deliberate subset of the full page messages.
+} as unknown as LicensingGuidePageMessages;
+
+const license = (overrides: Partial<License> = {}): License => ({
+  name: "A-901 License to Transport Waste",
+  urlSlug: "a-901-license-to-transport-waste",
+  webflowType: "business-license",
+  industry: "Waste",
+  summaryDescriptionMd: "You need an A-901 license to transport waste.",
+  agency: "NJ Division of Consumer Affairs",
+  division: "Board of Accountancy",
+  divisionPhone: "(973) 504-6380",
+  callToActionText: "Apply for My A-901 License",
+  callToActionLink: "https://example.com",
+  ...overrides,
+});
+
+const renderCard = (props: Partial<ComponentProps<typeof LicenseCard>> = {}) =>
+  render(<LicenseCard messages={messages} license={license()} {...props} />);
+
+describe("LicenseCard", () => {
+  it("renders title, meta, agency, phone, and CTA", () => {
+    renderCard();
+    expect(screen.getByText("A-901 License to Transport Waste")).toBeInTheDocument();
+    expect(screen.getByText(/Who it's for:/)).toBeInTheDocument();
+    expect(screen.getByText(/NJ Division of Consumer Affairs/)).toBeInTheDocument();
+    expect(screen.getByText("(973) 504-6380")).toBeInTheDocument();
+    const cta = screen.getByRole("link", { name: "Apply for My A-901 License" });
+    expect(cta).toHaveAttribute("href", "https://example.com");
+  });
+
+  it("renders the agency name and additional context comma-joined when both are present", () => {
+    renderCard({
+      license: license({
+        agency: "Department of Agriculture",
+        division: "Division of Animal Health",
+      }),
+    });
+    expect(
+      screen.getByText(/Department of Agriculture, Division of Animal Health/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders only the agency name when no additional context is present", () => {
+    renderCard({ license: license({ agency: "Federal Trade Commission", division: undefined }) });
+    expect(screen.getByText(/Federal Trade Commission/)).toBeInTheDocument();
+    expect(screen.queryByText(/,/)).not.toBeInTheDocument();
+  });
+
+  it("renders only the additional context when the agency name is absent", () => {
+    renderCard({ license: license({ agency: undefined, division: "Office of Licensing" }) });
+    expect(screen.getByText(/Office of Licensing/)).toBeInTheDocument();
+    expect(screen.queryByText(/,/)).not.toBeInTheDocument();
+  });
+
+  it("prefixes agency with the account_balance icon and phone with the phone icon", () => {
+    const { container } = renderCard();
+    const hrefs = [...container.querySelectorAll("use")].map((u) => u.getAttribute("href"));
+    expect(hrefs).toContain("/assets/njwds/dist/img/sprite.svg#account_balance");
+    expect(hrefs).toContain("/assets/njwds/dist/img/sprite.svg#phone");
+  });
+
+  it("maps webflowType to its 'Who it's for' display label", () => {
+    const { container } = renderCard({ license: license({ webflowType: "individual-license" }) });
+    expect(screen.getByText(messages.cardWhoForLabel)).toBeInTheDocument();
+    expect(container.querySelector(".usa-card__header p")?.textContent).toContain(
+      messages.whoItsForLabels["individual-license"],
+    );
+  });
+
+  it("omits the 'Who it's for' row when webflowType is unknown or missing", () => {
+    renderCard({ license: license({ webflowType: undefined }) });
+    expect(screen.queryByText(messages.cardWhoForLabel)).not.toBeInTheDocument();
+  });
+
+  it("omits the Industry row when the value is the literal string 'undefined'", () => {
+    renderCard({ license: license({ webflowType: undefined, industry: "undefined" }) });
+    expect(screen.queryByText(messages.cardIndustryLabel)).not.toBeInTheDocument();
+    expect(screen.queryByText(/undefined/)).not.toBeInTheDocument();
+  });
+
+  it("omits the Industry row when the value is empty or whitespace", () => {
+    renderCard({ license: license({ webflowType: undefined, industry: "   " }) });
+    expect(screen.queryByText(messages.cardIndustryLabel)).not.toBeInTheDocument();
+  });
+
+  it("omits the entire meta line when neither classification nor industry is present", () => {
+    const { container } = renderCard({
+      license: license({ webflowType: undefined, industry: undefined }),
+    });
+    expect(screen.queryByText(messages.cardWhoForLabel)).not.toBeInTheDocument();
+    expect(screen.queryByText(messages.cardIndustryLabel)).not.toBeInTheDocument();
+    expect(container.querySelector(".usa-card__header p")).toBeNull();
+  });
+
+  it("omits the CTA when no link is present", () => {
+    renderCard({ license: license({ callToActionLink: undefined }) });
+    expect(screen.queryByRole("link", { name: /Apply/ })).not.toBeInTheDocument();
+  });
+
+  it("omits the CTA when the link or text still holds an unresolved template placeholder", () => {
+    // Location-dependent roadmap tasks (e.g. short-term-rental-registration)
+    // carry `${municipalityWebsite}` / `${municipalityName}` template variables
+    // that only the personalized `web/` roadmap fills in. On this static
+    // directory they never resolve. The button would render dead, so we omit the CTA.
+    const { container } = renderCard({
+      license: license({
+        // biome-ignore-start lint/suspicious/noTemplateCurlyInString: the unresolved literal placeholder is the input under test
+        callToActionText: "Visit the ${municipalityName} Website",
+        callToActionLink: "${municipalityWebsite}",
+        // biome-ignore-end lint/suspicious/noTemplateCurlyInString: the unresolved literal placeholder is the input under test
+      }),
+    });
+    expect(container.querySelector(".usa-card__footer")).toBeNull();
+    expect(screen.queryByText(/\$\{/)).not.toBeInTheDocument();
+  });
+
+  it("renders the summary/agency divider when only division context is present", () => {
+    // A card with division context (agencyAdditionalContext) but no agency name
+    // and no phone still renders an agency line, so the divider above it must
+    // render too. Keyed off the same value that gates the line, not agency alone.
+    const { container } = renderCard({
+      license: license({
+        agency: undefined,
+        division: "Your Municipality",
+        divisionPhone: undefined,
+        summaryDescriptionMd: "You may need to register with your municipal clerk.",
+      }),
+    });
+    expect(screen.getByText(/Your Municipality/)).toBeInTheDocument();
+    expect(container.querySelector("hr.margin-x-0")).not.toBeNull();
+  });
+
+  it("renders a base-light divider between the card header and body", () => {
+    const { container } = renderCard();
+    const divider = container.querySelector("hr.border-base-light");
+    expect(divider).not.toBeNull();
+    expect(divider?.previousElementSibling?.classList.contains("usa-card__header")).toBe(true);
+    expect(divider?.nextElementSibling?.classList.contains("usa-card__body")).toBe(true);
+  });
+
+  it("highlights a query match in the summary body", () => {
+    const { container } = renderCard({
+      license: license({ summaryDescriptionMd: "You need a license to transport waste." }),
+      query: "transport",
+    });
+    const marks = container.querySelectorAll("mark.funding-search-highlight");
+    expect([...marks].some((m) => m.textContent === "transport")).toBe(true);
+  });
+
+  it("renders no highlight marks in the body when no query is given", () => {
+    const { container } = renderCard({
+      license: license({ summaryDescriptionMd: "You need a license to transport waste." }),
+    });
+    expect(container.querySelector(".usa-card__body mark.funding-search-highlight")).toBeNull();
+  });
+
+  it("unwraps CMS directives in the summary instead of showing raw ::: fences", () => {
+    renderCard({
+      license: license({
+        summaryDescriptionMd: [
+          ":::infoAlert",
+          "**Keep in mind:** the A-901 process takes 14 to 16 months.",
+          ":::",
+          "",
+          "You need an A-901 license to transport waste.",
+        ].join("\n"),
+      }),
+    });
+    expect(screen.queryByText(/:::/)).not.toBeInTheDocument();
+    expect(screen.getByText(/the A-901 process takes 14 to 16 months/)).toBeInTheDocument();
+    expect(screen.getByText(/You need an A-901 license to transport waste/)).toBeInTheDocument();
+  });
+
+  it("does not render a leading separator when industry has no classification", () => {
+    renderCard({
+      license: license({ webflowType: undefined, industry: "Credit Union" }),
+    });
+    expect(screen.queryByText(/Who it's for:/)).not.toBeInTheDocument();
+    // The "|" separator must not appear when only Industry is present.
+    expect(screen.queryByText(/\|/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Industry:/)).toBeInTheDocument();
+  });
+
+  it("renders the separator only when both classification and industry are present", () => {
+    renderCard({ license: license({ webflowType: "business-license", industry: "Waste" }) });
+    expect(screen.getByText(/Who it's for:/)).toBeInTheDocument();
+    expect(screen.getByText(/Industry:/)).toBeInTheDocument();
+    expect(screen.getByText(/\|/)).toBeInTheDocument();
+  });
+});

--- a/packages/static-site/components/learn/LicenseCard.tsx
+++ b/packages/static-site/components/learn/LicenseCard.tsx
@@ -1,0 +1,115 @@
+import Markdown from "react-markdown";
+import { Icon } from "@/components/Icon";
+import type { LicensingGuidePageMessages } from "@/domain/content/messageTypes";
+import type { License } from "@/domain/content/types";
+import { HighlightedText, makeHighlightPlugin } from "./highlightMatches";
+import { stripContentDirectives } from "./stripContentDirectives";
+import { whoItsForLabel } from "./whoItsForLabel";
+
+interface Props {
+  readonly license: License;
+  readonly messages: LicensingGuidePageMessages;
+  readonly query?: string;
+}
+
+/**
+ * Returns the trimmed value, or undefined when it is blank or the literal
+ * string "undefined" — both stand in for "no value" in the synced content and
+ * must not be rendered as a label row.
+ */
+const presentValue = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim();
+  return trimmed && trimmed !== "undefined" ? trimmed : undefined;
+};
+
+/**
+ * Location-dependent roadmap tasks carry `${municipalityWebsite}`-style template
+ * variables in their CTA that only the personalized `web` roadmap fills in from
+ * the user's municipality. This static directory has no user, so they never
+ * resolve; rendering them yields a dead link and a literal `${…}` label.
+ */
+const hasUnresolvedTemplate = (value: string | undefined): boolean =>
+  value !== undefined && /\$\{[^}]+\}/.test(value);
+
+const LicenseCard = ({ license, messages, query = "" }: Props) => {
+  const rehypePlugins = query.trim() ? [makeHighlightPlugin(query)] : [];
+  const whoItsFor = whoItsForLabel(license.webflowType, messages.whoItsForLabels);
+  const industry = presentValue(license.industry);
+  // The agency line is the resolved agency name and its additional context
+  // (division), comma-joined when both are present, matching the published site.
+  const agencyLine = [license.agency, license.division].filter(Boolean).join(", ");
+  const showCallToAction =
+    license.callToActionLink !== undefined &&
+    !hasUnresolvedTemplate(license.callToActionLink) &&
+    !hasUnresolvedTemplate(license.callToActionText);
+
+  return (
+    <div className="usa-card__container margin-bottom-3">
+      <div className="usa-card__header">
+        <h3 className="usa-card__heading">
+          <HighlightedText text={license.name} query={query} />
+        </h3>
+        {(whoItsFor || industry) && (
+          <p className="margin-top-1">
+            {whoItsFor && (
+              <>
+                <strong>{messages.cardWhoForLabel}</strong> {whoItsFor}
+              </>
+            )}
+            {industry && (
+              <>
+                {whoItsFor && " | "}
+                <strong>{messages.cardIndustryLabel}</strong> {industry}
+              </>
+            )}
+          </p>
+        )}
+      </div>
+      <hr className="border-base-light border-top-1px margin-x-3 margin-y-1" />
+      <div className="usa-card__body">
+        {license.summaryDescriptionMd && (
+          <Markdown rehypePlugins={rehypePlugins}>
+            {stripContentDirectives(license.summaryDescriptionMd)}
+          </Markdown>
+        )}
+        {license.summaryDescriptionMd && (agencyLine || license.divisionPhone) && (
+          <hr className="border-base-light border-top-1px margin-x-0 margin-y-1" />
+        )}
+        {agencyLine && (
+          <p className="margin-bottom-1 display-flex flex-align-start">
+            <Icon
+              iconName="account_balance"
+              className="text-primary nj-margin-inline-end-05 nj-icon-text-top"
+            />
+            <span>
+              <strong>{messages.cardAgencyLabel}</strong> {agencyLine}
+            </span>
+          </p>
+        )}
+        {license.divisionPhone && (
+          <p className="margin-bottom-0 display-flex flex-align-start">
+            <Icon
+              iconName="phone"
+              className="text-primary nj-margin-inline-end-05 nj-icon-text-top"
+            />
+            <span>
+              <strong>{messages.cardPhoneLabel}</strong> {license.divisionPhone}
+            </span>
+          </p>
+        )}
+      </div>
+      {showCallToAction && (
+        <>
+          <hr className="border-base-light border-top-1px margin-x-3 margin-y-1" />
+          <div className="usa-card__footer">
+            <a href={license.callToActionLink} className="usa-button">
+              {license.callToActionText ?? license.callToActionLink}
+            </a>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default LicenseCard;

--- a/packages/static-site/components/learn/LicensingGuidePage.tsx
+++ b/packages/static-site/components/learn/LicensingGuidePage.tsx
@@ -1,0 +1,17 @@
+import LicensingGuidePageContent from "@/components/learn/LicensingGuidePageContent";
+import { loadLicenses } from "@/domain/content/loadContent";
+import type { PageItem } from "@/domain/content/types";
+import type { AppLocale } from "@/domain/i18n/locales";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+
+interface Props {
+  readonly page: PageItem;
+  readonly locale: AppLocale;
+}
+
+export const LicensingGuidePage = ({ page, locale }: Props) => {
+  const licenses = loadLicenses().sort((a, b) => a.name.localeCompare(b.name));
+  const { licensingGuide: messages } = getApplicationMessages({ locale });
+
+  return <LicensingGuidePageContent messages={messages} page={page} licenses={licenses} />;
+};

--- a/packages/static-site/components/learn/LicensingGuidePageContent.test.tsx
+++ b/packages/static-site/components/learn/LicensingGuidePageContent.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { LicensingGuidePageMessages } from "@/domain/content/messageTypes";
+import type { License, PageItem } from "@/domain/content/types";
+import LicensingGuidePageContent from "./LicensingGuidePageContent";
+
+const messages = {
+  title: "Licensing and Certification Guide",
+  ctaHeading: "Get Your Registration Guide!",
+  ctaBody: "Start today!",
+  ctaButton: "Get Started",
+  filterHeading: "Narrow Results",
+  filterSearch: "Search",
+  filterShowResults: "Show {count} Results",
+  filterReset: "Reset",
+  resultCountShowing: "Showing <bold>{start}–{end}</bold> of {total} items",
+  resultCountFiltered:
+    "Showing <bold>{start}–{end}</bold> of {filtered} matching items (of {total} total)",
+  resultCountFilteredEmpty: "0 matching items (of {total} total)",
+  filteringByLabel: "Filtering by:",
+  filterSearchChip: "Search: {query}",
+  filterRemoveLabel: "Remove filter {filter}",
+  paginationPrevious: "Previous",
+  paginationNext: "Next",
+  paginationLabel: "Pagination",
+  paginationPageLabel: "Page {page}",
+  cardWhoForLabel: "Who it's for:",
+  cardIndustryLabel: "Industry:",
+  cardAgencyLabel: "Agency:",
+  cardPhoneLabel: "Phone:",
+  whoItsForLabels: {
+    "business-license": "Businesses",
+    "individual-license": "Individuals",
+    "object-vehicle": "Object/Vehicle",
+  },
+} satisfies LicensingGuidePageMessages;
+
+const page = {
+  slug: "licensing-and-certification-guide",
+  name: "Guide",
+  "sub-heading-text": "Sub.",
+} as PageItem;
+
+const mk = (name: string): License => ({ name, urlSlug: name.toLowerCase().replace(/\s/g, "-") });
+
+const renderPage = (licenses: License[]) =>
+  render(<LicensingGuidePageContent messages={messages} page={page} licenses={licenses} />);
+
+describe("LicensingGuidePageContent", () => {
+  it("renders all cards initially", () => {
+    renderPage([mk("Alpha License"), mk("Beta License")]);
+    expect(screen.getByRole("heading", { level: 3, name: "Alpha License" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 3, name: "Beta License" })).toBeInTheDocument();
+  });
+
+  it("filters cards by search query", () => {
+    renderPage([mk("Alpha License"), mk("Beta License")]);
+    fireEvent.change(screen.getByLabelText("Search"), { target: { value: "Alpha" } });
+    expect(screen.getByRole("heading", { level: 3, name: "Alpha License" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { level: 3, name: "Beta License" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows an empty result count when nothing matches", () => {
+    renderPage([mk("Alpha License")]);
+    fireEvent.change(screen.getByLabelText("Search"), { target: { value: "zzz" } });
+    expect(
+      screen.queryByRole("heading", { level: 3, name: "Alpha License" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("0 matching items (of 1 total)")).toBeInTheDocument();
+  });
+
+  it("shows a search chip when query is non-empty and clears on remove", () => {
+    renderPage([mk("Alpha License"), mk("Beta License")]);
+    fireEvent.change(screen.getByLabelText("Search"), { target: { value: "transport" } });
+
+    // Chip appears with the query text
+    expect(screen.getByText("Search: transport")).toBeInTheDocument();
+
+    // Click the remove button to clear the query
+    const removeButton = screen.getByRole("button", {
+      name: "Remove filter Search: transport",
+    });
+    fireEvent.click(removeButton);
+
+    // Chip is gone and all cards return
+    expect(screen.queryByText("Search: transport")).not.toBeInTheDocument();
+    expect(screen.getByText("Alpha License")).toBeInTheDocument();
+    expect(screen.getByText("Beta License")).toBeInTheDocument();
+  });
+});

--- a/packages/static-site/components/learn/LicensingGuidePageContent.tsx
+++ b/packages/static-site/components/learn/LicensingGuidePageContent.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { LicensingGuidePageMessages } from "@/domain/content/messageTypes";
+import type { License, PageItem } from "@/domain/content/types";
+import LicenseCard from "./LicenseCard";
+import Pagination from "./Pagination";
+import { renderResultCount } from "./renderResultCount";
+import { usePaginatedScroll } from "./usePaginatedScroll";
+
+const ITEMS_PER_PAGE = 10;
+
+interface FilterChipProps {
+  readonly label: string;
+  readonly removeLabel: string;
+  readonly onRemove: () => void;
+}
+
+const FilterChip = ({ label, removeLabel, onRemove }: FilterChipProps) => (
+  <span className="funding-filter-chip">
+    {label}
+    <button
+      type="button"
+      className="funding-filter-chip__remove"
+      aria-label={removeLabel}
+      onClick={onRemove}
+    >
+      <span aria-hidden="true">×</span>
+    </button>
+  </span>
+);
+
+interface Props {
+  readonly messages: LicensingGuidePageMessages;
+  readonly page: PageItem;
+  readonly licenses: readonly License[];
+}
+
+const searchableText = (license: License): string =>
+  `${license.name} ${license.summaryDescriptionMd ?? ""}`.toLowerCase();
+
+const LicensingGuidePageContent = ({ messages, page, licenses }: Props) => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [query, setQuery] = useState("");
+  const { resultsRef, handlePageChange } = usePaginatedScroll(setCurrentPage);
+
+  const entries = useMemo(
+    () => licenses.map((license) => ({ license, text: searchableText(license) })),
+    [licenses],
+  );
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const filtered = useMemo(
+    () =>
+      entries
+        .filter(({ text }) => normalizedQuery === "" || text.includes(normalizedQuery))
+        .map(({ license }) => license),
+    [entries, normalizedQuery],
+  );
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / ITEMS_PER_PAGE));
+  const safePage = Math.min(currentPage, totalPages);
+  const pageStartIndex = (safePage - 1) * ITEMS_PER_PAGE;
+  const pageSlice = filtered.slice(pageStartIndex, safePage * ITEMS_PER_PAGE);
+
+  const resultCount = renderResultCount({
+    start: pageStartIndex + 1,
+    end: pageStartIndex + pageSlice.length,
+    shownCount: pageSlice.length,
+    filteredCount: filtered.length,
+    totalCount: licenses.length,
+    messages,
+  });
+  const showResultsLabel = messages.filterShowResults.replace("{count}", String(filtered.length));
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    setQuery(event.target.value);
+    setCurrentPage(1);
+  };
+
+  const clearSearch = (): void => {
+    setQuery("");
+    setCurrentPage(1);
+  };
+
+  const searchChipLabel = messages.filterSearchChip.replace("{query}", query);
+
+  return (
+    <div className="funding-layout layout-wide">
+      <div className="funding-header-col">
+        <h1>{messages.title}</h1>
+        {page["sub-heading-text"] && <p className="usa-intro">{page["sub-heading-text"]}</p>}
+
+        <div className="padding-3 margin-bottom-3 radius-lg border-2px border-base-lighter">
+          <h2 className="margin-top-0">{messages.ctaHeading}</h2>
+          <p>{messages.ctaBody}</p>
+          <a href="https://account.business.nj.gov/" className="usa-button">
+            {messages.ctaButton}
+          </a>
+        </div>
+      </div>
+
+      <aside className="border-1px border-base-lighter padding-3 radius-lg funding-filter-col">
+        <h2>{messages.filterHeading}</h2>
+        <div className="margin-y-3" style={{ display: "flow-root" }}>
+          <label className="usa-label text-bold margin-bottom-1" htmlFor="license-search">
+            {messages.filterSearch}
+          </label>
+          <input
+            id="license-search"
+            className="usa-input"
+            type="search"
+            value={query}
+            onChange={handleSearchChange}
+          />
+        </div>
+        <hr className="border-base-lighter border-top-1px margin-y-2" />
+        <div className="display-flex flex-justify">
+          <button
+            type="button"
+            className="usa-button width-full"
+            onClick={() => handlePageChange(1)}
+          >
+            {showResultsLabel}
+          </button>
+          <button
+            type="button"
+            className="usa-button usa-button--outline margin-right-0"
+            onClick={clearSearch}
+          >
+            {messages.filterReset}
+          </button>
+        </div>
+      </aside>
+
+      <section
+        ref={resultsRef}
+        tabIndex={-1}
+        aria-label={messages.title}
+        className="funding-results-col"
+      >
+        {query.trim() !== "" && (
+          <section
+            aria-label={messages.filteringByLabel}
+            className="funding-filtering-by margin-bottom-2 padding-2 radius-md bg-primary-lightest border-1px border-primary"
+          >
+            <span className="margin-right-1">{messages.filteringByLabel}</span>
+            <FilterChip
+              label={searchChipLabel}
+              removeLabel={messages.filterRemoveLabel.replace("{filter}", searchChipLabel)}
+              onRemove={clearSearch}
+            />
+          </section>
+        )}
+
+        <p className="margin-bottom-2">{resultCount}</p>
+        {pageSlice.map((license) => (
+          <LicenseCard
+            key={license.webflowId ?? license.urlSlug}
+            license={license}
+            messages={messages}
+            query={query}
+          />
+        ))}
+        <Pagination
+          messages={messages}
+          currentPage={safePage}
+          totalPages={totalPages}
+          onPageChange={handlePageChange}
+        />
+      </section>
+    </div>
+  );
+};
+
+export default LicensingGuidePageContent;

--- a/packages/static-site/components/learn/PageSwitchComponent.tsx
+++ b/packages/static-site/components/learn/PageSwitchComponent.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 import { FundingPage } from "@/components/learn/FundingPage";
+import { LicensingGuidePage } from "@/components/learn/LicensingGuidePage";
 import PageContent from "@/components/learn/PageContent";
 import { StarterKitsPage } from "@/components/learn/StarterKitsPage";
 import type { PageItem } from "@/domain/content/types";
@@ -16,6 +17,8 @@ export const PageSwitchComponent = ({ page, locale }: Props): ReactElement => {
       return <FundingPage page={page} locale={locale} />;
     case "starter-kits":
       return <StarterKitsPage page={page} locale={locale} />;
+    case "licensing-and-certification-guide":
+      return <LicensingGuidePage page={page} locale={locale} />;
     default:
       return <PageContent page={page} />;
   }

--- a/packages/static-site/components/learn/Pagination.test.tsx
+++ b/packages/static-site/components/learn/Pagination.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import Pagination from "./Pagination";
+
+const messages = {
+  paginationPrevious: "Previous",
+  paginationNext: "Next",
+  paginationLabel: "Pagination",
+  paginationPageLabel: "Page {page}",
+};
+
+const renderPagination = (props: {
+  currentPage: number;
+  totalPages: number;
+  onPageChange?: (p: number) => void;
+}) =>
+  render(
+    <Pagination
+      messages={messages}
+      currentPage={props.currentPage}
+      totalPages={props.totalPages}
+      onPageChange={props.onPageChange ?? (() => {})}
+    />,
+  );
+
+describe("Pagination", () => {
+  it("renders nothing when there is only one page", () => {
+    const { container } = renderPagination({ currentPage: 1, totalPages: 1 });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders every page button when pages fit without overflow", () => {
+    renderPagination({ currentPage: 1, totalPages: 5 });
+    for (const n of [1, 2, 3, 4, 5]) {
+      expect(screen.getByRole("button", { name: `Page ${n}` })).toBeInTheDocument();
+    }
+    expect(screen.queryByText("…")).not.toBeInTheDocument();
+  });
+
+  it("collapses long page ranges with overflow ellipses instead of every page", () => {
+    renderPagination({ currentPage: 1, totalPages: 56 });
+
+    // First, current, and last pages are always reachable.
+    expect(screen.getByRole("button", { name: "Page 1" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Page 56" })).toBeInTheDocument();
+
+    // A deep middle page is hidden behind the overflow indicator.
+    expect(screen.queryByRole("button", { name: "Page 30" })).not.toBeInTheDocument();
+
+    // The ellipsis indicator is present and non-interactive.
+    expect(screen.getAllByText("…").length).toBeGreaterThan(0);
+  });
+
+  it("marks the current page with aria-current", () => {
+    renderPagination({ currentPage: 3, totalPages: 5 });
+    expect(screen.getByRole("button", { name: "Page 3" })).toHaveAttribute("aria-current", "page");
+  });
+
+  it("invokes onPageChange with the chosen page", () => {
+    const onPageChange = vi.fn();
+    renderPagination({ currentPage: 1, totalPages: 5, onPageChange });
+    fireEvent.click(screen.getByRole("button", { name: "Page 4" }));
+    expect(onPageChange).toHaveBeenCalledWith(4);
+  });
+
+  it("disables Previous on the first page and Next on the last page", () => {
+    const { rerender } = renderPagination({ currentPage: 1, totalPages: 5 });
+    expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Next" })).toBeEnabled();
+
+    rerender(
+      <Pagination messages={messages} currentPage={5} totalPages={5} onPageChange={() => {}} />,
+    );
+    expect(screen.getByRole("button", { name: "Previous" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+  });
+});

--- a/packages/static-site/components/learn/Pagination.tsx
+++ b/packages/static-site/components/learn/Pagination.tsx
@@ -1,0 +1,96 @@
+import { paginationSlots } from "./paginationSlots";
+
+export interface PaginationMessages {
+  readonly paginationPrevious: string;
+  readonly paginationNext: string;
+  readonly paginationLabel: string;
+  readonly paginationPageLabel: string;
+}
+
+interface Props {
+  readonly messages: PaginationMessages;
+  readonly currentPage: number;
+  readonly totalPages: number;
+  readonly onPageChange: (page: number) => void;
+}
+
+/**
+ * NJWDS bounded pagination. Renders at most seven numbered slots around the
+ * current page, standing in for skipped ranges with non-selectable ellipsis
+ * indicators, and hides the numbered slots on narrow viewports (the mobile
+ * variant keeps only Previous/Next).
+ *
+ * See https://grove.nj.gov/reference/pagination/#behaviors
+ */
+const Pagination = ({ messages, currentPage, totalPages, onPageChange }: Props) => {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  const slots = paginationSlots({ current: currentPage, total: totalPages });
+
+  return (
+    <nav aria-label={messages.paginationLabel} className="usa-pagination">
+      <ul className="usa-pagination__list">
+        <li className="usa-pagination__item usa-pagination__arrow">
+          <button
+            type="button"
+            className="usa-pagination__link usa-pagination__previous-page"
+            onClick={() => onPageChange(currentPage - 1)}
+            disabled={currentPage === 1}
+            aria-label={messages.paginationPrevious}
+          >
+            <svg className="usa-icon" aria-hidden="true" focusable="false" role="img">
+              <use href="/assets/njwds/dist/img/sprite.svg#navigate_before" />
+            </svg>
+            <span className="usa-pagination__link-text">{messages.paginationPrevious}</span>
+          </button>
+        </li>
+        {slots.map((slot, index) => {
+          if (slot.type === "ellipsis") {
+            return (
+              <li
+                // biome-ignore lint/suspicious/noArrayIndexKey: ellipsis slots are positional and have no stable id
+                key={`ellipsis-${index}`}
+                className="usa-pagination__item usa-pagination__overflow"
+                aria-hidden="true"
+              >
+                <span>…</span>
+              </li>
+            );
+          }
+          const { page } = slot;
+          return (
+            <li key={`page-${page}`} className="usa-pagination__item usa-pagination__page-no">
+              <button
+                type="button"
+                className={`usa-pagination__button${page === currentPage ? " usa-current" : ""}`}
+                onClick={() => onPageChange(page)}
+                aria-label={messages.paginationPageLabel.replace("{page}", String(page))}
+                aria-current={page === currentPage ? "page" : undefined}
+              >
+                {page}
+              </button>
+            </li>
+          );
+        })}
+        <li className="usa-pagination__item usa-pagination__arrow">
+          <button
+            type="button"
+            className="usa-pagination__link usa-pagination__next-page"
+            onClick={() => onPageChange(currentPage + 1)}
+            disabled={currentPage === totalPages}
+            aria-label={messages.paginationNext}
+          >
+            <span className="usa-pagination__link-text">{messages.paginationNext}</span>
+            <svg className="usa-icon" aria-hidden="true" focusable="false" role="img">
+              <use href="/assets/njwds/dist/img/sprite.svg#navigate_next" />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  );
+};
+
+export default Pagination;

--- a/packages/static-site/components/learn/highlightMatches.tsx
+++ b/packages/static-site/components/learn/highlightMatches.tsx
@@ -1,4 +1,7 @@
+import type { Element, ElementContent, Parents, Root, Text } from "hast";
 import { Fragment, type ReactElement } from "react";
+import type { Node } from "unist";
+import { visitParents } from "unist-util-visit-parents";
 
 export interface HighlightSegment {
   readonly text: string;
@@ -54,3 +57,31 @@ export const HighlightedText = ({ text, query }: HighlightedTextProps): ReactEle
     )}
   </>
 );
+
+/**
+ * `react-markdown` rehype plugin that wraps query matches inside rendered
+ * markdown text nodes in `<mark>` elements, so search highlighting reaches card
+ * body content (not just the plain-text heading handled by `HighlightedText`).
+ */
+export const makeHighlightPlugin = (query: string) => () => (tree: Root) => {
+  visitParents(tree as Node, "text", (node: Text, ancestors) => {
+    const parent = ancestors.at(-1) as Parents | undefined;
+    if (parent === undefined) return;
+    const index = parent.children.indexOf(node);
+    const segments = splitHighlight(node.value, query);
+    if (segments.length === 1 && !segments[0].match) return;
+
+    const replacement: ElementContent[] = segments.map((seg) =>
+      seg.match
+        ? {
+            type: "element",
+            tagName: "mark",
+            properties: { className: ["funding-search-highlight"] },
+            children: [{ type: "text", value: seg.text }],
+          }
+        : { type: "text", value: seg.text },
+    );
+
+    (parent as Element).children.splice(index, 1, ...replacement);
+  });
+};

--- a/packages/static-site/components/learn/paginationSlots.test.ts
+++ b/packages/static-site/components/learn/paginationSlots.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { paginationSlots } from "./paginationSlots";
+
+const pages = (total: number, current: number): string =>
+  paginationSlots({ current, total })
+    .map((slot) => (slot.type === "ellipsis" ? "…" : String(slot.page)))
+    .join(" ");
+
+describe("paginationSlots", () => {
+  it("shows every page when total is seven or fewer", () => {
+    expect(pages(7, 1)).toBe("1 2 3 4 5 6 7");
+    expect(pages(3, 2)).toBe("1 2 3");
+    expect(pages(1, 1)).toBe("1");
+  });
+
+  it("shows the first five pages with a trailing ellipsis near the start", () => {
+    expect(pages(20, 1)).toBe("1 2 3 4 5 … 20");
+    expect(pages(20, 3)).toBe("1 2 3 4 5 … 20");
+    expect(pages(20, 4)).toBe("1 2 3 4 5 … 20");
+  });
+
+  it("shows ellipses on both sides when the current page is in the middle", () => {
+    expect(pages(20, 5)).toBe("1 … 4 5 6 … 20");
+    expect(pages(20, 10)).toBe("1 … 9 10 11 … 20");
+    expect(pages(20, 16)).toBe("1 … 15 16 17 … 20");
+  });
+
+  it("shows the last five pages with a leading ellipsis near the end", () => {
+    expect(pages(20, 17)).toBe("1 … 16 17 18 19 20");
+    expect(pages(20, 18)).toBe("1 … 16 17 18 19 20");
+    expect(pages(20, 20)).toBe("1 … 16 17 18 19 20");
+  });
+});

--- a/packages/static-site/components/learn/paginationSlots.ts
+++ b/packages/static-site/components/learn/paginationSlots.ts
@@ -1,0 +1,46 @@
+export type PaginationSlot =
+  | { readonly type: "page"; readonly page: number }
+  | { readonly type: "ellipsis" };
+
+interface PaginationSlotsParams {
+  readonly current: number;
+  readonly total: number;
+}
+
+const page = (n: number): PaginationSlot => ({ type: "page", page: n });
+const ellipsis: PaginationSlot = { type: "ellipsis" };
+
+const range = (start: number, end: number): PaginationSlot[] => {
+  const slots: PaginationSlot[] = [];
+  for (let n = start; n <= end; n += 1) {
+    slots.push(page(n));
+  }
+  return slots;
+};
+
+/**
+ * Computes the slot sequence for the NJWDS bounded pagination component. The
+ * component renders at most seven slots: the first page, the last page, the
+ * current page, and a window around it, with non-selectable ellipsis indicators
+ * standing in for any pages skipped between them.
+ *
+ * See https://grove.nj.gov/reference/pagination/#behaviors
+ */
+export const paginationSlots = ({ current, total }: PaginationSlotsParams): PaginationSlot[] => {
+  if (total <= 7) {
+    return range(1, total);
+  }
+
+  const nearStart = current <= 4;
+  const nearEnd = current >= total - 3;
+
+  if (nearStart) {
+    return [...range(1, 5), ellipsis, page(total)];
+  }
+
+  if (nearEnd) {
+    return [page(1), ellipsis, ...range(total - 4, total)];
+  }
+
+  return [page(1), ellipsis, ...range(current - 1, current + 1), ellipsis, page(total)];
+};

--- a/packages/static-site/components/learn/parseFundingContent.ts
+++ b/packages/static-site/components/learn/parseFundingContent.ts
@@ -1,3 +1,5 @@
+import { stripContextualInfoIds } from "./stripContentDirectives";
+
 export interface FundingContentSections {
   readonly eligibility: string;
   readonly benefits: string;
@@ -15,8 +17,6 @@ export const parseFundingContent = (contentMd: string): FundingContentSections =
   // beneath it, up to the callout when one is present.
   const headingMatch = contentMd.match(/^##[^\n#][^\n]*$/m);
   const headingStart = headingMatch?.index ?? -1;
-
-  const stripContextualInfoIds = (text: string): string => text.replace(/`([^`|]+)\|[^`]+`/g, "$1");
 
   let eligibility = "";
   if (headingStart !== -1) {

--- a/packages/static-site/components/learn/renderResultCount.test.tsx
+++ b/packages/static-site/components/learn/renderResultCount.test.tsx
@@ -1,0 +1,66 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderResultCount } from "./renderResultCount";
+
+const messages = {
+  resultCountShowing: "Showing <bold>{start}–{end}</bold> of {total} items",
+  resultCountFiltered:
+    "Showing <bold>{start}–{end}</bold> of {filtered} matching items (of {total} total)",
+  resultCountFilteredEmpty: "0 matching items (of {total} total)",
+};
+
+const renderCount = (params: Parameters<typeof renderResultCount>[0]) =>
+  render(<p>{renderResultCount(params)}</p>);
+
+describe("renderResultCount", () => {
+  it("shows the page range against the grand total when unfiltered", () => {
+    const { container } = renderCount({
+      start: 31,
+      end: 40,
+      shownCount: 10,
+      filteredCount: 551,
+      totalCount: 551,
+      messages,
+    });
+    expect(container.textContent).toBe("Showing 31–40 of 551 items");
+    expect(container.querySelector("strong")?.textContent).toBe("31–40");
+  });
+
+  it("shows the filtered count and grand-total parenthetical when filtered", () => {
+    const { container } = renderCount({
+      start: 31,
+      end: 40,
+      shownCount: 10,
+      filteredCount: 87,
+      totalCount: 551,
+      messages,
+    });
+    expect(container.textContent).toBe("Showing 31–40 of 87 matching items (of 551 total)");
+    expect(container.querySelector("strong")?.textContent).toBe("31–40");
+  });
+
+  it("shows the empty message with no range when a filter matches nothing", () => {
+    const { container } = renderCount({
+      start: 0,
+      end: 0,
+      shownCount: 0,
+      filteredCount: 0,
+      totalCount: 551,
+      messages,
+    });
+    expect(container.textContent).toBe("0 matching items (of 551 total)");
+    expect(container.querySelector("strong")).toBeNull();
+  });
+
+  it("treats a single-page filtered result as filtered, not unfiltered", () => {
+    const { container } = renderCount({
+      start: 1,
+      end: 7,
+      shownCount: 7,
+      filteredCount: 7,
+      totalCount: 551,
+      messages,
+    });
+    expect(container.textContent).toBe("Showing 1–7 of 7 matching items (of 551 total)");
+  });
+});

--- a/packages/static-site/components/learn/renderResultCount.tsx
+++ b/packages/static-site/components/learn/renderResultCount.tsx
@@ -1,0 +1,70 @@
+import { Fragment, type ReactNode } from "react";
+
+export interface ResultCountMessages {
+  /** Unfiltered window; {start}, {end}, {total}; range wrapped in <bold>. */
+  readonly resultCountShowing: string;
+  /** Filtered window; {start}, {end}, {filtered}, {total}; range wrapped in <bold>. */
+  readonly resultCountFiltered: string;
+  /** Filtered set is empty; {total}. */
+  readonly resultCountFilteredEmpty: string;
+}
+
+interface RenderResultCountParams {
+  /** 1-based index of the first item shown on the current page. */
+  readonly start: number;
+  /** 1-based index of the last item shown on the current page. */
+  readonly end: number;
+  /** Number of items on the current page. */
+  readonly shownCount: number;
+  /** Total items after filtering. */
+  readonly filteredCount: number;
+  /** Total items before filtering. */
+  readonly totalCount: number;
+  readonly messages: ResultCountMessages;
+}
+
+const substitute = (template: string, values: Record<string, number>): string =>
+  Object.entries(values).reduce(
+    (text, [key, value]) => text.replaceAll(`{${key}}`, String(value)),
+    template,
+  );
+
+/**
+ * Renders the paginated result-count line. Surfaces the current page window
+ * (bolded) against the active result set, adding a grand-total parenthetical
+ * only when a filter is narrowing the list, and collapsing to a no-range empty
+ * message when nothing matches. The whole sentence stays in one localized
+ * template per state so translators control word order around the bolded range.
+ */
+export const renderResultCount = ({
+  start,
+  end,
+  shownCount,
+  filteredCount,
+  totalCount,
+  messages,
+}: RenderResultCountParams): ReactNode => {
+  const isFiltered = filteredCount !== totalCount;
+
+  if (isFiltered && shownCount === 0) {
+    return substitute(messages.resultCountFilteredEmpty, { total: totalCount });
+  }
+
+  const template = isFiltered ? messages.resultCountFiltered : messages.resultCountShowing;
+  const filled = substitute(template, {
+    start,
+    end,
+    filtered: filteredCount,
+    total: totalCount,
+  });
+
+  return filled.split(/(<bold>.*?<\/bold>)/).map((part, index) => {
+    const boldMatch = part.match(/^<bold>(.*?)<\/bold>$/);
+    if (boldMatch === null) {
+      // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional and stable per render
+      return <Fragment key={index}>{part}</Fragment>;
+    }
+    // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional and stable per render
+    return <strong key={index}>{boldMatch[1]}</strong>;
+  });
+};

--- a/packages/static-site/components/learn/stripContentDirectives.test.ts
+++ b/packages/static-site/components/learn/stripContentDirectives.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { stripContentDirectives, stripContextualInfoIds } from "./stripContentDirectives";
+
+describe("stripContextualInfoIds", () => {
+  it("reduces a contextual-info span to its plain-text label", () => {
+    expect(stripContextualInfoIds("Contact your `Local Enforcing Agency (LEA)|lea` today.")).toBe(
+      "Contact your Local Enforcing Agency (LEA) today.",
+    );
+  });
+
+  it("strips every span in the text", () => {
+    expect(
+      stripContextualInfoIds("`pesticide|pesticide` and `animal facilities|animal-facilities`"),
+    ).toBe("pesticide and animal facilities");
+  });
+
+  it("leaves ordinary code spans untouched", () => {
+    expect(stripContextualInfoIds("Run `yarn build` first.")).toBe("Run `yarn build` first.");
+  });
+});
+
+describe("stripContentDirectives", () => {
+  it("leaves plain markdown untouched", () => {
+    const md = "You need a license to operate.\n\n- One\n- Two";
+    expect(stripContentDirectives(md)).toBe(md);
+  });
+
+  it("unwraps an infoAlert directive, keeping the inner content", () => {
+    const md = [
+      ":::infoAlert",
+      "**Keep in mind:** applications with missing documents are delayed.",
+      ":::",
+      "",
+      "You need an A-901 license to transport waste.",
+    ].join("\n");
+
+    const result = stripContentDirectives(md);
+    expect(result).not.toContain(":::");
+    expect(result).toContain("**Keep in mind:** applications with missing documents are delayed.");
+    expect(result).toContain("You need an A-901 license to transport waste.");
+  });
+
+  it("unwraps a largeCallout directive that carries an attribute block", () => {
+    const md = [
+      ':::largeCallout{ showHeader="true" headerText="Keep in mind:" calloutType="informational" }',
+      "",
+      "* A Motor Vehicle Commission EIN is required first.",
+      "",
+      ":::",
+      "",
+      "Your business vehicles must have a valid registration.",
+    ].join("\n");
+
+    const result = stripContentDirectives(md);
+    expect(result).not.toContain(":::");
+    expect(result).not.toContain("largeCallout");
+    expect(result).not.toContain('headerText="Keep in mind:"');
+    expect(result).toContain("* A Motor Vehicle Commission EIN is required first.");
+    expect(result).toContain("Your business vehicles must have a valid registration.");
+  });
+
+  it("strips contextual-info-link ids and their code-span backticks, leaving plain text", () => {
+    const md = "Contact the `Local Enforcing Agency (LEA)|lea` in your town.";
+    expect(stripContentDirectives(md)).toBe(
+      "Contact the Local Enforcing Agency (LEA) in your town.",
+    );
+  });
+
+  it("handles multiple directives in one document", () => {
+    const md = [
+      ":::infoAlert",
+      "First note.",
+      ":::",
+      "",
+      "Body text.",
+      "",
+      ":::note",
+      "Second note.",
+      ":::",
+    ].join("\n");
+
+    const result = stripContentDirectives(md);
+    expect(result).not.toContain(":::");
+    expect(result).toContain("First note.");
+    expect(result).toContain("Body text.");
+    expect(result).toContain("Second note.");
+  });
+});

--- a/packages/static-site/components/learn/stripContentDirectives.ts
+++ b/packages/static-site/components/learn/stripContentDirectives.ts
@@ -1,0 +1,29 @@
+/**
+ * Removes the custom CMS content directives that the main `web` app renders as
+ * styled callout boxes (`:::infoAlert`, `:::largeCallout`, `:::note`, …). The
+ * static site renders summaries with plain `react-markdown`, which has no
+ * directive support, so the raw `:::` fences would otherwise show as literal
+ * text. We unwrap them and keep the inner content as ordinary markdown, mirroring
+ * how `parseFundingContent` treats the funding `:::largeCallout` block.
+ *
+ * The directive opener may carry an attribute block, e.g.
+ * `:::largeCallout{ headerText="Keep in mind:" }`; the attributes (including any
+ * header text) are dropped, matching the funding precedent.
+ */
+const directiveFenceLine = /^:::\w*(?:\{[^}]*\})?\s*$/gm;
+
+const contextualInfoSpan = /`([^`|]+)\|[^`]+`/g;
+
+/**
+ * Strips contextual-info-link code spans down to their visible label, dropping
+ * both the `|id` and the surrounding backticks: `` `Local Enforcing Agency
+ * (LEA)|lea` `` becomes `Local Enforcing Agency (LEA)`. The backticks must go —
+ * the main `web` app renders these spans as interactive info links, but the
+ * static site has no such component, so leaving the backticks would render the
+ * label as a monospace `<code>` span.
+ */
+export const stripContextualInfoIds = (text: string): string =>
+  text.replace(contextualInfoSpan, "$1");
+
+export const stripContentDirectives = (md: string): string =>
+  stripContextualInfoIds(md.replace(directiveFenceLine, ""));

--- a/packages/static-site/components/learn/usePaginatedScroll.test.ts
+++ b/packages/static-site/components/learn/usePaginatedScroll.test.ts
@@ -1,0 +1,63 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { usePaginatedScroll } from "./usePaginatedScroll";
+
+describe("usePaginatedScroll", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("sets the page, then scrolls and focuses the results region", () => {
+    const setCurrentPage = vi.fn();
+    const { result } = renderHook(() => usePaginatedScroll(setCurrentPage));
+
+    const scrollIntoView = vi.fn();
+    const focus = vi.fn();
+    const element = { scrollIntoView, focus } as unknown as HTMLDivElement;
+    result.current.resultsRef.current = element;
+
+    result.current.handlePageChange(3);
+
+    expect(setCurrentPage).toHaveBeenCalledWith(3);
+
+    // Scroll/focus is deferred until after the new page renders.
+    vi.runAllTimers();
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it("uses an instant scroll when the user prefers reduced motion", () => {
+    const matchMedia = vi.fn().mockReturnValue({ matches: true });
+    vi.stubGlobal("matchMedia", matchMedia);
+
+    const setCurrentPage = vi.fn();
+    const { result } = renderHook(() => usePaginatedScroll(setCurrentPage));
+    const scrollIntoView = vi.fn();
+    result.current.resultsRef.current = {
+      scrollIntoView,
+      focus: vi.fn(),
+    } as unknown as HTMLDivElement;
+
+    result.current.handlePageChange(2);
+    vi.runAllTimers();
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "auto", block: "start" });
+    vi.unstubAllGlobals();
+  });
+
+  it("does nothing extra when the results ref is unset", () => {
+    const setCurrentPage = vi.fn();
+    const { result } = renderHook(() => usePaginatedScroll(setCurrentPage));
+
+    expect(() => {
+      result.current.handlePageChange(2);
+      vi.runAllTimers();
+    }).not.toThrow();
+    expect(setCurrentPage).toHaveBeenCalledWith(2);
+  });
+});

--- a/packages/static-site/components/learn/usePaginatedScroll.ts
+++ b/packages/static-site/components/learn/usePaginatedScroll.ts
@@ -1,0 +1,48 @@
+import { useCallback, useRef } from "react";
+
+interface PaginatedScroll {
+  /** Attach to the results region that should scroll into view on page change. */
+  readonly resultsRef: React.RefObject<HTMLElement | null>;
+  /** Sets the page, then scrolls the results region into view and focuses it. */
+  readonly handlePageChange: (page: number) => void;
+}
+
+const prefersReducedMotion = (): boolean =>
+  typeof window !== "undefined" &&
+  typeof window.matchMedia === "function" &&
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+/**
+ * Wires a paginated list's page-change handler to scroll the results region to
+ * the top and move focus there. Neither Grove nor USWDS prescribe scroll
+ * behavior for pagination, so this follows the `web` app's convention
+ * (`scrollToTopOfElement` with focus) and standard accessible-pagination
+ * practice: after switching pages, reposition the user at the first result and
+ * move focus so assistive technology announces the new content.
+ */
+export const usePaginatedScroll = (setCurrentPage: (page: number) => void): PaginatedScroll => {
+  const resultsRef = useRef<HTMLElement | null>(null);
+
+  const handlePageChange = useCallback(
+    (page: number) => {
+      setCurrentPage(page);
+      // Defer until the new page has rendered so we scroll to settled content.
+      setTimeout(() => {
+        const element = resultsRef.current;
+        // `scrollIntoView`/`focus` are unavailable in non-DOM environments (SSR,
+        // JSDOM); skip rather than throw when they are missing.
+        if (element === null || typeof element.scrollIntoView !== "function") {
+          return;
+        }
+        element.scrollIntoView({
+          behavior: prefersReducedMotion() ? "auto" : "smooth",
+          block: "start",
+        });
+        element.focus?.({ preventScroll: true });
+      }, 0);
+    },
+    [setCurrentPage],
+  );
+
+  return { resultsRef, handlePageChange };
+};

--- a/packages/static-site/components/learn/whoItsForLabel.test.ts
+++ b/packages/static-site/components/learn/whoItsForLabel.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { whoItsForLabel } from "./whoItsForLabel";
+
+// A stand-in for the localized `whoItsForLabels` message map, keyed by the
+// Webflow classification key. Values are deliberately not the production English
+// copy: the assertions can only pass if the function resolves through the
+// supplied map, proving labels come from i18n config rather than a hardcoded
+// table. This also keeps the test locale-agnostic.
+const labels: Record<string, string> = {
+  "business-license": "who-for::business",
+  "individual-license": "who-for::individual",
+  "object-vehicle": "who-for::object",
+};
+
+describe("whoItsForLabel", () => {
+  it("resolves each known Webflow classification key through the supplied label map", () => {
+    for (const key of Object.keys(labels)) {
+      expect(whoItsForLabel(key, labels)).toBe(labels[key]);
+    }
+  });
+
+  it("returns undefined for a key absent from the map, so the row is omitted", () => {
+    expect(whoItsForLabel("school-course", labels)).toBeUndefined();
+    expect(whoItsForLabel("", labels)).toBeUndefined();
+    expect(whoItsForLabel(undefined, labels)).toBeUndefined();
+    expect(whoItsForLabel("LICENSE", labels)).toBeUndefined();
+  });
+});

--- a/packages/static-site/components/learn/whoItsForLabel.ts
+++ b/packages/static-site/components/learn/whoItsForLabel.ts
@@ -1,0 +1,19 @@
+/**
+ * Resolves a license's Webflow classification key (`webflowType`) to its "Who
+ * it's for" display label using the supplied localized label map. Returns
+ * `undefined` for unknown or missing keys so the card omits the row entirely
+ * rather than showing a raw or blank value.
+ *
+ * The label map is the localized `whoItsForLabels` from the page messages, so
+ * the labels are translatable rather than hardcoded English.
+ *
+ * `school-course` is a valid key in the upstream Webflow classification
+ * vocabulary but no current license is assigned it, so it is intentionally
+ * absent from the map (and its live display label is unconfirmed). Worth
+ * revisiting: either add a label once verified in Webflow, or drop the value
+ * from the source vocabulary if it stays unused.
+ */
+export const whoItsForLabel = (
+  webflowType: string | undefined,
+  labels: Record<string, string>,
+): string | undefined => (webflowType ? labels[webflowType] : undefined);

--- a/packages/static-site/domain/content/loadContent.ts
+++ b/packages/static-site/domain/content/loadContent.ts
@@ -10,6 +10,7 @@ import type {
   Filing,
   Funding,
   Industry,
+  License,
   LicenseEventType,
   PageItem,
   RecentItem,
@@ -147,6 +148,9 @@ export const loadLicenseReinstatements = (): AnytimeActionLicenseReinstatement[]
       licenseReinstatements: AnytimeActionLicenseReinstatement[];
     }
   ).licenseReinstatements;
+
+export const loadLicenses = (): License[] =>
+  (readContentJson("licenses.json") as { licenses: License[] }).licenses;
 
 export const loadPages = (): PageItem[] => readMarkdownDirectory<PageItem>("pages");
 

--- a/packages/static-site/domain/content/messageTypes.ts
+++ b/packages/static-site/domain/content/messageTypes.ts
@@ -548,8 +548,12 @@ export interface FundingPageMessages {
   readonly filterShowResults: string;
   /** Label for the "Reset" button. */
   readonly filterReset: string;
-  /** Result count line; {filtered} (wrapped in <bold>) and {total} are substituted at runtime via t.rich. */
-  readonly resultCount: string;
+  /** Unfiltered result-count line; {start}, {end} (range wrapped in <bold>), and {total}. */
+  readonly resultCountShowing: string;
+  /** Filtered result-count line; {start}, {end} (range wrapped in <bold>), {filtered}, and {total}. */
+  readonly resultCountFiltered: string;
+  /** Result-count line when the filtered set is empty; {total}. */
+  readonly resultCountFilteredEmpty: string;
   /** Label preceding the filter chips ("Filtering by:"). */
   readonly filteringByLabel: string;
   /** Chip label for the active search query; {query} is replaced at runtime. */
@@ -573,6 +577,62 @@ export interface FundingPageMessages {
 }
 
 /**
+ * Localized content for the Licensing and Certification Guide page.
+ */
+export interface LicensingGuidePageMessages {
+  /** Page H1 title. */
+  readonly title: string;
+  /** Heading inside the CTA box. */
+  readonly ctaHeading: string;
+  /** Body text inside the CTA box. */
+  readonly ctaBody: string;
+  /** Label for the CTA button. */
+  readonly ctaButton: string;
+  /** Heading for the filter sidebar. */
+  readonly filterHeading: string;
+  /** Label for the search input. */
+  readonly filterSearch: string;
+  /** Label for the "Show Results" button; {count} is replaced at runtime. */
+  readonly filterShowResults: string;
+  /** Label for the "Reset" button. */
+  readonly filterReset: string;
+  /** Unfiltered result-count line; {start}, {end} (range wrapped in <bold>), and {total}. */
+  readonly resultCountShowing: string;
+  /** Filtered result-count line; {start}, {end} (range wrapped in <bold>), {filtered}, and {total}. */
+  readonly resultCountFiltered: string;
+  /** Result-count line when the filtered set is empty; {total}. */
+  readonly resultCountFilteredEmpty: string;
+  /** Label preceding the filter chips ("Filtering by:"). */
+  readonly filteringByLabel: string;
+  /** Chip label for the active search query; {query} is replaced at runtime. */
+  readonly filterSearchChip: string;
+  /** aria-label template for chip remove buttons; {filter} is replaced at runtime. */
+  readonly filterRemoveLabel: string;
+  /** Label for pagination "Previous" control. */
+  readonly paginationPrevious: string;
+  /** Label for pagination "Next" control. */
+  readonly paginationNext: string;
+  /** aria-label for the pagination navigation landmark. */
+  readonly paginationLabel: string;
+  /** aria-label template for a numbered page button; {page} is replaced at runtime. */
+  readonly paginationPageLabel: string;
+  /** Prefix label for the "Who it's for" field on a license card. */
+  readonly cardWhoForLabel: string;
+  /** Prefix label for the industry field on a license card. */
+  readonly cardIndustryLabel: string;
+  /** Prefix label for the agency field on a license card. */
+  readonly cardAgencyLabel: string;
+  /** Prefix label for the phone field on a license card. */
+  readonly cardPhoneLabel: string;
+  /**
+   * "Who it's for" display labels keyed by a license's Webflow classification
+   * (`webflowType`). A key present here is shown; an unmapped `webflowType`
+   * omits the row.
+   */
+  readonly whoItsForLabels: Record<string, string>;
+}
+
+/**
  * Complete localized message payload for one locale.
  */
 export interface ApplicationMessages {
@@ -586,4 +646,6 @@ export interface ApplicationMessages {
   readonly learn: LearnPageContent;
   /** Funding page content strings. */
   readonly funding: FundingPageMessages;
+  /** Licensing & Certification Guide page content strings. */
+  readonly licensingGuide: LicensingGuidePageMessages;
 }

--- a/packages/static-site/domain/content/types.ts
+++ b/packages/static-site/domain/content/types.ts
@@ -15,6 +15,7 @@ export type {
   FundingStatus,
   FundingType,
   Industry,
+  License,
   LicenseEventType,
   RoadmapStep,
   Sector,

--- a/packages/static-site/messages/en-US.json
+++ b/packages/static-site/messages/en-US.json
@@ -655,7 +655,9 @@
     "filterClear": "Clear",
     "filterShowResults": "Show {count} Results",
     "filterReset": "Reset",
-    "resultCount": "Showing <bold>{filtered}</bold> results of {total} items",
+    "resultCountShowing": "Showing <bold>{start}–{end}</bold> of {total} items",
+    "resultCountFiltered": "Showing <bold>{start}–{end}</bold> of {filtered} matching items (of {total} total)",
+    "resultCountFilteredEmpty": "0 matching items (of {total} total)",
     "filteringByLabel": "Filtering by:",
     "filterSearchChip": "Search: \"{query}\"",
     "filterRemoveLabel": "Remove {filter} filter",
@@ -666,5 +668,34 @@
     "cardDueLabel": "Due:",
     "cardEligibilityHeading": "Eligibility",
     "cardBenefitsHeading": "Benefits"
+  },
+  "licensingGuide": {
+    "title": "Licensing and Certification Guide",
+    "ctaHeading": "Get Your Registration Guide!",
+    "ctaBody": "Start your New Jersey or out-of-state business today!",
+    "ctaButton": "Get Started",
+    "filterHeading": "Narrow Results",
+    "filterSearch": "Search",
+    "filterShowResults": "Show {count} Results",
+    "filterReset": "Reset",
+    "resultCountShowing": "Showing <bold>{start}–{end}</bold> of {total} items",
+    "resultCountFiltered": "Showing <bold>{start}–{end}</bold> of {filtered} matching items (of {total} total)",
+    "resultCountFilteredEmpty": "0 matching items (of {total} total)",
+    "filteringByLabel": "Filtering by:",
+    "filterSearchChip": "Search: \"{query}\"",
+    "filterRemoveLabel": "Remove {filter} filter",
+    "paginationPrevious": "Previous",
+    "paginationNext": "Next",
+    "paginationLabel": "Pagination",
+    "paginationPageLabel": "Page {page}",
+    "cardWhoForLabel": "Who it's for:",
+    "cardIndustryLabel": "Industry:",
+    "cardAgencyLabel": "Agency:",
+    "cardPhoneLabel": "Phone:",
+    "whoItsForLabels": {
+      "business-license": "Businesses",
+      "individual-license": "Individuals",
+      "object-vehicle": "Object/Vehicle"
+    }
   }
 }

--- a/packages/static-site/messages/es-US.json
+++ b/packages/static-site/messages/es-US.json
@@ -655,7 +655,9 @@
     "filterClear": "Borrar",
     "filterShowResults": "Mostrar {count} resultados",
     "filterReset": "Restablecer",
-    "resultCount": "Mostrando <bold>{filtered}</bold> resultados de {total} elementos",
+    "resultCountShowing": "Mostrando <bold>{start}–{end}</bold> de {total} elementos",
+    "resultCountFiltered": "Mostrando <bold>{start}–{end}</bold> de {filtered} elementos coincidentes (de {total} en total)",
+    "resultCountFilteredEmpty": "0 elementos coincidentes (de {total} en total)",
     "filteringByLabel": "Filtrando por:",
     "filterSearchChip": "Búsqueda: \"{query}\"",
     "filterRemoveLabel": "Quitar el filtro {filter}",
@@ -666,5 +668,34 @@
     "cardDueLabel": "Fecha límite:",
     "cardEligibilityHeading": "Elegibilidad",
     "cardBenefitsHeading": "Beneficios"
+  },
+  "licensingGuide": {
+    "title": "Guía de Licencias y Certificaciones",
+    "ctaHeading": "¡Obtenga su Guía de Registro!",
+    "ctaBody": "¡Comience su negocio en Nueva Jersey o fuera del estado hoy!",
+    "ctaButton": "Comenzar",
+    "filterHeading": "Acotar Resultados",
+    "filterSearch": "Buscar",
+    "filterShowResults": "Mostrar {count} resultados",
+    "filterReset": "Restablecer",
+    "resultCountShowing": "Mostrando <bold>{start}–{end}</bold> de {total} elementos",
+    "resultCountFiltered": "Mostrando <bold>{start}–{end}</bold> de {filtered} elementos coincidentes (de {total} en total)",
+    "resultCountFilteredEmpty": "0 elementos coincidentes (de {total} en total)",
+    "filteringByLabel": "Filtrando por:",
+    "filterSearchChip": "Búsqueda: \"{query}\"",
+    "filterRemoveLabel": "Quitar el filtro {filter}",
+    "paginationPrevious": "Anterior",
+    "paginationNext": "Siguiente",
+    "paginationLabel": "Paginación",
+    "paginationPageLabel": "Página {page}",
+    "cardWhoForLabel": "Para quién es:",
+    "cardIndustryLabel": "Industria:",
+    "cardAgencyLabel": "Agencia:",
+    "cardPhoneLabel": "Teléfono:",
+    "whoItsForLabels": {
+      "business-license": "Empresas",
+      "individual-license": "Individuos",
+      "object-vehicle": "Objeto/Vehículo"
+    }
   }
 }

--- a/packages/static-site/tests/accessibility/licensing-guide.a11y.spec.ts
+++ b/packages/static-site/tests/accessibility/licensing-guide.a11y.spec.ts
@@ -1,0 +1,61 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+import type { BrowserContext, Page } from "playwright";
+import type { AppLocale } from "@/domain/i18n/locales";
+import { ENABLED_LOCALES } from "@/domain/i18n/locales";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+
+/**
+ * Defines the test context provided by Playwright.
+ */
+interface AccessibilityTestContext {
+  /** Browser page used by the test run. */
+  readonly page: Page;
+  /** Browser context, used to seed cookies before navigation. */
+  readonly context: BrowserContext;
+}
+
+/**
+ * Parameters for creating one locale-specific accessibility test.
+ */
+interface CreateLocaleAccessibilityTestParams {
+  /** Locale to evaluate in the browser accessibility audit. */
+  readonly locale: AppLocale;
+}
+
+/**
+ * Creates a Playwright accessibility test for one locale.
+ */
+const createLocaleAccessibilityTest = ({ locale }: CreateLocaleAccessibilityTestParams) => {
+  return async ({ page, context }: AccessibilityTestContext) => {
+    const messages = await getApplicationMessages({ locale });
+
+    // Suppress the preferred-language prompt modal so its open/animation state
+    // cannot race with the axe scan, which made this audit flaky.
+    await context.addCookies([
+      {
+        name: LANGUAGE_PROMPT_DISMISSED_COOKIE,
+        value: "true",
+        url: "http://127.0.0.1:3000",
+      },
+    ]);
+
+    await page.goto(`/${locale}/pages/licensing-and-certification-guide`);
+    await page.getByRole("heading", { level: 1, name: messages.licensingGuide.title }).waitFor();
+
+    // `color-contrast` is a pre-existing NJWDS banner/chrome issue present on
+    // every page (it also fails the homepage audit) and is outside this page's
+    // scope. Excluding it keeps this audit focused on licensing-page a11y.
+    const results = await new AxeBuilder({ page }).disableRules(["color-contrast"]).analyze();
+
+    expect(results.violations).toEqual([]);
+  };
+};
+
+for (const locale of ENABLED_LOCALES) {
+  test(
+    `licensing guide page has no automated WCAG violations for ${locale}`,
+    createLocaleAccessibilityTest({ locale }),
+  );
+}

--- a/shared/src/static/index.ts
+++ b/shared/src/static/index.ts
@@ -26,6 +26,7 @@ export * from "./loadPages";
 export * from "./loadStepsJson";
 export * from "./loadTaskDependencies";
 export * from "./loadTasks";
+export * from "./loadAllLicenses";
 export * from "./loadWebflowLicenses";
 export * from "./loadXrayRenewalCalendarEvent";
 export * from "./loadYamlFiles";

--- a/shared/src/static/loadAllLicenses.test.ts
+++ b/shared/src/static/loadAllLicenses.test.ts
@@ -1,0 +1,35 @@
+import { loadAllLicenses } from "./loadAllLicenses";
+
+describe("loadAllLicenses", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("includes all webflow-licenses and license-tasks, and only tasks flagged syncToWebflow", () => {
+    const all = loadAllLicenses();
+    // A webflow-license file appears (sample a known slug).
+    expect(all.some((l) => l.urlSlug === "adoption-agency")).toBe(true);
+    // A roadmaps/tasks file WITH syncToWebflow appears.
+    expect(all.some((l) => l.urlSlug === "trucking-usdot")).toBe(true);
+    // The municipal-tasks file appears.
+    expect(all.some((l) => l.urlSlug === "elevator-registration")).toBe(true);
+  });
+
+  it("dedupes by webflowId, keeping a single entry per id", () => {
+    const all = loadAllLicenses();
+    const ids = all.map((l) => l.webflowId).filter(Boolean);
+    const unique = new Set(ids);
+    expect(ids.length).toBe(unique.size);
+  });
+
+  it("loads the full license collection (guards against a dir-read regression)", () => {
+    // The Webflow license collection is ~551 cards. Assert a floor rather than an
+    // exact count so legitimate content edits don't break the test, while a
+    // missing source directory (which would drop hundreds of cards) still fails.
+    expect(loadAllLicenses().length).toBeGreaterThan(500);
+  });
+});

--- a/shared/src/static/loadAllLicenses.ts
+++ b/shared/src/static/loadAllLicenses.ts
@@ -1,0 +1,97 @@
+import fs from "fs";
+import matter from "gray-matter";
+import path from "path";
+
+export interface WebflowLicenseCard {
+  id: string;
+  webflowId?: string;
+  urlSlug: string;
+  name: string;
+  displayname?: string;
+  webflowName?: string;
+  filename: string;
+  callToActionLink?: string;
+  callToActionText?: string;
+  agencyId?: string;
+  agencyAdditionalContext?: string;
+  divisionPhone?: string;
+  industryId?: string;
+  webflowType?: string;
+  licenseCertificationClassification: string;
+  summaryDescriptionMd?: string;
+  contentMd: string;
+  syncToWebflow?: boolean | string;
+  formName?: string;
+  webflowIndustry?: string;
+  [key: string]: unknown;
+}
+
+// process.cwd() is the invoking package's own directory ("..", then content/src)
+// when run via `yarn workspace <pkg> build`, but repo root (content/src directly,
+// no "..") when run via Jest, which never chdirs regardless of which package.json's
+// `test` script triggers it. Only this loader's own test exercises the real
+// filesystem (its siblings all mock fs), so it's the only one that has to resolve
+// both conventions correctly.
+const resolveContentRoot = (): string => {
+  const fromPackageDirectory = path.join(process.cwd(), "..", "content", "src");
+  const fromRepoRoot = path.join(process.cwd(), "content", "src");
+  return fs.existsSync(fromPackageDirectory) ? fromPackageDirectory : fromRepoRoot;
+};
+const contentRoot = resolveContentRoot();
+const webflowLicenseDirectory = path.join(contentRoot, "webflow-licenses");
+const licenseTasksDirectory = path.join(contentRoot, "roadmaps", "license-tasks");
+const municipalDirectory = path.join(contentRoot, "roadmaps", "municipal-tasks");
+const tasksAllDirectory = path.join(contentRoot, "roadmaps", "tasks");
+
+const convertLicenseMd = (mdContents: string, filename: string): WebflowLicenseCard => {
+  const matterResult = matter(mdContents);
+  return {
+    ...matterResult.data,
+    contentMd: matterResult.content,
+    filename,
+  } as WebflowLicenseCard;
+};
+
+const loadDirectory = (directory: string): WebflowLicenseCard[] => {
+  if (!fs.existsSync(directory)) {
+    throw new Error(
+      `loadAllLicenses: content directory not found at ${directory} — a source directory was renamed or removed`,
+    );
+  }
+  return fs.readdirSync(directory).map((fileName) => {
+    const fileContents = fs.readFileSync(path.join(directory, fileName), "utf8");
+    return convertLicenseMd(fileContents, fileName.split(".md")[0]);
+  });
+};
+
+const dedupeByWebflowId = (licenses: WebflowLicenseCard[]): WebflowLicenseCard[] => {
+  const seen = new Set<string>();
+  const result: WebflowLicenseCard[] = [];
+  for (const license of licenses) {
+    if (license.webflowId === undefined || license.webflowId === "") {
+      result.push(license);
+      continue;
+    }
+    if (seen.has(license.webflowId)) {
+      console.warn(
+        `loadAllLicenses: duplicate webflowId ${license.webflowId} on ${license.filename} — skipping`,
+      );
+      continue;
+    }
+    seen.add(license.webflowId);
+    result.push(license);
+  }
+  return result;
+};
+
+export const loadAllLicenses = (): WebflowLicenseCard[] => {
+  const combined = [
+    ...loadDirectory(webflowLicenseDirectory),
+    ...loadDirectory(licenseTasksDirectory),
+    ...loadDirectory(municipalDirectory),
+    ...loadDirectory(tasksAllDirectory).filter(
+      (license) => license.syncToWebflow === true || license.syncToWebflow === "true",
+    ),
+  ];
+  return dedupeByWebflowId(combined);
+};

--- a/web/src/scripts/licenseLoader.test.ts
+++ b/web/src/scripts/licenseLoader.test.ts
@@ -166,6 +166,7 @@ Test content`;
 
   describe("loadAllLicenses", () => {
     it("combines navigator and webflow licenses", () => {
+      mockFs.existsSync.mockReturnValue(true);
       (mockFs.readdirSync as jest.Mock).mockReturnValue(["license1.md"]);
       mockFs.readFileSync.mockReturnValue("test content");
       mockMatter.mockReturnValue({

--- a/web/src/scripts/licenseLoader.ts
+++ b/web/src/scripts/licenseLoader.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import matter from "gray-matter";
 import path from "path";
+import { loadAllLicenses as loadAllLicensesShared } from "@businessnjgovnavigator/shared/static/loadAllLicenses";
 
 const webflowLicenseDir = path.resolve(`${__dirname}/../../../content/src/webflow-licenses`);
 
@@ -47,12 +48,11 @@ const convertLicenseMd = (mdContents: string, filename: string): LicenseData => 
   } as LicenseData;
 };
 
-export const loadAllLicenses = (): LicenseData[] => {
-  const webflowLicenses = loadAllNavigatorWebflowLicenses();
-  const navigatorLicenses = loadAllNavigatorLicenses();
-
-  return [...navigatorLicenses, ...webflowLicenses];
-};
+// The shared loader returns WebflowLicenseCard, which makes `id`/`displayname`
+// optional where this script's LicenseData requires them. The underlying
+// frontmatter is identical, so the bridge cast is safe.
+export const loadAllLicenses = (): LicenseData[] =>
+  loadAllLicensesShared() as unknown as LicenseData[];
 
 export const loadAllNavigatorWebflowLicenses = (): LicenseData[] => {
   const webflowFileNames = fs.readdirSync(webflowLicenseDir);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5193,6 +5193,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@businessnjgovnavigator/content@workspace:content"
   dependencies:
+    "@businessnjgovnavigator/content-types": "npm:*"
     "@businessnjgovnavigator/shared": "npm:*"
     "@types/node": "npm:24.12.2"
     "@vitest/coverage-v8": "npm:4.1.9"


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Adds the **Licensing & Certification Guide** page to the static site, mirroring the [existing page](https://business.nj.gov/licensing-and-certification-guide). There's a lot of polish that also improves the funding page, which shares a lot of styling and components.

**Note:** Commits are separated for clarity but will be squashed into one commit prior to merging.

**Additional Note:** One thing that's only in the [current Webflow page](https://business.nj.gov/licensing-and-certification-guide) are URLs that wrap agency names as links on the license cards. However, it requires backfilling/updating a lot of files with a single frontmatter property, so I moved that to a [follow-up PR](https://github.com/newjersey/navigator.business.nj.gov/pull/12872).

### Ticket

- This pull request resolves [#17823](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17823).
- [Figma Designs](https://www.figma.com/design/pk0neG436QNTm805O603Vp/96-100-Business-Experience-Sprint-Designs?node-id=69885-4594&t=gMJvE42D4lYPPOqL-4)

### Approach

- Licenses are assembled by a new shared `loadAllLicenses` loader (deduped by `webflowId`), emitted to `licenses.json` by the content build, and read by the static site through `loadLicenses()`. This makes sure we're sourcing things from the same place for `web/` and `packages/static-site`
- The page reuses the funding page's layout. Those two pages also share the same`Pagination` component and content-cleaning helpers
- Maps the "Who it's for" label from the clean `webflowType` classification rather than the raw CMS text.

**Note:** The `content` build must run so `licenses.json` exists (the static-site dev/build scripts already do this).

### Steps to Test

From `packages/static-site`:

1. `pnpm dev` and open http://localhost:4000/pages/licensing-and-certification-guide
2. **Search:** type a term (e.g. `waste`); matching cards filter live and the matched text is highlighted in the card body.
3. **Pagination:** with no filter, page through results. The pager shows the NJWDS overflow style (`Previous 1 2 3 4 5 … 56 Next`), and clicking a page scrolls to the top of the results list.
4. **Result count:** confirm the count line reads `Showing 1–10 of 551 items`; after searching, `Showing 1–10 of N matching items (of 551 total)`; with no matches, `0 matching items (of 551 total)`.
5. **Cards:** make sure spacing looks right and markdown parsing is properly rendering (i.e. no stray `:::` directives or backtick/code text in the summary)
6. **Responsive:** narrow the window to ~836–1024px; the search input, dividers, checkbox rows, and the filter "Clear" buttons should all fill and align to the right edge of the `aside` element with the search filter
7. Repeat the shared behaviors (pagination, result count, dividers, filter aside) on http://localhost:4000/pages/funding to confirm no regression.
8. Verify `pnpm test && pnpm typecheck && pnpm lint` all pass; `pnpm test:accessibility` passes for the new page.

### Notes

- The target branch is currently `funding-page`, since it branches off and is a continuation of that PR's work
- `webflowType` value `school-course` is intentionally left unmapped — no current license uses it and its display label is unconfirmed (noted in `whoItsForLabel.ts`).

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
