### PR TITLE
feat: [AB#17879]  footer contact us launches intercom

### DIFF
--- a/packages/static-site/app/globals.css
+++ b/packages/static-site/app/globals.css
@@ -232,3 +232,13 @@ li {
 .usa-language__submenu .usa-language__submenu-item {
   border-top: none;
 }
+
+.button-styled-as-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  text-decoration: underline;
+}

--- a/packages/static-site/components/landing/IdentifierSection.tsx
+++ b/packages/static-site/components/landing/IdentifierSection.tsx
@@ -62,6 +62,29 @@ const renderIdentifierRequiredLink = ({ item, index }: RenderIdentifierRequiredL
 };
 
 /**
+ * Renders an Intercom launch button styled as an identifier required link.
+ *
+ * This button maintains the visual appearance of other identifier links while
+ * providing click functionality to open the Intercom chat widget instead of
+ * navigating to a new page.
+ *
+ * @param content The display text for the button.
+ * @returns One `<li>` element containing a styled button for the required links list.
+ */
+const ContactUsIntercomLaunch = (content: string) => {
+  return (
+    <li className="usa-identifier__required-links-item">
+      <button
+        className="usa-identifier__required-link usa-link button-styled-as-link intercomlaunch"
+        type="button"
+      >
+        {content}
+      </button>
+    </li>
+  );
+};
+
+/**
  * Renders the full identifier section from typed content.
  *
  * @param props Component props.
@@ -111,6 +134,7 @@ export const IdentifierSection = ({ content }: IdentifierSectionProps) => {
             {content.requiredLinks.map((item, index) => {
               return renderIdentifierRequiredLink({ item, index });
             })}
+            {ContactUsIntercomLaunch(content.contactUs)}
           </ul>
         </div>
       </nav>

--- a/packages/static-site/domain/content/messageTypes.ts
+++ b/packages/static-site/domain/content/messageTypes.ts
@@ -228,6 +228,8 @@ export interface LayoutIdentifierContent {
   readonly importantLinksAriaLabel: string;
   /** Required links rendered in identifier navigation. */
   readonly requiredLinks: readonly LandingIdentifierRequiredLink[];
+  /** Contact Us button text that launches Intercom when clicked. */
+  readonly contactUs: string;
   /** Accessible label for the U.S. government information section. */
   readonly usGovernmentSectionAriaLabel: string;
   /** Description text rendered in the U.S. government section. */

--- a/packages/static-site/messages/ar-US.json
+++ b/packages/static-site/messages/ar-US.json
@@ -239,14 +239,6 @@
         },
         {
           "link": {
-            "label": "لاختبار هذا",
-            "href": "https://nj.gov/nj/feedback.html",
-            "isInternal": false,
-            "opensInNewTab": false
-          }
-        },
-        {
-          "link": {
             "label": "المحتوى المنتج",
             "href": "https://nj.gov/nj/privacy.html",
             "isInternal": false,
@@ -278,6 +270,7 @@
           }
         }
       ],
+      "contactUs": "لاختبار هذا",
       "usGovernmentSectionAriaLabel": "اليمين الكتابة هذا اليسار الصفحة",
       "usGovernmentDescription": "المنتج اليسار النهائي عربي هذا المحتوى لاختبار"
     }

--- a/packages/static-site/messages/en-US.json
+++ b/packages/static-site/messages/en-US.json
@@ -249,14 +249,6 @@
         },
         {
           "link": {
-            "label": "Contact Us",
-            "href": "https://nj.gov/nj/feedback.html",
-            "isInternal": false,
-            "opensInNewTab": false
-          }
-        },
-        {
-          "link": {
             "label": "Privacy Notice",
             "href": "https://nj.gov/nj/privacy.html",
             "isInternal": false,
@@ -288,6 +280,7 @@
           }
         }
       ],
+      "contactUs": "Contact Us",
       "usGovernmentSectionAriaLabel": "U.S. government information and services",
       "usGovernmentDescription": "Copyright © 2026 State of New Jersey"
     }

--- a/packages/static-site/messages/es-US.json
+++ b/packages/static-site/messages/es-US.json
@@ -249,14 +249,6 @@
         },
         {
           "link": {
-            "label": "Contáctenos",
-            "href": "https://nj.gov/nj/feedback.html",
-            "isInternal": false,
-            "opensInNewTab": false
-          }
-        },
-        {
-          "link": {
             "label": "Aviso de privacidad",
             "href": "https://nj.gov/nj/privacy.html",
             "isInternal": false,
@@ -288,6 +280,7 @@
           }
         }
       ],
+      "contactUs": "Contáctenos",
       "usGovernmentSectionAriaLabel": "Información y servicios del gobierno de EE. UU.",
       "usGovernmentDescription": "Copyright © 2026 Estado de New Jersey"
     }


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
Contact us within the footer now launches intercom. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to provided URL. -->

This pull request resolves [#17879](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17879).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
From my understanding, intercom doesn't launch on our local or dev environments. It only launches on the prod website. 

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
