### PR TITLE
feat: [AB#17912] add `/newsletter-signup` route to static site with GovDelivery embed

### DIFF
--- a/packages/static-site/app/[locale]/newsletter-signup/page.test.tsx
+++ b/packages/static-site/app/[locale]/newsletter-signup/page.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import NewsletterSignupRoute, { generateMetadata } from "./page";
+
+const { newsletterSignup } = getApplicationMessages({ locale: "en-US" });
+
+describe("generateMetadata", () => {
+  it("builds hreflang alternates for /newsletter-signup", () => {
+    const metadata = generateMetadata();
+    expect(metadata.alternates?.canonical).toBe("/newsletter-signup");
+  });
+});
+
+describe("NewsletterSignupRoute", () => {
+  it("renders the newsletter signup page for a supported locale", async () => {
+    render(
+      await NewsletterSignupRoute({
+        params: Promise.resolve({ locale: "en-US" }),
+      }),
+    );
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: newsletterSignup.title }),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/static-site/app/[locale]/newsletter-signup/page.tsx
+++ b/packages/static-site/app/[locale]/newsletter-signup/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { NewsletterSignupPage } from "@/components/newsletterSignup/NewsletterSignupPage";
+import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
+import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
+
+interface PageParams {
+  readonly locale: AppLocale;
+}
+
+interface Props {
+  readonly params: Promise<PageParams>;
+}
+
+/**
+ * Generates metadata advertising hreflang alternates for the newsletter signup page.
+ *
+ * @returns Metadata containing canonical and alternate-language links.
+ */
+export const generateMetadata = (): Metadata => {
+  return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: "/newsletter-signup" }) };
+};
+
+const NewsletterSignupRoute = async ({ params }: Props) => {
+  const { locale } = await params;
+
+  if (!hasAppLocale(locale)) {
+    notFound();
+  }
+
+  return <NewsletterSignupPage locale={locale} />;
+};
+
+export default NewsletterSignupRoute;

--- a/packages/static-site/components/newsletterSignup/GovDeliverySignupForm.test.tsx
+++ b/packages/static-site/components/newsletterSignup/GovDeliverySignupForm.test.tsx
@@ -1,0 +1,37 @@
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { GovDeliverySignupForm } from "./GovDeliverySignupForm";
+
+const removeInjectedLoaders = (): void => {
+  for (const script of document.querySelectorAll('script[src*="Signup.js"]')) {
+    script.remove();
+  }
+};
+
+afterEach(removeInjectedLoaders);
+
+describe("GovDeliverySignupForm", () => {
+  it("injects the GovDelivery loader with the account and signup id", () => {
+    const { container } = render(<GovDeliverySignupForm />);
+
+    const loader = container.querySelector('script[src*="Signup.js"]');
+    expect(loader).not.toBeNull();
+    expect(loader?.getAttribute("src")).toBe("https://public.govdelivery.com/assets/Signup.js");
+    expect(loader?.getAttribute("data-account-code")).toBe("NJGOV");
+    expect(loader?.getAttribute("data-signup-id")).toBe("31933");
+  });
+
+  it("does not set data-element-id, so the loader injects the form inline", () => {
+    const { container } = render(<GovDeliverySignupForm />);
+
+    const loader = container.querySelector('script[src*="Signup.js"]');
+    expect(loader?.hasAttribute("data-element-id")).toBe(false);
+  });
+
+  it("injects the loader only once", () => {
+    const { container, rerender } = render(<GovDeliverySignupForm />);
+    rerender(<GovDeliverySignupForm />);
+
+    expect(container.querySelectorAll('script[src*="Signup.js"]')).toHaveLength(1);
+  });
+});

--- a/packages/static-site/components/newsletterSignup/GovDeliverySignupForm.tsx
+++ b/packages/static-site/components/newsletterSignup/GovDeliverySignupForm.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const GOVDELIVERY_ACCOUNT_CODE = "NJGOV";
+const GOVDELIVERY_SIGNUP_ID = "31933";
+const GOVDELIVERY_SIGNUP_LOADER_SRC = "https://public.govdelivery.com/assets/Signup.js";
+
+/**
+ * GovDelivery injects an iframe and sizes it itself, so the container has no
+ * height until the iframe loads. Reserving the settled height keeps the card
+ * from expanding underneath the user mid-read. The height is a little taller
+ * on mobile screens, but setting min-height for desktop is sufficient to cover
+ * the most jarring scenario of no height without resorting to media queries.
+ */
+const GOVDELIVERY_FORM_HEIGHT_PX = 371;
+
+/**
+ * This uses a plain `<script>` rather than `next/script` because `next/script`
+ * hoists the tag to `<body>`, and GovDelivery injects the form next to its own
+ * tag so it would render outside the card. React-created script elements never
+ * execute on the client. Manual injection into a `ref`'d div makes sure the
+ * script executes while keeping the tag inline where the form should appear.
+ */
+export const GovDeliverySignupForm = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || container.querySelector("script")) {
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = GOVDELIVERY_SIGNUP_LOADER_SRC;
+    script.setAttribute("data-account-code", GOVDELIVERY_ACCOUNT_CODE);
+    script.setAttribute("data-signup-id", GOVDELIVERY_SIGNUP_ID);
+    container.appendChild(script);
+  }, []);
+
+  return <div ref={containerRef} style={{ minHeight: GOVDELIVERY_FORM_HEIGHT_PX }} />;
+};

--- a/packages/static-site/components/newsletterSignup/NewsletterSignupPage.test.tsx
+++ b/packages/static-site/components/newsletterSignup/NewsletterSignupPage.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { NewsletterSignupPage } from "./NewsletterSignupPage";
+
+const { newsletterSignup } = getApplicationMessages({ locale: "en-US" });
+
+describe("NewsletterSignupPage", () => {
+  it("renders the page heading", () => {
+    render(<NewsletterSignupPage locale="en-US" />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: newsletterSignup.title }),
+    ).toBeInTheDocument();
+  });
+
+  it("mounts the GovDelivery signup form", () => {
+    render(<NewsletterSignupPage locale="en-US" />);
+
+    expect(document.querySelector('script[data-signup-id="31933"]')).not.toBeNull();
+  });
+
+  it("wraps the signup form in a card", () => {
+    const { container } = render(<NewsletterSignupPage locale="en-US" />);
+
+    const card = container.querySelector(".usa-card__container");
+    expect(card).not.toBeNull();
+    expect(card?.querySelector('script[data-signup-id="31933"]')).not.toBeNull();
+  });
+});

--- a/packages/static-site/components/newsletterSignup/NewsletterSignupPage.tsx
+++ b/packages/static-site/components/newsletterSignup/NewsletterSignupPage.tsx
@@ -1,0 +1,28 @@
+import { GovDeliverySignupForm } from "@/components/newsletterSignup/GovDeliverySignupForm";
+import type { AppLocale } from "@/domain/i18n/locales";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+
+interface Props {
+  readonly locale: AppLocale;
+}
+
+/**
+ * Renders the newsletter signup page: a heading and the GovDelivery signup form.
+ *
+ * @param props.locale Locale used to resolve the heading copy.
+ * @returns The newsletter signup page content.
+ */
+export const NewsletterSignupPage = ({ locale }: Props) => {
+  const { newsletterSignup } = getApplicationMessages({ locale });
+
+  return (
+    <div className="grid-container usa-section">
+      <h1>{newsletterSignup.title}</h1>
+      <div className="usa-card__container">
+        <div className="usa-card__body">
+          <GovDeliverySignupForm />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/static-site/domain/content/messageTypes.ts
+++ b/packages/static-site/domain/content/messageTypes.ts
@@ -895,6 +895,14 @@ export interface ImpactReportMessages {
 }
 
 /**
+ * Localized content for the newsletter signup page.
+ */
+export interface NewsletterSignupMessages {
+  /** Page H1 title. */
+  readonly title: string;
+}
+
+/**
  * Complete localized message payload for one locale.
  */
 export interface ApplicationMessages {
@@ -916,4 +924,6 @@ export interface ApplicationMessages {
   readonly pageNotFound: PageNotFoundContent;
   /** Impact report page content strings. */
   readonly impactReport: ImpactReportMessages;
+  /** Newsletter signup page content strings. */
+  readonly newsletterSignup: NewsletterSignupMessages;
 }

--- a/packages/static-site/messages/en-US.json
+++ b/packages/static-site/messages/en-US.json
@@ -887,5 +887,8 @@
         }
       ]
     }
+  },
+  "newsletterSignup": {
+    "title": "Subscribe to Business.NJ.gov Updates"
   }
 }

--- a/packages/static-site/messages/es-US.json
+++ b/packages/static-site/messages/es-US.json
@@ -887,5 +887,8 @@
         }
       ]
     }
+  },
+  "newsletterSignup": {
+    "title": "Subscribe to Business.NJ.gov Updates"
   }
 }

--- a/packages/static-site/tests/accessibility/newsletter-signup.a11y.spec.ts
+++ b/packages/static-site/tests/accessibility/newsletter-signup.a11y.spec.ts
@@ -1,0 +1,61 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+import type { BrowserContext, Page } from "playwright";
+import type { AppLocale } from "@/domain/i18n/locales";
+import { ENABLED_LOCALES } from "@/domain/i18n/locales";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+
+/**
+ * Defines the test context provided by Playwright.
+ */
+interface AccessibilityTestContext {
+  /** Browser page used by the test run. */
+  readonly page: Page;
+  /** Browser context, used to seed cookies before navigation. */
+  readonly context: BrowserContext;
+}
+
+/**
+ * Parameters for creating one locale-specific accessibility test.
+ */
+interface CreateLocaleAccessibilityTestParams {
+  /** Locale to evaluate in the browser accessibility audit. */
+  readonly locale: AppLocale;
+}
+
+/**
+ * Creates a Playwright accessibility test for one locale.
+ *
+ * The audit covers the page shell only. The GovDelivery signup form renders in
+ * a cross-origin iframe that axe cannot inspect and the site does not control.
+ */
+const createLocaleAccessibilityTest = ({ locale }: CreateLocaleAccessibilityTestParams) => {
+  return async ({ page, context }: AccessibilityTestContext) => {
+    const { newsletterSignup } = getApplicationMessages({ locale });
+
+    // Suppress the preferred-language prompt modal so its open/animation state
+    // cannot race with the axe scan, which made this audit flaky.
+    await context.addCookies([
+      {
+        name: LANGUAGE_PROMPT_DISMISSED_COOKIE,
+        value: "true",
+        url: "http://127.0.0.1:3000",
+      },
+    ]);
+
+    await page.goto(`/${locale}/newsletter-signup`);
+    await page.getByRole("heading", { level: 1, name: newsletterSignup.title }).waitFor();
+
+    const results = await new AxeBuilder({ page }).analyze();
+
+    expect(results.violations).toEqual([]);
+  };
+};
+
+for (const locale of ENABLED_LOCALES) {
+  test(
+    `newsletter signup page has no automated WCAG violations for ${locale}`,
+    createLocaleAccessibilityTest({ locale }),
+  );
+}


### PR DESCRIPTION
## Description

Migrates the `/newsletter-signup` page from Webflow to the static site. The page renders a heading and the GovDelivery Signup Builder form, wrapped in an NJWDS card. Since the GovDelivery form renders inside an iframe, we can't get 100% visual parity with the NJWDS aesthetic (i.e form input and buttons aren't rounded), but fonts and colors remain consistent

### Ticket

This pull request resolves [#17912](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17912).

### Approach

- Route `app/[locale]/newsletter-signup` mirrors the `impact-report` pattern
  (hreflang metadata + locale guard).
- The GovDelivery `Signup.js` loader injects the form as a sibling of its own
  `<script>` tag, so `next/script` (which hoists to `<body>`) can't be used. A
  `"use client"` component appends the loader into a `ref`'d container instead.
- Adds a `newsletterSignup` message key to both `en-US` and `es-US`.

### Steps to Test

1. Visit `/newsletter-signup`.
2. Enter an email, check the consent box, and submit.
3. Confirm the subscription lands in GovDelivery via the admin panel.

### Screenshots

<details>

<summary>Initial page</summary>

<img width="1208" height="1162" alt="Screenshot 2026-07-15 at 19 14 17" src="https://github.com/user-attachments/assets/17ba97bc-9cbd-4287-bd44-5852df490265" />

</details>

<details>

<summary>Form message after submission</summary>

<img width="1208" height="1162" alt="Screenshot 2026-07-15 at 19 14 45" src="https://github.com/user-attachments/assets/73957389-73b1-4503-a595-89912faa3400" />

</details>


