### PR TITLE
feat: (static site) link agency names to their respective websites on license cards

### DIFF
--- a/content/build.test.ts
+++ b/content/build.test.ts
@@ -27,7 +27,10 @@ import {
   buildChecklistItemTaskMap,
   buildAndWriteChecklistItemTasks,
   toLicenseCard,
+  deriveSingleAgencyWebsites,
+  applyAgencyWebsiteFallback,
 } from "./build";
+import type { WebflowLicenseCard } from "@businessnjgovnavigator/shared/static/loadAllLicenses";
 
 // ============================================================================
 // TEST UTILITIES - Mock Ports
@@ -542,6 +545,7 @@ describe("Application Layer", () => {
         certificationsCount: 5,
         filingsCount: 15,
         fundingsCount: 25,
+        licensesCount: 42,
         licenseCalendarEventsCount: 8,
         licenseReinstatementsCount: 12,
         checklistItemTasksCount: 77,
@@ -556,6 +560,7 @@ describe("Application Layer", () => {
       expect(consoleSpy).toHaveBeenCalledWith("✓ Built certifications.json with 5 certifications");
       expect(consoleSpy).toHaveBeenCalledWith("✓ Built filings.json with 15 filings");
       expect(consoleSpy).toHaveBeenCalledWith("✓ Built fundings.json with 25 fundings");
+      expect(consoleSpy).toHaveBeenCalledWith("✓ Built licenses.json with 42 licenses");
       expect(consoleSpy).toHaveBeenCalledWith(
         "✓ Built license-calendar-events.json with 8 license-related calendar events",
       );
@@ -849,5 +854,110 @@ describe("toLicenseCard", () => {
       new Map(),
     );
     expect(card.name).toBe("Veterinarian");
+  });
+
+  it("carries the agency website url through", () => {
+    const card = toLicenseCard(
+      {
+        id: "animal-dealer",
+        filename: "animal-dealer",
+        urlSlug: "animal-dealer",
+        name: "Animal Dealer",
+        licenseCertificationClassification: "LICENSE",
+        contentMd: "",
+        agencyWebsite: "https://www.nj.gov/agriculture/",
+      },
+      new Map(),
+    );
+    expect(card.agencyWebsite).toBe("https://www.nj.gov/agriculture/");
+  });
+
+  it("leaves the agency website undefined when the source has none", () => {
+    const card = toLicenseCard(
+      {
+        id: "no-website",
+        filename: "no-website",
+        urlSlug: "no-website",
+        name: "No Website",
+        licenseCertificationClassification: "LICENSE",
+        contentMd: "",
+      },
+      new Map(),
+    );
+    expect(card.agencyWebsite).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// AGENCY WEBSITE FALLBACK
+// ============================================================================
+
+const rawLicense = (overrides: Partial<WebflowLicenseCard>): WebflowLicenseCard => ({
+  id: "x",
+  filename: "x",
+  urlSlug: "x",
+  name: "X",
+  licenseCertificationClassification: "LICENSE",
+  contentMd: "",
+  ...overrides,
+});
+
+describe("deriveSingleAgencyWebsites", () => {
+  it("maps an agencyId to its website when every populated sibling agrees", () => {
+    const map = deriveSingleAgencyWebsites([
+      rawLicense({ agencyId: "agriculture", agencyWebsite: "https://www.nj.gov/agriculture/" }),
+      rawLicense({ agencyId: "agriculture" }),
+    ]);
+    expect(map.get("agriculture")).toBe("https://www.nj.gov/agriculture/");
+  });
+
+  it("omits an agencyId whose licenses carry conflicting websites", () => {
+    const map = deriveSingleAgencyWebsites([
+      rawLicense({ agencyId: "njdep", agencyWebsite: "https://www.nj.gov/dep/" }),
+      rawLicense({ agencyId: "njdep", agencyWebsite: "https://www.nj.gov/bpu/" }),
+    ]);
+    expect(map.has("njdep")).toBe(false);
+  });
+
+  it("omits an agencyId that has no website on any license", () => {
+    const map = deriveSingleAgencyWebsites([rawLicense({ agencyId: "empty" })]);
+    expect(map.has("empty")).toBe(false);
+  });
+
+  it("ignores licenses without an agencyId", () => {
+    const map = deriveSingleAgencyWebsites([
+      rawLicense({ agencyId: undefined, agencyWebsite: "https://www.fcc.gov/" }),
+    ]);
+    expect(map.size).toBe(0);
+  });
+});
+
+describe("applyAgencyWebsiteFallback", () => {
+  it("fills a blank agencyWebsite from its agencyId's single known website", () => {
+    const licenses = [
+      rawLicense({ agencyId: "agriculture", agencyWebsite: "https://www.nj.gov/agriculture/" }),
+      rawLicense({ agencyId: "agriculture" }),
+    ];
+    const filled = applyAgencyWebsiteFallback(licenses);
+    expect(filled[1].agencyWebsite).toBe("https://www.nj.gov/agriculture/");
+  });
+
+  it("leaves an explicit agencyWebsite untouched", () => {
+    const licenses = [
+      rawLicense({ agencyId: "agriculture", agencyWebsite: "https://www.nj.gov/agriculture/" }),
+      rawLicense({ agencyId: "agriculture", agencyWebsite: "https://special.example.gov/" }),
+    ];
+    const filled = applyAgencyWebsiteFallback(licenses);
+    expect(filled[1].agencyWebsite).toBe("https://special.example.gov/");
+  });
+
+  it("leaves a blank agencyWebsite blank when the agencyId's websites conflict", () => {
+    const licenses = [
+      rawLicense({ agencyId: "njdep", agencyWebsite: "https://www.nj.gov/dep/" }),
+      rawLicense({ agencyId: "njdep", agencyWebsite: "https://www.nj.gov/bpu/" }),
+      rawLicense({ agencyId: "njdep" }),
+    ];
+    const filled = applyAgencyWebsiteFallback(licenses);
+    expect(filled[2].agencyWebsite).toBeUndefined();
   });
 });

--- a/content/build.ts
+++ b/content/build.ts
@@ -106,6 +106,47 @@ export interface FileSystemPort {
 // ============================================================================
 
 /**
+ * Builds an agencyId → website map from the license set, keeping only agencies
+ * whose populated licenses all point to the same website. Agencies with no
+ * website, or with conflicting websites across licenses, are omitted so the
+ * fallback never guesses between ambiguous URLs.
+ */
+export const deriveSingleAgencyWebsites = (
+  licenses: readonly WebflowLicenseCard[],
+): Map<string, string> => {
+  const websitesByAgencyId = new Map<string, Set<string>>();
+  for (const license of licenses) {
+    if (!license.agencyId || !license.agencyWebsite) continue;
+    const websites = websitesByAgencyId.get(license.agencyId) ?? new Set<string>();
+    websites.add(license.agencyWebsite);
+    websitesByAgencyId.set(license.agencyId, websites);
+  }
+
+  const singleWebsiteByAgencyId = new Map<string, string>();
+  for (const [agencyId, websites] of websitesByAgencyId) {
+    if (websites.size === 1) singleWebsiteByAgencyId.set(agencyId, [...websites][0]);
+  }
+  return singleWebsiteByAgencyId;
+};
+
+/**
+ * Fills a blank agencyWebsite from its agencyId's single known website, when one
+ * exists. Licenses that already carry a website, or whose agencyId has no single
+ * unambiguous website, are left unchanged. Matches the published site's behavior
+ * of linking the agency name to its department page where the URL is known.
+ */
+export const applyAgencyWebsiteFallback = (
+  licenses: readonly WebflowLicenseCard[],
+): WebflowLicenseCard[] => {
+  const singleWebsiteByAgencyId = deriveSingleAgencyWebsites(licenses);
+  return licenses.map((license) => {
+    if (license.agencyWebsite || !license.agencyId) return license;
+    const fallback = singleWebsiteByAgencyId.get(license.agencyId);
+    return fallback ? { ...license, agencyWebsite: fallback } : license;
+  });
+};
+
+/**
  * Converts a raw WebflowLicenseCard (from shared loader) to a display-ready License card.
  * Resolves agencyId → agency name and industryId → industry name, falling back to webflowIndustry.
  *
@@ -136,6 +177,7 @@ export const toLicenseCard = (
   summaryDescriptionMd: license.summaryDescriptionMd,
   agency: license.agencyId ? LookupTaskAgencyById(license.agencyId).name : undefined,
   division: license.agencyAdditionalContext,
+  agencyWebsite: license.agencyWebsite,
   divisionPhone: license.divisionPhone,
   callToActionText: license.callToActionText,
   callToActionLink: license.callToActionLink,
@@ -662,7 +704,10 @@ export const getContentConfigs = (
     resultKey: "fundingsCount",
   },
   {
-    loader: () => loadAllLicenses().map((license) => toLicenseCard(license, industryNamesById)),
+    loader: () =>
+      applyAgencyWebsiteFallback(loadAllLicenses()).map((license) =>
+        toLicenseCard(license, industryNamesById),
+      ),
     outputFileName: "licenses",
     dataKey: "licenses",
     resultKey: "licensesCount",

--- a/content/src/roadmaps/license-tasks/architect-license.md
+++ b/content/src/roadmaps/license-tasks/architect-license.md
@@ -18,6 +18,7 @@ agencyAdditionalContext: Board of Architects
 divisionPhone: (973) 504-6385
 webflowType: individual-license
 webflowId: 5f772971b0544fd3d536617b
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---
 
 ## Education Requirements (Initial Licensure by Examination)

--- a/content/src/roadmaps/license-tasks/authorization-architect-firm.md
+++ b/content/src/roadmaps/license-tasks/authorization-architect-firm.md
@@ -18,25 +18,27 @@ agencyAdditionalContext: Board of Architects
 divisionPhone: (973) 504-6385
 webflowType: business-license
 webflowId: 5f772971eb55580500feb5a2
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---
+
 ## Eligibility Criteria
 
 To be eligible, your firm must be 1 of the following business types:
 
-* A firm that is the sole proprietorship of a licensed architect
-* General partnership of licensed architects
-* General partnership of closely `allied professionals|allied-professionals` including at least 1 licensed architect
-* Corporation
+- A firm that is the sole proprietorship of a licensed architect
+- General partnership of licensed architects
+- General partnership of closely `allied professionals|allied-professionals` including at least 1 licensed architect
+- Corporation
 
 ## Application Requirements
 
-* Business name
-* Business address (and the address of any satellite office)
-* Name and license number of the `architect-in-charge|architect-in-charge` for all offices
-* Name, license number, and address of every `responsible charge|responsible-charge` 
-* Name, address, and license number of every officer, director, manager, and stockholder in your firm
-* Number of shares issued (if the firm is a corporation)
-* Applicable fees paid
+- Business name
+- Business address (and the address of any satellite office)
+- Name and license number of the `architect-in-charge|architect-in-charge` for all offices
+- Name, license number, and address of every `responsible charge|responsible-charge`
+- Name, address, and license number of every officer, director, manager, and stockholder in your firm
+- Number of shares issued (if the firm is a corporation)
+- Applicable fees paid
 
 :::largeCallout{ showHeader="true" headerText="" calloutType="informational" amountIconText="" filingTypeIconText="" frequencyIconText="" phoneIconText="" emailIconText="" }
 

--- a/content/src/roadmaps/license-tasks/auto-body-repair-license.md
+++ b/content/src/roadmaps/license-tasks/auto-body-repair-license.md
@@ -18,6 +18,7 @@ agencyId: nj-motor-vehicle
 divisionPhone: (609) 292-6500
 webflowType: business-license
 webflowId: 5f7729541a08097ccbbb2ecb
+agencyWebsite: "https://www.nj.gov/mvc/"
 ---
 
 ## Eligibility Criteria

--- a/content/src/roadmaps/license-tasks/daycare-license.md
+++ b/content/src/roadmaps/license-tasks/daycare-license.md
@@ -18,24 +18,26 @@ agencyId: nj-children-families
 agencyAdditionalContext: Office of Licensing
 divisionPhone: (609) 826-3999
 webflowId: 5f7728f5e8bf507c5e317899
+agencyWebsite: "https://www.nj.gov/dcf/"
 ---
+
 ## Application Requirements
 
-*  `EIN|ein` 
-*  `Business registration certificate (BRC)|business-reg-certificate` 
-*  `Certificate of Formation|certificate-formation` 
-* Letter of certification from the local government indicating the building’s previous type of use
-*  `Response Action Outcome (RAO)|response-action-outcome` 
-* Water bill and a water testing report from your local government
-* Map of your business location with the location of the outdoor playing area
-* Applicable fees paid
+- `EIN|ein`
+- `Business registration certificate (BRC)|business-reg-certificate`
+- `Certificate of Formation|certificate-formation`
+- Letter of certification from the local government indicating the building’s previous type of use
+- `Response Action Outcome (RAO)|response-action-outcome`
+- Water bill and a water testing report from your local government
+- Map of your business location with the location of the outdoor playing area
+- Applicable fees paid
 
 All staff must be at least 18 years old.
 
 ## After the Initial Application
 
-* You will receive a notice via email to request forms from the State of New Jersey for criminal background checks and Child Abuse Record Information (CARI) checks for all staff and business representatives
-* You will be contacted by a representative from the Office of Licensing to arrange for an official site inspection
+- You will receive a notice via email to request forms from the State of New Jersey for criminal background checks and Child Abuse Record Information (CARI) checks for all staff and business representatives
+- You will be contacted by a representative from the Office of Licensing to arrange for an official site inspection
 
 :::largeCallout{ showHeader="true" headerText="" calloutType="conditional" amountIconText="" filingTypeIconText="" frequencyIconText="" phoneIconText="" emailIconText="" }
 

--- a/content/src/roadmaps/license-tasks/detective-agency-license.md
+++ b/content/src/roadmaps/license-tasks/detective-agency-license.md
@@ -22,22 +22,24 @@ agencyAdditionalContext: Private Detective Unit
 divisionPhone: (609) 882-2000
 webflowType: business-license
 webflowId: 5f772960a67e4a21735c0f36
+agencyWebsite: "https://www.nj.gov/oag/"
 ---
+
 ## Eligibility Criteria
 
-* At least 1 of the business owners has 5 years of full-time work experience as an investigator or a police officer
-* All applicants are at least 25 years old
-* Applicant and business associates are U.S. citizens
-* None of the applicants are active law enforcement officers
+- At least 1 of the business owners has 5 years of full-time work experience as an investigator or a police officer
+- All applicants are at least 25 years old
+- Applicant and business associates are U.S. citizens
+- None of the applicants are active law enforcement officers
 
 ## Application Requirements
 
-* The names and addresses of all the business owners
-* Two trade name options for your agency
-* A passport photo and personal information for the `qualifying applicant|qualifying-applicant` and all other business owners
-* The qualifying applicant's work history as an investigator, completed by their former employer
-* The names, addresses, phone numbers, email addresses, and signatures of 5 people unrelated to each of the applicants that can provide character references
-* Applicable fees paid
+- The names and addresses of all the business owners
+- Two trade name options for your agency
+- A passport photo and personal information for the `qualifying applicant|qualifying-applicant` and all other business owners
+- The qualifying applicant's work history as an investigator, completed by their former employer
+- The names, addresses, phone numbers, email addresses, and signatures of 5 people unrelated to each of the applicants that can provide character references
+- Applicable fees paid
 
 :::largeCallout{ showHeader="false" headerText="" calloutType="informational" amountIconText="" filingTypeIconText="" frequencyIconText="" phoneIconText="" emailIconText="" }
 

--- a/content/src/roadmaps/license-tasks/hvac-license.md
+++ b/content/src/roadmaps/license-tasks/hvac-license.md
@@ -20,6 +20,7 @@ agencyAdditionalContext: Board of Examiners of Heating, Ventilation, Air
 divisionPhone: (973) 504-6250
 webflowType: individual-license
 webflowId: 5f772993a195c8849e15b18f
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---
 
 ## Eligibility Criteria

--- a/content/src/roadmaps/license-tasks/public-accountant-license.md
+++ b/content/src/roadmaps/license-tasks/public-accountant-license.md
@@ -21,6 +21,7 @@ agencyAdditionalContext: Board of Accountancy
 divisionPhone: (973) 504-6380
 webflowType: individual-license
 webflowId: 5f77296ee10dec7593024f1c
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---
 
 ## Eligibility Criteria

--- a/content/src/roadmaps/license-tasks/register-accounting-firm.md
+++ b/content/src/roadmaps/license-tasks/register-accounting-firm.md
@@ -18,6 +18,7 @@ agencyId: nj-consumer-affairs
 agencyAdditionalContext: Board of Accountancy
 divisionPhone: (973) 504-6380
 webflowId: 5f7729d28aa6e3de76f1e60c
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---
 
 ## Eligibility Criteria

--- a/content/src/roadmaps/license-tasks/school-bus-license.md
+++ b/content/src/roadmaps/license-tasks/school-bus-license.md
@@ -26,6 +26,7 @@ agencyAdditionalContext: Student Transportation
 divisionPhone: (609) 292-4469
 webflowType: individual-license
 webflowId: 5f772935f278cc9d99b0ce1e
+agencyWebsite: "https://www.nj.gov/education/"
 ---
 
 ## Eligibility Criteria

--- a/content/src/roadmaps/license-tasks/social-affair.md
+++ b/content/src/roadmaps/license-tasks/social-affair.md
@@ -14,6 +14,7 @@ callToActionText: Apply for My Social Affair Permit
 callToActionLink: https://www.njoag.gov/about/divisions-and-offices/division-of-alcoholic-beverage-control-home/posse-online-licensing-system/
 webflowId: 6902260638a874c45142d3d3
 licenseCertificationClassification: undefined
+agencyWebsite: "https://www.njoag.gov/about/divisions-and-offices/division-of-alcoholic-beverage-control-home/"
 ---
 
 :::largeCallout{ showHeader="true" headerText="" calloutType="informational" amountIconText="" filingTypeIconText="" frequencyIconText="" phoneIconText="" emailIconText="" }

--- a/content/src/roadmaps/license-tasks/xray-reg.md
+++ b/content/src/roadmaps/license-tasks/xray-reg.md
@@ -18,6 +18,7 @@ callToActionLink: https://www.nj.gov/dep/rpp/reg/index.htm
 divisionPhone: (609) 984-5463
 webflowId: 676af48d3cee0bce2f93edd8
 licenseCertificationClassification: undefined
+agencyWebsite: "https://www.nj.gov/dep/rpp/reg/index.htm"
 ---
 
 ## Registration Requirements

--- a/content/src/roadmaps/tasks/state-bar-attorney.md
+++ b/content/src/roadmaps/tasks/state-bar-attorney.md
@@ -16,6 +16,7 @@ summaryDescriptionMd: >-
   may apply for admission to the State Bar by transferring your Uniform Bar
   Examination (UBE) Score.
 syncToWebflow: true
+agencyWebsite: "https://www.njbarexams.org/home"
 ---
 
 ## Eligibility Criteria

--- a/content/src/webflow-licenses/adoption-agency.md
+++ b/content/src/webflow-licenses/adoption-agency.md
@@ -11,4 +11,5 @@ webflowIndustry: Adoption
 divisionPhone: (877) 667-9845 or (609) 826-3999
 webflowId: 5f77295c4bc777deefa6e23b
 licenseCertificationClassification: LICENSE/ CERTIFICATION
+agencyWebsite: "https://www.nj.gov/njfosteradopt/"
 ---

--- a/content/src/webflow-licenses/advertising-outdoor-off-premises-advertising-signs-i-e-billboards.md
+++ b/content/src/webflow-licenses/advertising-outdoor-off-premises-advertising-signs-i-e-billboards.md
@@ -11,4 +11,5 @@ webflowIndustry: Advertising
 divisionPhone: (609) 530-3337
 webflowId: 5f7729678075e880daa8d96e
 licenseCertificationClassification: PERMIT REGISTRATION
+agencyWebsite: "https://www.nj.gov/transportation/"
 ---

--- a/content/src/webflow-licenses/advertising-regular.md
+++ b/content/src/webflow-licenses/advertising-regular.md
@@ -10,4 +10,5 @@ webflowIndustry: Advertising
 licenseCertificationClassification: REGULATIONS
 divisionPhone: ""
 webflowId: 5f7728de5adbb97443052cf5
+agencyWebsite: "https://www.fcc.gov/"
 ---

--- a/content/src/webflow-licenses/advisor-investment.md
+++ b/content/src/webflow-licenses/advisor-investment.md
@@ -11,4 +11,5 @@ webflowIndustry: Investment Advisor
 divisionPhone: (973) 504-3600
 webflowId: 5f77296ff17efb0a3aeefb3d
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/aerial-advertising-planes.md
+++ b/content/src/webflow-licenses/aerial-advertising-planes.md
@@ -11,4 +11,5 @@ webflowIndustry: Advertising
 divisionPhone: (609) 530-2900
 webflowId: 5f7729677fe89d6b7a054792
 licenseCertificationClassification: INFORMATION
+agencyWebsite: "https://www.nj.gov/transportation/"
 ---

--- a/content/src/webflow-licenses/agricultural-chemicals.md
+++ b/content/src/webflow-licenses/agricultural-chemicals.md
@@ -12,4 +12,5 @@ webflowIndustry: Agricultural Chemicals
 divisionPhone: (609) 984-6507
 webflowId: 5f7728fae10dec0d72024f10
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/agricultural-crew-leader-bringing-seasonal-farm-labor-into-nj-to-work.md
+++ b/content/src/webflow-licenses/agricultural-crew-leader-bringing-seasonal-farm-labor-into-nj-to-work.md
@@ -11,4 +11,5 @@ webflowIndustry: Agricultural Crew
 divisionPhone: (609) 292-2515
 webflowId: 5f77294ddd6a49eddc9b6064
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/air-ambulance.md
+++ b/content/src/webflow-licenses/air-ambulance.md
@@ -11,4 +11,5 @@ webflowIndustry: Ambulance
 divisionPhone: (609) 633-7777
 webflowId: 5f772948a6bfb527bf02ee03
 licenseCertificationClassification: INFORMATION
+agencyWebsite: "https://www.nj.gov/health/ems/"
 ---

--- a/content/src/webflow-licenses/air-meet-show-or-exhibition.md
+++ b/content/src/webflow-licenses/air-meet-show-or-exhibition.md
@@ -11,4 +11,5 @@ webflowIndustry: Air Show
 divisionPhone: ""
 webflowId: 5f7728fa2f04da505558b5e7
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/aircraft-dealers-mechanic.md
+++ b/content/src/webflow-licenses/aircraft-dealers-mechanic.md
@@ -10,4 +10,5 @@ webflowIndustry: Aircraft Dealer
 licenseCertificationClassification: CONTACT
 divisionPhone: (866) 635-5322
 webflowId: 5f7728dd90d9acc6a31306f4
+agencyWebsite: "https://www.faa.gov/"
 ---

--- a/content/src/webflow-licenses/airline.md
+++ b/content/src/webflow-licenses/airline.md
@@ -10,4 +10,5 @@ webflowIndustry: Airline
 licenseCertificationClassification: CONTACT
 divisionPhone: (866) 635-5322
 webflowId: 5f7728dd5ef8c1332d019ebc
+agencyWebsite: "https://www.faa.gov/"
 ---

--- a/content/src/webflow-licenses/airport-landing-field-strip-heliport-sea-plane-base.md
+++ b/content/src/webflow-licenses/airport-landing-field-strip-heliport-sea-plane-base.md
@@ -10,4 +10,5 @@ webflowIndustry: Airport
 licenseCertificationClassification: LICENSE
 divisionPhone: (866) 635-5322
 webflowId: 5f7728de5ef8c1673c019ebd
+agencyWebsite: "https://www.faa.gov/"
 ---

--- a/content/src/webflow-licenses/alcohol-beverage-bulk-sale-bsp.md
+++ b/content/src/webflow-licenses/alcohol-beverage-bulk-sale-bsp.md
@@ -11,4 +11,5 @@ webflowIndustry: Alcohol Beverage Bulk Sale
 divisionPhone: (609) 984-2830
 webflowId: 5f772965f17efbd901eefb3a
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/oag/abc/"
 ---

--- a/content/src/webflow-licenses/alcohol-beverage-home-brewer-brw.md
+++ b/content/src/webflow-licenses/alcohol-beverage-home-brewer-brw.md
@@ -11,4 +11,5 @@ webflowIndustry: Alcohol Beverage Home Brewer
 divisionPhone: (609) 984-2830
 webflowId: 5f772965a6bfb52b2702ee09
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/oag/abc/"
 ---

--- a/content/src/webflow-licenses/alcohol-plenary-retail-consumption.md
+++ b/content/src/webflow-licenses/alcohol-plenary-retail-consumption.md
@@ -11,4 +11,5 @@ webflowIndustry: Alcohol Retail Consumption
 divisionPhone: (609) 984-2830
 webflowId: 5f77296690d9ac40531309de
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.nj.gov/oag/abc/"
 ---

--- a/content/src/webflow-licenses/alcoholism-counselor.md
+++ b/content/src/webflow-licenses/alcoholism-counselor.md
@@ -10,4 +10,5 @@ webflowIndustry: Alcoholism Counselor
 licenseCertificationClassification: CERTIFICATE
 divisionPhone: (973) 504-6582
 webflowId: 5f772970df77de8b55e1a52c
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/alcoholism-treatment-center-residential.md
+++ b/content/src/webflow-licenses/alcoholism-treatment-center-residential.md
@@ -11,4 +11,5 @@ webflowIndustry: Alcoholism Treatment
 divisionPhone: (609) 826-4935
 webflowId: 5f772947614a2d98b1d207a5
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/ceohs/"
 ---

--- a/content/src/webflow-licenses/alien-labor-certification.md
+++ b/content/src/webflow-licenses/alien-labor-certification.md
@@ -11,4 +11,5 @@ webflowIndustry: Seasonal Labor
 divisionPhone: (609) 777-1838
 webflowId: 5f77294de022944a11eaa5c7
 licenseCertificationClassification: ALIEN LABOR CERTIFICATION PROGRAM
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/ambulance-service-invalid-coach-transport-ambulance-services-emergency-ambulance-service-volunteer-first-air-squads-are-exempt.md
+++ b/content/src/webflow-licenses/ambulance-service-invalid-coach-transport-ambulance-services-emergency-ambulance-service-volunteer-first-air-squads-are-exempt.md
@@ -12,4 +12,5 @@ webflowIndustry: Ambulance
 divisionPhone: (609) 633-7777
 webflowId: 5f7729495ef8c1ca9d019ec1
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/ems/"
 ---

--- a/content/src/webflow-licenses/ambulatory-care-facility.md
+++ b/content/src/webflow-licenses/ambulatory-care-facility.md
@@ -11,4 +11,5 @@ webflowIndustry: Ambulatory Care
 divisionPhone: (609) 826-4935
 webflowId: 5f77294871c49e0649913b80
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/ceohs/"
 ---

--- a/content/src/webflow-licenses/amusement-games-arcades-seashore-amusement-parks-county-state-fairs.md
+++ b/content/src/webflow-licenses/amusement-games-arcades-seashore-amusement-parks-county-state-fairs.md
@@ -11,4 +11,5 @@ webflowIndustry: Amusement
 divisionPhone: (973) 273-8000
 webflowId: 5f772970e8bf5063bb3178a1
 licenseCertificationClassification: APPROVAL
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/animal-control-office.md
+++ b/content/src/webflow-licenses/animal-control-office.md
@@ -11,4 +11,5 @@ webflowIndustry: Animal Control
 divisionPhone: (609) 826-5964
 webflowId: 5f77293b2f04da051958b5ef
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/animal-dealer-broker-cattle-sheep-swine.md
+++ b/content/src/webflow-licenses/animal-dealer-broker-cattle-sheep-swine.md
@@ -11,4 +11,5 @@ webflowIndustry: Animal Dealer
 divisionPhone: (609) 633-2954
 webflowId: 5f7728e0a67e4a4dbe5c0f2e
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/agriculture/"
 ---

--- a/content/src/webflow-licenses/apiary-bee-hive.md
+++ b/content/src/webflow-licenses/apiary-bee-hive.md
@@ -11,4 +11,5 @@ webflowIndustry: Bee
 divisionPhone: (609) 462-7820
 webflowId: 5f7728e0486eeb444bc2560c
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.nj.gov/agriculture/"
 ---

--- a/content/src/webflow-licenses/apparel-business.md
+++ b/content/src/webflow-licenses/apparel-business.md
@@ -11,4 +11,5 @@ webflowIndustry: Apparel Manufacturer
 divisionPhone: (609) 984-3008
 webflowId: 5f77294d90d9accc271309db
 licenseCertificationClassification: CERTIFICATE
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/arson-investigation.md
+++ b/content/src/webflow-licenses/arson-investigation.md
@@ -11,4 +11,5 @@ webflowIndustry: Arson Investigation
 divisionPhone: (609) 984-7860
 webflowId: 5f7728f38075e845a4a8d93a
 licenseCertificationClassification: CERTIFICATE
+agencyWebsite: "https://www.nj.gov/dca/"
 ---

--- a/content/src/webflow-licenses/art-school-adult.md
+++ b/content/src/webflow-licenses/art-school-adult.md
@@ -11,4 +11,5 @@ webflowIndustry: Art School
 divisionPhone: "(609) 292-2070  (Press # 3)"
 webflowId: 5f7729307fe89dd01f054790
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/asbestos-certification-of-training-agencies-or-worker-supervisor.md
+++ b/content/src/webflow-licenses/asbestos-certification-of-training-agencies-or-worker-supervisor.md
@@ -11,4 +11,5 @@ webflowIndustry: Asbestos Training
 divisionPhone: (609) 633-3760
 webflowId: 5f77294ea6bfb560bc02ee04
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/asbestos-removal-contractor-or-company.md
+++ b/content/src/webflow-licenses/asbestos-removal-contractor-or-company.md
@@ -11,4 +11,5 @@ webflowIndustry: Asbestos Removal
 divisionPhone: (609) 633-3760
 webflowId: 5f77294edd6a494e4c9b6065
 licenseCertificationClassification: LICENSE/CERTIFICATIONS
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/asbestos-safety-control-monitoring-company-third-party-agency-for-the-state.md
+++ b/content/src/webflow-licenses/asbestos-safety-control-monitoring-company-third-party-agency-for-the-state.md
@@ -11,4 +11,5 @@ webflowIndustry: Asbestos Monitoring
 divisionPhone: (609) 633-6224
 webflowId: 5f772971b0544f387536617c
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/asbestos-training-course.md
+++ b/content/src/webflow-licenses/asbestos-training-course.md
@@ -11,4 +11,5 @@ webflowIndustry: Asbestos Training
 divisionPhone: (609) 631-6749
 webflowId: 5f77293ba536a31edcc0b342
 licenseCertificationClassification: CERTIFICATE, COMPLETE TRAINING
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/asbestos-worker-technician-or-supervisor-individuals.md
+++ b/content/src/webflow-licenses/asbestos-worker-technician-or-supervisor-individuals.md
@@ -11,4 +11,5 @@ webflowIndustry: Asbestos
 divisionPhone: (609) 633-3760
 webflowId: 5f77294eb4710f7a7a3c37ba
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/assisted-living-administrator.md
+++ b/content/src/webflow-licenses/assisted-living-administrator.md
@@ -11,4 +11,5 @@ webflowIndustry: Assisted Living
 divisionPhone: (609) 292-9900
 webflowId: 5f77293bde9e063d927f599f
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/associate-counselor.md
+++ b/content/src/webflow-licenses/associate-counselor.md
@@ -11,4 +11,5 @@ webflowIndustry: Associate Counselor
 divisionPhone: (908) 504-6582
 webflowId: 5f772971b0544f24ac36617d
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/athletic-promoter-second-manager-manager.md
+++ b/content/src/webflow-licenses/athletic-promoter-second-manager-manager.md
@@ -11,4 +11,5 @@ webflowIndustry: Athletic Manager
 divisionPhone: (609) 292-0317
 webflowId: 5f77295ddf77de3828e1a528
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/athletic-trainer.md
+++ b/content/src/webflow-licenses/athletic-trainer.md
@@ -11,4 +11,5 @@ webflowIndustry: Athletic Trainer
 divisionPhone: (609) 826-7100
 webflowId: 5f772972e022948cbaeaa5cc
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/attorney-at-law.md
+++ b/content/src/webflow-licenses/attorney-at-law.md
@@ -10,4 +10,5 @@ webflowIndustry: Attorney
 licenseCertificationClassification: CERTIFICATE OF ADMISSION
 divisionPhone: (609) 815-2911
 webflowId: 5f77296d8150be09eaf3be2a
+agencyWebsite: "https://www.njbarexams.org/"
 ---

--- a/content/src/webflow-licenses/auction.md
+++ b/content/src/webflow-licenses/auction.md
@@ -10,4 +10,5 @@ webflowIndustry: Auction
 licenseCertificationClassification: INFORMATION
 divisionPhone: (908) 789-9999
 webflowId: 5f7728db2400617eff7834b5
+agencyWebsite: "http://www.njssa.com/"
 ---

--- a/content/src/webflow-licenses/auto-emissions-repairs-technician.md
+++ b/content/src/webflow-licenses/auto-emissions-repairs-technician.md
@@ -11,4 +11,5 @@ webflowIndustry: Auto Emissions
 divisionPhone: (609) 292-7953
 webflowId: 5f7728fbd2749aec8e9cf7d4
 licenseCertificationClassification: CERTIFICATION
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/aviation-facility-private.md
+++ b/content/src/webflow-licenses/aviation-facility-private.md
@@ -11,4 +11,5 @@ webflowIndustry: Aviation Facility
 divisionPhone: (609) 530-2900
 webflowId: 5f7729676f3d8d8bc875ef35
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/transportation/"
 ---

--- a/content/src/webflow-licenses/bail-bondsman.md
+++ b/content/src/webflow-licenses/bail-bondsman.md
@@ -11,4 +11,5 @@ webflowIndustry: Bail Bondsman
 divisionPhone: (609) 292-4337 ext-50552
 webflowId: 5f7729234ad0ae279fa54a51
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/balloonport-or-balloonsport.md
+++ b/content/src/webflow-licenses/balloonport-or-balloonsport.md
@@ -11,4 +11,5 @@ webflowIndustry: Balloon
 divisionPhone: (609) 530-2900
 webflowId: 5f772967b4710ff2113c37bd
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/transportation/"
 ---

--- a/content/src/webflow-licenses/bank-savings-commercial.md
+++ b/content/src/webflow-licenses/bank-savings-commercial.md
@@ -11,4 +11,5 @@ webflowIndustry: Bank
 divisionPhone: (609) 292-7272
 webflowId: 5f772923df77dec01ae1a4c3
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/bartending-school.md
+++ b/content/src/webflow-licenses/bartending-school.md
@@ -11,4 +11,5 @@ webflowIndustry: Bartending School
 divisionPhone: (609) 984-2242
 webflowId: 5f77294e8fbb22532a6ec08a
 licenseCertificationClassification: CERTIFICATE OF APPROVAL
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/bio-analytical-laboratory-director.md
+++ b/content/src/webflow-licenses/bio-analytical-laboratory-director.md
@@ -11,4 +11,5 @@ webflowIndustry: Bio-analytical Laboratory Director
 divisionPhone: (973) 504-6200
 webflowId: 5f772978e8bf5057e73178a2
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/black-seal.md
+++ b/content/src/webflow-licenses/black-seal.md
@@ -11,4 +11,5 @@ webflowIndustry: Black Seal
 divisionPhone: (609) 292-2345
 webflowId: 5f77294f8e9f8735f86859bc
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/blue-seal.md
+++ b/content/src/webflow-licenses/blue-seal.md
@@ -11,4 +11,5 @@ webflowIndustry: Blue Seal
 divisionPhone: (609) 292-2345
 webflowId: 5f77294fb4710f2cf13c37bb
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/boiler-operator.md
+++ b/content/src/webflow-licenses/boiler-operator.md
@@ -11,4 +11,5 @@ webflowIndustry: Boiler Operator
 divisionPhone: (609) 292-2345
 webflowId: 5f77294fa536a3471fc0b345
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/bonding-company.md
+++ b/content/src/webflow-licenses/bonding-company.md
@@ -11,4 +11,5 @@ webflowIndustry: Bonding Company
 divisionPhone: (609) 292-9292
 webflowId: 5f7729698075e831d2a8d96f
 licenseCertificationClassification: CERTIFICATE OF AUTHORITY
+agencyWebsite: "https://www.nj.gov/treasury/"
 ---

--- a/content/src/webflow-licenses/bonds.md
+++ b/content/src/webflow-licenses/bonds.md
@@ -11,4 +11,5 @@ webflowIndustry: Bond
 divisionPhone: (973) 504-3600
 webflowId: 5f772979b0544f6d3636617e
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/bottled-water.md
+++ b/content/src/webflow-licenses/bottled-water.md
@@ -10,4 +10,5 @@ webflowIndustry: Bottled Water
 licenseCertificationClassification: LABELS/REGULATIONS
 divisionPhone: (908) 351-7931
 webflowId: 5f7728e06f3d8daa6775ef2c
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/bottling-plants.md
+++ b/content/src/webflow-licenses/bottling-plants.md
@@ -12,4 +12,5 @@ webflowIndustry: Bottling Plants
 divisionPhone: (609) 826-4941
 webflowId: 5f77293b386254c598bb0e42
 licenseCertificationClassification: LICENSE OR CERTIFICATION
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/boxer.md
+++ b/content/src/webflow-licenses/boxer.md
@@ -11,4 +11,5 @@ webflowIndustry: Boxer
 divisionPhone: (609) 292-0317
 webflowId: 5f77295e71c49e0678913b82
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/broadcast-station.md
+++ b/content/src/webflow-licenses/broadcast-station.md
@@ -10,4 +10,5 @@ webflowIndustry: Broadcast Station
 licenseCertificationClassification: LICENSE/REGULATIONS
 divisionPhone: ""
 webflowId: 5f7728deda6f6070d05a75e9
+agencyWebsite: "https://www.fcc.gov/"
 ---

--- a/content/src/webflow-licenses/building-inspector-or-sub-code-official-ucc.md
+++ b/content/src/webflow-licenses/building-inspector-or-sub-code-official-ucc.md
@@ -11,4 +11,5 @@ webflowIndustry: Building Inspector
 divisionPhone: (609) 984-7834
 webflowId: 5f77297ddd6a49a4dd9b6068
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/bulk-sales-registration.md
+++ b/content/src/webflow-licenses/bulk-sales-registration.md
@@ -11,4 +11,5 @@ webflowIndustry: Bulk Sales
 divisionPhone: (609) 292-6400
 webflowId: 5f772969147ced6ccf26bf43
 licenseCertificationClassification: NOTIFICATION
+agencyWebsite: "https://www.nj.gov/treasury/"
 ---

--- a/content/src/webflow-licenses/business-education.md
+++ b/content/src/webflow-licenses/business-education.md
@@ -11,4 +11,5 @@ webflowIndustry: Business Education
 divisionPhone: "(609) 376-3500 #3"
 webflowId: 5f772930d9d237bdcb6f48bc
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/business-school-adult.md
+++ b/content/src/webflow-licenses/business-school-adult.md
@@ -11,4 +11,5 @@ webflowIndustry: Business School
 divisionPhone: (609) 292-7272
 webflowId: 5f772931b4710f3b0d3c37b3
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/cable-operator.md
+++ b/content/src/webflow-licenses/cable-operator.md
@@ -11,4 +11,5 @@ webflowIndustry: Cable Operator
 divisionPhone: (973) 648-2670
 webflowId: 5f7728e8e8bf505df2317897
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/bpu/"
 ---

--- a/content/src/webflow-licenses/cable-tv-company-public.md
+++ b/content/src/webflow-licenses/cable-tv-company-public.md
@@ -11,4 +11,5 @@ webflowIndustry: Cable TV
 divisionPhone: (973) 648-2670
 webflowId: 5f7728e9f17efb6651eefb30
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/bpu/"
 ---

--- a/content/src/webflow-licenses/cable-tv-wiring-installation.md
+++ b/content/src/webflow-licenses/cable-tv-wiring-installation.md
@@ -10,4 +10,5 @@ webflowIndustry: Cable TV Wiring
 licenseCertificationClassification: CONTACT
 divisionPhone: (973)504-6410
 webflowId: 5f77297e8e9f87de4f6859c3
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/cafeteria-catered-school.md
+++ b/content/src/webflow-licenses/cafeteria-catered-school.md
@@ -12,4 +12,5 @@ webflowIndustry: Cafeteria
 divisionPhone: (609) 826-4941
 webflowId: 5f77293c6f3d8d8dfc75ef30
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/captain-chartered-fishing-boat.md
+++ b/content/src/webflow-licenses/captain-chartered-fishing-boat.md
@@ -10,4 +10,5 @@ webflowIndustry: Fishing Boat
 licenseCertificationClassification: LICENSE
 divisionPhone: (212) 668-7492
 webflowId: 5f7728dcd2749a2bfb9cf7d2
+agencyWebsite: "https://www.dco.uscg.mil/"
 ---

--- a/content/src/webflow-licenses/casino-key-employee.md
+++ b/content/src/webflow-licenses/casino-key-employee.md
@@ -11,4 +11,5 @@ webflowIndustry: Casino Key Employee
 divisionPhone: (609) 441-3422
 webflowId: 5f77295eecb74e2b5223aad7
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/casino-owner.md
+++ b/content/src/webflow-licenses/casino-owner.md
@@ -11,4 +11,5 @@ webflowIndustry: Casino Owner
 divisionPhone: (609) 441-3422
 webflowId: 5f77295fa6bfb56eb702ee08
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/casino.md
+++ b/content/src/webflow-licenses/casino.md
@@ -11,4 +11,5 @@ webflowIndustry: Casino
 divisionPhone: (609) 441-3422
 webflowId: 5f77295ea6bfb58d9c02ee07
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/certified-environmental-laboratory-medical.md
+++ b/content/src/webflow-licenses/certified-environmental-laboratory-medical.md
@@ -12,4 +12,5 @@ webflowIndustry: Certified Environmental Laboratory
 divisionPhone: (609) 292-3950
 webflowId: 5f77293c0b0d004731f25220
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/certified-environmental-laboratory.md
+++ b/content/src/webflow-licenses/certified-environmental-laboratory.md
@@ -11,4 +11,5 @@ webflowIndustry: Certified Environmental Laboratory
 divisionPhone: (609) 292-3950
 webflowId: 5f7728fbf17efb302ceefb31
 licenseCertificationClassification: CERTIFICATE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/certified-interpreter.md
+++ b/content/src/webflow-licenses/certified-interpreter.md
@@ -10,4 +10,5 @@ webflowIndustry: Interpreter
 licenseCertificationClassification: APPROVAL
 divisionPhone: 609-815-2900 ext. 52376
 webflowId: 5f7729e4252e3daeadf5a10e
+agencyWebsite: "https://www.njcourts.gov/"
 ---

--- a/content/src/webflow-licenses/certified-pool-operator.md
+++ b/content/src/webflow-licenses/certified-pool-operator.md
@@ -11,4 +11,5 @@ webflowIndustry: Certified Pool Operator
 divisionPhone: (609) 826-4935
 webflowId: 5f77293cdf77ded7fce1a4c5
 licenseCertificationClassification: CERTIFIED
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/charitable-annuities.md
+++ b/content/src/webflow-licenses/charitable-annuities.md
@@ -12,4 +12,5 @@ webflowIndustry: Charitable Annuity
 divisionPhone: (609) 292-7053/7055
 webflowId: 5f772924dd6a49961f9b605e
 licenseCertificationClassification: POLICY FORM INQUIRIES
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/charitable-organization.md
+++ b/content/src/webflow-licenses/charitable-organization.md
@@ -11,4 +11,5 @@ webflowIndustry: Charitable Organization
 divisionPhone: (973) 504-6262
 webflowId: 5f77297ff278ccfbccb0ce23
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/check-casher.md
+++ b/content/src/webflow-licenses/check-casher.md
@@ -11,4 +11,5 @@ webflowIndustry: Check Cashier
 divisionPhone: (609) 292-7272
 webflowId: 5f77292428e855a1071958c1
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/cheese-plant.md
+++ b/content/src/webflow-licenses/cheese-plant.md
@@ -11,4 +11,5 @@ webflowIndustry: Cheese Plant
 divisionPhone: (609) 826-4935
 webflowId: 5f77293d8fbb22d3816ec089
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/chest-radiologic-technician.md
+++ b/content/src/webflow-licenses/chest-radiologic-technician.md
@@ -11,4 +11,5 @@ webflowIndustry: X-ray Technician
 divisionPhone: (609) 984-5890
 webflowId: 5f7728fbe10dec0a6d024f11
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/child-abuse-counselor.md
+++ b/content/src/webflow-licenses/child-abuse-counselor.md
@@ -11,4 +11,5 @@ webflowIndustry: Child Abuse Counselor
 divisionPhone: (973) 504-6495
 webflowId: 5f772980eb5558041efeb5a3
 licenseCertificationClassification: REGISTRATION/LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/child-care-provider.md
+++ b/content/src/webflow-licenses/child-care-provider.md
@@ -11,4 +11,5 @@ webflowIndustry: Child Care
 divisionPhone: (609) 826-3999
 webflowId: 5f7728f5614a2d19e7d2079f
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dcf/"
 ---

--- a/content/src/webflow-licenses/chiropractor.md
+++ b/content/src/webflow-licenses/chiropractor.md
@@ -11,4 +11,5 @@ webflowIndustry: Chiropractor
 divisionPhone: (973) 504-6395
 webflowId: 5f7729804ad0ae1e87a54a59
 licenseCertificationClassification: LICENSE/REGULATED
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/clinical-laboratory-medical.md
+++ b/content/src/webflow-licenses/clinical-laboratory-medical.md
@@ -12,4 +12,5 @@ webflowIndustry: Clinical Laboratory
 divisionPhone: (609) 406-6830
 webflowId: 5f77293db0544fd37836614b
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/coastal-wetlands.md
+++ b/content/src/webflow-licenses/coastal-wetlands.md
@@ -11,4 +11,5 @@ webflowIndustry: Coastal Wetlands
 divisionPhone: (609) 292-0060
 webflowId: 5f7728fb24006107aa7834b8
 licenseCertificationClassification: PERMIT
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/collections-business.md
+++ b/content/src/webflow-licenses/collections-business.md
@@ -11,4 +11,5 @@ webflowIndustry: Collections Business
 divisionPhone: (609) 292-9292
 webflowId: 5f7729698075e83d60a8d970
 licenseCertificationClassification: COLLECTION AGENCY BOND REQUIRED
+agencyWebsite: "https://www.nj.gov/treasury/"
 ---

--- a/content/src/webflow-licenses/commercial-driving-school.md
+++ b/content/src/webflow-licenses/commercial-driving-school.md
@@ -11,4 +11,5 @@ webflowIndustry: Commercial Driving School
 divisionPhone: (609) 292-6500
 webflowId: 5f7729565ddf76fe313ac438
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/mvc/"
 ---

--- a/content/src/webflow-licenses/commodities-broker-dealer-agricultural-commodities.md
+++ b/content/src/webflow-licenses/commodities-broker-dealer-agricultural-commodities.md
@@ -11,4 +11,5 @@ webflowIndustry: Commodities Broker
 divisionPhone: (609) 292-5576
 webflowId: 5f7728e18150be052bf3be1b
 licenseCertificationClassification: LICENSE & BOND
+agencyWebsite: "https://www.nj.gov/agriculture/"
 ---

--- a/content/src/webflow-licenses/community-residence-for-developmentally-disabled-group-home-supervised-apartment.md
+++ b/content/src/webflow-licenses/community-residence-for-developmentally-disabled-group-home-supervised-apartment.md
@@ -12,4 +12,5 @@ webflowIndustry: Community Residence
 divisionPhone: (609) 984-5321
 webflowId: 5f77294b2edc670123b4a704
 licenseCertificationClassification: LICENSE TO OPERATE
+agencyWebsite: "https://www.nj.gov/humanservices/"
 ---

--- a/content/src/webflow-licenses/concrete-products-permit.md
+++ b/content/src/webflow-licenses/concrete-products-permit.md
@@ -11,4 +11,5 @@ webflowIndustry: Concrete Product
 divisionPhone: (609) 633-7021
 webflowId: 5f7728fcb0544f6ee6366146
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/continuing-care-retirement-community.md
+++ b/content/src/webflow-licenses/continuing-care-retirement-community.md
@@ -11,4 +11,5 @@ webflowIndustry: Continuing Care
 divisionPhone: (609) 633-3888
 webflowId: 5f772981d9d23735566f48c1
 licenseCertificationClassification: CERTIFICATE OF AUTHORITY
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/copyright-service.md
+++ b/content/src/webflow-licenses/copyright-service.md
@@ -11,4 +11,5 @@ webflowIndustry: Copyright
 divisionPhone: (609) 292-9292
 webflowId: 5f77296aef49624a7546d0e0
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.nj.gov/treasury/"
 ---

--- a/content/src/webflow-licenses/cosmetics-manufacture-wholesale.md
+++ b/content/src/webflow-licenses/cosmetics-manufacture-wholesale.md
@@ -14,4 +14,5 @@ webflowIndustry: Cosmetics
 divisionPhone: (609) 826-4935
 webflowId: 5f77293d6f3d8df32775ef31
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/counselor-alcoholism-or-drug.md
+++ b/content/src/webflow-licenses/counselor-alcoholism-or-drug.md
@@ -10,4 +10,5 @@ webflowIndustry: Substance Counselor
 licenseCertificationClassification: CERTIFICATE
 divisionPhone: (973) 504-6582
 webflowId: 5f7729838fbb22725e6ec090
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/court-reporter.md
+++ b/content/src/webflow-licenses/court-reporter.md
@@ -11,4 +11,5 @@ webflowIndustry: Court Reporter
 divisionPhone: (973) 504-6490
 webflowId: 5f772983614a2d7668d207b5
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/crane-crane-operator-long-boom-over-99.md
+++ b/content/src/webflow-licenses/crane-crane-operator-long-boom-over-99.md
@@ -11,4 +11,5 @@ webflowIndustry: Crane Operator
 divisionPhone: (609) 292-5626
 webflowId: 5f77294f24006134967834ba
 licenseCertificationClassification: OPERATOR'S LICENSE
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/credit-union-state-chartered.md
+++ b/content/src/webflow-licenses/credit-union-state-chartered.md
@@ -11,4 +11,5 @@ webflowIndustry: Credit Union
 divisionPhone: ""
 webflowId: 5f772924a536a3b4e2c0b340
 licenseCertificationClassification: ""
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/dental-assistant.md
+++ b/content/src/webflow-licenses/dental-assistant.md
@@ -11,4 +11,5 @@ webflowIndustry: Dental Assistant
 divisionPhone: (973) 504-6405
 webflowId: 5f772983a6bfb5e72b02ee16
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/dental-x-ray-tech.md
+++ b/content/src/webflow-licenses/dental-x-ray-tech.md
@@ -11,4 +11,5 @@ webflowIndustry: Dental X-ray
 divisionPhone: (609) 984-5890
 webflowId: 5f7728fc1a08091cedbb2ec6
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/deputy-sheriff.md
+++ b/content/src/webflow-licenses/deputy-sheriff.md
@@ -12,4 +12,5 @@ divisionPhone: (Department of Law & Public Safety, Division of Criminal
   JusticePolice Training Commission
 webflowId: 5f77295f0b0d002a64f25226
 licenseCertificationClassification: CERTIFICATE
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/desserts-frozen.md
+++ b/content/src/webflow-licenses/desserts-frozen.md
@@ -12,4 +12,5 @@ webflowIndustry: Frozen Desserts
 divisionPhone: (609) 826-4941
 webflowId: 5f77293ee022945832eaa5c5
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/diagnostic-radiologic-technologist.md
+++ b/content/src/webflow-licenses/diagnostic-radiologic-technologist.md
@@ -11,4 +11,5 @@ webflowIndustry: X-ray Technologist
 divisionPhone: (609) 984-5890
 webflowId: 5f7728fc0b0d0071b8f25121
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/driving-school-agent.md
+++ b/content/src/webflow-licenses/driving-school-agent.md
@@ -11,4 +11,5 @@ webflowIndustry: Driving School Agent
 divisionPhone: (609) 292-6500  5094
 webflowId: 5f772957c8aaf51eaec9b533
 licenseCertificationClassification: AUTHORIZATION
+agencyWebsite: "https://www.nj.gov/mvc/"
 ---

--- a/content/src/webflow-licenses/driving-school-instructor.md
+++ b/content/src/webflow-licenses/driving-school-instructor.md
@@ -11,4 +11,5 @@ webflowIndustry: Driving School Instructor
 divisionPhone: (609) 292-6500  5094
 webflowId: 5f772957c8aaf5a7fac9b534
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/mvc/"
 ---

--- a/content/src/webflow-licenses/drop-zone-parachuting.md
+++ b/content/src/webflow-licenses/drop-zone-parachuting.md
@@ -11,4 +11,5 @@ webflowIndustry: Drop Zone
 divisionPhone: (609) 530-2913
 webflowId: 5f772968a67e4a2f6a5c0f37
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/transportation/"
 ---

--- a/content/src/webflow-licenses/drug-abuse-counselor.md
+++ b/content/src/webflow-licenses/drug-abuse-counselor.md
@@ -11,4 +11,5 @@ webflowIndustry: Substance Counselor
 divisionPhone: (973) 504-6415
 webflowId: 5f7729858150beacc0f3be2b
 licenseCertificationClassification: CERTIFICATE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/drugs-distributed-to-other-counties.md
+++ b/content/src/webflow-licenses/drugs-distributed-to-other-counties.md
@@ -11,4 +11,5 @@ webflowIndustry: Drug Exports
 divisionPhone: (609) 826-4935
 webflowId: 5f772948147ced9d0d26bf40
 licenseCertificationClassification: FREE SALE CERTIFICATE
+agencyWebsite: "https://www.nj.gov/health/ceohs/"
 ---

--- a/content/src/webflow-licenses/drugs-manufacture-wholesale-to-medical-professionals.md
+++ b/content/src/webflow-licenses/drugs-manufacture-wholesale-to-medical-professionals.md
@@ -12,4 +12,5 @@ webflowIndustry: Drug Manufacture
 divisionPhone: (609) 826-4935
 webflowId: 5f77293e4ad0aedffea54a57
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/drugs-non-prescription.md
+++ b/content/src/webflow-licenses/drugs-non-prescription.md
@@ -12,4 +12,5 @@ webflowIndustry: Non-Prescription Drugs
 divisionPhone: (609) 826-4935
 webflowId: 5f77293e8e9f87160e6859b8
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/education-higher-institutions.md
+++ b/content/src/webflow-licenses/education-higher-institutions.md
@@ -10,4 +10,5 @@ webflowIndustry: Education
 licenseCertificationClassification: LICENSE
 divisionPhone: (609) 292-2955
 webflowId: 640b8468e10ad956fbb3ede4
+agencyWebsite: "https://www.nj.gov/highereducation/"
 ---

--- a/content/src/webflow-licenses/elected-office.md
+++ b/content/src/webflow-licenses/elected-office.md
@@ -10,4 +10,5 @@ webflowIndustry: Elected Office
 licenseCertificationClassification: CERTIFICATE
 divisionPhone: (609) 292-3760
 webflowId: 5f7728dbb0544ffb79366144
+agencyWebsite: "https://nj.gov/state/elections/"
 ---

--- a/content/src/webflow-licenses/electric-company-public.md
+++ b/content/src/webflow-licenses/electric-company-public.md
@@ -11,4 +11,5 @@ webflowIndustry: Electric Power
 divisionPhone: (800) 624-0331
 webflowId: 5f7728ead2749a39779cf7d3
 licenseCertificationClassification: APPROVAL
+agencyWebsite: "https://www.nj.gov/bpu/"
 ---

--- a/content/src/webflow-licenses/electrical-inspector-ucc.md
+++ b/content/src/webflow-licenses/electrical-inspector-ucc.md
@@ -11,4 +11,5 @@ webflowIndustry: Electrical Inspector
 divisionPhone: (609) 984-7834
 webflowId: 5f7729869491d50131036b59
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/electrical-sub-code-ucc.md
+++ b/content/src/webflow-licenses/electrical-sub-code-ucc.md
@@ -11,4 +11,5 @@ webflowIndustry: Electrical Sub code
 divisionPhone: (609) 984-7834
 webflowId: 5f772986862dc166babe49a4
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/electroplating.md
+++ b/content/src/webflow-licenses/electroplating.md
@@ -12,4 +12,5 @@ webflowIndustry: Electroplating
 divisionPhone: (609) 292-2121
 webflowId: 5f772950d2749a6ec39cf7d8
 licenseCertificationClassification: LICENSE & PERMIT
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/elevator-inspector-ucc.md
+++ b/content/src/webflow-licenses/elevator-inspector-ucc.md
@@ -11,4 +11,5 @@ webflowIndustry: Elevator Inspector
 divisionPhone: (609) 984-7834
 webflowId: 5f772988a195c80a3815b18a
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/emergency-ambulance-service.md
+++ b/content/src/webflow-licenses/emergency-ambulance-service.md
@@ -11,4 +11,5 @@ webflowIndustry: Emergency Ambulance
 divisionPhone: (609) 633-7777
 webflowId: 5f77294971c49e6862913b81
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/ems/"
 ---

--- a/content/src/webflow-licenses/emergency-medical-technician.md
+++ b/content/src/webflow-licenses/emergency-medical-technician.md
@@ -11,4 +11,5 @@ webflowIndustry: Emergency Medical Technician
 divisionPhone: (609) 633-7777
 webflowId: 5f77293fdf77de204ce1a4c7
 licenseCertificationClassification: CERTIFICATE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/engineer-nuclear-operating.md
+++ b/content/src/webflow-licenses/engineer-nuclear-operating.md
@@ -12,4 +12,5 @@ webflowIndustry: Nuclear Engineer
 divisionPhone: (609) 292-2345
 webflowId: 5f772950c8aaf53279c9b531
 licenseCertificationClassification: CERTIFICATE
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/engineer-refrigeration-plant.md
+++ b/content/src/webflow-licenses/engineer-refrigeration-plant.md
@@ -11,4 +11,5 @@ webflowIndustry: Refrigeration Plant Engineer
 divisionPhone: (609) 292-2345
 webflowId: 5f77298ae022944cf3eaa5cd
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/environmental-health-specialist.md
+++ b/content/src/webflow-licenses/environmental-health-specialist.md
@@ -11,4 +11,5 @@ webflowIndustry: Environmental Health Specialist
 divisionPhone: (609) 292-4993
 webflowId: 5f77293fef496238ef46d0dd
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/environmental-laboratory-medical.md
+++ b/content/src/webflow-licenses/environmental-laboratory-medical.md
@@ -12,4 +12,5 @@ webflowIndustry: Environmental Laboratory
 divisionPhone: (609) 292-3950
 webflowId: 5f77293f486eeb74cdc25611
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/environmental-laboratory.md
+++ b/content/src/webflow-licenses/environmental-laboratory.md
@@ -11,4 +11,5 @@ webflowIndustry: Environmental Laboratory
 divisionPhone: (609) 292-3950
 webflowId: 5f7728fd7fe89d677205478e
 licenseCertificationClassification: CERTIFICATE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/export-service.md
+++ b/content/src/webflow-licenses/export-service.md
@@ -10,4 +10,5 @@ webflowIndustry: Export Service
 licenseCertificationClassification: REGULATIONS
 divisionPhone: (202) 326-2221
 webflowId: 5f7728dd5ef8c17113019ebb
+agencyWebsite: "https://www.export.gov/"
 ---

--- a/content/src/webflow-licenses/family-first-program-assistance-program.md
+++ b/content/src/webflow-licenses/family-first-program-assistance-program.md
@@ -11,4 +11,5 @@ webflowIndustry: Family First Program
 divisionPhone: (609) 588-2000
 webflowId: 5f77294bc68adf446d4cdc16
 licenseCertificationClassification: IMPORTANT INFORMATION
+agencyWebsite: "https://www.nj.gov/humanservices/"
 ---

--- a/content/src/webflow-licenses/financial-planner.md
+++ b/content/src/webflow-licenses/financial-planner.md
@@ -11,4 +11,5 @@ webflowIndustry: Financial Planner
 divisionPhone: (973) 504-3600
 webflowId: 5f77298ba195c8507115b18c
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/financing-agency.md
+++ b/content/src/webflow-licenses/financing-agency.md
@@ -11,4 +11,5 @@ webflowIndustry: Finance Agency
 divisionPhone: (609) 292-7272
 webflowId: 5f7729258fbb2210c16ec088
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/fire-inspector-instructor-official.md
+++ b/content/src/webflow-licenses/fire-inspector-instructor-official.md
@@ -11,4 +11,5 @@ webflowIndustry: Fire Inspector
 divisionPhone: (609) 777-3552
 webflowId: 5f77298b486eebc0a2c25619
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/fire-protection-inspector-ucc.md
+++ b/content/src/webflow-licenses/fire-protection-inspector-ucc.md
@@ -11,4 +11,5 @@ webflowIndustry: Fire Inspector
 divisionPhone: 609-984-7860
 webflowId: 5f77298cd2749a8ce79cf7de
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/fire-sprinkler-installer.md
+++ b/content/src/webflow-licenses/fire-sprinkler-installer.md
@@ -11,4 +11,5 @@ webflowIndustry: Fire Sprinkler
 divisionPhone: (609) 984-7860
 webflowId: 5f7728f3dd6a49cc439b605c
 licenseCertificationClassification: CERTIFICATION
+agencyWebsite: "https://www.nj.gov/dca/"
 ---

--- a/content/src/webflow-licenses/fire-suppression-system-installer.md
+++ b/content/src/webflow-licenses/fire-suppression-system-installer.md
@@ -11,4 +11,5 @@ webflowIndustry: Fire Suppression
 divisionPhone: (609) 633-8105
 webflowId: 5f77298c5adcc8a5d0b64a80
 licenseCertificationClassification: CERTIFICATION
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/firearms-retail-wholesale-and-manufacture.md
+++ b/content/src/webflow-licenses/firearms-retail-wholesale-and-manufacture.md
@@ -11,4 +11,5 @@ webflowIndustry: Firearms
 divisionPhone: (609) 882-2000
 webflowId: 5f7729604ad0ae6bffa54a58
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/first-aid-squad.md
+++ b/content/src/webflow-licenses/first-aid-squad.md
@@ -11,4 +11,5 @@ webflowIndustry: First Aid
 divisionPhone: (609) 633-7777
 webflowId: 5f7729493862544011bb0e45
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/ems/"
 ---

--- a/content/src/webflow-licenses/fish-commercial-fresh-water-fish-shellfish.md
+++ b/content/src/webflow-licenses/fish-commercial-fresh-water-fish-shellfish.md
@@ -11,4 +11,5 @@ webflowIndustry: Fish
 divisionPhone: (609) 292-2965
 webflowId: 5f7728fd90d9ac17051309d4
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/fish-shellfish-shuck-store-or-distribute.md
+++ b/content/src/webflow-licenses/fish-shellfish-shuck-store-or-distribute.md
@@ -11,4 +11,5 @@ webflowIndustry: Fish Store
 divisionPhone: (609) 292-7837
 webflowId: 5f7729402f04da7d4258b5f0
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/fishing-commercial-salt-water.md
+++ b/content/src/webflow-licenses/fishing-commercial-salt-water.md
@@ -11,4 +11,5 @@ webflowIndustry: Commercial Fishing
 divisionPhone: (609) 748-2020
 webflowId: 5f7729002f04da3b5958b5e8
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/fishing-equipment-licenses.md
+++ b/content/src/webflow-licenses/fishing-equipment-licenses.md
@@ -11,4 +11,5 @@ webflowIndustry: Fishing Equipment Licenses
 divisionPhone: (609) 292-4860
 webflowId: 5f7728ffef49622ad146d0d4
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/flea-market-swap-meet-kiosk.md
+++ b/content/src/webflow-licenses/flea-market-swap-meet-kiosk.md
@@ -10,4 +10,5 @@ webflowIndustry: Flea Swap
 licenseCertificationClassification: CERTIFICATE OF AUTHORITY
 divisionPhone: (609) 292-6400
 webflowId: 5f77296ab0544f884636617a
+agencyWebsite: "https://www.nj.gov/treasury/"
 ---

--- a/content/src/webflow-licenses/food-co-op.md
+++ b/content/src/webflow-licenses/food-co-op.md
@@ -11,4 +11,5 @@ webflowIndustry: Food Co-op
 divisionPhone: (609) 826-4935
 webflowId: 5f772941862dc16398be49a3
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/food-manufacturing-sales-wholesale.md
+++ b/content/src/webflow-licenses/food-manufacturing-sales-wholesale.md
@@ -11,4 +11,5 @@ webflowIndustry: Food Manufacturing
 divisionPhone: (609) 826-4935
 webflowId: 5f772940b4710f56bc3c37b6
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/food-warehouse.md
+++ b/content/src/webflow-licenses/food-warehouse.md
@@ -11,4 +11,5 @@ webflowIndustry: Food Warehouse
 divisionPhone: (609) 826-4941
 webflowId: 5f772940486eeb57a4c25612
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/foreign-money-transmitter.md
+++ b/content/src/webflow-licenses/foreign-money-transmitter.md
@@ -11,4 +11,5 @@ webflowIndustry: Foreign Money
 divisionPhone: (609) 292-7272
 webflowId: 5f772925b0544f50e8366149
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/forester-professional.md
+++ b/content/src/webflow-licenses/forester-professional.md
@@ -11,4 +11,5 @@ webflowIndustry: Forester
 divisionPhone: (609) 292-2520
 webflowId: 5f7729018150be2dc1f3be20
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/franchise.md
+++ b/content/src/webflow-licenses/franchise.md
@@ -10,4 +10,5 @@ webflowIndustry: Franchise
 licenseCertificationClassification: CONTACT
 divisionPhone: ""
 webflowId: 5f7728df5ddf76c5173ac42d
+agencyWebsite: "https://www.fcc.gov/"
 ---

--- a/content/src/webflow-licenses/freight-forwarding.md
+++ b/content/src/webflow-licenses/freight-forwarding.md
@@ -10,4 +10,5 @@ webflowIndustry: Freight Forwarding
 licenseCertificationClassification: REGISTRATION/LICENSE
 divisionPhone: ""
 webflowId: 5f7728dfa536a34425c0b339
+agencyWebsite: "https://www.maritime.dot.gov/"
 ---

--- a/content/src/webflow-licenses/freight-rail-freight-tariff.md
+++ b/content/src/webflow-licenses/freight-rail-freight-tariff.md
@@ -11,4 +11,5 @@ webflowIndustry: Freight
 divisionPhone: (609) 777-4379
 webflowId: 5f77295738625436d2bb0e46
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/mvc/"
 ---

--- a/content/src/webflow-licenses/fundraiser.md
+++ b/content/src/webflow-licenses/fundraiser.md
@@ -11,4 +11,5 @@ webflowIndustry: Fundraiser
 divisionPhone: (973) 504-6262
 webflowId: 5f77298d147ced7cb526bf47
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/games-of-chance.md
+++ b/content/src/webflow-licenses/games-of-chance.md
@@ -11,4 +11,5 @@ webflowIndustry: Games of Chance
 divisionPhone: (973) 273-8000
 webflowId: 5f77298ee8bf5046be3178a4
 licenseCertificationClassification: LICENSE & REGISTRATION
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/gas-company-public.md
+++ b/content/src/webflow-licenses/gas-company-public.md
@@ -11,4 +11,5 @@ webflowIndustry: Gas Utility
 divisionPhone: (800) 624-0331
 webflowId: 5f7728ea1a08099cc1bb2ec4
 licenseCertificationClassification: APPROVAL
+agencyWebsite: "https://www.nj.gov/bpu/"
 ---

--- a/content/src/webflow-licenses/gas-station.md
+++ b/content/src/webflow-licenses/gas-station.md
@@ -11,4 +11,5 @@ webflowIndustry: Gas Station
 divisionPhone: (609) 292-9292
 webflowId: 5f77296a71c49efb25913b83
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/treasury/"
 ---

--- a/content/src/webflow-licenses/gasoline-jobber.md
+++ b/content/src/webflow-licenses/gasoline-jobber.md
@@ -11,4 +11,5 @@ webflowIndustry: Gasoline Jobber
 divisionPhone: (609) 292-9292
 webflowId: 5f77296a5ef8c1d6df019ec5
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/treasury/"
 ---

--- a/content/src/webflow-licenses/general-petroleum-product-cleanup-permit.md
+++ b/content/src/webflow-licenses/general-petroleum-product-cleanup-permit.md
@@ -11,4 +11,5 @@ webflowIndustry: Petroleum Cleanup
 divisionPhone: (609) 292-6480
 webflowId: 5f7729042edc677975b4a6fe
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/grain-dealer.md
+++ b/content/src/webflow-licenses/grain-dealer.md
@@ -11,4 +11,5 @@ webflowIndustry: Grain Dealer
 divisionPhone: (609) 292-5649
 webflowId: 5f7728e11a08098953bb2ec3
 licenseCertificationClassification: LICENSE/BOND
+agencyWebsite: "https://www.nj.gov/agriculture/"
 ---

--- a/content/src/webflow-licenses/groom-horses.md
+++ b/content/src/webflow-licenses/groom-horses.md
@@ -11,4 +11,5 @@ webflowIndustry: Groom
 divisionPhone: (609) 292-0613
 webflowId: 5f7729606f3d8d585a75ef34
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/group-home.md
+++ b/content/src/webflow-licenses/group-home.md
@@ -11,4 +11,5 @@ webflowIndustry: Home Group
 divisionPhone: (609) 984-5321
 webflowId: 5f77294cdf77de360de1a525
 licenseCertificationClassification: LICENSE TO OPERATE
+agencyWebsite: "https://www.nj.gov/humanservices/"
 ---

--- a/content/src/webflow-licenses/guns.md
+++ b/content/src/webflow-licenses/guns.md
@@ -11,4 +11,5 @@ webflowIndustry: Guns
 divisionPhone: (609) 882-2000
 webflowId: 5f7729619a1bb8d37fb3b917
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/handicapped-homes-for-the.md
+++ b/content/src/webflow-licenses/handicapped-homes-for-the.md
@@ -11,4 +11,5 @@ webflowIndustry: Handicapped
 divisionPhone: (609) 984-5321
 webflowId: 5f77294ca536a34f8dc0b344
 licenseCertificationClassification: LICENSE TO OPERATE
+agencyWebsite: "https://www.nj.gov/humanservices/"
 ---

--- a/content/src/webflow-licenses/harbor-pilots.md
+++ b/content/src/webflow-licenses/harbor-pilots.md
@@ -11,4 +11,5 @@ webflowIndustry: Harbor Pilot
 divisionPhone: (973) 491-7693
 webflowId: 5f7729688e9f87519f6859c2
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/transportation/"
 ---

--- a/content/src/webflow-licenses/hauling-service-hazardous-waste-transporter.md
+++ b/content/src/webflow-licenses/hauling-service-hazardous-waste-transporter.md
@@ -11,4 +11,5 @@ webflowIndustry: Hazardous Hauling
 divisionPhone: (212) 292-7081
 webflowId: 5f772905386254b049bb0e3e
 licenseCertificationClassification: ""
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/health-care-facility.md
+++ b/content/src/webflow-licenses/health-care-facility.md
@@ -12,4 +12,5 @@ webflowIndustry: Health Care Facility
 divisionPhone: (609) 292-5960
 webflowId: 5f772941f278ccdf91b0ce1f
 licenseCertificationClassification: CERTIFICATE OF NEED/LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/health-care-service.md
+++ b/content/src/webflow-licenses/health-care-service.md
@@ -12,4 +12,5 @@ webflowIndustry: Health Care
 divisionPhone: (973) 273-8016
 webflowId: 5f772941b4710f0fc13c37b8
 licenseCertificationClassification: LICENSE/CONTACT
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/health-maintenance-organization-hmo.md
+++ b/content/src/webflow-licenses/health-maintenance-organization-hmo.md
@@ -11,4 +11,5 @@ webflowIndustry: Health Maintenance Organization
 divisionPhone: (609) 292-7272  50582
 webflowId: 5f772925d9d2375f9d6f48ba
 licenseCertificationClassification: BOND/LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/health-officer.md
+++ b/content/src/webflow-licenses/health-officer.md
@@ -11,4 +11,5 @@ webflowIndustry: Health Officer
 divisionPhone: (609) 292-4993
 webflowId: 5f772942a6bfb5566b02ee01
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/hearing-aid-dispenser.md
+++ b/content/src/webflow-licenses/hearing-aid-dispenser.md
@@ -11,4 +11,5 @@ webflowIndustry: Hearing Aid
 divisionPhone: (973) 504-6233
 webflowId: 5f772990b0544f2445366180
 licenseCertificationClassification: LICENSE/REGISTRATION
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/heating-oil-motor-fuel-oil.md
+++ b/content/src/webflow-licenses/heating-oil-motor-fuel-oil.md
@@ -10,4 +10,5 @@ webflowIndustry: Heating Oil
 licenseCertificationClassification: LICENSE
 divisionPhone: (609) 984-7171
 webflowId: 5f77296ae02294833deaa5c9
+agencyWebsite: "https://www.nj.gov/treasury/"
 ---

--- a/content/src/webflow-licenses/helicopter-ambulance.md
+++ b/content/src/webflow-licenses/helicopter-ambulance.md
@@ -11,4 +11,5 @@ webflowIndustry: Ambulance
 divisionPhone: (609) 633-7777
 webflowId: 5f7729495ef8c1ee2f019ec2
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/ems/"
 ---

--- a/content/src/webflow-licenses/high-school-driver-education.md
+++ b/content/src/webflow-licenses/high-school-driver-education.md
@@ -11,4 +11,5 @@ webflowIndustry: Driver Education
 divisionPhone: (609) 292-6500  5094
 webflowId: 5f772958614a2d2a93d207a7
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/mvc/"
 ---

--- a/content/src/webflow-licenses/historic-preservation.md
+++ b/content/src/webflow-licenses/historic-preservation.md
@@ -11,4 +11,5 @@ webflowIndustry: Historic Preservation
 divisionPhone: (609) 292-2023
 webflowId: 5f7729065adbb9a6e9052cf6
 licenseCertificationClassification: CERTIFICATE, FEDERAL TAX CREDIT
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/hog-dealer-broker.md
+++ b/content/src/webflow-licenses/hog-dealer-broker.md
@@ -11,4 +11,5 @@ webflowIndustry: Hog Dealer
 divisionPhone: (609) 633-2954
 webflowId: 5f7728e1240061e2267834b7
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/agriculture/"
 ---

--- a/content/src/webflow-licenses/home-financing.md
+++ b/content/src/webflow-licenses/home-financing.md
@@ -11,4 +11,5 @@ webflowIndustry: Home Financing
 divisionPhone: (609) 292-7272
 webflowId: 5f772925a195c88e2715b184
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/home-for-the-aged.md
+++ b/content/src/webflow-licenses/home-for-the-aged.md
@@ -11,4 +11,5 @@ webflowIndustry: Home for the Aged
 divisionPhone: (609) 292-8773
 webflowId: 5f772942c8aaf5cca3c9b52f
 licenseCertificationClassification: CERTIFICATE OF NEED
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/home-repair-contractor-financing.md
+++ b/content/src/webflow-licenses/home-repair-contractor-financing.md
@@ -11,4 +11,5 @@ webflowIndustry: Home Contractor
 divisionPhone: (609) 633-0822
 webflowId: 5f77292690d9ac51101309d8
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/home-repair-salesman.md
+++ b/content/src/webflow-licenses/home-repair-salesman.md
@@ -11,4 +11,5 @@ webflowIndustry: Home Repair Sales
 divisionPhone: (888) 656-6225
 webflowId: 5f7729922f04da2d7158b5f6
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/home-tutoring.md
+++ b/content/src/webflow-licenses/home-tutoring.md
@@ -11,4 +11,5 @@ webflowIndustry: Home Tutoring
 divisionPhone: (609) 292-2070
 webflowId: 5f772931dd6a4921d89b6061
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/homeless-shelter.md
+++ b/content/src/webflow-licenses/homeless-shelter.md
@@ -11,4 +11,5 @@ webflowIndustry: Homeless Shelter
 divisionPhone: (609) 984-1706
 webflowId: 5f7729925ef8c11c45019ec8
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/horse-appraiser.md
+++ b/content/src/webflow-licenses/horse-appraiser.md
@@ -10,4 +10,5 @@ webflowIndustry: Horse Appraiser
 licenseCertificationClassification: CERTIFICATION
 divisionPhone: (208) 733-1122 or (800) 704-7020
 webflowId: 5f7728ddeb55581493feb56b
+agencyWebsite: "https://www.equineappraiser.com/"
 ---

--- a/content/src/webflow-licenses/horse-races.md
+++ b/content/src/webflow-licenses/horse-races.md
@@ -11,4 +11,5 @@ webflowIndustry: Horse Races
 divisionPhone: (609) 292-0613
 webflowId: 5f7729618e9f8777bc6859bf
 licenseCertificationClassification: PERMIT
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/hospital.md
+++ b/content/src/webflow-licenses/hospital.md
@@ -12,4 +12,5 @@ webflowIndustry: Hospital
 divisionPhone: (609) 292-5960
 webflowId: 5f772942f278ccc751b0ce20
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/housing-sponsor-of-low-middle-income.md
+++ b/content/src/webflow-licenses/housing-sponsor-of-low-middle-income.md
@@ -11,4 +11,5 @@ webflowIndustry: Low or Middle Income Housing
 divisionPhone: (609) 633-6216
 webflowId: 5f7729933862542890bb0e4b
 licenseCertificationClassification: CERTIFICATION & APPROVAL
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/hunting-fishing-equipment-licenses.md
+++ b/content/src/webflow-licenses/hunting-fishing-equipment-licenses.md
@@ -11,4 +11,5 @@ webflowIndustry: Hunting and Fishing
 divisionPhone: (609) 292-4860
 webflowId: 5f7729081a08092ef5bb2ec7
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/hydrostatic-test-water-discharges-permit.md
+++ b/content/src/webflow-licenses/hydrostatic-test-water-discharges-permit.md
@@ -11,4 +11,5 @@ webflowIndustry: Hydrostatic Water Discharge
 divisionPhone: (609) 292-4860
 webflowId: 5f77290a8e9f8750706859b4
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/implant-inspector-ucc.md
+++ b/content/src/webflow-licenses/implant-inspector-ucc.md
@@ -11,4 +11,5 @@ webflowIndustry: Implant Inspector
 divisionPhone: (609) 984-7834
 webflowId: 5f7729941a0809f031bb2ed0
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/import-export-business.md
+++ b/content/src/webflow-licenses/import-export-business.md
@@ -10,4 +10,5 @@ webflowIndustry: Import Export
 licenseCertificationClassification: CONTACT (FOR IMPORT ONLY)
 divisionPhone: (877) CBP-5511
 webflowId: 5f7728dc9491d58588036b4f
+agencyWebsite: "https://www.cbp.gov/"
 ---

--- a/content/src/webflow-licenses/inspector-electrical-ucc.md
+++ b/content/src/webflow-licenses/inspector-electrical-ucc.md
@@ -11,4 +11,5 @@ webflowIndustry: Electrical Inspector
 divisionPhone: (609) 984-7834
 webflowId: 5f7729958e9f8750f56859c7
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/inspector-elevator-ucc.md
+++ b/content/src/webflow-licenses/inspector-elevator-ucc.md
@@ -11,4 +11,5 @@ webflowIndustry: Elevator Inspector
 divisionPhone: (609) 984-7834
 webflowId: 5f772995862dc18444be49a5
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/inspector-fire-protection-ucc.md
+++ b/content/src/webflow-licenses/inspector-fire-protection-ucc.md
@@ -11,4 +11,5 @@ webflowIndustry: Fire Inspector
 divisionPhone: (609) 984-7834
 webflowId: 5f7729959a1bb8fcddb3b919
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/inspector-hotels-multiple-dwellings.md
+++ b/content/src/webflow-licenses/inspector-hotels-multiple-dwellings.md
@@ -11,4 +11,5 @@ webflowIndustry: Hotel Inspector
 divisionPhone: (609) 984-7834
 webflowId: 5f7729945adcc85451b64a81
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/inspector-mechanical-ucc.md
+++ b/content/src/webflow-licenses/inspector-mechanical-ucc.md
@@ -11,4 +11,5 @@ webflowIndustry: Mechanical Inspector
 divisionPhone: (609) 984-7834
 webflowId: 5f772996d2749af8c79cf7e0
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/inspector-plumbing-ucc.md
+++ b/content/src/webflow-licenses/inspector-plumbing-ucc.md
@@ -11,4 +11,5 @@ webflowIndustry: Plumbing Inspector
 divisionPhone: (609) 984-7834
 webflowId: 5f7729969491d59452036b5c
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dca/"
 ---

--- a/content/src/webflow-licenses/inspector-ucc.md
+++ b/content/src/webflow-licenses/inspector-ucc.md
@@ -11,4 +11,5 @@ webflowIndustry: Inspector
 divisionPhone: (609) 984-7834
 webflowId: 5f772997a195c8fa2e15b190
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/instructor-of-insurance-education.md
+++ b/content/src/webflow-licenses/instructor-of-insurance-education.md
@@ -11,4 +11,5 @@ webflowIndustry: Insurance Instructor
 divisionPhone: (609) 292-7272  50552
 webflowId: 5f7729262f04daea3758b5ed
 licenseCertificationClassification: LICENSE/REGISTER
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/insurance-company-life-health.md
+++ b/content/src/webflow-licenses/insurance-company-life-health.md
@@ -11,4 +11,5 @@ webflowIndustry: Insurance Company
 divisionPhone: (609) 292-5427  50328
 webflowId: 5f772927ecb74e2bbd23aacd
 licenseCertificationClassification: CERTIFICATE OF AUTHORITY
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/insurance-company.md
+++ b/content/src/webflow-licenses/insurance-company.md
@@ -11,4 +11,5 @@ webflowIndustry: Insurance Company
 divisionPhone: (609) 292-7272
 webflowId: 5f772927147ced714f26bf3b
 licenseCertificationClassification: LICENSE/REGISTER
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/insurance-premium-finance.md
+++ b/content/src/webflow-licenses/insurance-premium-finance.md
@@ -11,4 +11,5 @@ webflowIndustry: Insurance Premium Finance
 divisionPhone: (609) 292-7272
 webflowId: 5f772927f17efb52d6eefb33
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/international-standard-book-number-isbn.md
+++ b/content/src/webflow-licenses/international-standard-book-number-isbn.md
@@ -10,4 +10,5 @@ webflowIndustry: ISBN
 licenseCertificationClassification: CONTACT
 divisionPhone: (877) 310-7333
 webflowId: 5f7728dff17efb3a6ceefb2f
+agencyWebsite: "https://www.isbn.org/"
 ---

--- a/content/src/webflow-licenses/invalid-coach.md
+++ b/content/src/webflow-licenses/invalid-coach.md
@@ -11,4 +11,5 @@ webflowIndustry: Invalid Coach
 divisionPhone: (609) 633-7777
 webflowId: 5f77294a5ddf7683313ac435
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/ems/"
 ---

--- a/content/src/webflow-licenses/jersey-fresh.md
+++ b/content/src/webflow-licenses/jersey-fresh.md
@@ -11,4 +11,5 @@ webflowIndustry: Jersey Fresh
 divisionPhone: (609) 292-5536
 webflowId: 5f7728e1b4710f3f613c37ae
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/agriculture/"
 ---

--- a/content/src/webflow-licenses/job-fair.md
+++ b/content/src/webflow-licenses/job-fair.md
@@ -11,4 +11,5 @@ webflowIndustry: Job Fair
 divisionPhone: (973) 504-6370
 webflowId: 5f772997a67e4ae1e45c0f39
 licenseCertificationClassification: LICENSE (IF RESUMES ARE COLLECTED & REGISTRATION FEE CHARGED ATTENDEES)
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/judgement-recovery.md
+++ b/content/src/webflow-licenses/judgement-recovery.md
@@ -11,4 +11,5 @@ webflowIndustry: Judgement Recovery
 divisionPhone: (866) 534-7789
 webflowId: 5f77296bdf77de7652e1a52a
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.nj.gov/treasury/"
 ---

--- a/content/src/webflow-licenses/kick-boxer.md
+++ b/content/src/webflow-licenses/kick-boxer.md
@@ -11,4 +11,5 @@ webflowIndustry: Kick Boxer
 divisionPhone: (609) 292-0317
 webflowId: 5f772961df77de6417e1a529
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/laboratory-director.md
+++ b/content/src/webflow-licenses/laboratory-director.md
@@ -11,4 +11,5 @@ webflowIndustry: Laboratory Director
 divisionPhone: (973) 504-6200
 webflowId: 5f7729982400611df77834c0
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/landscape-irrigation-contractor.md
+++ b/content/src/webflow-licenses/landscape-irrigation-contractor.md
@@ -11,4 +11,5 @@ webflowIndustry: Landscape Irrigation Contractor
 divisionPhone: (609) 984-7834
 webflowId: 5f77290d8e9f87815a6859b5
 licenseCertificationClassification: CERTIFICATION
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/landscaping-business.md
+++ b/content/src/webflow-licenses/landscaping-business.md
@@ -11,4 +11,5 @@ webflowIndustry: Landscaping
 divisionPhone: (973) 424-8150
 webflowId: 5f7729984bc777dd5da6e254
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/law-firm-incorporation.md
+++ b/content/src/webflow-licenses/law-firm-incorporation.md
@@ -11,4 +11,5 @@ webflowIndustry: Law Firm
 divisionPhone: (609) 292-9292
 webflowId: 5f77296be02294215feaa5ca
 licenseCertificationClassification: CERTIFICATE
+agencyWebsite: "https://www.nj.gov/treasury/"
 ---

--- a/content/src/webflow-licenses/lawyer.md
+++ b/content/src/webflow-licenses/lawyer.md
@@ -10,4 +10,5 @@ webflowIndustry: Lawyer
 licenseCertificationClassification: CERTIFICATE OF ADMISSION
 divisionPhone: (609) 815-2911
 webflowId: 5f77296d7fe89d4980054793
+agencyWebsite: "https://www.njbarexams.org/"
 ---

--- a/content/src/webflow-licenses/lead-abatement-certification-of-training-agencies-for-workers-supervisors.md
+++ b/content/src/webflow-licenses/lead-abatement-certification-of-training-agencies-for-workers-supervisors.md
@@ -12,4 +12,5 @@ webflowIndustry: Lead
 divisionPhone: (609) 826-4950
 webflowId: 5f7729438e9f8783f46859b9
 licenseCertificationClassification: CERTIFICATION
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/lead-abatement-contractor-or-companies.md
+++ b/content/src/webflow-licenses/lead-abatement-contractor-or-companies.md
@@ -11,4 +11,5 @@ webflowIndustry: Lead
 divisionPhone: (609) 633-6224
 webflowId: 5f772998e8bf5039e73178a5
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/lead-abatement-workers-supervisors-inspectors.md
+++ b/content/src/webflow-licenses/lead-abatement-workers-supervisors-inspectors.md
@@ -11,4 +11,5 @@ webflowIndustry: Lead
 divisionPhone: (609) 826-4950
 webflowId: 5f7729434bc7772f6ea6e23a
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/learning-disability-teacher-consultant.md
+++ b/content/src/webflow-licenses/learning-disability-teacher-consultant.md
@@ -11,4 +11,5 @@ webflowIndustry: Learning Disability Teacher
 divisionPhone: (609) 292-2070
 webflowId: 5f772932f17efbfec7eefb34
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/legislative-agent.md
+++ b/content/src/webflow-licenses/legislative-agent.md
@@ -11,4 +11,5 @@ webflowIndustry: Legislative Agent
 divisionPhone: (609) 292-8700
 webflowId: 5f772961ef496213b346d0df
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/librarian.md
+++ b/content/src/webflow-licenses/librarian.md
@@ -11,4 +11,5 @@ webflowIndustry: Librarian
 divisionPhone: (609) 292-2070
 webflowId: 5f772932de9e0660177f599c
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/license-lender.md
+++ b/content/src/webflow-licenses/license-lender.md
@@ -11,4 +11,5 @@ webflowIndustry: Lender License
 divisionPhone: (609) 292-7272
 webflowId: 5f772928e8bf5078ed31789c
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/liming-materials.md
+++ b/content/src/webflow-licenses/liming-materials.md
@@ -11,4 +11,5 @@ webflowIndustry: Liming Materials
 divisionPhone: (609) 984-8421
 webflowId: 5f7728e2614a2d030ad2079e
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.nj.gov/agriculture/"
 ---

--- a/content/src/webflow-licenses/livestock-dealer-broker.md
+++ b/content/src/webflow-licenses/livestock-dealer-broker.md
@@ -11,4 +11,5 @@ webflowIndustry: Livestock Dealer
 divisionPhone: (609) 633-2954
 webflowId: 5f7728e2306c6c2570066f9c
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/agriculture/"
 ---

--- a/content/src/webflow-licenses/livestock-dealer.md
+++ b/content/src/webflow-licenses/livestock-dealer.md
@@ -11,4 +11,5 @@ webflowIndustry: Livestock Dealer
 divisionPhone: (609) 671-6400
 webflowId: 5f7728e24ad0ae6b9ba54a4b
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/agriculture/"
 ---

--- a/content/src/webflow-licenses/loan-company.md
+++ b/content/src/webflow-licenses/loan-company.md
@@ -11,4 +11,5 @@ webflowIndustry: Loan Company
 divisionPhone: (609) 292-7272
 webflowId: 5f7729295ddf76cd4c3ac431
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/lobbyist.md
+++ b/content/src/webflow-licenses/lobbyist.md
@@ -11,4 +11,5 @@ webflowIndustry: Lobbyist
 divisionPhone: (609) 292-8700
 webflowId: 5f77296228e855e5671958c4
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/lottery-sales-agent.md
+++ b/content/src/webflow-licenses/lottery-sales-agent.md
@@ -10,4 +10,5 @@ webflowIndustry: Lottery Agent
 licenseCertificationClassification: LICENSE
 divisionPhone: (609) 599-5877
 webflowId: 5f77296beb555857a1feb5a1
+agencyWebsite: "https://www.nj.gov/treasury/"
 ---

--- a/content/src/webflow-licenses/low-income-housing-sponsors.md
+++ b/content/src/webflow-licenses/low-income-housing-sponsors.md
@@ -11,4 +11,5 @@ webflowIndustry: Low Income Housing
 divisionPhone: (609) 633-6216
 webflowId: 5f772999306c6cee60066f9e
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/marriage-and-family-therapist.md
+++ b/content/src/webflow-licenses/marriage-and-family-therapist.md
@@ -11,4 +11,5 @@ webflowIndustry: Marriage Family Therapist
 divisionPhone: (973) 504-6582
 webflowId: 5f77299a2edc670afab4a70b
 licenseCertificationClassification: REGISTRATION/LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/marriage-associate-counselor.md
+++ b/content/src/webflow-licenses/marriage-associate-counselor.md
@@ -11,4 +11,5 @@ webflowIndustry: Marriage Counselor
 divisionPhone: (973) 504-6582
 webflowId: 5f77299aa195c8841a15b194
 licenseCertificationClassification: REGISTRATION/LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/master-plumber.md
+++ b/content/src/webflow-licenses/master-plumber.md
@@ -11,4 +11,5 @@ webflowIndustry: Master Plumber
 divisionPhone: (973) 504-6420
 webflowId: 5f77299b8fbb224c906ec092
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/maternal-child-health-consortium.md
+++ b/content/src/webflow-licenses/maternal-child-health-consortium.md
@@ -12,4 +12,5 @@ webflowIndustry: Maternal and Child Health
 divisionPhone: (609) 292-5960
 webflowId: 5f772943c68adf84ec4cdc13
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/media-specialist.md
+++ b/content/src/webflow-licenses/media-specialist.md
@@ -11,4 +11,5 @@ webflowIndustry: Media Specialist
 divisionPhone: (609) 292-2070
 webflowId: 5f7729328150bef012f3be26
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/medical-billing.md
+++ b/content/src/webflow-licenses/medical-billing.md
@@ -11,4 +11,5 @@ webflowIndustry: Medical Billing
 divisionPhone: (609) 292-9292
 webflowId: 5f77296b5adbb9d7a4052d6a
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.nj.gov/treasury/"
 ---

--- a/content/src/webflow-licenses/medical-devices.md
+++ b/content/src/webflow-licenses/medical-devices.md
@@ -12,4 +12,5 @@ webflowIndustry: Medical Devices
 divisionPhone: (609) 826-4920
 webflowId: 5f7729449491d5bd24036b55
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/medical-laboratory.md
+++ b/content/src/webflow-licenses/medical-laboratory.md
@@ -11,4 +11,5 @@ webflowIndustry: Medical Laboratory
 divisionPhone: (609) 826-7100
 webflowId: 5f77299cdd6a49425e9b606b
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/medical-transcription.md
+++ b/content/src/webflow-licenses/medical-transcription.md
@@ -11,4 +11,5 @@ webflowIndustry: Medical Transcription
 divisionPhone: (609) 292-9292
 webflowId: 5f77296b2edc672fd0b4a707
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.nj.gov/treasury/"
 ---

--- a/content/src/webflow-licenses/midwife-certified-nurse.md
+++ b/content/src/webflow-licenses/midwife-certified-nurse.md
@@ -11,4 +11,5 @@ webflowIndustry: Midwife
 divisionPhone: ""
 webflowId: 5f77299c4bc777eca1a6e255
 licenseCertificationClassification: LICENSE/REGISTRATION
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/midwife-lay.md
+++ b/content/src/webflow-licenses/midwife-lay.md
@@ -11,4 +11,5 @@ webflowIndustry: Midwife
 divisionPhone: ""
 webflowId: 5f77299c306c6c3f77066fa0
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/milk-dealer.md
+++ b/content/src/webflow-licenses/milk-dealer.md
@@ -11,4 +11,5 @@ webflowIndustry: Milk Dealer
 divisionPhone: (609) 292-5646
 webflowId: 5f7728e2862dc1da74be499d
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/agriculture/"
 ---

--- a/content/src/webflow-licenses/milk-plant.md
+++ b/content/src/webflow-licenses/milk-plant.md
@@ -12,4 +12,5 @@ webflowIndustry: Milk Plant
 divisionPhone: (609) 826-4935
 webflowId: 5f7729446f3d8d215775ef32
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/milk-weighed-sampler.md
+++ b/content/src/webflow-licenses/milk-weighed-sampler.md
@@ -11,4 +11,5 @@ webflowIndustry: Milk Weighed and Sampler
 divisionPhone: (609) 292-5648
 webflowId: 5f7728e38075e87980a8d937
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/agriculture/"
 ---

--- a/content/src/webflow-licenses/modular-homes.md
+++ b/content/src/webflow-licenses/modular-homes.md
@@ -11,4 +11,5 @@ webflowIndustry: Modular Homes
 divisionPhone: (973) 504-6370
 webflowId: 5f77299de10decf559025081
 licenseCertificationClassification: REGISTRATION & WARRANTING OF NEW HOMES
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/money-order-seller.md
+++ b/content/src/webflow-licenses/money-order-seller.md
@@ -11,4 +11,5 @@ webflowIndustry: Money Order
 divisionPhone: (609) 292-7272
 webflowId: 5f772929c8aaf5eacbc9b52b
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/money-transmitter.md
+++ b/content/src/webflow-licenses/money-transmitter.md
@@ -11,4 +11,5 @@ webflowIndustry: Money Transmitter
 divisionPhone: (609) 292-7272
 webflowId: 5f77292ad9d237ac296f48bb
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/mortgage-solicitor.md
+++ b/content/src/webflow-licenses/mortgage-solicitor.md
@@ -11,4 +11,5 @@ webflowIndustry: Mortgage Solicitor
 divisionPhone: (609) 292-7272
 webflowId: 5f77292a147ced832426bf3e
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/mortuary-science-trainee.md
+++ b/content/src/webflow-licenses/mortuary-science-trainee.md
@@ -11,4 +11,5 @@ webflowIndustry: Mortuary Science
 divisionPhone: (973) 504-6425
 webflowId: 5f77299eeb5558747cfeb5a7
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/motor-vehicle-installment-seller.md
+++ b/content/src/webflow-licenses/motor-vehicle-installment-seller.md
@@ -11,4 +11,5 @@ webflowIndustry: Automobile
 divisionPhone: (609) 292-7272
 webflowId: 5f77292a2f04da3bc158b5ee
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/motor-vehicle-race-track.md
+++ b/content/src/webflow-licenses/motor-vehicle-race-track.md
@@ -11,4 +11,5 @@ webflowIndustry: Automobile Race
 divisionPhone: (609) 882-2000
 webflowId: 5f7729622400610b667834bd
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/natural-gas-pipeline-company-public.md
+++ b/content/src/webflow-licenses/natural-gas-pipeline-company-public.md
@@ -11,4 +11,5 @@ webflowIndustry: Natural Gas Pipeline
 divisionPhone: (800) 624-0331
 webflowId: 5f7728edeb5558933dfeb59a
 licenseCertificationClassification: APPROVAL
+agencyWebsite: "https://www.nj.gov/bpu/"
 ---

--- a/content/src/webflow-licenses/non-profit-corporate.md
+++ b/content/src/webflow-licenses/non-profit-corporate.md
@@ -10,4 +10,5 @@ webflowIndustry: Non-Profit
 licenseCertificationClassification: CERTIFICATE OF INCORPORATION
 divisionPhone: (609) 292-9292
 webflowId: 5f77296cc8aaf57b5dc9b535
+agencyWebsite: "https://www.nj.gov/treasury/"
 ---

--- a/content/src/webflow-licenses/non-public-real-estate-school.md
+++ b/content/src/webflow-licenses/non-public-real-estate-school.md
@@ -11,4 +11,5 @@ webflowIndustry: Real Estate School
 divisionPhone: (609) 292-7272
 webflowId: 5f77292a5ef8c1c035019ec0
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/notice-of-classification.md
+++ b/content/src/webflow-licenses/notice-of-classification.md
@@ -10,4 +10,5 @@ webflowIndustry: Notice of Classification
 licenseCertificationClassification: CONTACT
 divisionPhone: (609) 292-4330
 webflowId: 5f77296cef496265b546d0e1
+agencyWebsite: "https://www.nj.gov/treasury/"
 ---

--- a/content/src/webflow-licenses/nuclear-medicine-technologist.md
+++ b/content/src/webflow-licenses/nuclear-medicine-technologist.md
@@ -11,4 +11,5 @@ webflowIndustry: Nuclear Medicine Technologist
 divisionPhone: (609) 984-5890
 webflowId: 5f77291190d9ac440e1309d7
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/nurse.md
+++ b/content/src/webflow-licenses/nurse.md
@@ -11,4 +11,5 @@ webflowIndustry: Nurse
 divisionPhone: (973) 504-6430
 webflowId: 5f7729a62edc67cbbfb4a70c
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/nursery.md
+++ b/content/src/webflow-licenses/nursery.md
@@ -11,4 +11,5 @@ webflowIndustry: Nursery
 divisionPhone: (609) 406-6939
 webflowId: 5f7728e35ddf765f3e3ac42e
 licenseCertificationClassification: CERTIFICATE
+agencyWebsite: "https://www.nj.gov/agriculture/"
 ---

--- a/content/src/webflow-licenses/occupational-therapist-assistant.md
+++ b/content/src/webflow-licenses/occupational-therapist-assistant.md
@@ -11,4 +11,5 @@ webflowIndustry: Occupational Therapist Assistant
 divisionPhone: (973) 504-6570
 webflowId: 5f7729a7306c6c1a67066fa3
 licenseCertificationClassification: REGISTRATION/LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/occupational-therapist.md
+++ b/content/src/webflow-licenses/occupational-therapist.md
@@ -11,4 +11,5 @@ webflowIndustry: Occupational Therapist
 divisionPhone: (973) 504-6570
 webflowId: 5f7729a7306c6c1b28066fa2
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/oil-distribution-company-public.md
+++ b/content/src/webflow-licenses/oil-distribution-company-public.md
@@ -11,4 +11,5 @@ webflowIndustry: Oil Distribution
 divisionPhone: (800) 624-0331
 webflowId: 5f7728eee8bf508cb9317898
 licenseCertificationClassification: APPROVAL
+agencyWebsite: "https://www.nj.gov/bpu/"
 ---

--- a/content/src/webflow-licenses/operating-engineer-pressure-vessel.md
+++ b/content/src/webflow-licenses/operating-engineer-pressure-vessel.md
@@ -11,4 +11,5 @@ webflowIndustry: Engineer
 divisionPhone: (609) 292-2345
 webflowId: 5f7729512f04da521958b5f3
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/ophthalmic-dispensers.md
+++ b/content/src/webflow-licenses/ophthalmic-dispensers.md
@@ -11,4 +11,5 @@ webflowIndustry: Ophthalmic Dispensers
 divisionPhone: (973) 504-6435
 webflowId: 5f7729a8b0544f6846366182
 licenseCertificationClassification: REGISTRATION/LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/ophthalmologist-technician.md
+++ b/content/src/webflow-licenses/ophthalmologist-technician.md
@@ -11,4 +11,5 @@ webflowIndustry: Ophthalmologist Technician
 divisionPhone: (973) 504-6435
 webflowId: 5f7729a84ad0ae1f91a54a5d
 licenseCertificationClassification: REGISTRATION/LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/optometrist.md
+++ b/content/src/webflow-licenses/optometrist.md
@@ -11,4 +11,5 @@ webflowIndustry: Optometrist
 divisionPhone: (973) 504-6435
 webflowId: 5f7729a8f278cc6eccb0ce24
 licenseCertificationClassification: REGISTRATION/LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/osteopath.md
+++ b/content/src/webflow-licenses/osteopath.md
@@ -11,4 +11,5 @@ webflowIndustry: Osteopath
 divisionPhone: (973) 826-7100
 webflowId: 5f7729a9dd6a4950c09b606d
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/out-of-state-payroll-record-keeping.md
+++ b/content/src/webflow-licenses/out-of-state-payroll-record-keeping.md
@@ -11,4 +11,5 @@ webflowIndustry: Out of State Payroll
 divisionPhone: (609) 292-9664
 webflowId: 5f772951486eeb23f7c25614
 licenseCertificationClassification: PERMIT
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/painting-house.md
+++ b/content/src/webflow-licenses/painting-house.md
@@ -11,4 +11,5 @@ webflowIndustry: Painting House
 divisionPhone: "(888) 656-6225 #21"
 webflowId: 5f772911614a2d913ad207a1
 licenseCertificationClassification: PERMIT/LICENSE (LEAD BASED)
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/painting-spray.md
+++ b/content/src/webflow-licenses/painting-spray.md
@@ -11,4 +11,5 @@ webflowIndustry: Spray Painting
 divisionPhone: "(888) 656-6225 #21"
 webflowId: 5f7729119a1bb864c0b3b90f
 licenseCertificationClassification: PERMIT/LICENSE (LEAD BASED)
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/parachuting.md
+++ b/content/src/webflow-licenses/parachuting.md
@@ -11,4 +11,5 @@ webflowIndustry: Parachuting
 divisionPhone: (609) 530-2913
 webflowId: 5f7729682edc676014b4a706
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/transportation/"
 ---

--- a/content/src/webflow-licenses/paramedic.md
+++ b/content/src/webflow-licenses/paramedic.md
@@ -11,4 +11,5 @@ webflowIndustry: Paramedic
 divisionPhone: (609) 633-7777
 webflowId: 5f77294a5ef8c176ff019ec3
 licenseCertificationClassification: CERTIFICATE
+agencyWebsite: "https://www.nj.gov/health/ems/"
 ---

--- a/content/src/webflow-licenses/pawnbroker.md
+++ b/content/src/webflow-licenses/pawnbroker.md
@@ -11,4 +11,5 @@ webflowIndustry: Pawnbroker
 divisionPhone: (609) 292-7272
 webflowId: 5f77292b8150be1726f3be24
 licenseCertificationClassification: PERMIT
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/payroll-records.md
+++ b/content/src/webflow-licenses/payroll-records.md
@@ -11,4 +11,5 @@ webflowIndustry: Payroll Records
 divisionPhone: (609) 292-9664
 webflowId: 5f772952ef49623c3846d0de
 licenseCertificationClassification: PERMIT
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/pet-store.md
+++ b/content/src/webflow-licenses/pet-store.md
@@ -11,4 +11,5 @@ webflowIndustry: Pet Store
 divisionPhone: (908) 735-6200
 webflowId: 5f772916d9d23748de6f48b8
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/phlebotomy-blood-bank.md
+++ b/content/src/webflow-licenses/phlebotomy-blood-bank.md
@@ -11,4 +11,5 @@ webflowIndustry: Phlebotomy
 divisionPhone: (866) 534-7789
 webflowId: 5f7729ab862dc1b2e9be49a8
 licenseCertificationClassification: LICENSE/NATIONAL CERTIFICATION
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/phone-wiring.md
+++ b/content/src/webflow-licenses/phone-wiring.md
@@ -10,4 +10,5 @@ webflowIndustry: Telephone Wiring
 licenseCertificationClassification: CONTACT
 divisionPhone: (973)504-6410
 webflowId: 5f7729b015a3950288f71660
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/physical-therapist-assistant.md
+++ b/content/src/webflow-licenses/physical-therapist-assistant.md
@@ -11,4 +11,5 @@ webflowIndustry: Physical Therapist Assistant
 divisionPhone: (973)504-6455
 webflowId: 5f7729c1d20a7f5a503604e6
 licenseCertificationClassification: REGISTRATION/LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/physicist.md
+++ b/content/src/webflow-licenses/physicist.md
@@ -11,4 +11,5 @@ webflowIndustry: Physicist
 divisionPhone: (866) 534-7789
 webflowId: 5f77291aecb74e8cbd23aacc
 licenseCertificationClassification: CERTIFICATION
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/pilot.md
+++ b/content/src/webflow-licenses/pilot.md
@@ -10,4 +10,5 @@ webflowIndustry: Pilot
 licenseCertificationClassification: LICENSE
 divisionPhone: (866) 635-5322
 webflowId: 5f7728de240061a8637834b6
+agencyWebsite: "https://www.faa.gov/"
 ---

--- a/content/src/webflow-licenses/planned-parenthood-organization.md
+++ b/content/src/webflow-licenses/planned-parenthood-organization.md
@@ -10,4 +10,5 @@ webflowIndustry: Planned Parenthood Organization
 licenseCertificationClassification: LICENSE & CERTIFICATE OF NEED
 divisionPhone: (609) 984-7574
 webflowId: 5f7728dbe10dec3afb024f0e
+agencyWebsite: "http://www.plannedparenthood.org/"
 ---

--- a/content/src/webflow-licenses/planned-unit-development.md
+++ b/content/src/webflow-licenses/planned-unit-development.md
@@ -11,4 +11,5 @@ webflowIndustry: Planned Unit
 divisionPhone: ""
 webflowId: 5f7729c2862dc1ec04be49a9
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/planner-in-training.md
+++ b/content/src/webflow-licenses/planner-in-training.md
@@ -11,4 +11,5 @@ webflowIndustry: Planner In-Training
 divisionPhone: (973) 504-6465
 webflowId: 5f7729c3a67e4a059f5c0f3a
 licenseCertificationClassification: CERTIFICATE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/plant-exporter-export-to-foreign-countries.md
+++ b/content/src/webflow-licenses/plant-exporter-export-to-foreign-countries.md
@@ -11,4 +11,5 @@ webflowIndustry: Plant Exporter
 divisionPhone: (609) 406-6939
 webflowId: 5f7728e390d9ac73241306f5
 licenseCertificationClassification: CERTIFICATE OF INSPECTION
+agencyWebsite: "https://www.nj.gov/agriculture/"
 ---

--- a/content/src/webflow-licenses/plants-buy-out-of-state-to-seed-in-nj.md
+++ b/content/src/webflow-licenses/plants-buy-out-of-state-to-seed-in-nj.md
@@ -11,4 +11,5 @@ webflowIndustry: Plants
 divisionPhone: (609) 406-6939
 webflowId: 5f7728e42edc678a57b4a6fd
 licenseCertificationClassification: CERTIFICATE
+agencyWebsite: "https://www.nj.gov/agriculture/"
 ---

--- a/content/src/webflow-licenses/police.md
+++ b/content/src/webflow-licenses/police.md
@@ -11,4 +11,5 @@ webflowIndustry: Police
 divisionPhone: (609) 376-2800
 webflowId: 5f7729630b0d002834f25227
 licenseCertificationClassification: CERTIFICATION
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/practical-nurse.md
+++ b/content/src/webflow-licenses/practical-nurse.md
@@ -11,4 +11,5 @@ webflowIndustry: Practical Nurse
 divisionPhone: (973) 504-6430
 webflowId: 5f7729cbebae0c00632b868f
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/preferred-provider-organization.md
+++ b/content/src/webflow-licenses/preferred-provider-organization.md
@@ -11,4 +11,5 @@ webflowIndustry: Preferred Provider Organization
 divisionPhone: (609) 292-5427
 webflowId: 5f77292b0b0d001c19f2520c
 licenseCertificationClassification: INFORMATION FILING
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/pressure-vessel.md
+++ b/content/src/webflow-licenses/pressure-vessel.md
@@ -11,4 +11,5 @@ webflowIndustry: Pressure Vessel
 divisionPhone: (609) 292-2345
 webflowId: 5f77295290d9accc911309dc
 licenseCertificationClassification: LICENSE/FILING
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/principal.md
+++ b/content/src/webflow-licenses/principal.md
@@ -11,4 +11,5 @@ webflowIndustry: Principal
 divisionPhone: (609) 292-2070
 webflowId: 5f772933da6f6013a55a75f0
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/private-detective-investigator.md
+++ b/content/src/webflow-licenses/private-detective-investigator.md
@@ -11,4 +11,5 @@ webflowIndustry: Private Detective
 divisionPhone: (609) 882-2000
 webflowId: 5f77296338625456e5bb0e47
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/produce-dealer-wholesale-dealer-in-hay-grain-straw-eggs-poultry-fruits-and-vegetables.md
+++ b/content/src/webflow-licenses/produce-dealer-wholesale-dealer-in-hay-grain-straw-eggs-poultry-fruits-and-vegetables.md
@@ -12,4 +12,5 @@ webflowIndustry: Produce Dealer
 divisionPhone: (609) 292-5651
 webflowId: 5f7728e5147ced6a7326bf2e
 licenseCertificationClassification: LICENSE/BOND
+agencyWebsite: "https://www.nj.gov/agriculture/"
 ---

--- a/content/src/webflow-licenses/professional-librarian-school.md
+++ b/content/src/webflow-licenses/professional-librarian-school.md
@@ -11,4 +11,5 @@ webflowIndustry: Librarian
 divisionPhone: (609) 292-2070
 webflowId: 5f7729339a1bb8710db3b913
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/proprietary-school-adult.md
+++ b/content/src/webflow-licenses/proprietary-school-adult.md
@@ -11,4 +11,5 @@ webflowIndustry: Adult School
 divisionPhone: (609) 292-7272
 webflowId: 5f7729525ddf762af53ac436
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/prosecutors-detectives-investigators.md
+++ b/content/src/webflow-licenses/prosecutors-detectives-investigators.md
@@ -11,4 +11,5 @@ webflowIndustry: Prosecutors Detectives and Investigators
 divisionPhone: (609) 984-6500
 webflowId: 5f772963614a2d1694d207b1
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/public-adjuster.md
+++ b/content/src/webflow-licenses/public-adjuster.md
@@ -11,4 +11,5 @@ webflowIndustry: Public Adjuster
 divisionPhone: (609) 292-4337
 webflowId: 5f77292b4ad0ae0e6ba54a52
 licenseCertificationClassification: LICENSE/REGISTRATION
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/public-utilities.md
+++ b/content/src/webflow-licenses/public-utilities.md
@@ -11,4 +11,5 @@ webflowIndustry: Public Utility
 divisionPhone: (800) 624-0331
 webflowId: 5f7728ef9491d596b2036b50
 licenseCertificationClassification: APPROVAL
+agencyWebsite: "https://www.nj.gov/bpu/"
 ---

--- a/content/src/webflow-licenses/pump-installer.md
+++ b/content/src/webflow-licenses/pump-installer.md
@@ -12,4 +12,5 @@ webflowIndustry: Pump Installer
 divisionPhone: (609) 984-6831
 webflowId: 5f77291ac8aaf5e912c9b52a
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/race-regatta.md
+++ b/content/src/webflow-licenses/race-regatta.md
@@ -11,4 +11,5 @@ webflowIndustry: Race Regatta
 divisionPhone: (609) 882-2000  6173
 webflowId: 5f7729649491d5352b036b58
 licenseCertificationClassification: PERMIT
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/radiation-producing-machines.md
+++ b/content/src/webflow-licenses/radiation-producing-machines.md
@@ -11,4 +11,5 @@ webflowIndustry: Radiation Machine
 divisionPhone: (609) 984-5890
 webflowId: 5f77291bef4962087946d0d7
 licenseCertificationClassification: LICENSE/REGISTRATION
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/radio-station.md
+++ b/content/src/webflow-licenses/radio-station.md
@@ -10,4 +10,5 @@ webflowIndustry: Radio Station
 licenseCertificationClassification: LICENSE
 divisionPhone: ""
 webflowId: 5f7728dfeb5558675efeb56c
+agencyWebsite: "https://www.fcc.gov/"
 ---

--- a/content/src/webflow-licenses/radio-therapy-technologist.md
+++ b/content/src/webflow-licenses/radio-therapy-technologist.md
@@ -11,4 +11,5 @@ webflowIndustry: Radio Therapy Technologist
 divisionPhone: (609) 984-5890
 webflowId: 5f77291be02294838beaa5ad
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/radiologic-technologist.md
+++ b/content/src/webflow-licenses/radiologic-technologist.md
@@ -11,4 +11,5 @@ webflowIndustry: Radiologic Technologist
 divisionPhone: (609) 984-5890
 webflowId: 5f77291b614a2d58ced207a2
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/radon-measurement-specialist-technician.md
+++ b/content/src/webflow-licenses/radon-measurement-specialist-technician.md
@@ -11,4 +11,5 @@ webflowIndustry: Radon Measurement
 divisionPhone: (609) 984-5400
 webflowId: 5f77291ceb55581b71feb59b
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/radon-mitigation-specialist-technician.md
+++ b/content/src/webflow-licenses/radon-mitigation-specialist-technician.md
@@ -11,4 +11,5 @@ webflowIndustry: Radon Mitigation
 divisionPhone: (609) 984-5400
 webflowId: 5f77291d8fbb2228a36ec084
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/radon.md
+++ b/content/src/webflow-licenses/radon.md
@@ -11,4 +11,5 @@ webflowIndustry: Radon
 divisionPhone: (609) 984-5400
 webflowId: 5f77291be8bf50896431789a
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/rates-property-casualty.md
+++ b/content/src/webflow-licenses/rates-property-casualty.md
@@ -11,4 +11,5 @@ webflowIndustry: Insurance Rates
 divisionPhone: (609) 984-7310
 webflowId: 5f77292c2edc6719c2b4a702
 licenseCertificationClassification: APPROVAL
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/rating-organization.md
+++ b/content/src/webflow-licenses/rating-organization.md
@@ -11,4 +11,5 @@ webflowIndustry: Rating Organization
 divisionPhone: (609) 984-7310
 webflowId: 5f77292cb4710f244c3c37b2
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/reading-specialist.md
+++ b/content/src/webflow-licenses/reading-specialist.md
@@ -11,4 +11,5 @@ webflowIndustry: Reading
 divisionPhone: (609) 292-2070
 webflowId: 5f7729351a0809490fbb2ec9
 licenseCertificationClassification: CERTIFICATION
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/real-estate-corp-partnership-other-entity.md
+++ b/content/src/webflow-licenses/real-estate-corp-partnership-other-entity.md
@@ -11,4 +11,5 @@ webflowIndustry: Real Estate
 divisionPhone: (609) 292-7272
 webflowId: 5f77292d486eeb38adc2560f
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/real-estate-instructor.md
+++ b/content/src/webflow-licenses/real-estate-instructor.md
@@ -11,4 +11,5 @@ webflowIndustry: Real Estate
 divisionPhone: (609) 292-7272
 webflowId: 5f77292dc8aaf5061fc9b52c
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/real-estate-school-non-public.md
+++ b/content/src/webflow-licenses/real-estate-school-non-public.md
@@ -11,4 +11,5 @@ webflowIndustry: Real Estate
 divisionPhone: (609) 292-7272
 webflowId: 5f77292eef4962ad0546d0d8
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/recycling-transfer-station.md
+++ b/content/src/webflow-licenses/recycling-transfer-station.md
@@ -11,4 +11,5 @@ webflowIndustry: Recycling Transfer Station
 divisionPhone: (609) 292-5855
 webflowId: 5f77291db4710faf9d3c37b0
 licenseCertificationClassification: PERMIT
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/red-seal.md
+++ b/content/src/webflow-licenses/red-seal.md
@@ -11,4 +11,5 @@ webflowIndustry: Red Seal
 divisionPhone: (609) 292-2345
 webflowId: 5f772953eb555847e8feb5a0
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/registered-environmental-health-specialty.md
+++ b/content/src/webflow-licenses/registered-environmental-health-specialty.md
@@ -11,4 +11,5 @@ webflowIndustry: Registered Environmental Health
 divisionPhone: (609) 292-4993
 webflowId: 5f772945386254aba0bb0e43
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/registered-nurse.md
+++ b/content/src/webflow-licenses/registered-nurse.md
@@ -11,4 +11,5 @@ webflowIndustry: Registered Nurse
 divisionPhone: (973) 504-6430
 webflowId: 5f7729d63e1b77676efb8f81
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/rehabilitation-hospital.md
+++ b/content/src/webflow-licenses/rehabilitation-hospital.md
@@ -12,4 +12,5 @@ webflowIndustry: Rehabilitation Hospital
 divisionPhone: (609) 292-5960
 webflowId: 5f772945e022948cdceaa5c6
 licenseCertificationClassification: LICENSE/CERTIFICATE OF NEED
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/repossession-motor-vehicles.md
+++ b/content/src/webflow-licenses/repossession-motor-vehicles.md
@@ -11,4 +11,5 @@ webflowIndustry: Vehicle Repossession
 divisionPhone: (609) 292-6500  5070
 webflowId: 5f772958c68adf14704cdc18
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/mvc/"
 ---

--- a/content/src/webflow-licenses/residences-for-disabled.md
+++ b/content/src/webflow-licenses/residences-for-disabled.md
@@ -11,4 +11,5 @@ webflowIndustry: Community Residence
 divisionPhone: (609) 984-5321
 webflowId: 5f77294c5adcc8cf56b64a7e
 licenseCertificationClassification: LICENSE TO OPERATE
+agencyWebsite: "https://www.nj.gov/humanservices/"
 ---

--- a/content/src/webflow-licenses/residential-facilities-for-children.md
+++ b/content/src/webflow-licenses/residential-facilities-for-children.md
@@ -11,4 +11,5 @@ webflowIndustry: Children Residential Facilities
 divisionPhone: (609) 826-3999
 webflowId: 5f7728f728e8553dc61958bf
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dcf/"
 ---

--- a/content/src/webflow-licenses/respiratory-care-practitioner.md
+++ b/content/src/webflow-licenses/respiratory-care-practitioner.md
@@ -11,4 +11,5 @@ webflowIndustry: Respiratory Care
 divisionPhone: (973) 504-6485
 webflowId: 5f7729d6a2f6f897c680c685
 licenseCertificationClassification: REGISTRATION/LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/sales-finance-company.md
+++ b/content/src/webflow-licenses/sales-finance-company.md
@@ -11,4 +11,5 @@ webflowIndustry: Sales Finance Company
 divisionPhone: "(609) 292-5340 #3"
 webflowId: 5f77292eeb55586ce2feb59d
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/school-nurse.md
+++ b/content/src/webflow-licenses/school-nurse.md
@@ -11,4 +11,5 @@ webflowIndustry: School Nurse
 divisionPhone: (609) 292-2070
 webflowId: 5f7729365ddf76c0d73ac433
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/school-social-worker.md
+++ b/content/src/webflow-licenses/school-social-worker.md
@@ -11,4 +11,5 @@ webflowIndustry: School Social Worker
 divisionPhone: (609) 292-2070
 webflowId: 5f7729364bc777816ba6e238
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/secondary-mortgage-loan-company.md
+++ b/content/src/webflow-licenses/secondary-mortgage-loan-company.md
@@ -11,4 +11,5 @@ webflowIndustry: Secondary Mortgage Company
 divisionPhone: (609) 292-7272
 webflowId: 5f77292eef4962202a46d0d9
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/securities.md
+++ b/content/src/webflow-licenses/securities.md
@@ -11,4 +11,5 @@ webflowIndustry: Securities
 divisionPhone: (973) 504-3600
 webflowId: 5f7729da9491d5234f036b5f
 licenseCertificationClassification: REGISTRATION
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/seed-wholesaler.md
+++ b/content/src/webflow-licenses/seed-wholesaler.md
@@ -11,4 +11,5 @@ webflowIndustry: Seed Wholesale
 divisionPhone: (609) 947-7512
 webflowId: 5f7728e6eb55585c5afeb56d
 licenseCertificationClassification: CERTIFICATE OF VARIETAL PURITY
+agencyWebsite: "https://www.nj.gov/agriculture/"
 ---

--- a/content/src/webflow-licenses/sewer-company-public.md
+++ b/content/src/webflow-licenses/sewer-company-public.md
@@ -11,4 +11,5 @@ webflowIndustry: Sewer Company
 divisionPhone: (800) 624-0331
 webflowId: 5f7728f18fbb2273166ec082
 licenseCertificationClassification: APPROVAL
+agencyWebsite: "https://www.nj.gov/bpu/"
 ---

--- a/content/src/webflow-licenses/sewerage-treatment-plant-operator.md
+++ b/content/src/webflow-licenses/sewerage-treatment-plant-operator.md
@@ -11,4 +11,5 @@ webflowIndustry: Sewage Treatment Plant
 divisionPhone: (609) 984-6507
 webflowId: 5f77291e4ad0ae9777a54a50
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/shellfish-special-permit-programs.md
+++ b/content/src/webflow-licenses/shellfish-special-permit-programs.md
@@ -11,4 +11,5 @@ webflowIndustry: Shellfish Program
 divisionPhone: ""
 webflowId: 5f77291e3862541895bb0e3f
 licenseCertificationClassification: PERMIT
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/sheltered-workshop.md
+++ b/content/src/webflow-licenses/sheltered-workshop.md
@@ -11,4 +11,5 @@ webflowIndustry: Sheltered Workshop
 divisionPhone: (609) 292-1704
 webflowId: 5f772954a6bfb5ef0702ee05
 licenseCertificationClassification: CERTIFICATE
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/sludge-hauling.md
+++ b/content/src/webflow-licenses/sludge-hauling.md
@@ -11,4 +11,5 @@ webflowIndustry: Sludge Hauling
 divisionPhone: (609) 633-1418
 webflowId: 5f77291e2f04da696758b5ea
 licenseCertificationClassification: CERTIFICATE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/small-loan-company.md
+++ b/content/src/webflow-licenses/small-loan-company.md
@@ -11,4 +11,5 @@ webflowIndustry: Small Loan Company
 divisionPhone: (609) 292-7272
 webflowId: 5f77292feb55581183feb59f
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/social-worker-licensed.md
+++ b/content/src/webflow-licenses/social-worker-licensed.md
@@ -11,4 +11,5 @@ webflowIndustry: Social Worker
 divisionPhone: (973) 504-6495
 webflowId: 5f7729dc1b42b9eccdbf1ce3
 licenseCertificationClassification: REGISTRATION/LICENSE
+agencyWebsite: "https://www.njconsumeraffairs.gov/"
 ---

--- a/content/src/webflow-licenses/soft-drinks.md
+++ b/content/src/webflow-licenses/soft-drinks.md
@@ -12,4 +12,5 @@ webflowIndustry: Soft Drink
 divisionPhone: (609) 826-4935
 webflowId: 5f772946e10decf478024f18
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/solid-waste-facility.md
+++ b/content/src/webflow-licenses/solid-waste-facility.md
@@ -11,4 +11,5 @@ webflowIndustry: Solid Waste Facility
 divisionPhone: (609) 292-7081
 webflowId: 5f77291f486eeb6579c2560e
 licenseCertificationClassification: CERTIFICATE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/solid-waste.md
+++ b/content/src/webflow-licenses/solid-waste.md
@@ -11,4 +11,5 @@ webflowIndustry: Solid Waste
 divisionPhone: (609) 633-1418
 webflowId: 5f77291f4bc7777822a6e235
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/special-education.md
+++ b/content/src/webflow-licenses/special-education.md
@@ -11,4 +11,5 @@ webflowIndustry: Special Education
 divisionPhone: (609) 292-2070
 webflowId: 5f7729368075e80042a8d93f
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/special-officer.md
+++ b/content/src/webflow-licenses/special-officer.md
@@ -11,4 +11,5 @@ webflowIndustry: Special Officer
 divisionPhone: (609) 984-0960
 webflowId: 5f7729642edc6760a2b4a705
 licenseCertificationClassification: CERTIFICATE
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/statistical-organization.md
+++ b/content/src/webflow-licenses/statistical-organization.md
@@ -11,4 +11,5 @@ webflowIndustry: Statistical Organization
 divisionPhone: (609) 984-7310
 webflowId: 5f77292f862dc1148cbe49a0
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dobi/"
 ---

--- a/content/src/webflow-licenses/student-personnel-services.md
+++ b/content/src/webflow-licenses/student-personnel-services.md
@@ -11,4 +11,5 @@ webflowIndustry: Student Personnel Services
 divisionPhone: (609) 292-2070
 webflowId: 5f772936a6bfb5096202ee00
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/stuffed-products-pillows-mattresses-plush-toys-etc.md
+++ b/content/src/webflow-licenses/stuffed-products-pillows-mattresses-plush-toys-etc.md
@@ -12,4 +12,5 @@ webflowIndustry: Stuffed Products
 divisionPhone: (609) 826-4941
 webflowId: 5f7729469a1bb85893b3b916
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/teacher-business-education.md
+++ b/content/src/webflow-licenses/teacher-business-education.md
@@ -11,4 +11,5 @@ webflowIndustry: Business Education Teacher
 divisionPhone: (609) 292-2070
 webflowId: 5f7729375adbb9bb4e052d66
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/teacher-of-agricultural-occupations.md
+++ b/content/src/webflow-licenses/teacher-of-agricultural-occupations.md
@@ -11,4 +11,5 @@ webflowIndustry: Teacher of Agriculture Occupations
 divisionPhone: (609) 292-2070
 webflowId: 5f772937e0229428f1eaa5c4
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/teacher-of-allied-health-occupations.md
+++ b/content/src/webflow-licenses/teacher-of-allied-health-occupations.md
@@ -11,4 +11,5 @@ webflowIndustry: Teacher of Allied Health Occupations
 divisionPhone: (609) 292-2070
 webflowId: 5f7729379491d57317036b54
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/teacher-of-data-processing.md
+++ b/content/src/webflow-licenses/teacher-of-data-processing.md
@@ -11,4 +11,5 @@ webflowIndustry: Teacher of Data Processing
 divisionPhone: (609) 292-2070
 webflowId: 5f7729388e9f87feb06859b7
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/teacher-of-handicapped.md
+++ b/content/src/webflow-licenses/teacher-of-handicapped.md
@@ -11,4 +11,5 @@ webflowIndustry: Teacher of Handicapped
 divisionPhone: (609) 292-2070
 webflowId: 5f772938c68adf80a14cdc12
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/teacher-of-military-science.md
+++ b/content/src/webflow-licenses/teacher-of-military-science.md
@@ -11,4 +11,5 @@ webflowIndustry: Teacher of Military Science
 divisionPhone: (609) 292-2070
 webflowId: 5f7729382edc67b82eb4a703
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/teacher-of-part-time-adult-evening-vocational.md
+++ b/content/src/webflow-licenses/teacher-of-part-time-adult-evening-vocational.md
@@ -11,4 +11,5 @@ webflowIndustry: Teacher of Vocational Occupations
 divisionPhone: (609) 292-2070
 webflowId: 5f7729388075e89585a8d940
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/teacher-of-practical-nursing.md
+++ b/content/src/webflow-licenses/teacher-of-practical-nursing.md
@@ -11,4 +11,5 @@ webflowIndustry: Teacher of Practical Nursing
 divisionPhone: (609) 292-2070
 webflowId: 5f77293990d9ac342c1309d9
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/teacher-of-production-personal-or-service-occupations.md
+++ b/content/src/webflow-licenses/teacher-of-production-personal-or-service-occupations.md
@@ -11,4 +11,5 @@ webflowIndustry: Teacher of Occupations
 divisionPhone: (609) 292-2070
 webflowId: 5f772939ef4962a21746d0dc
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/teacher-of-technical-occupations.md
+++ b/content/src/webflow-licenses/teacher-of-technical-occupations.md
@@ -11,4 +11,5 @@ webflowIndustry: Teacher of Technical Occupations
 divisionPhone: (609) 292-2070
 webflowId: 5f772939e8bf50b6f031789e
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/teacher-of-typewriting.md
+++ b/content/src/webflow-licenses/teacher-of-typewriting.md
@@ -11,4 +11,5 @@ webflowIndustry: Teacher of Typewriting
 divisionPhone: (609) 292-2070
 webflowId: 5f77293a9a1bb837ccb3b915
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/teacher-of-vocational-arts-dance.md
+++ b/content/src/webflow-licenses/teacher-of-vocational-arts-dance.md
@@ -11,4 +11,5 @@ webflowIndustry: Teacher of Vocational Arts and Dance
 divisionPhone: (609) 292-2070
 webflowId: 5f77293adf77de7f3ae1a4c4
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/teacher-special-education.md
+++ b/content/src/webflow-licenses/teacher-special-education.md
@@ -11,4 +11,5 @@ webflowIndustry: Teacher of Special Education
 divisionPhone: (609) 292-2070
 webflowId: 5f77293becb74e1a5123aad0
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/teacher.md
+++ b/content/src/webflow-licenses/teacher.md
@@ -11,4 +11,5 @@ webflowIndustry: Teacher
 divisionPhone: (609) 292-2070
 webflowId: 5f772937a67e4a20b95c0f35
 licenseCertificationClassification: CERTIFICATION
+agencyWebsite: "https://www.nj.gov/education/"
 ---

--- a/content/src/webflow-licenses/technical-school-adult.md
+++ b/content/src/webflow-licenses/technical-school-adult.md
@@ -11,4 +11,5 @@ webflowIndustry: Technical School
 divisionPhone: (609) 292-7272
 webflowId: 5f77295428e8559bb31958c2
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/labor/"
 ---

--- a/content/src/webflow-licenses/thoroughbred-race-horse-owner-occupations.md
+++ b/content/src/webflow-licenses/thoroughbred-race-horse-owner-occupations.md
@@ -10,4 +10,5 @@ webflowIndustry: Thoroughbred Race Horse
 licenseCertificationClassification: LICENSE
 divisionPhone: (609) 504-6370
 webflowId: 5f772965b4710f3d183c37bc
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/toxicology-laboratory.md
+++ b/content/src/webflow-licenses/toxicology-laboratory.md
@@ -11,4 +11,5 @@ webflowIndustry: Toxicology Laboratory
 divisionPhone: (609) 292-3950
 webflowId: 5f772921eb55581671feb59c
 licenseCertificationClassification: CERTIFICATION
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/toys-manufacture.md
+++ b/content/src/webflow-licenses/toys-manufacture.md
@@ -10,4 +10,5 @@ webflowIndustry: Toy Manufacture
 licenseCertificationClassification: APPROVAL
 divisionPhone: (800) 638-2772
 webflowId: 5f7728dcf17efb1a0ceefb2e
+agencyWebsite: "https://www.cpsc.gov/"
 ---

--- a/content/src/webflow-licenses/tractor-trailer-driving-school.md
+++ b/content/src/webflow-licenses/tractor-trailer-driving-school.md
@@ -11,4 +11,5 @@ webflowIndustry: Tractor Trailer Driving School
 divisionPhone: (609) 292-6500  5094
 webflowId: 5f77295bdf77de1d22e1a527
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/mvc/"
 ---

--- a/content/src/webflow-licenses/training-court-asbestos-abatement.md
+++ b/content/src/webflow-licenses/training-court-asbestos-abatement.md
@@ -11,4 +11,5 @@ webflowIndustry: Asbestos Training
 divisionPhone: (609) 631-6749
 webflowId: 5f772946b4710f78ac3c37b9
 licenseCertificationClassification: CERTIFICATE, COMPLETE TRAINING
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/transport-ambulance-service.md
+++ b/content/src/webflow-licenses/transport-ambulance-service.md
@@ -11,4 +11,5 @@ webflowIndustry: Ambulance
 divisionPhone: (609) 633-7777
 webflowId: 5f77294ac68adf067d4cdc15
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/ems/"
 ---

--- a/content/src/webflow-licenses/travel-agency.md
+++ b/content/src/webflow-licenses/travel-agency.md
@@ -10,4 +10,5 @@ webflowIndustry: Agency
 licenseCertificationClassification: FOR RULES & REGULATIONS/CONTACT
 divisionPhone: (305) 264-7772 ext. 318
 webflowId: 5f7728df71c49e2d73913b7c
+agencyWebsite: "https://www.iata.org/"
 ---

--- a/content/src/webflow-licenses/underground-storage-tank-firm.md
+++ b/content/src/webflow-licenses/underground-storage-tank-firm.md
@@ -11,4 +11,5 @@ webflowIndustry: Underground Storage Tank
 divisionPhone: (609) 984-6831
 webflowId: 5f772921e02294681beaa5ae
 licenseCertificationClassification: CERTIFICATION
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/underground-storage-tank-individuals.md
+++ b/content/src/webflow-licenses/underground-storage-tank-individuals.md
@@ -11,4 +11,5 @@ webflowIndustry: Underground Storage Tank
 divisionPhone: (609) 984-6831
 webflowId: 5f7729212f04da35ff58b5eb
 licenseCertificationClassification: CERTIFICATION
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/warehouses-refrigerated-or-wholesale.md
+++ b/content/src/webflow-licenses/warehouses-refrigerated-or-wholesale.md
@@ -11,4 +11,5 @@ webflowIndustry: Warehouse
 divisionPhone: (609) 826-4941
 webflowId: 5f77294790d9ac7ae51309da
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/water-laboratory.md
+++ b/content/src/webflow-licenses/water-laboratory.md
@@ -11,4 +11,5 @@ webflowIndustry: Water Laboratory
 divisionPhone: (609) 292-3950
 webflowId: 5f7729220b0d005e26f25209
 licenseCertificationClassification: CERTIFICATION
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/water-supply-and-wastewater-operator.md
+++ b/content/src/webflow-licenses/water-supply-and-wastewater-operator.md
@@ -11,4 +11,5 @@ webflowIndustry: Water Supply and Wastewater
 divisionPhone: (609) 777-1013
 webflowId: 5f7729228150be7347f3be22
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/wic-women-infant-children.md
+++ b/content/src/webflow-licenses/wic-women-infant-children.md
@@ -11,4 +11,5 @@ webflowIndustry: WIC
 divisionPhone: (866) 446-5942
 webflowId: 5f7729473862542f6abb0e44
 licenseCertificationClassification: REGISTRATION TO ACCEPT WIC
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/content/src/webflow-licenses/wildlife.md
+++ b/content/src/webflow-licenses/wildlife.md
@@ -11,4 +11,5 @@ webflowIndustry: Wildlife
 divisionPhone: (908) 735-6200
 webflowId: 5f772922e10dec2d9c024f15
 licenseCertificationClassification: CONTACT
+agencyWebsite: "https://www.nj.gov/dep/"
 ---

--- a/content/src/webflow-licenses/wine-making-home.md
+++ b/content/src/webflow-licenses/wine-making-home.md
@@ -11,4 +11,5 @@ webflowIndustry: Wine Making
 divisionPhone: (609) 984-2830
 webflowId: 5f7729650b0d004991f25228
 licenseCertificationClassification: PERMIT
+agencyWebsite: "https://www.nj.gov/oag/"
 ---

--- a/content/src/webflow-licenses/youth-camp.md
+++ b/content/src/webflow-licenses/youth-camp.md
@@ -11,4 +11,5 @@ webflowIndustry: Youth Camp
 divisionPhone: (609) 826-4941
 webflowId: 5f772947f17efbb3c0eefb37
 licenseCertificationClassification: LICENSE
+agencyWebsite: "https://www.nj.gov/health/"
 ---

--- a/packages/content-types/src/license.ts
+++ b/packages/content-types/src/license.ts
@@ -20,10 +20,12 @@ export interface License {
   industry?: string;
   /** Summary description markdown rendered in the card body. */
   summaryDescriptionMd?: string;
-  /** Resolved agency display name (no URL — TaskAgency has no link field). */
+  /** Resolved agency display name. */
   agency?: string;
   /** Agency division / additional context. */
   division?: string;
+  /** Agency website URL; the agency name links to this when present. */
+  agencyWebsite?: string;
   /** Division phone number. */
   divisionPhone?: string;
   /** Primary CTA button label. */

--- a/packages/static-site/components/learn/LicenseCard.test.tsx
+++ b/packages/static-site/components/learn/LicenseCard.test.tsx
@@ -71,6 +71,34 @@ describe("LicenseCard", () => {
     expect(screen.queryByText(/,/)).not.toBeInTheDocument();
   });
 
+  it("links the agency name to the agency website, keeping the division as plain text", () => {
+    renderCard({
+      license: license({
+        agency: "Department of Agriculture",
+        division: "Division of Animal Health",
+        agencyWebsite: "https://www.nj.gov/agriculture/",
+      }),
+    });
+    const link = screen.getByRole("link", { name: "Department of Agriculture" });
+    expect(link).toHaveAttribute("href", "https://www.nj.gov/agriculture/");
+    // External agency site opens in a new tab, matching the published site and
+    // the sibling funding card convention.
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noreferrer");
+    // The division stays plain text, not part of the link.
+    expect(screen.getByText(/, Division of Animal Health/)).toBeInTheDocument();
+  });
+
+  it("renders the agency name as plain text when there is no agency website", () => {
+    renderCard({
+      license: license({ agency: "Federal Trade Commission", agencyWebsite: undefined }),
+    });
+    expect(
+      screen.queryByRole("link", { name: "Federal Trade Commission" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/Federal Trade Commission/)).toBeInTheDocument();
+  });
+
   it("prefixes agency with the account_balance icon and phone with the phone icon", () => {
     const { container } = renderCard();
     const hrefs = [...container.querySelectorAll("use")].map((u) => u.getAttribute("href"));

--- a/packages/static-site/components/learn/LicenseCard.tsx
+++ b/packages/static-site/components/learn/LicenseCard.tsx
@@ -35,9 +35,11 @@ const LicenseCard = ({ license, messages, query = "" }: Props) => {
   const rehypePlugins = query.trim() ? [makeHighlightPlugin(query)] : [];
   const whoItsFor = whoItsForLabel(license.webflowType, messages.whoItsForLabels);
   const industry = presentValue(license.industry);
-  // The agency line is the resolved agency name and its additional context
-  // (division), comma-joined when both are present, matching the published site.
-  const agencyLine = [license.agency, license.division].filter(Boolean).join(", ");
+  // The agency line shows the resolved agency name followed by its additional
+  // context (division), comma-separated. Matching the published site, the agency
+  // name links to the agency website when one is present; the division stays
+  // plain text.
+  const hasAgencyLine = Boolean(license.agency || license.division);
   const showCallToAction =
     license.callToActionLink !== undefined &&
     !hasUnresolvedTemplate(license.callToActionLink) &&
@@ -72,17 +74,27 @@ const LicenseCard = ({ license, messages, query = "" }: Props) => {
             {stripContentDirectives(license.summaryDescriptionMd)}
           </Markdown>
         )}
-        {license.summaryDescriptionMd && (agencyLine || license.divisionPhone) && (
+        {license.summaryDescriptionMd && (hasAgencyLine || license.divisionPhone) && (
           <hr className="border-base-light border-top-1px margin-x-0 margin-y-1" />
         )}
-        {agencyLine && (
+        {hasAgencyLine && (
           <p className="margin-bottom-1 display-flex flex-align-start">
             <Icon
               iconName="account_balance"
               className="text-primary nj-margin-inline-end-05 nj-icon-text-top"
             />
             <span>
-              <strong>{messages.cardAgencyLabel}</strong> {agencyLine}
+              <strong>{messages.cardAgencyLabel}</strong>{" "}
+              {license.agency &&
+                (license.agencyWebsite ? (
+                  <a href={license.agencyWebsite} rel="noreferrer" target="_blank">
+                    {license.agency}
+                  </a>
+                ) : (
+                  license.agency
+                ))}
+              {license.agency && license.division && ", "}
+              {license.division}
             </span>
           </p>
         )}

--- a/shared/src/static/loadAllLicenses.ts
+++ b/shared/src/static/loadAllLicenses.ts
@@ -14,6 +14,7 @@ export interface WebflowLicenseCard {
   callToActionText?: string;
   agencyId?: string;
   agencyAdditionalContext?: string;
+  agencyWebsite?: string;
   divisionPhone?: string;
   industryId?: string;
   webflowType?: string;

--- a/web/decap-config/collections/06-tasks.yml
+++ b/web/decap-config/collections/06-tasks.yml
@@ -367,6 +367,13 @@ collections:
           widget: "string",
           required: false,
         }
+      - {
+          label: "Agency Website (Static Site License Cards)",
+          name: "agencyWebsite",
+          widget: "string",
+          required: false,
+          hint: "URL the agency name links to on the license card.",
+        }
       - { label: "Form Name", name: "formName", widget: "string", required: false }
       - label: "Type (Webflow)"
         name: "webflowType"
@@ -481,6 +488,13 @@ collections:
           widget: "string",
           required: false,
         }
+      - {
+          label: "Agency Website (Static Site License Cards)",
+          name: "agencyWebsite",
+          widget: "string",
+          required: false,
+          hint: "URL the agency name links to on the license card.",
+        }
       - { label: "Division Phone", name: "divisionPhone", widget: "string", required: false }
       - label: "Type (Webflow)"
         name: "webflowType"
@@ -579,6 +593,13 @@ collections:
           name: "agencyAdditionalContext",
           widget: "string",
           required: false,
+        }
+      - {
+          label: "Agency Website (Static Site License Cards)",
+          name: "agencyWebsite",
+          widget: "string",
+          required: false,
+          hint: "URL the agency name links to on the license card.",
         }
       - {
           label: "Form Name (Webflow & Navigator)",

--- a/web/package.json
+++ b/web/package.json
@@ -40,7 +40,8 @@
     "webflow:faq-pull": "tsx ./src/scripts/webflow/faqPull.ts",
     "webflow:pages-pull": "tsx ./src/scripts/webflow/pagePull.ts",
     "webflow:recents-pull": "tsx ./src/scripts/webflow/recentPull.ts",
-    "webflow:tropical-storm-ida-pull": "tsx ./src/scripts/webflow/tropicalStormIdaPull.ts"
+    "webflow:tropical-storm-ida-pull": "tsx ./src/scripts/webflow/tropicalStormIdaPull.ts",
+    "webflow:license-department-website-pull": "tsx ./src/scripts/webflow/licenseDepartmentWebsitePull.ts"
   },
   "dependencies": {
     "@aws-crypto/sha256-browser": "5.2.0",

--- a/web/src/scripts/webflow/licenseDepartmentWebsitePull.test.ts
+++ b/web/src/scripts/webflow/licenseDepartmentWebsitePull.test.ts
@@ -1,0 +1,150 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as fs from "fs";
+import { backfill, insertAgencyWebsiteLine } from "./licenseDepartmentWebsitePull";
+
+jest.mock("./methods", () => ({
+  getAllItems: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock("fs", () => ({
+  existsSync: jest.fn().mockReturnValue(true),
+  readdirSync: jest.fn().mockReturnValue([]),
+  readFileSync: jest.fn().mockReturnValue(""),
+  writeFileSync: jest.fn(),
+}));
+
+const mockedFs = jest.mocked(fs);
+
+const fileWithFrontmatter = (frontmatter: string, body = "\nBody text.\n"): string =>
+  `---\n${frontmatter}\n---${body}`;
+
+describe("insertAgencyWebsiteLine", () => {
+  it("adds agencyWebsite as the last frontmatter line, leaving other lines byte-identical", () => {
+    const raw = fileWithFrontmatter("id: adoption-agency\nwebflowId: abc123");
+
+    const result = insertAgencyWebsiteLine(raw, "https://www.nj.gov/njfosteradopt/");
+
+    expect(result).toBe(
+      fileWithFrontmatter(
+        'id: adoption-agency\nwebflowId: abc123\nagencyWebsite: "https://www.nj.gov/njfosteradopt/"',
+      ),
+    );
+  });
+
+  it("uses double quotes, matching the committed content style", () => {
+    const raw = fileWithFrontmatter("id: x");
+
+    const result = insertAgencyWebsiteLine(raw, "https://example.gov/");
+
+    expect(result).toContain('agencyWebsite: "https://example.gov/"');
+  });
+
+  it("escapes embedded double quotes and backslashes so the YAML stays valid", () => {
+    const raw = fileWithFrontmatter("id: x");
+
+    const result = insertAgencyWebsiteLine(raw, 'https://example.gov/a"b\\c');
+
+    expect(result).toContain('agencyWebsite: "https://example.gov/a\\"b\\\\c"');
+  });
+
+  it("returns undefined when the file has no frontmatter fence", () => {
+    expect(
+      insertAgencyWebsiteLine("Just a body, no frontmatter.\n", "https://x.gov/"),
+    ).toBeUndefined();
+  });
+});
+
+describe("backfill", () => {
+  const websitesByWebflowId = new Map<string, string>([
+    ["wf-agriculture", "https://www.nj.gov/agriculture/"],
+  ]);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedFs.existsSync.mockReturnValue(true);
+  });
+
+  const runWith = (files: Record<string, string>): ReturnType<typeof backfill> => {
+    mockedFs.readdirSync.mockReturnValue(Object.keys(files) as any);
+    mockedFs.readFileSync.mockImplementation((filePath) => {
+      const fileName = String(filePath).split("/").pop() as string;
+      return files[fileName];
+    });
+    return backfill(websitesByWebflowId, ["/content/webflow-licenses"]);
+  };
+
+  it("writes the agencyWebsite line for a file whose webflowId has a website", () => {
+    const result = runWith({
+      "animal-dealer.md": fileWithFrontmatter("id: animal-dealer\nwebflowId: wf-agriculture"),
+    });
+
+    expect(result.updated).toBe(1);
+    expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("animal-dealer.md"),
+      expect.stringContaining('agencyWebsite: "https://www.nj.gov/agriculture/"'),
+    );
+  });
+
+  it("skips a file that already has an agencyWebsite, leaving it untouched", () => {
+    const result = runWith({
+      "already.md": fileWithFrontmatter(
+        'id: already\nwebflowId: wf-agriculture\nagencyWebsite: "https://existing.gov/"',
+      ),
+    });
+
+    expect(result.alreadyPresent).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(mockedFs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("counts a file with no webflowId separately from one that matched no website", () => {
+    const result = runWith({
+      "no-id.md": fileWithFrontmatter("id: no-id"),
+      "unmatched.md": fileWithFrontmatter("id: unmatched\nwebflowId: wf-unknown"),
+    });
+
+    expect(result.noWebflowId).toBe(1);
+    expect(result.noWebsite).toBe(1);
+    expect(mockedFs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("counts a matched file whose fence the line inserter can't parse without writing it", () => {
+    // gray-matter parses a CRLF fence, so the file yields a real webflowId, but the
+    // LF-only insert regex rejects it — the guarded path that increments noFence.
+    mockedFs.readdirSync.mockReturnValue(["crlf.md"] as any);
+    mockedFs.readFileSync.mockReturnValue("---\r\nwebflowId: wf-agriculture\r\n---\r\nbody");
+
+    const result = backfill(websitesByWebflowId, ["/content/webflow-licenses"]);
+
+    expect(result.noFence).toBe(1);
+    expect(mockedFs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("skips a directory that does not exist", () => {
+    mockedFs.existsSync.mockReturnValue(false);
+
+    const result = backfill(websitesByWebflowId, ["/missing"]);
+
+    expect(result).toEqual({
+      updated: 0,
+      alreadyPresent: 0,
+      noWebflowId: 0,
+      noWebsite: 0,
+      noFence: 0,
+    });
+  });
+
+  it("only reads .md files", () => {
+    mockedFs.readdirSync.mockReturnValue(["keep.md", "ignore.txt", "notes"] as any);
+    mockedFs.readFileSync.mockReturnValue(
+      fileWithFrontmatter("id: keep\nwebflowId: wf-agriculture"),
+    );
+
+    backfill(websitesByWebflowId, ["/content/webflow-licenses"]);
+
+    const readPaths = mockedFs.readFileSync.mock.calls.map((c) => String(c[0]));
+    expect(readPaths.some((p) => p.endsWith("ignore.txt"))).toBe(false);
+    expect(readPaths.some((p) => p.endsWith("notes"))).toBe(false);
+    expect(readPaths.some((p) => p.endsWith("keep.md"))).toBe(true);
+  });
+});

--- a/web/src/scripts/webflow/licenseDepartmentWebsitePull.ts
+++ b/web/src/scripts/webflow/licenseDepartmentWebsitePull.ts
@@ -1,0 +1,131 @@
+import fs from "fs";
+import matter from "gray-matter";
+import path from "path";
+import { fileURLToPath } from "url";
+import { getAllItems } from "./methods";
+import { WebflowLicenseDataFieldData } from "./types";
+import { licenseCollectionId } from "./webflowIds";
+
+/**
+ * Backfills the `agencyWebsite` frontmatter field on license source files from
+ * Webflow's `department-website` field. The agency name links to this URL on the
+ * Licensing & Certification Guide card. This data originated only in Webflow and
+ * was never carried into our content pipeline; this script folds it in so it can
+ * live in Decap-managed content going forward.
+ *
+ * Files are matched to Webflow items by `webflowId`. The field is inserted as a
+ * single raw line before the closing frontmatter fence so unrelated lines are
+ * left byte-identical.
+ */
+
+const contentRoot = path.resolve(
+  `${path.dirname(fileURLToPath(import.meta.url))}/../../../../content/src`,
+);
+
+const licenseSourceDirectories = [
+  path.join(contentRoot, "webflow-licenses"),
+  path.join(contentRoot, "roadmaps", "license-tasks"),
+  path.join(contentRoot, "roadmaps", "municipal-tasks"),
+  path.join(contentRoot, "roadmaps", "tasks"),
+];
+
+const fetchDepartmentWebsitesByWebflowId = async (): Promise<Map<string, string>> => {
+  const items = await getAllItems<WebflowLicenseDataFieldData & { "department-website"?: string }>(
+    licenseCollectionId,
+  );
+  const websitesByWebflowId = new Map<string, string>();
+  for (const item of items) {
+    const website = item.fieldData["department-website"];
+    if (website) websitesByWebflowId.set(item.id, website);
+  }
+  return websitesByWebflowId;
+};
+
+/**
+ * Inserts `agencyWebsite: "<url>"` as the last frontmatter line, preserving every
+ * other line exactly. Returns undefined when the file has no frontmatter fence.
+ */
+const insertAgencyWebsiteLine = (raw: string, url: string): string | undefined => {
+  const fenceMatch = raw.match(/^---\n([\S\s]*?)\n---/);
+  if (!fenceMatch) return undefined;
+  const frontmatter = fenceMatch[1];
+  const escaped = url.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+  const newFrontmatter = `${frontmatter}\nagencyWebsite: "${escaped}"`;
+  return raw.replace(fenceMatch[0], `---\n${newFrontmatter}\n---`);
+};
+
+interface BackfillResult {
+  updated: number;
+  alreadyPresent: number;
+  noWebflowId: number;
+  noWebsite: number;
+  noFence: number;
+}
+
+const backfill = (
+  websitesByWebflowId: Map<string, string>,
+  directories: readonly string[],
+): BackfillResult => {
+  const result: BackfillResult = {
+    updated: 0,
+    alreadyPresent: 0,
+    noWebflowId: 0,
+    noWebsite: 0,
+    noFence: 0,
+  };
+
+  for (const directory of directories) {
+    if (!fs.existsSync(directory)) continue;
+    for (const fileName of fs.readdirSync(directory).filter((f) => f.endsWith(".md"))) {
+      const filePath = path.join(directory, fileName);
+      const raw = fs.readFileSync(filePath, "utf8");
+      const { data } = matter(raw);
+      const webflowId = typeof data.webflowId === "string" ? data.webflowId : undefined;
+
+      if (!webflowId) {
+        result.noWebflowId += 1;
+        continue;
+      }
+      const url = websitesByWebflowId.get(webflowId);
+      if (!url) {
+        result.noWebsite += 1;
+        continue;
+      }
+      if (data.agencyWebsite !== undefined) {
+        result.alreadyPresent += 1;
+        continue;
+      }
+      const updated = insertAgencyWebsiteLine(raw, url);
+      if (updated === undefined) {
+        result.noFence += 1;
+        continue;
+      }
+      fs.writeFileSync(filePath, updated);
+      result.updated += 1;
+    }
+  }
+
+  return result;
+};
+
+const main = async (): Promise<void> => {
+  const websitesByWebflowId = await fetchDepartmentWebsitesByWebflowId();
+  console.log(`Fetched ${websitesByWebflowId.size} department-website values from Webflow`);
+  const result = backfill(websitesByWebflowId, licenseSourceDirectories);
+  console.log(
+    `Backfill complete: ${result.updated} updated, ${result.alreadyPresent} already present, ` +
+      `${result.noWebflowId} without a webflowId, ${result.noWebsite} matched but with no website, ` +
+      `${result.noFence} without a frontmatter fence`,
+  );
+  /* eslint-disable-next-line unicorn/no-process-exit */
+  process.exit(0);
+};
+
+if (process.env.NODE_ENV !== "test") {
+  // eslint-disable-next-line unicorn/prefer-top-level-await
+  (async (): Promise<void> => {
+    await main();
+  })();
+}
+
+export { backfill, insertAgencyWebsiteLine };


### PR DESCRIPTION
## Description

Links a license's agency name to the agency's website on the Licensing & Certification Guide cards, which matches the current view in Webflow. That URL previously lived only in Webflow's `department-website` field and was never carried into our content pipeline.

Since this PR functions as more of a backfill, it touches a lot of of content files, which added significant bloat to https://github.com/newjersey/navigator.business.nj.gov/pull/12868. Since the `agencyWebsite` is not crucial to the Licenses and Certifications page, I'm adding this as a follow-up PR for clarity.

### Ticket

This is a fast follow to [#17823](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17823).

### Approach

1. Add an `agencyWebsite` field through the pipeline: shared license loader, `License` content type, content build mapper, and the Decap `webflow-licenses`/`license-tasks` CMS collections. `LicenseCard` renders the agency name as a new-tab link when a website is present.
2. One-time backfill: a pull script (`webflow:license-department-website-pull`) matches license source files to Webflow items by `webflowId` and inserts the `agencyWebsite` frontmatter line, populating  directly from Webflow's `department-website` field.
3. Fallback: when a license has no `agencyWebsite` of its own, derive one from its `agencyId` at build time, but only when every license under that `agencyId` shares the same website. This recovers the link for ~88 more licenses without guessing between sub-agency URLs that share an `agencyId` (e.g. `njdep` -> `dep/` vs `bpu/`), which correctly stay plain text. No content files change for this step — it's derived at build time from the license set.

### Steps to Test

1. `yarn build`
2. Visit the Licensing & Certification Guide page and confirm agency names render as links to the agency's website where one is known (e.g. search "Veterinarian" or another license with a populated `agencyWebsite`).
3. Confirm a license whose `agencyId` has ambiguous sub-agency URls (e.g. `njdep`) still renders the agency name as plain text, not a link.
4. Confirm a license with no known website at all (no direct `agencyWebsite` and no unambiguous `agencyId` fallback) renders as plain text.

### Notes

This PR is large in surface area but a vast majority of the files touched are purely frontmatter updates. The logic worth reviewing is in all the non-markdown files

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [ ] ~~I have created and/or updated relevant documentation on the engineering documentation website~~ N/A
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [ ] ~~If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file~~ N/A
- [x] I have checked for and removed instances of unused config from CMS
- [ ] ~~If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)~~ N/A
- [ ] ~~I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces~~ N/A
- [ ] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
