### PR TITLE
feat: [AB#17863] add `/updates` and individual `/updates/[update-slug]` detail pages

### DIFF
--- a/packages/static-site/app/[locale]/updates/[slug]/page.tsx
+++ b/packages/static-site/app/[locale]/updates/[slug]/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import UpdateDetail from "@/components/learn/UpdateDetail";
+import { loadRecents } from "@/domain/content/loadContent";
+import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
+import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+
+interface PageParams {
+  readonly locale: AppLocale;
+  readonly slug: string;
+}
+
+interface Props {
+  readonly params: Promise<PageParams>;
+}
+
+/**
+ * Generates metadata advertising hreflang alternates for an update's detail page.
+ *
+ * @param props Route props provided by Next.js.
+ * @param props.params Async route params including the slug segment.
+ * @returns Metadata containing canonical and alternate-language links.
+ */
+export const generateMetadata = async ({ params }: Props): Promise<Metadata> => {
+  const { slug } = await params;
+
+  return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: `/updates/${slug}` }) };
+};
+
+export const generateStaticParams = () => loadRecents().map((recent) => ({ slug: recent.slug }));
+
+const UpdateDetailRoute = async ({ params }: Props) => {
+  const { locale, slug } = await params;
+
+  if (!hasAppLocale(locale)) {
+    notFound();
+  }
+
+  const recent = loadRecents().find((item) => item.slug === slug);
+  if (!recent) {
+    notFound();
+  }
+
+  const { updates: messages } = getApplicationMessages({ locale });
+
+  return <UpdateDetail recent={recent} messages={messages} />;
+};
+
+export default UpdateDetailRoute;

--- a/packages/static-site/app/[locale]/updates/page.tsx
+++ b/packages/static-site/app/[locale]/updates/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { UpdatesPage } from "@/components/learn/UpdatesPage";
+import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
+import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
+
+interface PageParams {
+  readonly locale: AppLocale;
+}
+
+interface Props {
+  readonly params: Promise<PageParams>;
+}
+
+/**
+ * Generates metadata advertising hreflang alternates for the updates page.
+ *
+ * @returns Metadata containing canonical and alternate-language links.
+ */
+export const generateMetadata = (): Metadata => {
+  return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: "/updates" }) };
+};
+
+const UpdatesRoute = async ({ params }: Props) => {
+  const { locale } = await params;
+
+  if (!hasAppLocale(locale)) {
+    notFound();
+  }
+
+  return <UpdatesPage locale={locale} />;
+};
+
+export default UpdatesRoute;

--- a/packages/static-site/app/funding.css
+++ b/packages/static-site/app/funding.css
@@ -95,12 +95,15 @@
 
 /* Scrollable checkbox list. The inline-start padding (offset by a negative
    margin to preserve alignment) keeps the focused checkbox's outline from being
-   clipped against the scroll container's inline-start overflow edge. */
+   clipped against the scroll container's inline-start overflow edge. The
+   block-end padding keeps the last checkbox's border from sitting flush
+   against the container's bottom edge, which otherwise reads as cut off. */
 .funding-filter-options {
   max-height: 240px;
   overflow-y: auto;
   padding-inline-start: 6px;
   margin-inline-start: -6px;
+  padding-block-end: 4px;
 }
 
 .funding-search-highlight {
@@ -111,6 +114,16 @@
 .funding-card__heading-link {
   color: inherit;
   text-decoration: underline;
+}
+
+/* NJWDS's `.usa-tag` rule forces text to uppercase and loads after this
+   stylesheet, so a same-specificity override here loses the cascade. The
+   compound selector raises specificity above `.usa-tag` alone to win
+   regardless of load order. Update categories ("Grants and Resources",
+   "Rules and Regulations") are proper nouns meant to display in title case
+   as authored. */
+.usa-tag.updates-category-tag {
+  text-transform: none;
 }
 
 .funding-card__heading-link:hover,

--- a/packages/static-site/components/landing/WhatsNewSection.test.tsx
+++ b/packages/static-site/components/landing/WhatsNewSection.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { WhatsNewContent } from "@/domain/content/messageTypes";
+import type { RecentItem } from "@/domain/content/types";
+import { WhatsNewSection } from "./WhatsNewSection";
+
+const content: WhatsNewContent = {
+  title: "What's New",
+  viewAllLink: {
+    label: "View All Updates",
+    href: "/updates",
+    isInternal: true,
+    opensInNewTab: false,
+  },
+};
+
+const makeRecent = (overrides: Partial<RecentItem> = {}): RecentItem =>
+  ({
+    name: "NJ Ignite",
+    slug: "nj-ignite",
+    date: "2022-07-14",
+    topics: "Grants and Resources",
+    body: "",
+    ...overrides,
+  }) as RecentItem;
+
+describe("WhatsNewSection", () => {
+  it("renders nothing when there are no recents", () => {
+    const { container } = render(<WhatsNewSection content={content} recents={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("links each card to the update's /updates/[slug] detail page", () => {
+    render(<WhatsNewSection content={content} recents={[makeRecent({ slug: "nj-ignite" })]} />);
+    const link = screen.getByRole("link", { name: /NJ Ignite/ });
+    expect(link).toHaveAttribute("href", "/updates/nj-ignite");
+  });
+
+  it("renders the View All Updates link pointing at /updates", () => {
+    render(<WhatsNewSection content={content} recents={[makeRecent()]} />);
+    const link = screen.getByRole("link", { name: "View All Updates" });
+    expect(link).toHaveAttribute("href", "/updates");
+  });
+});

--- a/packages/static-site/components/landing/WhatsNewSection.tsx
+++ b/packages/static-site/components/landing/WhatsNewSection.tsx
@@ -32,8 +32,8 @@ export const WhatsNewSection = ({ content, recents }: WhatsNewSectionProps) => {
 
 const WhatsNewCardElement = (props: { recent: RecentItem }) => {
   return (
-    <li key={props.recent.slug} className="usa-card tablet:grid-col-4">
-      <Link href={`/recent/${props.recent.slug}`}>
+    <li key={props.recent.slug} className="usa-card tablet:grid-col-4 padding-x-1">
+      <Link href={`/updates/${props.recent.slug}`}>
         <div className="usa-card__container">
           <div className="usa-card__header">
             {props.recent.topics && <span className="usa-tag">{props.recent.topics}</span>}

--- a/packages/static-site/components/learn/UpdateDetail.test.tsx
+++ b/packages/static-site/components/learn/UpdateDetail.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { UpdatesPageMessages } from "@/domain/content/messageTypes";
+import type { RecentItem } from "@/domain/content/types";
+import UpdateDetail from "./UpdateDetail";
+
+const messages = {
+  cardUpdatedLabel: "Last Updated",
+  detailCtaFallback: "Learn More",
+  categoryLabels: {
+    "Grants and Resources": "Grants and Resources",
+    "Rules and Regulations": "Rules and Regulations",
+  },
+} as unknown as UpdatesPageMessages;
+
+const recent = (overrides: Partial<RecentItem> = {}): RecentItem =>
+  ({
+    name: "NJ Ignite",
+    slug: "nj-ignite",
+    date: "2022-07-14",
+    topics: "Grants and Resources",
+    status: "Published",
+    body: "NJ Ignite provides rent support for tech startups.",
+    ...overrides,
+  }) as RecentItem;
+
+describe("UpdateDetail", () => {
+  it("renders the update name as an h1", () => {
+    render(<UpdateDetail recent={recent()} messages={messages} />);
+    expect(screen.getByRole("heading", { level: 1, name: "NJ Ignite" })).toBeInTheDocument();
+  });
+
+  it("renders the last-updated date formatted as Month D, YYYY", () => {
+    render(<UpdateDetail recent={recent({ date: "2022-07-14" })} messages={messages} />);
+    expect(screen.getByText(/Last Updated/)).toBeInTheDocument();
+    expect(screen.getByText(/July 14, 2022/)).toBeInTheDocument();
+  });
+
+  it("renders the category tag", () => {
+    render(
+      <UpdateDetail recent={recent({ topics: "Grants and Resources" })} messages={messages} />,
+    );
+    expect(screen.getByText("Grants and Resources")).toBeInTheDocument();
+  });
+
+  it("overrides usa-tag's uppercase transform to keep the category label title case", () => {
+    render(
+      <UpdateDetail recent={recent({ topics: "Grants and Resources" })} messages={messages} />,
+    );
+    expect(screen.getByText("Grants and Resources")).toHaveClass("updates-category-tag");
+  });
+
+  it("renders the body as markdown", () => {
+    render(
+      <UpdateDetail recent={recent({ body: "Some **bold** content." })} messages={messages} />,
+    );
+    expect(screen.getByText("bold")).toBeInTheDocument();
+  });
+
+  it("renders a CTA button using cta-text when both cta-text and cta-link are present", () => {
+    render(
+      <UpdateDetail
+        recent={recent({ "cta-text": "Apply Now", "cta-link": "https://example.com/apply" })}
+        messages={messages}
+      />,
+    );
+    const link = screen.getByRole("link", { name: "Apply Now" });
+    expect(link).toHaveAttribute("href", "https://example.com/apply");
+  });
+
+  it("falls back to detailCtaFallback label when cta-link is present without cta-text", () => {
+    render(
+      <UpdateDetail
+        recent={recent({ "cta-link": "https://example.com/apply" })}
+        messages={messages}
+      />,
+    );
+    expect(screen.getByRole("link", { name: "Learn More" })).toBeInTheDocument();
+  });
+
+  it("does not render a CTA button when cta-link is missing", () => {
+    render(<UpdateDetail recent={recent({ "cta-link": undefined })} messages={messages} />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/packages/static-site/components/learn/UpdateDetail.tsx
+++ b/packages/static-site/components/learn/UpdateDetail.tsx
@@ -1,0 +1,44 @@
+import Markdown from "react-markdown";
+import type { UpdatesPageMessages } from "@/domain/content/messageTypes";
+import type { RecentItem } from "@/domain/content/types";
+import { formatUpdateDate } from "./formatUpdateDate";
+
+interface Props {
+  readonly recent: RecentItem;
+  readonly messages: UpdatesPageMessages;
+}
+
+const UpdateDetail = ({ recent, messages }: Props) => {
+  const ctaLabel = recent["cta-text"] ?? messages.detailCtaFallback;
+
+  return (
+    <article className="grid-container usa-section">
+      <h1>{recent.name}</h1>
+      <div className="margin-bottom-3">
+        {recent.date && (
+          <p className="text-base margin-bottom-1">
+            <strong>{messages.cardUpdatedLabel}</strong> {formatUpdateDate(recent.date)}
+          </p>
+        )}
+        {recent.topics && (
+          <span className="usa-tag bg-primary-lighter text-ink radius-md updates-category-tag">
+            {messages.categoryLabels[recent.topics] ?? recent.topics}
+          </span>
+        )}
+      </div>
+      <Markdown>{recent.body}</Markdown>
+      {recent["cta-link"] && (
+        <a
+          href={recent["cta-link"]}
+          className="usa-button margin-top-3"
+          rel="noreferrer"
+          target="_blank"
+        >
+          {ctaLabel}
+        </a>
+      )}
+    </article>
+  );
+};
+
+export default UpdateDetail;

--- a/packages/static-site/components/learn/UpdatesCard.test.tsx
+++ b/packages/static-site/components/learn/UpdatesCard.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { describe, expect, it } from "vitest";
+import type { UpdatesPageMessages } from "@/domain/content/messageTypes";
+import type { RecentItem } from "@/domain/content/types";
+import UpdatesCard from "./UpdatesCard";
+
+const cardMessages = {
+  cardUpdatedLabel: "Last Updated",
+  cardReadMore: "Read more",
+  categoryLabels: {
+    "Grants and Resources": "Grants and Resources",
+    "Rules and Regulations": "Rules and Regulations",
+  },
+} as unknown as UpdatesPageMessages;
+
+const renderCard = (props: Omit<ComponentProps<typeof UpdatesCard>, "messages">) =>
+  render(<UpdatesCard messages={cardMessages} {...props} />);
+
+const recent = (overrides: Partial<RecentItem> = {}): RecentItem =>
+  ({
+    name: "NJ Ignite",
+    slug: "nj-ignite",
+    date: "2022-07-14",
+    topics: "Grants and Resources",
+    status: "Published",
+    body: "NJ Ignite provides rent support for tech startups that are moving to an approved collaborative workspace.",
+    ...overrides,
+  }) as RecentItem;
+
+describe("UpdatesCard", () => {
+  it("renders the update name as a heading", () => {
+    renderCard({ recent: recent() });
+    expect(screen.getByRole("heading", { name: "NJ Ignite" })).toBeInTheDocument();
+  });
+
+  it("links the heading to the update's detail page", () => {
+    renderCard({ recent: recent({ slug: "nj-ignite" }) });
+    const link = screen.getByRole("link", { name: "NJ Ignite" });
+    expect(link).toHaveAttribute("href", "/updates/nj-ignite");
+  });
+
+  it("renders the last-updated date formatted as Month D, YYYY", () => {
+    renderCard({ recent: recent({ date: "2022-07-14" }) });
+    expect(screen.getByText(/Last Updated/)).toBeInTheDocument();
+    expect(screen.getByText(/July 14, 2022/)).toBeInTheDocument();
+  });
+
+  it("does not render a last-updated line when date is missing", () => {
+    renderCard({ recent: recent({ date: undefined }) });
+    expect(screen.queryByText(/Last Updated/)).not.toBeInTheDocument();
+  });
+
+  it("renders the category tag", () => {
+    renderCard({ recent: recent({ topics: "Grants and Resources" }) });
+    expect(screen.getByText("Grants and Resources")).toBeInTheDocument();
+  });
+
+  it("overrides usa-tag's uppercase transform to keep the category label title case", () => {
+    renderCard({ recent: recent({ topics: "Grants and Resources" }) });
+    expect(screen.getByText("Grants and Resources")).toHaveClass("updates-category-tag");
+  });
+
+  it("does not render a category tag when topics is missing", () => {
+    const { container } = renderCard({ recent: recent({ topics: undefined }) });
+    expect(container.querySelector(".usa-tag")).toBeNull();
+  });
+
+  it("renders a Read more link to the detail page", () => {
+    renderCard({ recent: recent({ slug: "nj-ignite" }) });
+    const readMore = screen.getByRole("link", { name: "Read more" });
+    expect(readMore).toHaveAttribute("href", "/updates/nj-ignite");
+  });
+
+  it("renders the summary as the excerpt when present", () => {
+    renderCard({ recent: recent({ summary: "A short summary.", body: "Full body content." }) });
+    expect(screen.getByText("A short summary.")).toBeInTheDocument();
+    expect(screen.queryByText("Full body content.")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the body as the excerpt when summary is missing", () => {
+    renderCard({ recent: recent({ summary: undefined, body: "Full body content." }) });
+    expect(screen.getByText(/Full body content\./)).toBeInTheDocument();
+  });
+
+  it("highlights a query match in the name", () => {
+    renderCard({ recent: recent({ name: "Grant Program" }), query: "grant" });
+    const heading = screen.getByRole("heading", { name: "Grant Program" });
+    const mark = heading.querySelector("mark.funding-search-highlight");
+    expect(mark).not.toBeNull();
+    expect(mark).toHaveTextContent("Grant");
+  });
+
+  it("renders no highlight marks when no query is given", () => {
+    const { container } = renderCard({ recent: recent() });
+    expect(container.querySelector("mark.funding-search-highlight")).toBeNull();
+  });
+});

--- a/packages/static-site/components/learn/UpdatesCard.tsx
+++ b/packages/static-site/components/learn/UpdatesCard.tsx
@@ -1,0 +1,51 @@
+import Markdown from "react-markdown";
+import type { UpdatesPageMessages } from "@/domain/content/messageTypes";
+import type { RecentItem } from "@/domain/content/types";
+import { Link } from "@/domain/i18n/navigation";
+import { formatUpdateDate } from "./formatUpdateDate";
+import { HighlightedText, makeHighlightPlugin } from "./highlightMatches";
+
+interface Props {
+  readonly recent: RecentItem;
+  readonly messages: UpdatesPageMessages;
+  readonly query?: string;
+}
+
+const UpdatesCard = ({ recent, messages, query = "" }: Props) => {
+  const rehypePlugins = query.trim() ? [makeHighlightPlugin(query)] : [];
+  const excerpt = recent.summary ?? recent.body;
+  const detailHref = `/updates/${recent.slug}`;
+
+  return (
+    <div className="usa-card__container margin-bottom-3">
+      <div className="usa-card__header">
+        <h3 className="usa-card__heading">
+          <Link className="text-ink" href={detailHref}>
+            <HighlightedText text={recent.name} query={query} />
+          </Link>
+        </h3>
+        {recent.date && (
+          <p className="text-base margin-top-1">
+            {messages.cardUpdatedLabel} {formatUpdateDate(recent.date)}
+          </p>
+        )}
+      </div>
+      <hr className="border-base-light border-top-1px margin-x-3 margin-y-1" />
+      <div className="usa-card__body">
+        <Markdown rehypePlugins={rehypePlugins}>{excerpt}</Markdown>
+      </div>
+      <div className="usa-card__footer display-flex flex-justify">
+        <Link href={detailHref} className="text-primary-dark text-bold">
+          {messages.cardReadMore}
+        </Link>
+        {recent.topics && (
+          <span className="usa-tag bg-primary-lighter text-ink radius-md updates-category-tag">
+            {messages.categoryLabels[recent.topics] ?? recent.topics}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default UpdatesCard;

--- a/packages/static-site/components/learn/UpdatesPage.tsx
+++ b/packages/static-site/components/learn/UpdatesPage.tsx
@@ -1,0 +1,19 @@
+import UpdatesPageContent from "@/components/learn/UpdatesPageContent";
+import { loadRecents } from "@/domain/content/loadContent";
+import type { AppLocale } from "@/domain/i18n/locales";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+
+interface Props {
+  readonly locale: AppLocale;
+}
+
+export const UpdatesPage = ({ locale }: Props) => {
+  const recents = loadRecents();
+  const { updates: messages } = getApplicationMessages({ locale });
+
+  return (
+    <div className="grid-container usa-section">
+      <UpdatesPageContent messages={messages} recents={recents} />
+    </div>
+  );
+};

--- a/packages/static-site/components/learn/UpdatesPageContent.test.tsx
+++ b/packages/static-site/components/learn/UpdatesPageContent.test.tsx
@@ -1,0 +1,194 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import type { UpdatesPageMessages } from "@/domain/content/messageTypes";
+import type { RecentItem } from "@/domain/content/types";
+import UpdatesPageContent from "./UpdatesPageContent";
+
+const messages: UpdatesPageMessages = {
+  title: "All Updates",
+  intro: "Learn about new rules, resources, and upcoming changes.",
+  filterHeading: "Filter All Updates",
+  filterSearch: "Search",
+  filterCategory: "Category",
+  categoryLabels: {
+    "Grants and Resources": "Grants and Resources",
+    "Rules and Regulations": "Rules and Regulations",
+  },
+  filterClear: "Clear",
+  filterShowResults: "Show {count} Results",
+  filterReset: "Reset",
+  sortLabel: "Sort by:",
+  sortMostRecent: "Most Recent",
+  sortAZ: "A-Z",
+  sortZA: "Z-A",
+  resultCountShowing: "Showing <bold>{start}–{end}</bold> of {total} Updates",
+  resultCountFiltered:
+    "Showing <bold>{start}–{end}</bold> of {filtered} Updates (of {total} total)",
+  resultCountFilteredEmpty: "0 matching Updates (of {total} total)",
+  filteringByLabel: "Filtering by:",
+  filterSearchChip: 'Search: "{query}"',
+  filterRemoveLabel: "Remove {filter} filter",
+  paginationPrevious: "Previous",
+  paginationNext: "Next",
+  paginationLabel: "Pagination",
+  paginationPageLabel: "Page {page}",
+  cardUpdatedLabel: "Last Updated",
+  cardReadMore: "Read more",
+  detailCtaFallback: "Learn More",
+};
+
+const makeRecent = (name: string, overrides: Partial<RecentItem> = {}): RecentItem =>
+  ({
+    name,
+    slug: name.toLowerCase().replace(/\s+/g, "-"),
+    date: "2022-01-01",
+    topics: "Grants and Resources",
+    status: "Published",
+    body: `Body for ${name}.`,
+    ...overrides,
+  }) as RecentItem;
+
+const makeRecents = (count: number): RecentItem[] =>
+  Array.from({ length: count }, (_, i) => makeRecent(`Update ${String(i + 1).padStart(2, "0")}`));
+
+const renderPage = (recents: RecentItem[]) =>
+  render(<UpdatesPageContent messages={messages} recents={recents} />);
+
+describe("UpdatesPageContent", () => {
+  it("renders the page title", () => {
+    renderPage([]);
+    expect(screen.getByRole("heading", { level: 1, name: "All Updates" })).toBeInTheDocument();
+  });
+
+  it("renders the intro text", () => {
+    renderPage([]);
+    expect(
+      screen.getByText("Learn about new rules, resources, and upcoming changes."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders result count with total updates", () => {
+    const recents = makeRecents(5);
+    renderPage(recents);
+    const countLine = screen.getByText(/Showing/).closest("p");
+    expect(countLine).toHaveTextContent("Showing 1–5 of 5 Updates");
+  });
+
+  it("renders up to 10 cards on the first page", () => {
+    renderPage(makeRecents(15));
+    expect(screen.getAllByRole("heading", { level: 3 })).toHaveLength(10);
+  });
+
+  it("renders next page of cards when Next is clicked", async () => {
+    renderPage(makeRecents(15));
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getAllByRole("heading", { level: 3 })).toHaveLength(5);
+  });
+
+  it("filters live by search query without needing Show Results", async () => {
+    const user = userEvent.setup();
+    renderPage([makeRecent("Alpha Update"), makeRecent("Beta Update")]);
+
+    await user.type(screen.getByRole("searchbox"), "Alpha");
+
+    expect(screen.getByRole("heading", { level: 3, name: "Alpha Update" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { level: 3, name: "Beta Update" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders category checkboxes from categoryLabels", () => {
+    renderPage([]);
+    expect(screen.getByLabelText("Grants and Resources")).toBeInTheDocument();
+    expect(screen.getByLabelText("Rules and Regulations")).toBeInTheDocument();
+  });
+
+  it("filters by category only after Show Results is clicked", async () => {
+    const user = userEvent.setup();
+    const recents = [
+      makeRecent("Grant Update", { topics: "Grants and Resources" }),
+      makeRecent("Rule Update", { topics: "Rules and Regulations" }),
+    ];
+    renderPage(recents);
+
+    // Before Show Results: both cards visible
+    expect(screen.getByText("Grant Update")).toBeInTheDocument();
+    expect(screen.getByText("Rule Update")).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Rules and Regulations"));
+
+    // Pending: still both visible; button count reflects pending = 1
+    expect(screen.getByText("Grant Update")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show 1 Results" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Show 1 Results" }));
+
+    // Applied: only Rule Update visible
+    expect(screen.getByText("Rule Update")).toBeInTheDocument();
+    expect(screen.queryByText("Grant Update")).not.toBeInTheDocument();
+  });
+
+  it("shows a Filtering by chip for an applied category filter", async () => {
+    const user = userEvent.setup();
+    renderPage([makeRecent("Grant Update", { topics: "Grants and Resources" })]);
+
+    expect(screen.queryByText("Filtering by:")).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Grants and Resources"));
+    await user.click(screen.getByRole("button", { name: "Show 1 Results" }));
+
+    expect(screen.getByText("Filtering by:")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Remove Grants and Resources filter" }),
+    ).toBeInTheDocument();
+  });
+
+  it("resets search, category filters, and page on Reset", async () => {
+    const user = userEvent.setup();
+    const recents = [
+      makeRecent("Grant Update", { topics: "Grants and Resources" }),
+      makeRecent("Rule Update", { topics: "Rules and Regulations" }),
+    ];
+    renderPage(recents);
+
+    await user.type(screen.getByRole("searchbox"), "Grant");
+    await user.click(screen.getByLabelText("Rules and Regulations"));
+    await user.click(screen.getByRole("button", { name: "Reset" }));
+
+    expect(screen.getByRole("searchbox")).toHaveValue("");
+    expect(screen.getByLabelText("Rules and Regulations")).not.toBeChecked();
+    expect(screen.getByText("Grant Update")).toBeInTheDocument();
+    expect(screen.getByText("Rule Update")).toBeInTheDocument();
+  });
+
+  it("sorts alphabetically A-Z when selected", async () => {
+    const user = userEvent.setup();
+    renderPage([makeRecent("Zeta"), makeRecent("Alpha"), makeRecent("Mid")]);
+
+    await user.selectOptions(screen.getByLabelText("Sort by:"), "A-Z");
+
+    const headings = screen.getAllByRole("heading", { level: 3 });
+    expect(headings.map((h) => h.textContent)).toEqual(["Alpha", "Mid", "Zeta"]);
+  });
+
+  it("sorts alphabetically Z-A when selected", async () => {
+    const user = userEvent.setup();
+    renderPage([makeRecent("Zeta"), makeRecent("Alpha"), makeRecent("Mid")]);
+
+    await user.selectOptions(screen.getByLabelText("Sort by:"), "Z-A");
+
+    const headings = screen.getAllByRole("heading", { level: 3 });
+    expect(headings.map((h) => h.textContent)).toEqual(["Zeta", "Mid", "Alpha"]);
+  });
+
+  it("sorts by most recent date by default", () => {
+    renderPage([
+      makeRecent("Older", { date: "2020-01-01" }),
+      makeRecent("Newer", { date: "2024-01-01" }),
+    ]);
+
+    const headings = screen.getAllByRole("heading", { level: 3 });
+    expect(headings.map((h) => h.textContent)).toEqual(["Newer", "Older"]);
+  });
+});

--- a/packages/static-site/components/learn/UpdatesPageContent.tsx
+++ b/packages/static-site/components/learn/UpdatesPageContent.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { UpdatesPageMessages } from "@/domain/content/messageTypes";
+import type { RecentItem } from "@/domain/content/types";
+import Pagination from "./Pagination";
+import { renderResultCount } from "./renderResultCount";
+import UpdatesCard from "./UpdatesCard";
+import { usePaginatedScroll } from "./usePaginatedScroll";
+
+const ITEMS_PER_PAGE = 10;
+
+type SortOrder = "recent" | "az" | "za";
+
+interface Props {
+  readonly messages: UpdatesPageMessages;
+  readonly recents: readonly RecentItem[];
+}
+
+const categories = (messages: UpdatesPageMessages): readonly string[] =>
+  Object.keys(messages.categoryLabels);
+
+const matchesCategories = (recent: RecentItem, applied: ReadonlySet<string>): boolean =>
+  applied.size === 0 || (recent.topics !== undefined && applied.has(recent.topics));
+
+const searchableText = (recent: RecentItem): string =>
+  `${recent.name} ${recent.body} ${recent.topics ?? ""} ${recent.agency ?? ""}`.toLowerCase();
+
+const matchesQuery = (text: string, normalizedQuery: string): boolean =>
+  normalizedQuery === "" || text.includes(normalizedQuery);
+
+const sortRecents = (recents: readonly RecentItem[], order: SortOrder): RecentItem[] => {
+  const sorted = [...recents];
+  if (order === "az") {
+    return sorted.sort((a, b) => a.name.localeCompare(b.name));
+  }
+  if (order === "za") {
+    return sorted.sort((a, b) => b.name.localeCompare(a.name));
+  }
+  return sorted.sort((a, b) => (b.date ?? "").localeCompare(a.date ?? ""));
+};
+
+interface FilterChipProps {
+  readonly label: string;
+  readonly removeLabel: string;
+  readonly onRemove: () => void;
+}
+
+const FilterChip = ({ label, removeLabel, onRemove }: FilterChipProps) => (
+  <span className="funding-filter-chip">
+    {label}
+    <button
+      type="button"
+      className="funding-filter-chip__remove"
+      aria-label={removeLabel}
+      onClick={onRemove}
+    >
+      <span aria-hidden="true">×</span>
+    </button>
+  </span>
+);
+
+interface FilteringByBarProps {
+  readonly messages: UpdatesPageMessages;
+  readonly appliedCategories: ReadonlySet<string>;
+  readonly query: string;
+  readonly onRemoveCategory: (category: string) => void;
+  readonly onRemoveQuery: () => void;
+}
+
+const FilteringByBar = ({
+  messages,
+  appliedCategories,
+  query,
+  onRemoveCategory,
+  onRemoveQuery,
+}: FilteringByBarProps) => {
+  if (appliedCategories.size === 0 && query.trim() === "") {
+    return null;
+  }
+
+  const removeLabel = (filterName: string): string =>
+    messages.filterRemoveLabel.replace("{filter}", filterName);
+
+  return (
+    <section
+      aria-label={messages.filteringByLabel}
+      className="funding-filtering-by margin-y-2 padding-2 radius-md bg-primary-lightest border-1px border-primary"
+    >
+      <span className="margin-right-1">{messages.filteringByLabel}</span>
+      {query.trim() !== "" && (
+        <FilterChip
+          key="search"
+          label={messages.filterSearchChip.replace("{query}", query)}
+          removeLabel={removeLabel(messages.filterSearchChip.replace("{query}", query))}
+          onRemove={onRemoveQuery}
+        />
+      )}
+      {categories(messages)
+        .filter((category) => appliedCategories.has(category))
+        .map((category) => {
+          const label = messages.categoryLabels[category];
+          return (
+            <FilterChip
+              key={`category-${category}`}
+              label={label}
+              removeLabel={removeLabel(label)}
+              onRemove={() => onRemoveCategory(category)}
+            />
+          );
+        })}
+    </section>
+  );
+};
+
+const UpdatesPageContent = ({ messages, recents }: Props) => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pendingCategories, setPendingCategories] = useState<ReadonlySet<string>>(new Set());
+  const [appliedCategories, setAppliedCategories] = useState<ReadonlySet<string>>(new Set());
+  const [query, setQuery] = useState("");
+  const [sortOrder, setSortOrder] = useState<SortOrder>("recent");
+  const { resultsRef, handlePageChange } = usePaginatedScroll(setCurrentPage);
+
+  const searchableEntries = useMemo(
+    () => recents.map((recent) => ({ recent, text: searchableText(recent) })),
+    [recents],
+  );
+
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const filteredRecents = useMemo(
+    () =>
+      sortRecents(
+        searchableEntries
+          .filter(
+            ({ recent, text }) =>
+              matchesCategories(recent, appliedCategories) && matchesQuery(text, normalizedQuery),
+          )
+          .map(({ recent }) => recent),
+        sortOrder,
+      ),
+    [searchableEntries, appliedCategories, normalizedQuery, sortOrder],
+  );
+
+  const pendingFiltered = useMemo(
+    () =>
+      searchableEntries.filter(
+        ({ recent, text }) =>
+          matchesCategories(recent, pendingCategories) && matchesQuery(text, normalizedQuery),
+      ),
+    [searchableEntries, pendingCategories, normalizedQuery],
+  );
+
+  const totalPages = Math.max(1, Math.ceil(filteredRecents.length / ITEMS_PER_PAGE));
+  const safePage = Math.min(currentPage, totalPages);
+  const pageStartIndex = (safePage - 1) * ITEMS_PER_PAGE;
+  const pageSlice = filteredRecents.slice(pageStartIndex, safePage * ITEMS_PER_PAGE);
+
+  const resultCount = renderResultCount({
+    start: pageStartIndex + 1,
+    end: pageStartIndex + pageSlice.length,
+    shownCount: pageSlice.length,
+    filteredCount: filteredRecents.length,
+    totalCount: recents.length,
+    messages,
+  });
+  const showResultsLabel = messages.filterShowResults.replace(
+    "{count}",
+    String(pendingFiltered.length),
+  );
+
+  const toggleCategory = (category: string): void => {
+    setPendingCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(category)) {
+        next.delete(category);
+      } else {
+        next.add(category);
+      }
+      return next;
+    });
+  };
+
+  const applyPending = (): void => {
+    setAppliedCategories(new Set(pendingCategories));
+    setCurrentPage(1);
+  };
+
+  const removeCategory = (category: string): void => {
+    setAppliedCategories((prev) => {
+      const next = new Set(prev);
+      next.delete(category);
+      return next;
+    });
+    setPendingCategories((prev) => {
+      const next = new Set(prev);
+      next.delete(category);
+      return next;
+    });
+    setCurrentPage(1);
+  };
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    setQuery(event.target.value);
+    setCurrentPage(1);
+  };
+
+  const removeQuery = (): void => {
+    setQuery("");
+    setCurrentPage(1);
+  };
+
+  const clearPendingCategories = (): void => {
+    setPendingCategories(new Set());
+  };
+
+  const resetAll = (): void => {
+    setPendingCategories(new Set());
+    setAppliedCategories(new Set());
+    setQuery("");
+    setCurrentPage(1);
+  };
+
+  const handleSortChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
+    setSortOrder(event.target.value as SortOrder);
+    setCurrentPage(1);
+  };
+
+  return (
+    <div className="funding-layout layout-wide">
+      <div className="funding-header-col">
+        <h1>{messages.title}</h1>
+        <p className="usa-intro">{messages.intro}</p>
+      </div>
+
+      <aside className="border-1px border-base-lighter padding-3 radius-lg funding-filter-col">
+        <h2>{messages.filterHeading}</h2>
+
+        <div className="margin-y-3 funding-search-field">
+          <label className="usa-label text-bold margin-bottom-1" htmlFor="updates-search">
+            {messages.filterSearch}
+          </label>
+          <input
+            id="updates-search"
+            className="usa-input"
+            type="search"
+            value={query}
+            onChange={handleSearchChange}
+          />
+        </div>
+
+        <hr className="border-base-lighter border-top-1px margin-y-2" />
+        <fieldset className="usa-fieldset margin-bottom-2">
+          <legend className="usa-legend text-bold display-flex flex-justify flex-align-center width-full margin-bottom-1">
+            {messages.filterCategory}
+            <button
+              type="button"
+              className="usa-button usa-button--unstyled font-sans-xs"
+              onClick={clearPendingCategories}
+            >
+              {messages.filterClear}
+            </button>
+          </legend>
+          <div className="funding-filter-options">
+            {categories(messages).map((category) => {
+              const inputId = `category-${category.replace(/\s+/g, "-")}`;
+              return (
+                <div key={category} className="usa-checkbox">
+                  <input
+                    className="usa-checkbox__input"
+                    id={inputId}
+                    type="checkbox"
+                    checked={pendingCategories.has(category)}
+                    onChange={() => toggleCategory(category)}
+                  />
+                  <label className="usa-checkbox__label" htmlFor={inputId}>
+                    {messages.categoryLabels[category]}
+                  </label>
+                </div>
+              );
+            })}
+          </div>
+        </fieldset>
+
+        <hr className="border-base-lighter border-top-1px margin-y-2" />
+
+        <div className="display-flex flex-justify">
+          <button type="button" className="usa-button width-full" onClick={applyPending}>
+            {showResultsLabel}
+          </button>
+          <button
+            type="button"
+            className="usa-button usa-button--outline margin-right-0"
+            onClick={resetAll}
+          >
+            {messages.filterReset}
+          </button>
+        </div>
+      </aside>
+
+      <section
+        ref={resultsRef}
+        tabIndex={-1}
+        aria-label={messages.title}
+        className="funding-results-col"
+      >
+        <FilteringByBar
+          messages={messages}
+          appliedCategories={appliedCategories}
+          query={query}
+          onRemoveCategory={removeCategory}
+          onRemoveQuery={removeQuery}
+        />
+
+        <div className="display-flex flex-justify flex-align-center margin-y-3">
+          <p role="status" aria-live="polite" className="margin-y-0">
+            {resultCount}
+          </p>
+          <div className="display-flex flex-align-center margin-y-0">
+            <label
+              className="usa-label text-bold text-no-wrap margin-right-1 margin-y-0"
+              htmlFor="updates-sort"
+            >
+              {messages.sortLabel}
+            </label>
+            <select
+              id="updates-sort"
+              className="usa-select margin-y-0"
+              value={sortOrder}
+              onChange={handleSortChange}
+            >
+              <option value="recent">{messages.sortMostRecent}</option>
+              <option value="az">{messages.sortAZ}</option>
+              <option value="za">{messages.sortZA}</option>
+            </select>
+          </div>
+        </div>
+
+        <hr className="border-base-lighter border-top-1px margin-y-3" />
+
+        {pageSlice.map((recent) => (
+          <UpdatesCard key={recent.slug} recent={recent} messages={messages} query={query} />
+        ))}
+
+        <Pagination
+          messages={messages}
+          currentPage={safePage}
+          totalPages={totalPages}
+          onPageChange={handlePageChange}
+        />
+      </section>
+    </div>
+  );
+};
+
+export default UpdatesPageContent;

--- a/packages/static-site/components/learn/formatUpdateDate.test.ts
+++ b/packages/static-site/components/learn/formatUpdateDate.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { formatUpdateDate } from "./formatUpdateDate";
+
+describe("formatUpdateDate", () => {
+  it("formats a YYYY-MM-DD date as Month D, YYYY", () => {
+    expect(formatUpdateDate("2026-05-19")).toBe("May 19, 2026");
+  });
+
+  it("does not shift the day across timezones", () => {
+    expect(formatUpdateDate("2026-01-01")).toBe("January 1, 2026");
+    expect(formatUpdateDate("2026-12-31")).toBe("December 31, 2026");
+  });
+
+  it("returns the original string when the date cannot be parsed", () => {
+    expect(formatUpdateDate("not-a-date")).toBe("not-a-date");
+  });
+});

--- a/packages/static-site/components/learn/formatUpdateDate.ts
+++ b/packages/static-site/components/learn/formatUpdateDate.ts
@@ -1,0 +1,19 @@
+/**
+ * Formats a `YYYY-MM-DD` content date as "Month D, YYYY" (e.g. "May 19, 2026").
+ *
+ * Parses as UTC and formats in the UTC timezone so the displayed day never
+ * shifts based on the reader's local timezone offset.
+ */
+export const formatUpdateDate = (date: string): string => {
+  const parsed = new Date(`${date}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    return date;
+  }
+
+  return parsed.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+};

--- a/packages/static-site/components/learn/highlightMatches.test.tsx
+++ b/packages/static-site/components/learn/highlightMatches.test.tsx
@@ -1,6 +1,7 @@
 import { render } from "@testing-library/react";
+import Markdown from "react-markdown";
 import { describe, expect, it } from "vitest";
-import { HighlightedText, splitHighlight } from "./highlightMatches";
+import { HighlightedText, makeHighlightPlugin, splitHighlight } from "./highlightMatches";
 
 describe("splitHighlight", () => {
   it("returns the whole string as one non-match segment for an empty query", () => {
@@ -59,5 +60,30 @@ describe("HighlightedText", () => {
     const { container } = render(<HighlightedText text="Grant Program" query="" />);
     expect(container.querySelector("mark")).toBeNull();
     expect(container).toHaveTextContent("Grant Program");
+  });
+});
+
+describe("makeHighlightPlugin", () => {
+  it("wraps a single match with one mark, not nested marks, when text surrounds the match", () => {
+    const { container } = render(
+      <Markdown rehypePlugins={[makeHighlightPlugin("Alpha")]}>Body for Alpha Update.</Markdown>,
+    );
+    const marks = container.querySelectorAll("mark.funding-search-highlight");
+    expect(marks).toHaveLength(1);
+    expect(marks[0]).toHaveTextContent("Alpha");
+    expect(marks[0].querySelector("mark")).toBeNull();
+  });
+
+  it("wraps each of multiple distinct matches with exactly one mark each", () => {
+    const { container } = render(
+      <Markdown rehypePlugins={[makeHighlightPlugin("grant")]}>
+        Apply for a grant and check the grant status later.
+      </Markdown>,
+    );
+    const marks = container.querySelectorAll("mark.funding-search-highlight");
+    expect(marks).toHaveLength(2);
+    for (const mark of marks) {
+      expect(mark.querySelector("mark")).toBeNull();
+    }
   });
 });

--- a/packages/static-site/components/learn/highlightMatches.tsx
+++ b/packages/static-site/components/learn/highlightMatches.tsx
@@ -1,7 +1,7 @@
 import type { Element, ElementContent, Parents, Root, Text } from "hast";
 import { Fragment, type ReactElement } from "react";
 import type { Node } from "unist";
-import { visitParents } from "unist-util-visit-parents";
+import { SKIP, visitParents } from "unist-util-visit-parents";
 
 export interface HighlightSegment {
   readonly text: string;
@@ -83,5 +83,9 @@ export const makeHighlightPlugin = (query: string) => () => (tree: Root) => {
     );
 
     (parent as Element).children.splice(index, 1, ...replacement);
+    // The replacement nodes (including their <mark> text children) are newly
+    // inserted, not part of the original tree. Without skipping past them,
+    // the visitor would re-visit and re-wrap the same matched text again.
+    return [SKIP, index + replacement.length];
   });
 };

--- a/packages/static-site/domain/content/loadContent.test.ts
+++ b/packages/static-site/domain/content/loadContent.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { generateIndustry } from "@/tests/factories";
-import { loadIndustries } from "./loadContent";
+import { loadIndustries, loadRecents } from "./loadContent";
 
 const enabledIndustry1 = generateIndustry({ isEnabled: true });
 const disabledIndustry = generateIndustry({ isEnabled: false });
@@ -33,5 +33,56 @@ describe("loadIndustries", () => {
 
     expect(industries).toHaveLength(2);
     expect(industries.map((i) => i.id)).toEqual([enabledIndustry1.id, enabledIndustry2.id]);
+  });
+});
+
+const recentMarkdown = (slug: string, status?: string): string => {
+  const frontmatter = [
+    "---",
+    `name: Recent ${slug}`,
+    `slug: ${slug}`,
+    ...(status ? [`status: ${status}`] : []),
+    "---",
+    "Body content",
+  ];
+  return frontmatter.join("\n");
+};
+
+describe("loadRecents", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("only returns recents with status Published", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    vi.spyOn(fs, "readdirSync").mockReturnValue([
+      "published.md",
+      "draft.md",
+      "archived.md",
+    ] as unknown as ReturnType<typeof fs.readdirSync>);
+    vi.spyOn(fs, "readFileSync").mockImplementation((filePath) => {
+      const fileName = filePath.toString();
+      if (fileName.endsWith("published.md")) return recentMarkdown("published", "Published");
+      if (fileName.endsWith("draft.md")) return recentMarkdown("draft", "Draft");
+      if (fileName.endsWith("archived.md")) return recentMarkdown("archived", "Archived");
+      throw new Error(`Unexpected file read: ${fileName}`);
+    });
+
+    const recents = loadRecents();
+
+    expect(recents).toHaveLength(1);
+    expect(recents[0].slug).toBe("published");
+  });
+
+  it("excludes recents with no status set", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    vi.spyOn(fs, "readdirSync").mockReturnValue(["no-status.md"] as unknown as ReturnType<
+      typeof fs.readdirSync
+    >);
+    vi.spyOn(fs, "readFileSync").mockReturnValue(recentMarkdown("no-status"));
+
+    const recents = loadRecents();
+
+    expect(recents).toHaveLength(0);
   });
 });

--- a/packages/static-site/domain/content/loadContent.ts
+++ b/packages/static-site/domain/content/loadContent.ts
@@ -156,7 +156,8 @@ export const loadPages = (): PageItem[] => readMarkdownDirectory<PageItem>("page
 
 export const loadPageBySlug = (slug: string): PageItem => readMarkdownFile<PageItem>("pages", slug);
 
-export const loadRecents = (): RecentItem[] => readMarkdownDirectory<RecentItem>("recents");
+export const loadRecents = (): RecentItem[] =>
+  readMarkdownDirectory<RecentItem>("recents").filter((recent) => recent.status === "Published");
 
 export const loadFaqs = (): FaqItem[] => readMarkdownDirectory<FaqItem>("faqs");
 

--- a/packages/static-site/domain/content/messageTypes.ts
+++ b/packages/static-site/domain/content/messageTypes.ts
@@ -633,6 +633,70 @@ export interface LicensingGuidePageMessages {
 }
 
 /**
+ * Localized content for the Updates page.
+ */
+export interface UpdatesPageMessages {
+  /** Page H1 title. */
+  readonly title: string;
+  /** Intro paragraph below the title. */
+  readonly intro: string;
+  /** Heading for the filter sidebar. */
+  readonly filterHeading: string;
+  /** Label for the search input. */
+  readonly filterSearch: string;
+  /** Label for the category filter group. */
+  readonly filterCategory: string;
+  /**
+   * Display labels for each update category, keyed by its content value
+   * (`topics`). These keys are the source of truth for the listing's category
+   * filter, so they must stay in lockstep with the `topics` vocabulary used in
+   * recents content: a `topics` value with no matching key here is silently
+   * unfilterable and renders untagged.
+   */
+  readonly categoryLabels: Record<string, string>;
+  /** Label for the "Clear" button inside the category fieldset. */
+  readonly filterClear: string;
+  /** Label for the "Show Results" button; {count} is replaced at runtime. */
+  readonly filterShowResults: string;
+  /** Label for the "Reset" button. */
+  readonly filterReset: string;
+  /** Label for the sort dropdown. */
+  readonly sortLabel: string;
+  /** Sort option: newest first by date. */
+  readonly sortMostRecent: string;
+  /** Sort option: alphabetical A-Z by name. */
+  readonly sortAZ: string;
+  /** Sort option: reverse alphabetical Z-A by name. */
+  readonly sortZA: string;
+  /** Unfiltered result-count line; {start}, {end} (range wrapped in <bold>), and {total}. */
+  readonly resultCountShowing: string;
+  /** Filtered result-count line; {start}, {end} (range wrapped in <bold>), {filtered}, and {total}. */
+  readonly resultCountFiltered: string;
+  /** Result-count line when the filtered set is empty; {total}. */
+  readonly resultCountFilteredEmpty: string;
+  /** Label preceding the filter chips ("Filtering by:"). */
+  readonly filteringByLabel: string;
+  /** Chip label for the active search query; {query} is replaced at runtime. */
+  readonly filterSearchChip: string;
+  /** aria-label template for chip remove buttons; {filter} is replaced at runtime. */
+  readonly filterRemoveLabel: string;
+  /** Label for pagination "Previous" control. */
+  readonly paginationPrevious: string;
+  /** Label for pagination "Next" control. */
+  readonly paginationNext: string;
+  /** aria-label for the pagination navigation landmark. */
+  readonly paginationLabel: string;
+  /** aria-label template for a numbered page button; {page} is replaced at runtime. */
+  readonly paginationPageLabel: string;
+  /** Prefix label for the "Last Updated" date on an update card. */
+  readonly cardUpdatedLabel: string;
+  /** Label for the "Read more" link on an update card. */
+  readonly cardReadMore: string;
+  /** Fallback label for the detail-page CTA button when the item has no `cta-text`. */
+  readonly detailCtaFallback: string;
+}
+
+/**
  * Localized content for the 404 (page not found) page.
  */
 export interface PageNotFoundContent {
@@ -844,6 +908,8 @@ export interface ApplicationMessages {
   readonly funding: FundingPageMessages;
   /** Licensing & Certification Guide page content strings. */
   readonly licensingGuide: LicensingGuidePageMessages;
+  /** Updates page content strings. */
+  readonly updates: UpdatesPageMessages;
   /** 404 page content strings and links. */
   readonly pageNotFound: PageNotFoundContent;
   /** Impact report page content strings. */

--- a/packages/static-site/messages/en-US.json
+++ b/packages/static-site/messages/en-US.json
@@ -690,6 +690,37 @@
       "object-vehicle": "Object/Vehicle"
     }
   },
+  "updates": {
+    "title": "All Updates",
+    "intro": "Learn about new rules, resources, and upcoming changes that may affect your business — including critical information and programs for state emergencies.",
+    "filterHeading": "Filter All Updates",
+    "filterSearch": "Search",
+    "filterCategory": "Category",
+    "categoryLabels": {
+      "Grants and Resources": "Grants and Resources",
+      "Rules and Regulations": "Rules and Regulations"
+    },
+    "filterClear": "Clear",
+    "filterShowResults": "Show {count} Results",
+    "filterReset": "Reset",
+    "sortLabel": "Sort by:",
+    "sortMostRecent": "Most Recent",
+    "sortAZ": "A-Z",
+    "sortZA": "Z-A",
+    "resultCountShowing": "Showing <bold>{start}–{end}</bold> of {total} Updates",
+    "resultCountFiltered": "Showing <bold>{start}–{end}</bold> of {filtered} Updates (of {total} total)",
+    "resultCountFilteredEmpty": "0 matching Updates (of {total} total)",
+    "filteringByLabel": "Filtering by:",
+    "filterSearchChip": "Search: \"{query}\"",
+    "filterRemoveLabel": "Remove {filter} filter",
+    "paginationPrevious": "Previous",
+    "paginationNext": "Next",
+    "paginationLabel": "Pagination",
+    "paginationPageLabel": "Page {page}",
+    "cardUpdatedLabel": "Last Updated",
+    "cardReadMore": "Read more",
+    "detailCtaFallback": "Learn More"
+  },
   "pageNotFound": {
     "iconAlt": "404 icon",
     "title": "An Error Occurred",

--- a/packages/static-site/messages/es-US.json
+++ b/packages/static-site/messages/es-US.json
@@ -690,6 +690,37 @@
       "object-vehicle": "Objeto/Vehículo"
     }
   },
+  "updates": {
+    "title": "Todas las Actualizaciones",
+    "intro": "Conozca las nuevas normas, recursos y próximos cambios que puedan afectar su negocio, incluyendo información crítica y programas para emergencias estatales.",
+    "filterHeading": "Filtrar Todas las Actualizaciones",
+    "filterSearch": "Buscar",
+    "filterCategory": "Categoría",
+    "categoryLabels": {
+      "Grants and Resources": "Subvenciones y Recursos",
+      "Rules and Regulations": "Normas y Regulaciones"
+    },
+    "filterClear": "Borrar",
+    "filterShowResults": "Mostrar {count} resultados",
+    "filterReset": "Restablecer",
+    "sortLabel": "Ordenar por:",
+    "sortMostRecent": "Más Reciente",
+    "sortAZ": "A-Z",
+    "sortZA": "Z-A",
+    "resultCountShowing": "Mostrando <bold>{start}–{end}</bold> de {total} actualizaciones",
+    "resultCountFiltered": "Mostrando <bold>{start}–{end}</bold> de {filtered} actualizaciones (de {total} en total)",
+    "resultCountFilteredEmpty": "0 actualizaciones coincidentes (de {total} en total)",
+    "filteringByLabel": "Filtrando por:",
+    "filterSearchChip": "Búsqueda: \"{query}\"",
+    "filterRemoveLabel": "Quitar el filtro {filter}",
+    "paginationPrevious": "Anterior",
+    "paginationNext": "Siguiente",
+    "paginationLabel": "Paginación",
+    "paginationPageLabel": "Página {page}",
+    "cardUpdatedLabel": "Última Actualización",
+    "cardReadMore": "Leer más",
+    "detailCtaFallback": "Más Información"
+  },
   "pageNotFound": {
     "iconAlt": "Ícono de error 404",
     "title": "Se produjo un error",

--- a/packages/static-site/tests/accessibility/updates.a11y.spec.ts
+++ b/packages/static-site/tests/accessibility/updates.a11y.spec.ts
@@ -1,0 +1,62 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+import type { BrowserContext, Page } from "playwright";
+import type { AppLocale } from "@/domain/i18n/locales";
+import { ENABLED_LOCALES } from "@/domain/i18n/locales";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+
+/**
+ * Defines the test context provided by Playwright.
+ */
+interface AccessibilityTestContext {
+  /** Browser page used by the test run. */
+  readonly page: Page;
+  /** Browser context, used to seed cookies before navigation. */
+  readonly context: BrowserContext;
+}
+
+/**
+ * Parameters for creating one locale-specific accessibility test.
+ */
+interface CreateLocaleAccessibilityTestParams {
+  /** Locale to evaluate in the browser accessibility audit. */
+  readonly locale: AppLocale;
+}
+
+/**
+ * Creates a Playwright accessibility test for the Updates listing page, one
+ * per locale.
+ */
+const createLocaleAccessibilityTest = ({ locale }: CreateLocaleAccessibilityTestParams) => {
+  return async ({ page, context }: AccessibilityTestContext) => {
+    const messages = await getApplicationMessages({ locale });
+
+    // Suppress the preferred-language prompt modal so its open/animation state
+    // cannot race with the axe scan, which made other page audits flaky.
+    await context.addCookies([
+      {
+        name: LANGUAGE_PROMPT_DISMISSED_COOKIE,
+        value: "true",
+        url: "http://127.0.0.1:3000",
+      },
+    ]);
+
+    await page.goto(`/${locale}/updates`);
+    await page.getByRole("heading", { level: 1, name: messages.updates.title }).waitFor();
+
+    // `color-contrast` is a pre-existing NJWDS banner/chrome issue present on
+    // every page (it also fails the homepage audit) and is outside this page's
+    // scope. Excluding it keeps this audit focused on the Updates page's own a11y.
+    const results = await new AxeBuilder({ page }).disableRules(["color-contrast"]).analyze();
+
+    expect(results.violations).toEqual([]);
+  };
+};
+
+for (const locale of ENABLED_LOCALES) {
+  test(
+    `updates page has no automated WCAG violations for ${locale}`,
+    createLocaleAccessibilityTest({ locale }),
+  );
+}


### PR DESCRIPTION
## Description

Adds `/updates` and `/updates/[slug]` to the static site, migrating the existing [Webflow "Updates" page](https://business.nj.gov/recent). Reuses the existing Funding/Licensing search-filter-pagination layout: live search, a single category checkbox filter (applied via "Show Results"), a Most Recent/A-Z/Z-A sort dropdown, and the shared `Pagination` component. Wires the homepage "What's New" cards to the new detail route (previously pointed at a `/recent/{slug}` path that was never built).

Builds on the already-merged https://github.com/newjersey/navigator.business.nj.gov/pull/12880, which added the `status` field that `loadRecents()` now filters on (`status === "Published"`). This is what keeps Webflow drafts/archived items out of the public listing and out of static generation entirely (`generateStaticParams` only builds pages for published items).

### Ticket

- This pull request resolves [#17863](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17863).
- Designs found at this [Figma link](https://www.figma.com/design/pk0neG436QNTm805O603Vp/96-100-Business-Experience-Sprint-Designs?node-id=68436-4245&t=zqfwj2vC9XpgAJd3-0).

### Approach

- New routes: `app/[locale]/updates/page.tsx` (listing) and `app/[locale]/updates/[slug]/page.tsx` (detail), follows the scaffolding conventions as other pages.
- Page-specific components:
   - `UpdatesPageContent.tsx` owns the interactive listing state (search, pending vs. applied category filters, sort, pagination) — same UX pattern as the Funding page.
   - `UpdatesCard.tsx` / `UpdateDetail.tsx` render an update's card/full view, including an optional CTA button driven by the content's `cta-text` / `cta-link` frontmatter.
- `formatUpdateDate.ts` formats content dates as "Month D, YYYY", parsed/formatted in UTC so the day can't shift for readers west of UTC.
- Fixed a pre-existing bug in the markdown search-highlight rehype plugin (`highlightMatches.tsx`) that could double-wrap matched text in `<mark>` when the plugin's tree-walker revisited nodes it had just inserted — only surfaced once real update bodies with repeated search terms were running through the plugin.
- New `UpdatesPageMessages` type

No dependency or migration changes.

### Steps to Test

1. From `packages/static-site`, run `pnpm dev` and visit `/en-US/updates`.
2. Confirm the listing shows only published updates, with working search, category filter (check a box, click "Show Results"), and sort dropdown.
3. Search for a term that appears in an update's body text and confirm it's highlighted once, not doubled, in the card excerpt.
4. Click into an update to confirm `/en-US/updates/[slug]` renders the full body, date, category tag, and CTA button (if the item has `cta-link`).
5. From the homepage, confirm a "What's New" card links to `/updates/[slug]` and loads correctly.
6. Repeat steps 2-5 on `/es-US/updates` to confirm Spanish copy renders.
7. Try a slug that doesn't exist (or belongs to a non-Published item) and confirm a 404.

### Notes

Email signup and the site-wide breadcrumb are explicitly out of scope for this story per product direction.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [ ] ~~I have created and/or updated relevant documentation on the engineering documentation website~~ N/A
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [ ] ~~If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file~~ N/A
- [x] I have checked for and removed instances of unused config from CMS
- [ ] ~~If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)~~ N/A
- [ ] ~~I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces~~ N/A
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews