### PR TITLE
feat: [AB#17886] use Business.NJ.gov logo in static-site footer

### DIFF
--- a/packages/static-site/components/landing/SiteFooter.tsx
+++ b/packages/static-site/components/landing/SiteFooter.tsx
@@ -15,9 +15,9 @@ import type {
 import { LocalizedLink } from "./LocalizedLink";
 
 /**
- * Public path for the synced NJWDS footer logo image.
+ * Public path for the Business.NJ.gov site logo.
  */
-const FOOTER_LOGO_IMAGE_PATH = "/assets/njwds/dist/img/logo-img.png";
+const SITE_LOGO_PATH = "/img/business.NJ.gov-logo.svg";
 
 /**
  * Describes props used by the site footer component.
@@ -142,15 +142,12 @@ export const SiteFooter = ({ content, mainContentId }: SiteFooterProps) => {
               <div className="mobile-lg:grid-col-auto">
                 <Image
                   alt={content.agencyLogoAlt}
-                  className="usa-footer__logo-img"
-                  height={80}
-                  src={FOOTER_LOGO_IMAGE_PATH}
+                  height={50}
+                  src={SITE_LOGO_PATH}
+                  style={{ height: "auto", maxWidth: "100%" }}
                   unoptimized
-                  width={80}
+                  width={200}
                 />
-              </div>
-              <div className="mobile-lg:grid-col-auto">
-                <h2 className="usa-footer__logo-heading">{content.agencyName}</h2>
               </div>
             </div>
             <div className="usa-footer__contact-links mobile-lg:grid-col-6">

--- a/packages/static-site/domain/content/messageTypes.ts
+++ b/packages/static-site/domain/content/messageTypes.ts
@@ -188,8 +188,6 @@ export interface LayoutFooterContent {
   readonly primaryLinks: readonly LandingFooterPrimaryLink[];
   /** Alt text for the agency logo image. */
   readonly agencyLogoAlt: string;
-  /** Agency name heading rendered near the logo. */
-  readonly agencyName: string;
   /** Social links rendered in the footer secondary row. */
   readonly socialLinks: readonly LandingSocialLink[];
   /** Contact heading rendered above phone/email links. */

--- a/packages/static-site/messages/ar-US.json
+++ b/packages/static-site/messages/ar-US.json
@@ -125,7 +125,6 @@
         }
       ],
       "agencyLogoAlt": "الكتابة هذا",
-      "agencyName": "Business.NJ.gov",
       "socialLinks": [
         {
           "modifier": "github",
@@ -179,7 +178,7 @@
       "agencySectionAriaLabel": "إلى تجريبي",
       "stateLogoAlt": "النهائي الكتابة هذا هذا من",
       "agencyLogoAlt": "سيتم النهائي",
-      "domain": "business.nj.gov",
+      "domain": "Business.NJ.gov",
       "disclaimerPrefix": "الكتابة اتجاه في إلى حذفه",
       "disclaimerLink": {
         "label": "في المنتج حذفه في",

--- a/packages/static-site/messages/en-US.json
+++ b/packages/static-site/messages/en-US.json
@@ -135,7 +135,6 @@
         }
       ],
       "agencyLogoAlt": "Business.NJ.gov logo",
-      "agencyName": "Business.NJ.gov",
       "socialLinks": [
         {
           "modifier": "github",
@@ -189,7 +188,7 @@
       "agencySectionAriaLabel": "Agency identifier",
       "stateLogoAlt": "State of New Jersey logo",
       "agencyLogoAlt": "Business.NJ.gov logo",
-      "domain": "business.nj.gov",
+      "domain": "Business.NJ.gov",
       "disclaimerPrefix": "An official website of the",
       "disclaimerLink": {
         "label": "State of New Jersey",

--- a/packages/static-site/messages/es-US.json
+++ b/packages/static-site/messages/es-US.json
@@ -135,7 +135,6 @@
         }
       ],
       "agencyLogoAlt": "Logotipo de Business.NJ.gov",
-      "agencyName": "Business.NJ.gov",
       "socialLinks": [
         {
           "modifier": "github",
@@ -189,7 +188,7 @@
       "agencySectionAriaLabel": "Identificador de la agencia",
       "stateLogoAlt": "Logotipo del estado de New Jersey",
       "agencyLogoAlt": "Logotipo de Business.NJ.gov",
-      "domain": "business.nj.gov",
+      "domain": "Business.NJ.gov",
       "disclaimerPrefix": "Un sitio web oficial del",
       "disclaimerLink": {
         "label": "Estado de New Jersey",

--- a/packages/static-site/scripts/syncNjwdsAssets.ts
+++ b/packages/static-site/scripts/syncNjwdsAssets.ts
@@ -188,10 +188,6 @@ const REQUIRED_NJWDS_ASSETS: readonly RequiredNjwdsAsset[] = [
     description: "NJWDS graphic-list image",
   },
   {
-    relativePath: "img/logo-img.png",
-    description: "NJWDS footer logo image",
-  },
-  {
     relativePath: "img/nj-logo-gray-20.png",
     description: "NJWDS New Jersey logo image",
   },


### PR DESCRIPTION
## Description

Replaces the NJWDS state-seal image placeholder and separate "Business.NJ.gov" heading in the static-site footer with the same Business.NJ.gov logo used in the header. Since the logo already includes the "Business.NJ.gov" text, the separate heading was redundant.

### Ticket

This pull request resolves [#17886](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17886).

### Approach

Straightforward swap from the existing boilerplate code

### Steps to Test

1. Run `pnpm dev` in `packages/static-site` (or visit the deployed preview)
2. Go to any static-site page and scroll to the footer
3. Confirm the Business.NJ.gov logo appears in the footer's secondary section (left side, above the "An official website of..." bar), sized larger than before, with no separate "Business.NJ.gov" heading text next to it
4. Confirm this looks correct in both `en-US` and `es-US` locales

### Notes

N/A

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [ ] ~~I have created and/or updated relevant documentation on the engineering documentation website~~ N/A
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [ ] ~~If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file~~ N/A
- [ ] ~~I have checked for and removed instances of unused config from CMS~~ N/A
- [ ] ~~If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)~~ N/A
- [ ] ~~I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces~~ N/A
- [ ] ~~I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews~~ N/A, small "ship" PR