### PR TITLE
feat: derive industry-specific answers to essential questions in tests

### DIFF
--- a/api/cdk/test/staticSiteServiceStack.test.ts
+++ b/api/cdk/test/staticSiteServiceStack.test.ts
@@ -133,23 +133,29 @@ describe("StaticSiteServiceStack", () => {
     });
   });
 
-  test("injects Basic Auth runtime settings for protected static-site tasks", () => {
-    const template = createStaticSiteTemplate("dev");
+  test.each(["dev", "content", "testing", "staging"])(
+    "injects Basic Auth runtime settings for the protected %s static-site task",
+    (stage) => {
+      const template = createStaticSiteTemplate(stage);
 
-    expect(template.toJSON()).toBeDefined();
-    template.hasResourceProperties("AWS::ECS::TaskDefinition", {
-      ContainerDefinitions: Match.arrayWith([
-        Match.objectLike({
-          Environment: Match.arrayWith([
-            { Name: "NEXT_PUBLIC_SURVEY_MONKEY_ENABLED", Value: "false" },
-            { Name: "USE_BASIC_AUTH", Value: "true" },
-            { Name: "BASIC_AUTH_USERNAME", Value: "test-user" },
-            { Name: "BASIC_AUTH_PASSWORD", Value: "test-password" },
-          ]),
-        }),
-      ]),
-    });
-  });
+      expect(template.toJSON()).toBeDefined();
+      template.hasResourceProperties("AWS::ECS::TaskDefinition", {
+        ContainerDefinitions: Match.arrayWith([
+          Match.objectLike({
+            Environment: Match.arrayEquals([
+              { Name: "HOSTNAME", Value: "0.0.0.0" },
+              { Name: "NODE_ENV", Value: "production" },
+              { Name: "PORT", Value: "3000" },
+              { Name: "NEXT_PUBLIC_SURVEY_MONKEY_ENABLED", Value: "false" },
+              { Name: "USE_BASIC_AUTH", Value: "true" },
+              { Name: "BASIC_AUTH_USERNAME", Value: "test-user" },
+              { Name: "BASIC_AUTH_PASSWORD", Value: "test-password" },
+            ]),
+          }),
+        ]),
+      });
+    },
+  );
 
   test("uses the staging account static-site certificate for staging", () => {
     const template = createStaticSiteTemplate("staging");
@@ -177,18 +183,19 @@ describe("StaticSiteServiceStack", () => {
     );
   });
 
-  test("injects Basic Auth runtime settings for production static-site tasks", () => {
+  test("disables Basic Auth for production static-site tasks and omits credentials", () => {
     const template = createStaticSiteTemplate("prod");
 
     expect(template.toJSON()).toBeDefined();
     template.hasResourceProperties("AWS::ECS::TaskDefinition", {
       ContainerDefinitions: Match.arrayWith([
         Match.objectLike({
-          Environment: Match.arrayWith([
+          Environment: Match.arrayEquals([
+            { Name: "HOSTNAME", Value: "0.0.0.0" },
+            { Name: "NODE_ENV", Value: "production" },
+            { Name: "PORT", Value: "3000" },
             { Name: "NEXT_PUBLIC_SURVEY_MONKEY_ENABLED", Value: "true" },
-            { Name: "USE_BASIC_AUTH", Value: "true" },
-            { Name: "BASIC_AUTH_USERNAME", Value: "test-user" },
-            { Name: "BASIC_AUTH_PASSWORD", Value: "test-password" },
+            { Name: "USE_BASIC_AUTH", Value: "false" },
           ]),
         }),
       ]),

--- a/web/cypress/e2e/profile.spec.ts
+++ b/web/cypress/e2e/profile.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
 
+import { deriveIndustrySpecificAnswers } from "@businessnjgovnavigator/cypress/support/helpers/helpers-industry-specific-questions";
 import {
   completeExistingBusinessOnboarding,
   completeForeignBusinessOnboarding,
@@ -13,7 +14,6 @@ import {
   updateNewBusinessProfilePage,
 } from "@businessnjgovnavigator/cypress/support/helpers/helpers-profile";
 import {
-  homeBasedIndustries,
   liquorLicenseIndustries,
   randomHomeBasedIndustry,
   randomNonHomeBasedNonDomesticEmployerIndustry,
@@ -67,11 +67,8 @@ describe("Profile [feature] [all] [group4]", () => {
       });
 
       const newBusinessName = `Generic Business Name ${randomInt()}`;
-      const newIndustry = randomElementFromArray(
-        homeBasedIndustries.filter((x) => {
-          return x.isEnabled;
-        }) as Industry[],
-      );
+      const newIndustry = randomHomeBasedIndustry();
+      const newIndustrySpecificAnswers = deriveIndustrySpecificAnswers(newIndustry);
       const newtownDisplayName = "Bass River";
       const newHomeBasedQuestion = Boolean(randomInt() % 2);
       const newEmployerId = randomInt(9).toString();
@@ -81,6 +78,7 @@ describe("Profile [feature] [all] [group4]", () => {
       updateNewBusinessProfilePage({
         businessName: newBusinessName,
         industry: newIndustry,
+        ...newIndustrySpecificAnswers,
         townDisplayName: newtownDisplayName,
         homeBasedQuestion: newHomeBasedQuestion,
         employerId: newEmployerId,

--- a/web/cypress/support/helpers/helpers-industry-specific-questions.ts
+++ b/web/cypress/support/helpers/helpers-industry-specific-questions.ts
@@ -1,0 +1,375 @@
+import { randomElementFromArray } from "@businessnjgovnavigator/cypress/support/helpers/helpers";
+import { OnboardingPage } from "@businessnjgovnavigator/cypress/support/page_objects/onboardingPage";
+import { StartingOnboardingData } from "@businessnjgovnavigator/cypress/support/types";
+import { Industry } from "@businessnjgovnavigator/shared/lib/shared/src/industry";
+import { randomInt } from "@businessnjgovnavigator/shared/lib/shared/src/intHelpers";
+import {
+  cannabisLicenseOptions,
+  carServiceOptions,
+  constructionOptions,
+  employmentPersonnelServiceOptions,
+  employmentPlacementOptions,
+  propertyLeaseTypeOptions,
+  residentialConstructionOptions,
+} from "@businessnjgovnavigator/shared/lib/shared/src/profileData";
+
+// The industry-specific "essential question" fields, shared by onboarding and the profile page.
+// homeBasedQuestion is a non-essential question handled separately by each caller.
+export type IndustrySpecificAnswers = Omit<
+  StartingOnboardingData,
+  "industry" | "homeBasedQuestion"
+>;
+
+/**
+ * Resolves a full set of industry-specific essential-question answers for the given industry.
+ * Any field left undefined in `overrides` is derived: a random valid value if the field is
+ * applicable to the industry, otherwise undefined (meaning the question should not render).
+ */
+export const deriveIndustrySpecificAnswers = (
+  industry: Industry,
+  overrides: Partial<IndustrySpecificAnswers> = {},
+): IndustrySpecificAnswers => {
+  let {
+    liquorLicenseQuestion,
+    requiresCpa,
+    providesStaffingService,
+    certifiedInteriorDesigner,
+    realEstateAppraisalManagement,
+    interstateLogistics,
+    interstateMoving,
+    carService,
+    isChildcareForSixOrMore,
+    willSellPetCareItems,
+    petCareHousing,
+    whatIsPropertyLeaseType,
+    hasThreeOrMoreRentalUnits,
+    cannabisLicenseType,
+    constructionType,
+    residentialConstructionType,
+    publicWorksContractor,
+    employmentPersonnelServiceType,
+    employmentPlacementType,
+  } = overrides;
+
+  if (carService === undefined) {
+    carService = industry.industryOnboardingQuestions.isCarServiceApplicable
+      ? randomElementFromArray([...carServiceOptions])
+      : undefined;
+  }
+
+  if (isChildcareForSixOrMore === undefined) {
+    isChildcareForSixOrMore = industry.industryOnboardingQuestions.isChildcareForSixOrMore
+      ? Boolean(randomInt() % 2)
+      : undefined;
+  }
+
+  if (petCareHousing === undefined) {
+    petCareHousing = industry.industryOnboardingQuestions.isPetCareHousingApplicable
+      ? Boolean(randomInt() % 2)
+      : undefined;
+  }
+  if (willSellPetCareItems === undefined) {
+    willSellPetCareItems = industry.industryOnboardingQuestions.willSellPetCareItems
+      ? Boolean(randomInt() % 2)
+      : undefined;
+  }
+
+  if (liquorLicenseQuestion === undefined) {
+    liquorLicenseQuestion = industry.industryOnboardingQuestions.isLiquorLicenseApplicable
+      ? Boolean(randomInt() % 2)
+      : undefined;
+  }
+
+  if (requiresCpa === undefined) {
+    requiresCpa = industry.industryOnboardingQuestions.isCpaRequiredApplicable
+      ? Boolean(randomInt() % 2)
+      : undefined;
+  }
+
+  if (providesStaffingService === undefined) {
+    providesStaffingService = industry.industryOnboardingQuestions
+      .isProvidesStaffingServicesApplicable
+      ? Boolean(randomInt() % 2)
+      : undefined;
+  }
+
+  if (certifiedInteriorDesigner === undefined) {
+    certifiedInteriorDesigner = industry.industryOnboardingQuestions
+      .isCertifiedInteriorDesignerApplicable
+      ? Boolean(randomInt() % 2)
+      : undefined;
+  }
+
+  if (realEstateAppraisalManagement === undefined) {
+    realEstateAppraisalManagement = industry.industryOnboardingQuestions
+      .isRealEstateAppraisalManagementApplicable
+      ? Boolean(randomInt() % 2)
+      : undefined;
+  }
+
+  if (interstateLogistics === undefined) {
+    interstateLogistics = industry.industryOnboardingQuestions.isInterstateLogisticsApplicable
+      ? Boolean(randomInt() % 2)
+      : undefined;
+  }
+
+  if (interstateMoving === undefined) {
+    interstateMoving = industry.industryOnboardingQuestions.isInterstateMovingApplicable
+      ? Boolean(randomInt() % 2)
+      : undefined;
+  }
+
+  if (whatIsPropertyLeaseType === undefined) {
+    whatIsPropertyLeaseType = industry.industryOnboardingQuestions.whatIsPropertyLeaseType
+      ? randomElementFromArray([...propertyLeaseTypeOptions])
+      : undefined;
+  }
+
+  if (hasThreeOrMoreRentalUnits === undefined) {
+    hasThreeOrMoreRentalUnits = industry.industryOnboardingQuestions.canHaveThreeOrMoreRentalUnits
+      ? Boolean(randomInt() % 2)
+      : undefined;
+  }
+
+  if (cannabisLicenseType === undefined) {
+    cannabisLicenseType = industry.industryOnboardingQuestions.isCannabisLicenseTypeApplicable
+      ? randomElementFromArray([...cannabisLicenseOptions])
+      : undefined;
+  }
+
+  if (constructionType === undefined) {
+    constructionType = industry.industryOnboardingQuestions.isConstructionTypeApplicable
+      ? randomElementFromArray([...constructionOptions])
+      : undefined;
+  }
+
+  if (residentialConstructionType === undefined) {
+    residentialConstructionType =
+      industry.industryOnboardingQuestions.isConstructionTypeApplicable &&
+      (constructionType === "RESIDENTIAL" || constructionType === "BOTH")
+        ? randomElementFromArray([...residentialConstructionOptions])
+        : undefined;
+  }
+
+  if (publicWorksContractor === undefined) {
+    publicWorksContractor =
+      industry.industryOnboardingQuestions.isConstructionTypeApplicable &&
+      (constructionType === "COMMERCIAL_OR_INDUSTRIAL" || constructionType === "BOTH")
+        ? Boolean(randomInt() % 2)
+        : undefined;
+  }
+
+  if (employmentPersonnelServiceType === undefined) {
+    employmentPersonnelServiceType = industry.industryOnboardingQuestions
+      .isEmploymentAndPersonnelTypeApplicable
+      ? randomElementFromArray([...employmentPersonnelServiceOptions])
+      : undefined;
+  }
+
+  if (employmentPlacementType === undefined) {
+    employmentPlacementType =
+      industry.industryOnboardingQuestions.isEmploymentAndPersonnelTypeApplicable &&
+      employmentPersonnelServiceType === "EMPLOYERS"
+        ? randomElementFromArray([...employmentPlacementOptions])
+        : undefined;
+  }
+
+  if (!industry.industryOnboardingQuestions.isCpaRequiredApplicable && requiresCpa) {
+    throw new Error("Cypress configuration error - CPA set for non-cpa industry");
+  }
+
+  return {
+    liquorLicenseQuestion,
+    requiresCpa,
+    providesStaffingService,
+    certifiedInteriorDesigner,
+    realEstateAppraisalManagement,
+    interstateLogistics,
+    interstateMoving,
+    carService,
+    isChildcareForSixOrMore,
+    willSellPetCareItems,
+    petCareHousing,
+    whatIsPropertyLeaseType,
+    hasThreeOrMoreRentalUnits,
+    cannabisLicenseType,
+    constructionType,
+    residentialConstructionType,
+    publicWorksContractor,
+    employmentPersonnelServiceType,
+    employmentPlacementType,
+  };
+};
+
+/**
+ * Applies and asserts every industry-specific essential-question answer against the given page
+ * object. Works on both the onboarding page and the profile page, since both render these
+ * questions through the same underlying fields.
+ */
+export const answerIndustrySpecificQuestions = ({
+  page,
+  liquorLicenseQuestion,
+  requiresCpa,
+  providesStaffingService,
+  certifiedInteriorDesigner,
+  realEstateAppraisalManagement,
+  interstateLogistics,
+  interstateMoving,
+  carService,
+  isChildcareForSixOrMore,
+  willSellPetCareItems,
+  petCareHousing,
+  cannabisLicenseType,
+  constructionType,
+  residentialConstructionType,
+  publicWorksContractor,
+  employmentPersonnelServiceType,
+  employmentPlacementType,
+  whatIsPropertyLeaseType,
+  hasThreeOrMoreRentalUnits,
+}: { page: OnboardingPage } & IndustrySpecificAnswers): void => {
+  if (liquorLicenseQuestion === undefined) {
+    page.getLiquorLicense().should("not.exist");
+  } else {
+    page.selectLiquorLicense(liquorLicenseQuestion);
+    page.getLiquorLicense(liquorLicenseQuestion).should("be.checked");
+    page.getLiquorLicense(!liquorLicenseQuestion).should("not.be.checked");
+  }
+
+  if (requiresCpa === undefined) {
+    page.getCpa().should("not.exist");
+  } else {
+    page.selectCpa(requiresCpa);
+    page.getCpa(requiresCpa).should("be.checked");
+    page.getCpa(!requiresCpa).should("not.be.checked");
+  }
+
+  if (providesStaffingService === undefined) {
+    page.getStaffingService().should("not.exist");
+  } else {
+    page.selectStaffingService(providesStaffingService);
+    page.getStaffingService(providesStaffingService).should("be.checked");
+    page.getStaffingService(!providesStaffingService).should("not.be.checked");
+  }
+
+  if (certifiedInteriorDesigner === undefined) {
+    page.getInteriorDesigner().should("not.exist");
+  } else {
+    page.selectInteriorDesigner(certifiedInteriorDesigner);
+    page.getInteriorDesigner(certifiedInteriorDesigner).should("be.checked");
+    page.getInteriorDesigner(!certifiedInteriorDesigner).should("not.be.checked");
+  }
+
+  if (realEstateAppraisalManagement === undefined) {
+    page.getRealEstateAppraisal().should("not.exist");
+  } else {
+    page.selectRealEstateAppraisal(realEstateAppraisalManagement);
+    page.getRealEstateAppraisal(realEstateAppraisalManagement).should("be.checked");
+    page.getRealEstateAppraisal(!realEstateAppraisalManagement).should("not.be.checked");
+  }
+
+  if (interstateLogistics === undefined) {
+    page.getInterstateLogistics().should("not.exist");
+  } else {
+    page.selectInterstateLogistics(!!interstateLogistics);
+    page.getInterstateLogistics(interstateLogistics).should("be.checked");
+    page.getInterstateLogistics(!interstateLogistics).should("not.be.checked");
+  }
+
+  if (interstateMoving === undefined) {
+    page.getInterstateMoving().should("not.exist");
+  } else {
+    page.selectInterstateMoving(!!interstateMoving);
+    page.getInterstateMoving(interstateMoving).should("be.checked");
+    page.getInterstateMoving(!interstateMoving).should("not.be.checked");
+  }
+
+  if (carService === undefined) {
+    page.getCarService().should("not.exist");
+  } else {
+    page.selectCarService(carService);
+    page.getCarService(carService).should("be.checked");
+
+    const otherValues = carServiceOptions.filter((value) => value !== carService);
+    otherValues.forEach((value) => {
+      page.getCarService(value).should("not.be.checked");
+    });
+  }
+
+  if (isChildcareForSixOrMore === undefined) {
+    page.getChildcare().should("not.exist");
+  } else {
+    page.selectChildcare(isChildcareForSixOrMore);
+    page.getChildcare(isChildcareForSixOrMore).should("be.checked");
+    page.getChildcare(!isChildcareForSixOrMore).should("not.be.checked");
+  }
+
+  if (willSellPetCareItems === undefined) {
+    page.getWillSellPetcareItems().should("not.exist");
+  } else {
+    page.selectWillSellPetcareItems(willSellPetCareItems);
+    page.getWillSellPetcareItems(willSellPetCareItems).should("be.checked");
+    page.getWillSellPetcareItems(!willSellPetCareItems).should("not.be.checked");
+  }
+
+  if (petCareHousing === undefined) {
+    page.getPetCareHousing().should("not.exist");
+  } else {
+    page.selectPetCareHousing(petCareHousing);
+    page.getPetCareHousing(petCareHousing).should("be.checked");
+    page.getPetCareHousing(!petCareHousing).should("not.be.checked");
+  }
+
+  if (cannabisLicenseType === undefined) {
+    page.getCannabisLicenseType().should("not.exist");
+  } else {
+    page.selectCannabisLicenseType(cannabisLicenseType);
+    page.getCannabisLicenseType(cannabisLicenseType).should("be.checked");
+  }
+
+  if (constructionType === undefined) {
+    page.getConstructionType().should("not.exist");
+  } else {
+    page.selectConstructionType(constructionType);
+    page.getConstructionType(constructionType).should("be.checked");
+    if (
+      residentialConstructionType !== undefined &&
+      (constructionType === "RESIDENTIAL" || constructionType === "BOTH")
+    ) {
+      page.selectResidentialConstructionType(residentialConstructionType);
+      page.getResidentialConstructionType(residentialConstructionType).should("be.checked");
+    }
+    if (
+      publicWorksContractor !== undefined &&
+      (constructionType === "COMMERCIAL_OR_INDUSTRIAL" || constructionType === "BOTH")
+    ) {
+      page.selectPublicWorksContractor(publicWorksContractor);
+      page.getPublicWorksContractor(publicWorksContractor).should("be.checked");
+    }
+  }
+
+  if (employmentPersonnelServiceType === undefined) {
+    page.getEmploymentPersonnelServiceType().should("not.exist");
+  } else {
+    page.selectEmploymentPersonnelServiceType(employmentPersonnelServiceType);
+    page.getEmploymentPersonnelServiceType(employmentPersonnelServiceType).should("be.checked");
+    if (employmentPlacementType !== undefined && employmentPersonnelServiceType === "EMPLOYERS") {
+      page.selectEmploymentPlacementType(employmentPlacementType);
+      page.getEmploymentPlacementType(employmentPlacementType).should("be.checked");
+    }
+  }
+
+  if (whatIsPropertyLeaseType === undefined) {
+    page.getPropertyLeaseType().should("not.exist");
+  } else {
+    page.selectPropertyLeaseType(whatIsPropertyLeaseType);
+    page.getPropertyLeaseType(whatIsPropertyLeaseType).should("be.checked");
+    if (
+      hasThreeOrMoreRentalUnits !== undefined &&
+      (whatIsPropertyLeaseType === "LONG_TERM_RENTAL" || whatIsPropertyLeaseType === "BOTH")
+    ) {
+      page.selectHasThreeOrMoreRentalUnits(hasThreeOrMoreRentalUnits);
+      page.getHasThreeOrMoreRentalUnits(hasThreeOrMoreRentalUnits).should("be.checked");
+    }
+  }
+};

--- a/web/cypress/support/helpers/helpers-onboarding.ts
+++ b/web/cypress/support/helpers/helpers-onboarding.ts
@@ -1,4 +1,8 @@
 import { randomElementFromArray } from "@businessnjgovnavigator/cypress/support/helpers/helpers";
+import {
+  answerIndustrySpecificQuestions,
+  deriveIndustrySpecificAnswers,
+} from "@businessnjgovnavigator/cypress/support/helpers/helpers-industry-specific-questions";
 import { onOnboardingPage } from "@businessnjgovnavigator/cypress/support/page_objects/onboardingPage";
 import {
   ExistingOnboardingData,
@@ -7,16 +11,6 @@ import {
   StartingOnboardingData,
 } from "@businessnjgovnavigator/cypress/support/types";
 import { getIndustries, Industry } from "@businessnjgovnavigator/shared/lib/shared/src/industry";
-import { randomInt } from "@businessnjgovnavigator/shared/lib/shared/src/intHelpers";
-import {
-  cannabisLicenseOptions,
-  carServiceOptions,
-  constructionOptions,
-  employmentPersonnelServiceOptions,
-  employmentPlacementOptions,
-  propertyLeaseTypeOptions,
-  residentialConstructionOptions,
-} from "@businessnjgovnavigator/shared/lib/shared/src/profileData";
 import {
   arrayOfSectors,
   LookupSectorTypeById,
@@ -48,132 +42,27 @@ export const completeNewBusinessOnboarding = ({
     industry = randomElementFromArray(getIndustries()) as Industry;
   }
 
-  if (carService === undefined) {
-    carService = industry.industryOnboardingQuestions.isCarServiceApplicable
-      ? randomElementFromArray([...carServiceOptions])
-      : undefined;
-  }
-
-  if (isChildcareForSixOrMore === undefined) {
-    isChildcareForSixOrMore = industry.industryOnboardingQuestions.isChildcareForSixOrMore
-      ? Boolean(randomInt() % 2)
-      : undefined;
-  }
-
-  if (petCareHousing === undefined) {
-    petCareHousing = industry.industryOnboardingQuestions.isPetCareHousingApplicable
-      ? Boolean(randomInt() % 2)
-      : undefined;
-  }
-  if (willSellPetCareItems === undefined) {
-    willSellPetCareItems = industry.industryOnboardingQuestions.willSellPetCareItems
-      ? Boolean(randomInt() % 2)
-      : undefined;
-  }
-
-  if (liquorLicenseQuestion === undefined) {
-    liquorLicenseQuestion = industry.industryOnboardingQuestions.isLiquorLicenseApplicable
-      ? Boolean(randomInt() % 2)
-      : undefined;
-  }
-
-  if (requiresCpa === undefined) {
-    requiresCpa = industry.industryOnboardingQuestions.isCpaRequiredApplicable
-      ? Boolean(randomInt() % 2)
-      : undefined;
-  }
-
-  if (providesStaffingService === undefined) {
-    providesStaffingService = industry.industryOnboardingQuestions
-      .isProvidesStaffingServicesApplicable
-      ? Boolean(randomInt() % 2)
-      : undefined;
-  }
-
-  if (certifiedInteriorDesigner === undefined) {
-    certifiedInteriorDesigner = industry.industryOnboardingQuestions
-      .isCertifiedInteriorDesignerApplicable
-      ? Boolean(randomInt() % 2)
-      : undefined;
-  }
-
-  if (realEstateAppraisalManagement === undefined) {
-    realEstateAppraisalManagement = industry.industryOnboardingQuestions
-      .isRealEstateAppraisalManagementApplicable
-      ? Boolean(randomInt() % 2)
-      : undefined;
-  }
-
-  if (interstateLogistics === undefined) {
-    interstateLogistics = industry.industryOnboardingQuestions.isInterstateLogisticsApplicable
-      ? Boolean(randomInt() % 2)
-      : undefined;
-  }
-
-  if (interstateMoving === undefined) {
-    interstateMoving = industry.industryOnboardingQuestions.isInterstateMovingApplicable
-      ? Boolean(randomInt() % 2)
-      : undefined;
-  }
-
-  if (whatIsPropertyLeaseType === undefined) {
-    whatIsPropertyLeaseType = industry.industryOnboardingQuestions.whatIsPropertyLeaseType
-      ? randomElementFromArray([...propertyLeaseTypeOptions])
-      : undefined;
-  }
-
-  if (hasThreeOrMoreRentalUnits === undefined) {
-    hasThreeOrMoreRentalUnits = industry.industryOnboardingQuestions.canHaveThreeOrMoreRentalUnits
-      ? Boolean(randomInt() % 2)
-      : undefined;
-  }
-
-  if (cannabisLicenseType === undefined) {
-    cannabisLicenseType = industry.industryOnboardingQuestions.isCannabisLicenseTypeApplicable
-      ? randomElementFromArray([...cannabisLicenseOptions])
-      : undefined;
-  }
-
-  if (constructionType === undefined) {
-    constructionType = industry.industryOnboardingQuestions.isConstructionTypeApplicable
-      ? randomElementFromArray([...constructionOptions])
-      : undefined;
-  }
-
-  if (residentialConstructionType === undefined) {
-    residentialConstructionType =
-      industry.industryOnboardingQuestions.isConstructionTypeApplicable &&
-      (constructionType === "RESIDENTIAL" || constructionType === "BOTH")
-        ? randomElementFromArray([...residentialConstructionOptions])
-        : undefined;
-  }
-
-  if (publicWorksContractor === undefined) {
-    publicWorksContractor =
-      industry.industryOnboardingQuestions.isConstructionTypeApplicable &&
-      (constructionType === "COMMERCIAL_OR_INDUSTRIAL" || constructionType === "BOTH")
-        ? Boolean(randomInt() % 2)
-        : undefined;
-  }
-
-  if (employmentPersonnelServiceType === undefined) {
-    employmentPersonnelServiceType = industry.industryOnboardingQuestions
-      .isEmploymentAndPersonnelTypeApplicable
-      ? randomElementFromArray([...employmentPersonnelServiceOptions])
-      : undefined;
-  }
-
-  if (employmentPlacementType === undefined) {
-    employmentPlacementType =
-      industry.industryOnboardingQuestions.isEmploymentAndPersonnelTypeApplicable &&
-      employmentPersonnelServiceType === "EMPLOYERS"
-        ? randomElementFromArray([...employmentPlacementOptions])
-        : undefined;
-  }
-
-  if (!industry.industryOnboardingQuestions.isCpaRequiredApplicable && requiresCpa) {
-    throw new Error("Cypress configuration error - CPA set for non-cpa industry");
-  }
+  const industrySpecificAnswers = deriveIndustrySpecificAnswers(industry, {
+    liquorLicenseQuestion,
+    requiresCpa,
+    providesStaffingService,
+    certifiedInteriorDesigner,
+    realEstateAppraisalManagement,
+    interstateLogistics,
+    interstateMoving,
+    carService,
+    isChildcareForSixOrMore,
+    willSellPetCareItems,
+    petCareHousing,
+    whatIsPropertyLeaseType,
+    hasThreeOrMoreRentalUnits,
+    cannabisLicenseType,
+    constructionType,
+    residentialConstructionType,
+    publicWorksContractor,
+    employmentPersonnelServiceType,
+    employmentPlacementType,
+  });
 
   cy.url().should("include", "onboarding?page=1");
   onOnboardingPage.selectBusinessPersona("STARTING");
@@ -190,156 +79,7 @@ export const completeNewBusinessOnboarding = ({
     .invoke("prop", "value")
     .should("contain", (industry as Industry).name);
 
-  if (liquorLicenseQuestion === undefined) {
-    onOnboardingPage.getLiquorLicense().should("not.exist");
-  } else {
-    onOnboardingPage.selectLiquorLicense(liquorLicenseQuestion);
-    onOnboardingPage.getLiquorLicense(liquorLicenseQuestion).should("be.checked");
-    onOnboardingPage.getLiquorLicense(!liquorLicenseQuestion).should("not.be.checked");
-  }
-
-  if (requiresCpa === undefined) {
-    onOnboardingPage.getCpa().should("not.exist");
-  } else {
-    onOnboardingPage.selectCpa(requiresCpa);
-    onOnboardingPage.getCpa(requiresCpa).should("be.checked");
-    onOnboardingPage.getCpa(!requiresCpa).should("not.be.checked");
-  }
-
-  if (providesStaffingService === undefined) {
-    onOnboardingPage.getStaffingService().should("not.exist");
-  } else {
-    onOnboardingPage.selectStaffingService(providesStaffingService);
-    onOnboardingPage.getStaffingService(providesStaffingService).should("be.checked");
-    onOnboardingPage.getStaffingService(!providesStaffingService).should("not.be.checked");
-  }
-
-  if (certifiedInteriorDesigner === undefined) {
-    onOnboardingPage.getInteriorDesigner().should("not.exist");
-  } else {
-    onOnboardingPage.selectInteriorDesigner(certifiedInteriorDesigner);
-    onOnboardingPage.getInteriorDesigner(certifiedInteriorDesigner).should("be.checked");
-    onOnboardingPage.getInteriorDesigner(!certifiedInteriorDesigner).should("not.be.checked");
-  }
-
-  if (realEstateAppraisalManagement === undefined) {
-    onOnboardingPage.getRealEstateAppraisal().should("not.exist");
-  } else {
-    onOnboardingPage.selectRealEstateAppraisal(realEstateAppraisalManagement);
-    onOnboardingPage.getRealEstateAppraisal(realEstateAppraisalManagement).should("be.checked");
-    onOnboardingPage
-      .getRealEstateAppraisal(!realEstateAppraisalManagement)
-      .should("not.be.checked");
-  }
-
-  if (interstateLogistics === undefined) {
-    onOnboardingPage.getInterstateLogistics().should("not.exist");
-  } else {
-    onOnboardingPage.selectInterstateLogistics(!!interstateLogistics);
-    onOnboardingPage.getInterstateLogistics(interstateLogistics).should("be.checked");
-    onOnboardingPage.getInterstateLogistics(!interstateLogistics).should("not.be.checked");
-  }
-
-  if (interstateMoving === undefined) {
-    onOnboardingPage.getInterstateMoving().should("not.exist");
-  } else {
-    onOnboardingPage.selectInterstateMoving(!!interstateMoving);
-    onOnboardingPage.getInterstateMoving(interstateMoving).should("be.checked");
-    onOnboardingPage.getInterstateMoving(!interstateMoving).should("not.be.checked");
-  }
-
-  if (carService === undefined) {
-    onOnboardingPage.getCarService().should("not.exist");
-  } else {
-    onOnboardingPage.selectCarService(carService);
-    onOnboardingPage.getCarService(carService).should("be.checked");
-
-    const otherValues = carServiceOptions.filter((value) => value !== carService);
-    otherValues.forEach((value) => {
-      onOnboardingPage.getCarService(value).should("not.be.checked");
-    });
-  }
-
-  if (isChildcareForSixOrMore === undefined) {
-    onOnboardingPage.getChildcare().should("not.exist");
-  } else {
-    onOnboardingPage.selectChildcare(isChildcareForSixOrMore);
-    onOnboardingPage.getChildcare(isChildcareForSixOrMore).should("be.checked");
-    onOnboardingPage.getChildcare(!isChildcareForSixOrMore).should("not.be.checked");
-  }
-
-  if (willSellPetCareItems === undefined) {
-    onOnboardingPage.getWillSellPetcareItems().should("not.exist");
-  } else {
-    onOnboardingPage.selectWillSellPetcareItems(willSellPetCareItems);
-    onOnboardingPage.getWillSellPetcareItems(willSellPetCareItems).should("be.checked");
-    onOnboardingPage.getWillSellPetcareItems(!willSellPetCareItems).should("not.be.checked");
-  }
-
-  if (petCareHousing === undefined) {
-    onOnboardingPage.getPetCareHousing().should("not.exist");
-  } else {
-    onOnboardingPage.selectPetCareHousing(petCareHousing);
-    onOnboardingPage.getPetCareHousing(petCareHousing).should("be.checked");
-    onOnboardingPage.getPetCareHousing(!petCareHousing).should("not.be.checked");
-  }
-
-  if (cannabisLicenseType === undefined) {
-    onOnboardingPage.getCannabisLicenseType().should("not.exist");
-  } else {
-    onOnboardingPage.selectCannabisLicenseType(cannabisLicenseType);
-    onOnboardingPage.getCannabisLicenseType(cannabisLicenseType).should("be.checked");
-  }
-
-  if (constructionType === undefined) {
-    onOnboardingPage.getConstructionType().should("not.exist");
-  } else {
-    onOnboardingPage.selectConstructionType(constructionType);
-    onOnboardingPage.getConstructionType(constructionType).should("be.checked");
-    if (
-      residentialConstructionType !== undefined &&
-      (constructionType === "RESIDENTIAL" || constructionType === "BOTH")
-    ) {
-      onOnboardingPage.selectResidentialConstructionType(residentialConstructionType);
-      onOnboardingPage
-        .getResidentialConstructionType(residentialConstructionType)
-        .should("be.checked");
-    }
-    if (
-      publicWorksContractor !== undefined &&
-      (constructionType === "COMMERCIAL_OR_INDUSTRIAL" || constructionType === "BOTH")
-    ) {
-      onOnboardingPage.selectPublicWorksContractor(publicWorksContractor);
-      onOnboardingPage.getPublicWorksContractor(publicWorksContractor).should("be.checked");
-    }
-  }
-
-  if (employmentPersonnelServiceType === undefined) {
-    onOnboardingPage.getEmploymentPersonnelServiceType().should("not.exist");
-  } else {
-    onOnboardingPage.selectEmploymentPersonnelServiceType(employmentPersonnelServiceType);
-    onOnboardingPage
-      .getEmploymentPersonnelServiceType(employmentPersonnelServiceType)
-      .should("be.checked");
-    if (employmentPlacementType !== undefined && employmentPersonnelServiceType === "EMPLOYERS") {
-      onOnboardingPage.selectEmploymentPlacementType(employmentPlacementType);
-      onOnboardingPage.getEmploymentPlacementType(employmentPlacementType).should("be.checked");
-    }
-  }
-
-  if (whatIsPropertyLeaseType === undefined) {
-    onOnboardingPage.getPropertyLeaseType().should("not.exist");
-  } else {
-    onOnboardingPage.selectPropertyLeaseType(whatIsPropertyLeaseType);
-    onOnboardingPage.getPropertyLeaseType(whatIsPropertyLeaseType).should("be.checked");
-    if (
-      hasThreeOrMoreRentalUnits !== undefined &&
-      (whatIsPropertyLeaseType === "LONG_TERM_RENTAL" || whatIsPropertyLeaseType === "BOTH")
-    ) {
-      onOnboardingPage.selectHasThreeOrMoreRentalUnits(hasThreeOrMoreRentalUnits);
-      onOnboardingPage.getHasThreeOrMoreRentalUnits(hasThreeOrMoreRentalUnits).should("be.checked");
-    }
-  }
+  answerIndustrySpecificQuestions({ page: onOnboardingPage, ...industrySpecificAnswers });
 
   onOnboardingPage.clickNext();
   cy.url().should("include", `dashboard`);

--- a/web/cypress/support/helpers/helpers-profile.ts
+++ b/web/cypress/support/helpers/helpers-profile.ts
@@ -1,4 +1,8 @@
 import { formatTaxId } from "@/lib/domain-logic/formatTaxId";
+import {
+  answerIndustrySpecificQuestions,
+  deriveIndustrySpecificAnswers,
+} from "@businessnjgovnavigator/cypress/support/helpers/helpers-industry-specific-questions";
 import { onDashboardPage } from "@businessnjgovnavigator/cypress/support/page_objects/dashboardPage";
 import { onProfilePage } from "@businessnjgovnavigator/cypress/support/page_objects/profilePage";
 import {
@@ -145,6 +149,24 @@ export const updateNewBusinessProfilePage = ({
   townDisplayName,
   homeBasedQuestion,
   liquorLicenseQuestion,
+  requiresCpa,
+  providesStaffingService,
+  certifiedInteriorDesigner,
+  realEstateAppraisalManagement,
+  interstateLogistics,
+  interstateMoving,
+  carService,
+  isChildcareForSixOrMore,
+  willSellPetCareItems,
+  petCareHousing,
+  whatIsPropertyLeaseType,
+  hasThreeOrMoreRentalUnits,
+  cannabisLicenseType,
+  constructionType,
+  residentialConstructionType,
+  publicWorksContractor,
+  employmentPersonnelServiceType,
+  employmentPlacementType,
   employerId,
   taxId,
   notes,
@@ -161,6 +183,34 @@ export const updateNewBusinessProfilePage = ({
       .getIndustryDropdown()
       .invoke("prop", "value")
       .should("contain", (industry as Industry).name);
+
+    const industrySpecificAnswers = deriveIndustrySpecificAnswers(industry as Industry, {
+      liquorLicenseQuestion,
+      requiresCpa,
+      providesStaffingService,
+      certifiedInteriorDesigner,
+      realEstateAppraisalManagement,
+      interstateLogistics,
+      interstateMoving,
+      carService,
+      isChildcareForSixOrMore,
+      willSellPetCareItems,
+      petCareHousing,
+      whatIsPropertyLeaseType,
+      hasThreeOrMoreRentalUnits,
+      cannabisLicenseType,
+      constructionType,
+      residentialConstructionType,
+      publicWorksContractor,
+      employmentPersonnelServiceType,
+      employmentPlacementType,
+    });
+    answerIndustrySpecificQuestions({ page: onProfilePage, ...industrySpecificAnswers });
+  }
+
+  if (businessName && !legalStructureId) {
+    onProfilePage.typeBusinessName(businessName);
+    onProfilePage.getBusinessName().invoke("prop", "value").should("contain", businessName);
   }
 
   if (legalStructureId) {
@@ -224,7 +274,7 @@ export const updateNewBusinessProfilePage = ({
     onProfilePage.getNotes().invoke("prop", "value").should("contain", notes);
   }
 
-  if (liquorLicenseQuestion) {
+  if (liquorLicenseQuestion && !industry) {
     onProfilePage.selectLiquorLicense(liquorLicenseQuestion);
     onProfilePage.getLiquorLicense(liquorLicenseQuestion).should("be.checked");
     onProfilePage.getLiquorLicense(!liquorLicenseQuestion).should("not.be.checked");


### PR DESCRIPTION
## Description

Fixes CI failures in unit and e2e tests without reducing coverage. Both the original fixes on this branch had papered over real gaps by weakening assertions; this replaces them with fixes that restore full coverage while still passing.

### Approach

- `staticSiteServiceStack.test.ts`: Replaced the weak, subset-matching production assertion with explicit per-stage coverage. `dev`/`content`/`testing`/`staging` now assert the *complete* container environment with `USE_BASIC_AUTH=true` and credentials present; `prod` asserts the complete environment with `USE_BASIC_AUTH=false` and credentials absent. Uses `Match.arrayEquals` instead of `Match.arrayWith` so the tests can actually detect missing/extra env vars, not just one matching entry. No changes to `staticSiteTaskDefinition.ts` - the implementation already matched this matrix.
- `profile.spec.ts`: Restored random selection from all enabled home-based industries (`randomHomeBasedIndustry()`) instead of pinning to a single hardcoded industry (`cleaning-janitorial-services`). The pin had hidden the real bug rather than fixing it.
- Root-caused the underlying flake: `updateNewBusinessProfilePage` only answered `homeBasedQuestion`/`liquorLicenseQuestion`, so a randomly selected industry with other required essential questions (CPA, cannabis, construction, employment/personnel, property lease, etc.) would fail profile-save validation. Extracted the onboarding helper's answer-derivation and answer-application logic into a new shared module, `helpers-industry-specific-questions.ts` (`deriveIndustrySpecificAnswers` + `answerIndustrySpecificQuestions`), now reused by both onboarding and profile update helpers so the profile page answers every applicable essential question for the selected industry.
- Kept the existing fix in `helpers-profile.ts`'s `updateNewBusinessProfilePage` that types the business name when no legal structure change is involved.

### Steps to Test

- `yarn workspace @businessnjgovnavigator/api-cdk test staticSiteServiceStack`
- `yarn workspace @businessnjgovnavigator/web cypress:run --spec cypress/e2e/profile.spec.ts` (run with a few different `RANDOM_SEED` values to confirm no flakiness across random industries)

### Notes

Verified against the originally failing seed (`gfe1qwq7159`) plus an additional seed, both passing 5/5.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews