### PR TITLE
feat: add independent static site release pipeline

### DIFF
--- a/.github/workflows/static-site-release-pipeline.yml
+++ b/.github/workflows/static-site-release-pipeline.yml
@@ -1,0 +1,145 @@
+name: Static Site Release Pipeline
+
+# Deploys only the static site, independently of the navigator monorepo release.
+# The static site builds to its own image, ECR repository, and ECS service, so it
+# can ship on its own cadence. Both stages deploy the same image tag, so the
+# artifact approved on staging is the exact artifact promoted to production.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: static-site-release-pipeline
+  cancel-in-progress: false
+
+jobs:
+  # The tag is resolved once and reused by both stages. Resolving it per job would
+  # let staging and production diverge when an approval lands on a later date.
+  resolve-image-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      image_tag: ${{ steps.resolve.outputs.image_tag }}
+    steps:
+      - name: Resolve Image Tag
+        id: resolve
+        shell: bash
+        run: |
+          # Intentionally uses a date + short SHA instead of the application version.
+          # This release pipeline runs independently from the main release pipeline,
+          # so using a distinct tagging strategy helps prevent image tag collisions.
+          image_tag="$(date -u +%Y%m%d)-${GITHUB_SHA:0:7}"
+          echo "image_tag=$image_tag" >> "$GITHUB_OUTPUT"
+          echo "Static site image tag: $image_tag"
+
+  deploy-staging:
+    needs: resolve-image-tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment: staging
+    env:
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID_STAGING }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
+      AWS_REGION: ${{ vars.AWS_CRYPTO_CONTEXT_ORIGIN }}
+      BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
+      BASIC_AUTH_USERNAME: ${{ vars.BASIC_AUTH_USERNAME }}
+      NEXT_PUBLIC_MULTILINGUAL_ENABLED: ${{ vars.NEXT_PUBLIC_MULTILINGUAL_ENABLED }}
+      NEXT_PUBLIC_WEB_BASE_URL: ${{ vars.WEB_BASE_URL_STAGING }}
+      SG_ID: ${{ vars.SG_ID_AWS_STAGING }}
+      STAGE: ${{ vars.STAGE_STAGING }}
+      SUBNET_ID_01: ${{ vars.SUBNET_ID_01_AWS_STAGING }}
+      SUBNET_ID_02: ${{ vars.SUBNET_ID_02_AWS_STAGING }}
+      VPC_ID: ${{ vars.VPC_ID_AWS_STAGING }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - name: Install Dependencies
+        shell: bash
+        run: yarn install --immutable
+
+      # The static site Dockerfile copies content/lib into the build, and
+      # content/lib is generated rather than committed.
+      - name: Build Content
+        shell: bash
+        run: yarn workspace @businessnjgovnavigator/content build
+
+      - name: Build Content Types
+        shell: bash
+        run: yarn workspace @businessnjgovnavigator/content-types build
+
+      - name: Deploy Static Site
+        uses: ./.github/actions/deploy-static-site
+        with:
+          image_tag: ${{ needs.resolve-image-tag.outputs.image_tag }}
+
+  production-hold:
+    needs: deploy-staging
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment: prod-hold
+    steps:
+      - run: echo "Awaiting approval for static site production release."
+
+  deploy-production:
+    needs: [resolve-image-tag, production-hold]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment: prod
+    env:
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID_PROD }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
+      AWS_REGION: ${{ vars.AWS_CRYPTO_CONTEXT_ORIGIN }}
+      BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
+      BASIC_AUTH_USERNAME: ${{ vars.BASIC_AUTH_USERNAME }}
+      NEXT_PUBLIC_MULTILINGUAL_ENABLED: ${{ vars.NEXT_PUBLIC_MULTILINGUAL_ENABLED }}
+      NEXT_PUBLIC_WEB_BASE_URL: ${{ vars.WEB_BASE_URL_PROD }}
+      SG_ID: ${{ vars.SG_ID_AWS_PROD }}
+      STAGE: ${{ vars.STAGE_PROD }}
+      SUBNET_ID_01: ${{ vars.SUBNET_ID_01_AWS_PROD }}
+      SUBNET_ID_02: ${{ vars.SUBNET_ID_02_AWS_PROD }}
+      VPC_ID: ${{ vars.VPC_ID_AWS_PROD }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - name: Install Dependencies
+        shell: bash
+        run: yarn install --immutable
+
+      # The static site Dockerfile copies content/lib into the build, and
+      # content/lib is generated rather than committed.
+      - name: Build Content
+        shell: bash
+        run: yarn workspace @businessnjgovnavigator/content build
+
+      - name: Build Content Types
+        shell: bash
+        run: yarn workspace @businessnjgovnavigator/content-types build
+
+      - name: Deploy Static Site
+        uses: ./.github/actions/deploy-static-site
+        with:
+          image_tag: ${{ needs.resolve-image-tag.outputs.image_tag }}

--- a/api/cdk/lib/staticSiteRepositoryStack.ts
+++ b/api/cdk/lib/staticSiteRepositoryStack.ts
@@ -8,7 +8,8 @@ import { applyStandardTags } from "./stackUtils";
  * Number of tagged static-site images retained in the shared ECR repository.
  *
  * The shared repository carries dev, content, testing, staging, and production tags, so the policy
- * keeps enough history for lower-environment SHA tags and production point-release tags.
+ * keeps enough history for lower-environment SHA tags, the independent static-site pipeline's
+ * date-SHA tags, and production point-release tags.
  */
 const STATIC_SITE_TAGGED_IMAGE_RETENTION_COUNT = 100;
 


### PR DESCRIPTION
## Description

Today the static site can only reach production as the final step of `release-pipeline.yml`, which includes a full release of navigator (i.e. deploying `web/` and `api/`). This PR adds a workflow that lets us deploy the static site independently.

### Ticket

This pull request resolves [#17934](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17934).

### Approach

- This mostly strips out unnecessary navigator deploy elements and minimizes new logic. It reuses the existing `deploy-static-site` action and re-reaches the existing `StaticSiteServiceStack-{staging,prod}` CDK stacks.

- Uses separate tagging logic (`<YYYYMMDD>-<short-sha>` here vs. the `package.json` version in the full deploy). The ECS task definition pins whichever tag the most recent deploy set. See my inline review comments for the tag-format rationale, the `prod-hold` gate, and the `release-*` trigger contrast.

- Both jobs build `content` before deploying. The Dockerfile copies in `content/lib`, which is generated/gitignored, so a checkout alone can't produce it. `release-pipeline.yml` gets it for free from its full monorepo build, but this pipeline explicitly generates it.

- The two deploy jobs differ only by `_STAGING`/`_PROD` suffixes, matching how `release-pipeline.yml` already does it. A reusable workflow taking `stage` is a larger refactor we could consider in follow-up work.

### Steps to Test

The only testing is verification of the pipeline itself. I pre-verified the config to make sure all the `vars` and `secrets` references and the `prod-hold` environment are good, but **this has not been run against real infrastructure yet**, so the first dispatch is the real test.

1. Run the `Static Site Release Pipeline` workflow from this branch (or from `main` post-merge)
2. Watch `deploy-staging`: content build succeeds, image pushes to `bfs-static-site`, `StaticSiteServiceStack-staging` deploys. Confirm CDK touches **only** static site stacks.
3. Verify staging renders.
4. Approve at `production-hold`, confirm `deploy-production` promotes the same `<date>-<short-sha>` tag that staging deployed.
5. Confirm navigator prod is untouched.

Make sure to do a thorough staging-only trial before approving through to prod.

### Notes

Deliberately left for follow-ups:

- There's no automated verification between staging and prod. The gate is a human approval, same as the current release pipeline.
- `release-pipeline.yml` still deploys the static site, too. I think we'll want to continue that, but something to consider if this independent deploy seems to be reliable enough on its own.
- There's a redundant "Build Content Types" step in all three static-site workflows. The Dockerfile compiles content-types from source itself, so the host step is a no-op. Dropping it should be a separate PR touching all three together.