### PR TITLE
Remove HTTP Basic Auth from static site prod

### DIFF
--- a/api/cdk/lib/staticSiteTaskDefinition.ts
+++ b/api/cdk/lib/staticSiteTaskDefinition.ts
@@ -8,10 +8,10 @@ import {
   CONTENT_STAGE,
   DEV_STAGE,
   PROD_STAGE,
+  STAGING_STAGE,
   STATIC_SITE_CONTAINER_NAME,
   STATIC_SITE_CONTAINER_PORT,
   STATIC_SITE_SERVICE_BASE_NAME,
-  STAGING_STAGE,
   TESTING_STAGE,
 } from "./constants";
 import { applyStandardTags } from "./stackUtils";
@@ -69,7 +69,6 @@ const STATIC_SITE_BASIC_AUTH_STAGES = new Set([
   CONTENT_STAGE,
   TESTING_STAGE,
   STAGING_STAGE,
-  PROD_STAGE,
 ]);
 
 /** Inputs for creating runtime environment variables injected into the static-site ECS container. */


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

We're launching the static site. Remove HTTP Basic Auth so that users can access!

### Ticket

n/a

### Approach

Updated `STATIC_SITE_BASIC_AUTH_STAGES` within `staticSiteTaskDefinition.ts` to remove `prod` from the list of envs.

### Steps to Test

- Navigate to the production site in an incognito tab
- Confirm that the HTTP Basic Auth popup does not appear, and you can see the site

### Notes

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [X] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
