### PR TITLE
chore: [AB#17931] add task completion analytics

### DIFF
--- a/web/src/lib/UpdateQueue.ts
+++ b/web/src/lib/UpdateQueue.ts
@@ -1,3 +1,4 @@
+import analytics from "@/lib/utils/analytics";
 import {
   Business,
   BusinessUser,
@@ -158,6 +159,13 @@ export class UpdateQueueFactory implements UpdateQueue {
   }
 
   queueTaskProgress(taskProgress: Record<string, TaskProgress>): UpdateQueue {
+    for (const [taskName, progress] of Object.entries(taskProgress)) {
+      if (progress === "COMPLETED") {
+        analytics.event.task_progress.update.task_completed(taskName);
+      } else if (progress === "TO_DO") {
+        analytics.event.task_progress.update.task_uncompleted(taskName);
+      }
+    }
     this.internalQueue = {
       ...this.internalQueue,
       businesses: {

--- a/web/src/lib/utils/analytics.ts
+++ b/web/src/lib/utils/analytics.ts
@@ -32,6 +32,7 @@ type EventType =
   | "task_search_interactions"
   | "task_tab_clicked"
   | "task_tab_clicks"
+  | "task_progress_updates"
   | "task_tab_continue_button_clicks"
   | "tax_calendar_arrive_v2"
   | "tax_calendar_click_v2"
@@ -81,6 +82,7 @@ const eventMap: Record<EventType, string> = {
   task_search_interactions: "task_search_interactions",
   task_tab_clicked: "task_tab_clicked",
   task_tab_clicks: "task_tab_clicks",
+  task_progress_updates: "task_progress_updates",
   task_tab_continue_button_clicks: "task_tab_continue_button_clicks",
   tax_calendar_arrive_v2: "tax_calendar_arrive_v2",
   tax_calendar_click_v2: "tax_calendar_click_v2",
@@ -1104,6 +1106,28 @@ export default {
             legacy_event_category: "task_status_checklist_edit_button",
             legacy_event_label: "edit_address_form",
             form_name: "task_address_form",
+          });
+        },
+      },
+    },
+    task_progress: {
+      update: {
+        task_completed: (task_name: string) => {
+          eventRunner.track({
+            event: "task_progress_updates",
+            legacy_event_action: "submit",
+            legacy_event_category: "task_progress",
+            legacy_event_label: "task_completed",
+            on_task_id: task_name,
+          });
+        },
+        task_uncompleted: (task_name: string) => {
+          eventRunner.track({
+            event: "task_progress_updates",
+            legacy_event_action: "submit",
+            legacy_event_category: "task_progress",
+            legacy_event_label: "task_uncompleted",
+            on_task_id: task_name,
           });
         },
       },


### PR DESCRIPTION
## Description

Add analytics tracking for task completion and uncompletion events via the `task_progress_updates` event type.

### Ticket

This pull request resolves [#17931](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17931).

### Approach

- Added `task_progress_updates` event type and `task_progress.update.task_completed`/`task_uncompleted` analytics methods in `analytics.ts`
- No new dependencies

### Steps to Test

- Complete a task (e.g., the business structure task) and verify the `task_progress_updates` event fires with label `task_completed`
- Unmark a completed task and verify the event fires with label `task_uncompleted`

### Notes

None.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews