### PR TITLE
feat: [AB#17903] temporarily remove the Feedback Widget

### DIFF
--- a/packages/static-site/app/[locale]/page.tsx
+++ b/packages/static-site/app/[locale]/page.tsx
@@ -11,7 +11,6 @@ import Script from "next/script";
 
 import { BroughtToYouBySection } from "@/components/landing/BroughtToYouBySection";
 import { CtaBannerSection } from "@/components/landing/CtaBannerSection";
-import { FeedbackBar } from "@/components/landing/FeedbackBar";
 import { HeroSection } from "@/components/landing/HeroSection";
 import { QuickServicesSection } from "@/components/landing/QuickServicesSection";
 import { SupportSection } from "@/components/landing/SupportSection";
@@ -89,7 +88,7 @@ const LocalizedLandingPage = async ({ params }: LocalizedPageProps) => {
       <WhatsNewSection content={messages.landing.whatsNew} recents={recents} />
       <SupportSection content={messages.landing.support} />
       <BroughtToYouBySection content={messages.landing.broughtToYouBy} />
-      <FeedbackBar content={messages.landing.feedbackBar} />
+      {/* <FeedbackBar content={messages.landing.feedbackBar} /> */}
       {
         // biome-ignore lint/style/noProcessEnv: NEXT_PUBLIC_ vars are inlined at build time.
         process.env.NEXT_PUBLIC_SURVEY_MONKEY_ENABLED === "true" && (


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

The Feedback Widget is not working as expected. This work temporarily removes the widget from the homepage until it can be addressed post-launch.

### Ticket

This pull request resolves [#17903](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17903).

### Approach

Commented out the Feedback Widget. This leaves the rest of the structure in place to manage the component so that it can be quickly re-implemented post launch.

### Steps to Test

- Open the application
- Navigate to the home page
- Confirm the widget does not appear

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [X] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
