### PR TITLE
fix: [AB#17919] open starter kit links in a new tab

### DIFF
--- a/packages/static-site/components/learn/IndustrySelector.test.tsx
+++ b/packages/static-site/components/learn/IndustrySelector.test.tsx
@@ -67,4 +67,25 @@ describe("IndustrySelector", () => {
     expect(cta).toHaveAttribute("href", `${baseUrl}?industry=${targetIndustry.id}`);
     expect(cta).toHaveAttribute("aria-disabled", "false");
   });
+
+  it("opens the CTA in a new tab", () => {
+    render(
+      <IndustrySelector
+        industries={industries}
+        baseUrl={baseUrl}
+        heading={starterKits.industrySelectorHeading}
+        ctaText={starterKits.industrySelectorCta}
+      />,
+    );
+
+    const input = screen.getByRole("combobox");
+    fireEvent.click(input);
+
+    const option = screen.getByRole("option", { name: industries[0].name });
+    fireEvent.click(option);
+
+    const cta = screen.getByRole("link", { name: starterKits.industrySelectorCta });
+    expect(cta).toHaveAttribute("target", "_blank");
+    expect(cta).toHaveAttribute("rel", "noreferrer");
+  });
 });

--- a/packages/static-site/components/learn/IndustrySelector.tsx
+++ b/packages/static-site/components/learn/IndustrySelector.tsx
@@ -50,6 +50,8 @@ export const IndustrySelector = ({ industries, baseUrl, heading, ctaText }: Prop
             href={href}
             className={`usa-button width-full${!selectedIndustryId ? " usa-button--disabled" : ""}`}
             aria-disabled={!selectedIndustryId}
+            rel="noreferrer"
+            target="_blank"
             style={{ height: "2.5rem" }}
           >
             {ctaText}

--- a/packages/static-site/components/learn/StarterKitsPage.test.tsx
+++ b/packages/static-site/components/learn/StarterKitsPage.test.tsx
@@ -41,4 +41,14 @@ describe("StarterKitsPage", () => {
       screen.getByRole("heading", { name: starterKits.topIndustriesHeading }),
     ).toBeInTheDocument();
   });
+
+  it("opens each top industry tile link in a new tab", async () => {
+    render(await StarterKitsPage({ page, locale: "en-US" }));
+
+    for (const industry of starterKits.topIndustries) {
+      const link = screen.getByRole("link", { name: industry.ctaText });
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noreferrer");
+    }
+  });
 });

--- a/packages/static-site/components/learn/StarterKitsPage.tsx
+++ b/packages/static-site/components/learn/StarterKitsPage.tsx
@@ -48,7 +48,9 @@ export const StarterKitsPage = async ({ page, locale }: Props) => {
               <div className="usa-card__body">
                 <h3>{industry.name}</h3>
                 <p>{industry.description}</p>
-                <a href={buildOnboardingHref(industry.id)}>{industry.ctaText}</a>
+                <a href={buildOnboardingHref(industry.id)} rel="noreferrer" target="_blank">
+                  {industry.ctaText}
+                </a>
               </div>
             </div>
           </li>


### PR DESCRIPTION
## Description

Starter kit links on `/pages/starter-kits` now open in a new tab. Applies to both the industry combo-box CTA and the top-industry tiles.

### Ticket

This pull request resolves [#17919](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17919).

### Approach

- Adds `rel="noreferrer" target="_blank"` to the combo-box CTA in `IndustrySelector.tsx` and to each tile link in `StarterKitsPage.tsx`
- matches the existing convention used by `FundingCard`/`LicenseCard`.

### Steps to Test

1. Go to `/pages/starter-kits`.
2. Select an industry in the combo-box and click the CTA — it opens in a new tab.
3. Click any top-industry tile link — it opens in a new tab.

### Notes

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [ ] ~~I have created and/or updated relevant documentation on the engineering documentation website~~ N/A
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
