### PR TITLE
feat: [AB#17846] handle static-site legacy redirects

### DIFF
--- a/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.test.tsx
+++ b/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.test.tsx
@@ -19,13 +19,15 @@ vi.mock("@/domain/categories", () => ({
 }));
 
 vi.mock("@/domain/content/loadContent", () => ({
-  loadPageBySlug: (slug: string) => ({
-    slug,
-    name: slug === "funding" ? "Funding" : "Create a Business Plan",
-    category: slug === "funding" ? "grow" : "plan",
-    "sub-heading-text":
-      slug === "funding" ? "Whether you're looking for startup capital..." : undefined,
-  }),
+  loadPages: () => [
+    { slug: "create-a-business-plan", name: "Create a Business Plan", category: "plan" },
+    {
+      slug: "funding",
+      name: "Funding",
+      category: "grow",
+      "sub-heading-text": "Whether you're looking for startup capital...",
+    },
+  ],
   loadIndustries: () => [],
   loadFundings: () => [],
   loadSectors: () => [],
@@ -58,6 +60,19 @@ describe("ContentPage", () => {
     expect(
       screen.getByRole("heading", { level: 1, name: "Create a Business Plan" }),
     ).toBeInTheDocument();
+  });
+});
+
+describe("ContentPage — unknown slug", () => {
+  it("triggers a 404 for a slug with no matching content page", async () => {
+    await expect(
+      ContentPage({
+        params: Promise.resolve({
+          locale: "en-US",
+          slug: "something",
+        }),
+      }),
+    ).rejects.toThrow();
   });
 });
 

--- a/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.tsx
+++ b/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { PageSwitchComponent } from "@/components/learn/PageSwitchComponent";
 import { CATEGORY_HIERARCHY } from "@/domain/categories";
-import { loadPageBySlug } from "@/domain/content/loadContent";
+import { loadPages } from "@/domain/content/loadContent";
 import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
 import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
 
@@ -40,7 +40,10 @@ const ContentPage = async ({ params }: Props) => {
     notFound();
   }
 
-  const page = loadPageBySlug(slug);
+  const page = loadPages().find((item) => item.slug === slug);
+  if (!page) {
+    notFound();
+  }
 
   return <PageSwitchComponent page={page} locale={locale} />;
 };

--- a/packages/static-site/domain/redirects/legacyRedirects.test.ts
+++ b/packages/static-site/domain/redirects/legacyRedirects.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+import { buildLegacyRedirects, type LegacyRedirect } from "./legacyRedirects";
+
+const find = (rules: LegacyRedirect[], source: string): LegacyRedirect | undefined =>
+  rules.find((r) => r.source === source);
+
+const indexOf = (rules: LegacyRedirect[], source: string): number =>
+  rules.findIndex((r) => r.source === source);
+
+describe("buildLegacyRedirects — starter-kit slugs land on the real page", () => {
+  it("routes /starter-kits/:slug* straight to /pages/starter-kits (not the redirect-only /starter-kits)", () => {
+    const rule = find(buildLegacyRedirects(false), "/starter-kits/:slug*");
+    expect(rule?.destination).toBe("/pages/starter-kits");
+  });
+
+  it("never sends a starter-kit source to a destination that re-matches it (no loop)", () => {
+    for (const rule of buildLegacyRedirects(false)) {
+      if (rule.source.startsWith("/starter-kits")) {
+        expect(rule.destination).not.toBe("/starter-kits");
+      }
+    }
+  });
+});
+
+describe("buildLegacyRedirects — /recent topic-page one-offs win over the prefix", () => {
+  it("routes /recent/disposable-bag-ban to the plastic-ban page, before the /recent prefix", () => {
+    const rules = buildLegacyRedirects(false);
+    expect(find(rules, "/recent/disposable-bag-ban")?.destination).toBe("/pages/plastic-ban-law");
+    expect(indexOf(rules, "/recent/disposable-bag-ban")).toBeLessThan(
+      indexOf(rules, "/recent/:slug*"),
+    );
+  });
+
+  it("routes /recent/state-financial-assistance-programs to the covid19 page, before the prefix", () => {
+    const rules = buildLegacyRedirects(false);
+    expect(find(rules, "/recent/state-financial-assistance-programs")?.destination).toBe(
+      "/pages/covid19",
+    );
+    expect(indexOf(rules, "/recent/state-financial-assistance-programs")).toBeLessThan(
+      indexOf(rules, "/recent/:slug*"),
+    );
+  });
+});
+
+describe("buildLegacyRedirects — content-gap one-offs", () => {
+  it("routes the covid workplace-standards page to /pages/covid19", () => {
+    const rule = find(
+      buildLegacyRedirects(false),
+      "/pages/covid-19-required-workplace-health-and-safety-standards",
+    );
+    expect(rule?.destination).toBe("/pages/covid19");
+  });
+
+  it("routes the transferring-or-exiting page to /pages/closing-your-business", () => {
+    const rule = find(buildLegacyRedirects(false), "/pages/transferring-or-exiting-your-business");
+    expect(rule?.destination).toBe("/pages/closing-your-business");
+  });
+});
+
+describe("buildLegacyRedirects — /page/* singular-prefix one-offs", () => {
+  it("routes English /page/impactreport to /impact-report", () => {
+    expect(find(buildLegacyRedirects(false), "/page/impactreport")?.destination).toBe(
+      "/impact-report",
+    );
+  });
+
+  it("routes English /page/trucking to /pages/starter-kits", () => {
+    expect(find(buildLegacyRedirects(false), "/page/trucking")?.destination).toBe(
+      "/pages/starter-kits",
+    );
+  });
+
+  it("auto-generates the /es-us twins to the English page when the flag is OFF", () => {
+    const rules = buildLegacyRedirects(false);
+    expect(find(rules, "/es-us/page/impactreport")?.destination).toBe("/impact-report");
+    expect(find(rules, "/es-us/page/trucking")?.destination).toBe("/pages/starter-kits");
+  });
+
+  it("auto-generates the /es-us twins to the /es-US page when the flag is ON", () => {
+    const rules = buildLegacyRedirects(true);
+    expect(find(rules, "/es-us/page/impactreport")?.destination).toBe("/es-US/impact-report");
+    expect(find(rules, "/es-us/page/trucking")?.destination).toBe("/es-US/pages/starter-kits");
+  });
+
+  it("emits exactly one rule per /es-us/page source (no hand-written duplicate)", () => {
+    const rules = buildLegacyRedirects(false);
+    for (const source of ["/es-us/page/impactreport", "/es-us/page/trucking"]) {
+      expect(rules.filter((r) => r.source === source)).toHaveLength(1);
+    }
+  });
+});
+
+describe("buildLegacyRedirects — prefix rules", () => {
+  it("aggregates English /license/* to the licensing guide with a permanent 308", () => {
+    const rules = buildLegacyRedirects(false);
+    const rule = find(rules, "/license/:slug*");
+    expect(rule).toEqual({
+      source: "/license/:slug*",
+      destination: "/pages/licensing-and-certification-guide",
+      permanent: true,
+    });
+  });
+
+  it("slug-preserves English /recent/* to /updates/*", () => {
+    const rule = find(buildLegacyRedirects(false), "/recent/:slug*");
+    expect(rule?.destination).toBe("/updates/:slug*");
+  });
+
+  it("aggregates English /funding/* to the funding page", () => {
+    const rule = find(buildLegacyRedirects(false), "/funding/:slug*");
+    expect(rule?.destination).toBe("/pages/funding");
+  });
+
+  it("every rule uses permanent: true (308) and never sets statusCode", () => {
+    for (const rule of buildLegacyRedirects(false)) {
+      expect(rule.permanent).toBe(true);
+      expect(rule).not.toHaveProperty("statusCode");
+    }
+  });
+});
+
+describe("buildLegacyRedirects — Spanish routes (flag OFF)", () => {
+  it("emits a lowercase /es-us route for /license/* pointing at the English destination", () => {
+    const rule = find(buildLegacyRedirects(false), "/es-us/license/:slug*");
+    expect(rule?.destination).toBe("/pages/licensing-and-certification-guide");
+  });
+
+  it("emits a lowercase /es-us route for /recent/* preserving slug to the English /updates", () => {
+    const rule = find(buildLegacyRedirects(false), "/es-us/recent/:slug*");
+    expect(rule?.destination).toBe("/updates/:slug*");
+  });
+});
+
+describe("buildLegacyRedirects — Spanish routes (flag ON)", () => {
+  it("routes the /es-us/license route to the /es-US locale destination", () => {
+    const rule = find(buildLegacyRedirects(true), "/es-us/license/:slug*");
+    expect(rule?.destination).toBe("/es-US/pages/licensing-and-certification-guide");
+  });
+
+  it("routes the /es-us/recent route to /es-US/updates/*", () => {
+    const rule = find(buildLegacyRedirects(true), "/es-us/recent/:slug*");
+    expect(rule?.destination).toBe("/es-US/updates/:slug*");
+  });
+});
+
+describe("buildLegacyRedirects — blanket /es-us catch-all", () => {
+  it("strips any unlisted /es-us path to its English equivalent when the flag is OFF", () => {
+    const rule = find(buildLegacyRedirects(false), "/es-us/:path*");
+    expect(rule?.destination).toBe("/:path*");
+    expect(rule?.permanent).toBe(true);
+  });
+
+  it("emits NO /es-us path catch-all when the flag is ON (next-intl renders es-US, case-insensitive)", () => {
+    const rule = find(buildLegacyRedirects(true), "/es-us/:path*");
+    expect(rule).toBeUndefined();
+  });
+
+  it("redirects the bare /es-us root to the English root when the flag is OFF", () => {
+    const rule = find(buildLegacyRedirects(false), "/es-us");
+    expect(rule?.destination).toBe("/");
+    expect(rule?.permanent).toBe(true);
+  });
+
+  it("does NOT redirect the bare /es-us root when the flag is ON (the Spanish page renders)", () => {
+    const rule = find(buildLegacyRedirects(true), "/es-us");
+    expect(rule).toBeUndefined();
+  });
+
+  it("orders the catch-all after every specific /es-us rule so specifics win", () => {
+    const rules = buildLegacyRedirects(false);
+    const catchAllIndex = rules.findIndex((r) => r.source === "/es-us/:path*");
+    const lastSpecificIndex = rules.findLastIndex(
+      (r) => r.source.startsWith("/es-us/") && r.source !== "/es-us/:path*",
+    );
+    expect(catchAllIndex).toBeGreaterThan(lastSpecificIndex);
+  });
+});
+
+describe("buildLegacyRedirects — one-off internal rules", () => {
+  it("maps /category/grow to the /grow hub with a Spanish route", () => {
+    const rules = buildLegacyRedirects(false);
+    expect(find(rules, "/category/grow")?.destination).toBe("/grow");
+    expect(find(rules, "/es-us/category/grow")?.destination).toBe("/grow");
+  });
+
+  it("maps the whole covid cluster to /pages/covid19", () => {
+    const rules = buildLegacyRedirects(false);
+    for (const source of ["/covid", "/covid19", "/reopen", "/covid-19", "/covid-faqs"]) {
+      expect(find(rules, source)?.destination).toBe("/pages/covid19");
+    }
+  });
+
+  it("maps the lone /es/pages/funding legacy row to the funding page (no generated Spanish route)", () => {
+    const rules = buildLegacyRedirects(false);
+    expect(find(rules, "/es/pages/funding")?.destination).toBe("/pages/funding");
+  });
+});
+
+describe("buildLegacyRedirects — starter-kit slugs", () => {
+  it("collapses any starter-kit slug onto the on-site starter-kits page", () => {
+    expect(find(buildLegacyRedirects(false), "/starter-kits/:slug*")?.destination).toBe(
+      "/pages/starter-kits",
+    );
+  });
+
+  it("routes the /es-us starter-kit slug to the /es-US page when multilingual is on", () => {
+    expect(find(buildLegacyRedirects(true), "/es-us/starter-kits/:slug*")?.destination).toBe(
+      "/es-US/pages/starter-kits",
+    );
+  });
+});
+
+describe("buildLegacyRedirects — one-off external rules", () => {
+  it("does NOT locale-rewrite an external destination's Spanish route", () => {
+    const rule = find(buildLegacyRedirects(true), "/es-us/panel");
+    expect(rule?.destination).toBe("https://forms.business.nj.gov/panel/");
+  });
+});
+
+describe("buildLegacyRedirects — impact report", () => {
+  it("maps /impact to the on-site impact-report page", () => {
+    expect(find(buildLegacyRedirects(false), "/impact")?.destination).toBe("/impact-report");
+  });
+});

--- a/packages/static-site/domain/redirects/legacyRedirects.ts
+++ b/packages/static-site/domain/redirects/legacyRedirects.ts
@@ -1,0 +1,217 @@
+/**
+ * Builds the Webflow → static-site legacy redirect table.
+ *
+ * Every internal rule is emitted twice: once for the English (unprefixed) path
+ * and once for the lowercase `/es-us` Spanish path Webflow served. The Spanish
+ * route's destination is flag-aware — English path when multilingual is off,
+ * `/es-US`-prefixed when on. External (`http`) destinations are never rewritten.
+ * When the flag is off, a trailing catch-all strips any remaining `/es-us` path
+ * (and the bare `/es-us` root) to its English equivalent; when on, `next-intl`
+ * already renders `/es-US` so no catch-all is emitted. All rules are permanent
+ * (Next.js emits a 308 HTTP status code) to match the migration's SEO
+ * expectations.
+ */
+
+/** A single legacy redirect entry consumed by `next.config.ts` `redirects()`. */
+export interface LegacyRedirect {
+  readonly source: string;
+  readonly destination: string;
+  /** `permanent: true` makes Next.js emit a 308 HTTP status code. */
+  readonly permanent: true;
+}
+
+/** An internal rule before Spanish-route expansion. `destination` is an app path. */
+interface InternalRule {
+  readonly source: string;
+  readonly destination: string;
+}
+
+const LEGACY_SPANISH_PREFIX = "/es-us";
+const APP_SPANISH_LOCALE_PREFIX = "/es-US";
+
+/**
+ * Prefix and section rules. Aggregate rules drop the slug; /recent preserves it.
+ * A few /recent slugs are legacy article URLs whose content now lives on a topic
+ * page, so they are pinned to that page BEFORE the /recent/:slug* prefix — order
+ * matters because `redirects()` is first-match-wins.
+ */
+const PREFIX_RULES: readonly InternalRule[] = [
+  { source: "/recent", destination: "/updates" },
+  { source: "/recent/disposable-bag-ban", destination: "/pages/plastic-ban-law" },
+  { source: "/recent/state-financial-assistance-programs", destination: "/pages/covid19" },
+  { source: "/recent/:slug*", destination: "/updates/:slug*" },
+  { source: "/license", destination: "/pages/licensing-and-certification-guide" },
+  { source: "/license/:slug*", destination: "/pages/licensing-and-certification-guide" },
+  { source: "/funding", destination: "/pages/funding" },
+  { source: "/funding/:slug*", destination: "/pages/funding" },
+  { source: "/starter-kits/:slug*", destination: "/pages/starter-kits" },
+];
+
+/** Verified one-off rules with a real INTERNAL destination. Given an /es-us route. */
+const ONE_OFF_RULES: readonly InternalRule[] = [
+  // impact report
+  { source: "/impact", destination: "/impact-report" },
+  { source: "/impactreport", destination: "/impact-report" },
+  { source: "/page/impactreport", destination: "/impact-report" },
+  // learn category hubs
+  { source: "/category/grow", destination: "/grow" },
+  { source: "/category/operate", destination: "/operate" },
+  { source: "/category/plan", destination: "/plan" },
+  { source: "/category/start", destination: "/start" },
+  // covid cluster
+  { source: "/covid", destination: "/pages/covid19" },
+  { source: "/covid19", destination: "/pages/covid19" },
+  { source: "/COVID", destination: "/pages/covid19" },
+  { source: "/reopen", destination: "/pages/covid19" },
+  { source: "/covid-19", destination: "/pages/covid19" },
+  { source: "/covid-faqs", destination: "/pages/covid19" },
+  {
+    source: "/covid/check-status-njeda-small-business-emergency-assistance-grant-program",
+    destination: "/pages/covid19",
+  },
+  {
+    source: "/covid/required-workplace-health-and-safety-standards",
+    destination: "/pages/covid19",
+  },
+  {
+    source: "/covid/small-business-emergency-assistance-grant-program",
+    destination: "/pages/covid19",
+  },
+  { source: "/covid/state-financial-assistance-programs", destination: "/pages/covid19" },
+  {
+    source: "/pages/covid-19-required-workplace-health-and-safety-standards",
+    destination: "/pages/covid19",
+  },
+  { source: "/(.*)/articles/3835237(.*)", destination: "/pages/covid19" },
+  // plastic ban
+  { source: "/bags/vendorclearinghouse", destination: "/pages/plastic-ban-law" },
+  { source: "/plastic-ban-law", destination: "/pages/plastic-ban-law" },
+  { source: "/bags/plastic-ban-law", destination: "/pages/plastic-ban-law" },
+  { source: "/bags/vendors", destination: "/pages/plastic-ban-law" },
+  { source: "/bagupnj", destination: "/pages/plastic-ban-law" },
+  { source: "/vendors", destination: "/pages/plastic-ban-law" },
+  { source: "/Vendors", destination: "/pages/plastic-ban-law" },
+  // contracting / exporting
+  { source: "/contracting", destination: "/pages/government-contracting" },
+  { source: "/Contracting", destination: "/pages/government-contracting" },
+  { source: "/exporting", destination: "/pages/exporting" },
+  { source: "/Exporting", destination: "/pages/exporting" },
+  // licensing aggregate synonyms
+  { source: "/licensing", destination: "/pages/licensing-and-certification-guide" },
+  {
+    source: "/licensing-and-certification-guide",
+    destination: "/pages/licensing-and-certification-guide",
+  },
+  // starter-kits aggregate root
+  { source: "/starter-kits", destination: "/pages/starter-kits" },
+  { source: "/trucking", destination: "/pages/starter-kits" },
+  { source: "/page/trucking", destination: "/pages/starter-kits" },
+  // faqs → pages
+  {
+    source:
+      "/faqs/how-do-i-contract-with-the-state-as-a-small-business-minority-or-women-owned-business",
+    destination: "/pages/mwbe",
+  },
+  { source: "/faqs/what-are-new-jerseys-principal-industries", destination: "/pages/starter-kits" },
+  { source: "/archived/faqs", destination: "/" },
+  //Aggregation for "Choose A Business Structure",
+  { source: "/faqs/how-do-i-start-a-nonprofit", destination: "/pages/choose-a-business-structure" },
+  { source: "/pages/c-corporation-c-corp", destination: "/pages/choose-a-business-structure" },
+  { source: "/pages/general-partnership", destination: "/pages/choose-a-business-structure" },
+  {
+    source: "/pages/limited-liability-company-llc",
+    destination: "/pages/choose-a-business-structure",
+  },
+  { source: "/pages/llp-lp", destination: "/pages/choose-a-business-structure" },
+  { source: "/pages/nonprofit", destination: "/pages/choose-a-business-structure" },
+  { source: "/pages/s-corporation-s-corp", destination: "/pages/choose-a-business-structure" },
+  { source: "/pages/sole-proprietorship", destination: "/pages/choose-a-business-structure" },
+  // miscellaneous
+  { source: "/ida/impacted-by-ida", destination: "/updates" },
+  {
+    source: "/pages/transferring-or-exiting-your-business",
+    destination: "/pages/closing-your-business",
+  },
+];
+
+/**
+ * One-off rules whose source is a specific locale prefix OTHER than the
+ * `/es-us` route generator handles (a lone `/es/` legacy row). Emitted verbatim.
+ */
+const LOCALE_SPECIFIC_ONE_OFF_RULES: readonly InternalRule[] = [
+  { source: "/es/pages/funding", destination: "/pages/funding" },
+];
+
+/** One-off rules with an EXTERNAL destination. Given an /es-us route, but never locale-rewritten. */
+const EXTERNAL_ONE_OFF_RULES: readonly InternalRule[] = [
+  { source: "/panel", destination: "https://forms.business.nj.gov/panel/" },
+  { source: "/survey", destination: "https://www.surveymonkey.com/r/ZHQZP25" },
+  { source: "/navigator", destination: "https://account.business.nj.gov/" },
+];
+
+const isExternal = (destination: string): boolean => destination.startsWith("http");
+
+/**
+ * Returns the flag-aware Spanish-route destination for an internal destination.
+ * External URLs pass through unchanged; internal paths gain the `/es-US` locale
+ * prefix only when multilingual is enabled.
+ */
+const spanishDestination = (destination: string, multilingualEnabled: boolean): string => {
+  if (isExternal(destination)) return destination;
+  return multilingualEnabled ? `${APP_SPANISH_LOCALE_PREFIX}${destination}` : destination;
+};
+
+/**
+ * Expands one internal rule into its English rule plus its lowercase `/es-us`
+ * Spanish route, both stamped `permanent: true` (Next.js emits a 308 HTTP
+ * status code).
+ */
+const withSpanishRoute = (rule: InternalRule, multilingualEnabled: boolean): LegacyRedirect[] => [
+  { source: rule.source, destination: rule.destination, permanent: true },
+  {
+    source: `${LEGACY_SPANISH_PREFIX}${rule.source}`,
+    destination: spanishDestination(rule.destination, multilingualEnabled),
+    permanent: true,
+  },
+];
+
+/**
+ * Catches any lowercase `/es-us` request with no specific legacy rule, but only
+ * when multilingual is OFF. In that mode Spanish pages do not exist, so the bare
+ * `/es-us` root redirects to `/` and any `/es-us/<path>` is stripped to its
+ * English equivalent. The `/es-us/:path*` pattern does not match the bare root,
+ * so the root needs its own rule. Both must be emitted LAST so the specific
+ * `/es-us` rules match first.
+ *
+ * When multilingual is ON, no catch-all is emitted: `es-US` is a real locale and
+ * `next-intl` resolves the prefix case-insensitively, so both `/es-us/<path>`
+ * and `/es-US/<path>` already render. A normalizing redirect would be redundant
+ * and, because Next.js `redirects()` also matches case-insensitively, the
+ * canonical `/es-US/<path>` would match the rule and redirect to itself.
+ */
+const spanishCatchAll = (multilingualEnabled: boolean): LegacyRedirect[] => {
+  if (multilingualEnabled) {
+    return [];
+  }
+  return [
+    { source: LEGACY_SPANISH_PREFIX, destination: "/", permanent: true },
+    { source: `${LEGACY_SPANISH_PREFIX}/:path*`, destination: "/:path*", permanent: true },
+  ];
+};
+
+/**
+ * Builds the full legacy redirect table for the given multilingual flag state.
+ *
+ * @param multilingualEnabled Whether `NEXT_PUBLIC_MULTILINGUAL_ENABLED` is on.
+ * @returns Every English rule with its Spanish route, all permanent (Next.js
+ *   emits a 308 HTTP status code).
+ */
+export const buildLegacyRedirects = (multilingualEnabled: boolean): LegacyRedirect[] => {
+  const withSpanishRoutes = [...PREFIX_RULES, ...ONE_OFF_RULES, ...EXTERNAL_ONE_OFF_RULES].flatMap(
+    (rule) => withSpanishRoute(rule, multilingualEnabled),
+  );
+  const localeSpecific = LOCALE_SPECIFIC_ONE_OFF_RULES.map(
+    (rule): LegacyRedirect => ({ ...rule, permanent: true }),
+  );
+  return [...withSpanishRoutes, ...localeSpecific, ...spanishCatchAll(multilingualEnabled)];
+};

--- a/packages/static-site/next.config.ts
+++ b/packages/static-site/next.config.ts
@@ -2,6 +2,7 @@ import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
+import { buildLegacyRedirects } from "./domain/redirects/legacyRedirects";
 
 const withNextIntl = createNextIntlPlugin("./domain/i18n/request.ts");
 const PACKAGE_ROOT_DIRECTORY = dirname(fileURLToPath(import.meta.url));
@@ -12,6 +13,12 @@ const nextConfig: NextConfig = {
   reactCompiler: true,
   turbopack: {
     root: PACKAGE_ROOT_DIRECTORY,
+  },
+  async redirects() {
+    // NEXT_PUBLIC_* is inlined at build time; the redirect table is baked per build.
+    // biome-ignore lint/style/noProcessEnv: build-time flag read, consistent with locales.ts.
+    const multilingualEnabled = process.env.NEXT_PUBLIC_MULTILINGUAL_ENABLED === "true";
+    return buildLegacyRedirects(multilingualEnabled);
   },
 };
 

--- a/packages/static-site/tests/e2e-english-only/redirects.e2e.spec.ts
+++ b/packages/static-site/tests/e2e-english-only/redirects.e2e.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Verifies legacy Webflow URLs redirect to real new-site pages when
+ * NEXT_PUBLIC_MULTILINGUAL_ENABLED is false. Each case follows the redirect and
+ * asserts the final page is 200, not another 404. Also asserts a deliberately
+ * skipped legacy path still 404s (the "404 as signal" set).
+ */
+
+// A real published recents slug — becomes /updates/<slug>.
+const PUBLISHED_UPDATE_SLUG = "new-jersey-liquor-license-transfer-a-guide-for-license-holders";
+
+test.describe("Legacy redirects (English-only mode)", () => {
+  test("/recent redirects to /updates", async ({ page }) => {
+    const response = await page.goto("/recent");
+    expect(response?.status()).toBe(200);
+    expect(new URL(page.url()).pathname).toBe("/updates");
+  });
+
+  test("/recent/<slug> preserves the slug to /updates/<slug>", async ({ page }) => {
+    const response = await page.goto(`/recent/${PUBLISHED_UPDATE_SLUG}`);
+    expect(response?.status()).toBe(200);
+    expect(new URL(page.url()).pathname).toBe(`/updates/${PUBLISHED_UPDATE_SLUG}`);
+  });
+
+  test("/license/<anything> aggregates to the licensing guide", async ({ page }) => {
+    const response = await page.goto("/license/acupuncture-license");
+    expect(response?.status()).toBe(200);
+    expect(new URL(page.url()).pathname).toBe("/pages/licensing-and-certification-guide");
+  });
+
+  test("/es-us/license/<anything> aggregates to the English guide (flag off)", async ({ page }) => {
+    const response = await page.goto("/es-us/license/acupuncture-license");
+    expect(response?.status()).toBe(200);
+    expect(new URL(page.url()).pathname).toBe("/pages/licensing-and-certification-guide");
+  });
+
+  test("/category/grow redirects to the /grow hub", async ({ page }) => {
+    const response = await page.goto("/category/grow");
+    expect(response?.status()).toBe(200);
+    expect(new URL(page.url()).pathname).toBe("/grow");
+  });
+
+  test("/covid19 redirects to /pages/covid19", async ({ page }) => {
+    const response = await page.goto("/covid19");
+    expect(response?.status()).toBe(200);
+    expect(new URL(page.url()).pathname).toBe("/pages/covid19");
+  });
+
+  test("a deliberately skipped legacy path still 404s", async ({ page }) => {
+    const response = await page.goto("/search");
+    expect(response?.status()).toBe(404);
+  });
+});


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Adds Webflow → static-site legacy 308 redirects so old business.nj.gov URLs (English and Spanish) land on real new-site pages instead of 404ing, preserving inbound links, bookmarks, and SEO equity.

Route mappings based on [this exported spreadsheet from Webflow](https://docs.google.com/spreadsheets/d/1N1JiEPuIc1m74tCjJ-eh6bbi8Y2dGoS9vf_6DE9OO0w/edit?gid=500027024#gid=500027024).

### Ticket

This pull request resolves [#17846](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17846).

### Approach

Added a standalone script, `domain/redirects/legacyRedirects.ts`, that generates the redirect mapping from a small rule set and wires it into `next.config.ts` via `async redirects()`:

- **Prefix rules** collapse the high-volume detail sections:
	- `/license/*` to the new licensing and certification page
	- `/funding/*` to the new funding page
	- `/starter-kits/*` to the new starter-kits page
	- `/recent/*` preserves the slug to `/updates/*` (two legacy article slugs are pinned to topic pages ahead of the prefix).
- **One-off rules** cover the rest (category hubs, COVID, plastic-ban, contracting, exporting, business-structure synonyms, `/impact` → `/impact-report`, `/page/*` singular-prefix URLs, etc.).
- Every internal rule gets a lowercase `/es-us` **Spanish route** whose destination is flag-aware of `NEXT_PUBLIC_MULTILINGUAL_ENABLED`:
	- the English page when the flag is off
	- the `/es-US/…` page when on.
	- External destinations are never locale-rewritten. All rules are `permanent: true`, so Next.js emits a **308**.
- **`/es-us` fallback (flag off):** any unlisted `/es-us/<path>` is stripped to its English equivalent, and the bare `/es-us` root → `/`. When the flag is **on**, no catch-all is emitted — `next-intl` resolves the prefix case-insensitively and renders `/es-US` directly (a normalizing redirect would self-loop, since Next's `redirects()` also matches case-insensitively).
- **Unknown `/pages/<slug>`** now renders the 404 page (via `loadPages().find()` + `notFound()`) instead of throwing a 500, matching the `updates/[slug]` route.
- Legacy URLs with no verified new-site destination are intentionally left to 404 so they surface as signals. A triage doc (shared with product) tracks these and the grey-zone URLs still needing a decision.

No dependency, migration, or env changes.

### Steps to Test

From `packages/static-site`:

```bash
NEXT_PUBLIC_MULTILINGUAL_ENABLED=false pnpm build && pnpm start
```

Then check status codes (do not follow redirects; default port 3000):

```bash
curl -sI http://localhost:3000/recent                             # 308 → /updates
curl -sI http://localhost:3000/license/acupuncture-license        # 308 → /pages/licensing-and-certification-guide
curl -sI http://localhost:3000/es-us/license/acupuncture-license  # 308 → /pages/licensing-and-certification-guide (English, flag off)
curl -sI http://localhost:3000/category/grow                      # 308 → /grow
curl -sI http://localhost:3000/starter-kits/food-truck            # 308 → /pages/starter-kits (on-site, single hop)
curl -sI http://localhost:3000/es-us/plan                         # 308 → /plan (unlisted es-us stripped to English, flag off)
curl -sI http://localhost:3000/pages/does-not-exist               # 404 (unknown slug renders the 404 page, not a 500)
curl -sI http://localhost:3000/search                             # 404 (intentionally not redirected)
```

Follow a redirect end-to-end and confirm the final page is 200:

```bash
curl -sIL http://localhost:3000/license/acupuncture-license | grep -iE "^HTTP"
curl -sIL http://localhost:3000/starter-kits/food-truck   | grep -iE "^HTTP"   # single hop → /pages/starter-kits → 200
```

Flag-on Spanish behavior (rebuild with `NEXT_PUBLIC_MULTILINGUAL_ENABLED=true`):

```bash
curl -sI http://localhost:3000/es-us/license/acupuncture-license  # 308 → /es-US/pages/licensing-and-certification-guide
curl -sIL http://localhost:3000/es-US/plan | grep -iE "^HTTP"     # renders (no loop) — next-intl handles the prefix directly
```

Automated coverage: `pnpm test` (unit tests for the builder) and `pnpm test:e2e:english-only` (flag-off redirect e2e).

> Note: a fresh checkout needs `content` built first (`cd content && yarn build`) or the `/pages/*` redirect targets 500 on missing `content/lib/*.json`.

### Notes

- `/license/*` and `/funding/*` aggregate to their guide pages because individual detail pages aren't built on the new site. TBD on if we are actually building the individual pages or just keeping the top-level redirects as the new pattern moving forward. Deep-linking to individual licenses is a follow-up if those pages get built (requires reconciling old Webflow slugs against new-site slugs).
- Starter-kit slugs collapse onto the single `/pages/starter-kits` page (the old per-kit `account.business.nj.gov` external URLs are no longer used — all kit traffic stays on-site).
- With the flag **off**, `/es-us/…` routes send Spanish users to the English page; with it **on**, they go to the real `/es-US/…` page. `next-intl` resolves `/es-us` vs `/es-US` case-insensitively, so a flag-on normalizing redirect would self-loop — hence no catch-all in that mode.
- Redirects use `permanent: true`, so Next.js emits a `308` — the canonical permanent redirect, which preserves the request method (unlike the method-coercing `301`) and matches the ticket and SEO expectations. They run before the `proxy.ts`/next-intl middleware, so lowercase `/es-us/…` paths match before locale routing.
- Cross-checked the full 1,704-row compiled redirect spreadsheet against the shipped table: **1,617 exact matches, 0 mismatches** (remaining rows are unchanged paths that correctly don't redirect, or intentional 404s). Triage of the undecided rows is shared with product.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [ ] ~~I have created and/or updated relevant documentation on the engineering documentation website~~ N/A
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [ ] ~~If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file~~ N/A
- [ ] ~~I have checked for and removed instances of unused config from CMS~~ N/A
- [ ] ~~If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)~~ N/A
- [ ] ~~I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces~~ N/A
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews

