### PR TITLE
chore: [AB#17944] fix Quick Services click_text tracking

### DIFF
--- a/packages/static-site/app/landing.css
+++ b/packages/static-site/app/landing.css
@@ -41,10 +41,36 @@ a.card:hover {
 
 .quick-service-card {
   gap: 1rem;
+  position: relative;
+}
+
+.quick-service-card:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.quick-service-card:focus-within {
+  outline: 0.25rem solid #0050d8;
+  outline-offset: 0;
 }
 
 .quick-service-card__icon {
   flex-shrink: 0;
+}
+
+.quick-service-card__link,
+.quick-service-card__link:visited,
+.quick-service-card__link:hover {
+  color: inherit;
+}
+
+.quick-service-card__link:focus {
+  outline: 0;
+}
+
+.quick-service-card__link::after {
+  content: "";
+  position: absolute;
+  inset: 0;
 }
 
 .support-card {

--- a/packages/static-site/components/landing/LocalizedLink.tsx
+++ b/packages/static-site/components/landing/LocalizedLink.tsx
@@ -21,6 +21,8 @@ export interface LocalizedLinkProps {
   readonly className?: string;
   /** Optional aria-label override for the anchor element. */
   readonly ariaLabel?: string;
+  /** Optional ID of an element that describes the anchor. */
+  readonly ariaDescribedBy?: string;
   /** Optional title attribute for the anchor element. */
   readonly title?: string;
   /** Optional custom children for replacing the link label text. */
@@ -37,6 +39,7 @@ export interface LocalizedLinkProps {
  * @param props.link Link metadata used to select render behavior.
  * @param props.className Optional class names for the rendered link.
  * @param props.ariaLabel Optional aria-label override.
+ * @param props.ariaDescribedBy Optional ID of an element that describes the link.
  * @param props.title Optional title attribute.
  * @param props.children Optional custom link content.
  * @returns A locale-aware link element.
@@ -49,6 +52,7 @@ export const LocalizedLink = ({
   link,
   className,
   ariaLabel,
+  ariaDescribedBy,
   title,
   children,
 }: LocalizedLinkProps) => {
@@ -56,7 +60,13 @@ export const LocalizedLink = ({
 
   if (link.isInternal) {
     return (
-      <Link aria-label={ariaLabel} className={className} href={link.href} title={title}>
+      <Link
+        aria-describedby={ariaDescribedBy}
+        aria-label={ariaLabel}
+        className={className}
+        href={link.href}
+        title={title}
+      >
         {labelContent}
       </Link>
     );
@@ -67,6 +77,7 @@ export const LocalizedLink = ({
 
   return (
     <a
+      aria-describedby={ariaDescribedBy}
       aria-label={ariaLabel}
       className={className}
       href={link.href}

--- a/packages/static-site/components/landing/QuickServicesSection.test.tsx
+++ b/packages/static-site/components/landing/QuickServicesSection.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { QuickServicesSection } from "@/components/landing/QuickServicesSection";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+
+const content = getApplicationMessages({ locale: "en-US" }).landing.quickServices;
+
+describe("QuickServicesSection", () => {
+  it("uses only each service title as the link text", () => {
+    render(<QuickServicesSection content={content} />);
+
+    for (const item of content.items) {
+      const link = screen.getByRole("link", { name: item.title });
+
+      expect(link).toHaveTextContent(item.title);
+      expect(link).not.toHaveTextContent(item.description);
+      expect(link).toHaveAttribute("href", item.link.href);
+      expect(link).toHaveAccessibleDescription(item.description);
+      expect(screen.getByText(item.description)).not.toBe(link);
+    }
+  });
+});

--- a/packages/static-site/components/landing/QuickServicesSection.tsx
+++ b/packages/static-site/components/landing/QuickServicesSection.tsx
@@ -14,8 +14,12 @@ export const QuickServicesSection = ({ content }: QuickServicesSectionProps) => 
         <h2 className="font-heading-2xl dark-blue">{content.title}</h2>
         <p className="margin-bottom-5">{content.subtitle}</p>
         <div className="grid-row grid-gap">
-          {content.items.map((item) => (
-            <QuickServiceCard item={item} key={item.title} />
+          {content.items.map((item, index) => (
+            <QuickServiceCard
+              descriptionId={`quick-service-description-${index}`}
+              item={item}
+              key={item.title}
+            />
           ))}
         </div>
       </div>
@@ -23,18 +27,33 @@ export const QuickServicesSection = ({ content }: QuickServicesSectionProps) => 
   );
 };
 
-const QuickServiceCard = (props: { item: QuickServicesItem }) => {
+interface QuickServiceCardProps {
+  readonly descriptionId: string;
+  readonly item: QuickServicesItem;
+}
+
+const QuickServiceCard = ({ descriptionId, item }: QuickServiceCardProps) => {
   return (
     <div className="grid-col-12 tablet:grid-col-6 desktop:grid-col-4 margin-bottom-2">
-      <LocalizedLink className="card quick-service-card" link={props.item.link}>
+      <div className="card quick-service-card">
         <div className="quick-service-card__icon">
-          <Image src={props.item.iconPath} alt={props.item.iconAlt} width={48} height={48} />
+          <Image src={item.iconPath} alt={item.iconAlt} width={48} height={48} />
         </div>
         <div>
-          <h3 className="card__title">{props.item.title}</h3>
-          <p className="card__description">{props.item.description}</p>
+          <h3 className="card__title">
+            <LocalizedLink
+              ariaDescribedBy={descriptionId}
+              className="quick-service-card__link"
+              link={item.link}
+            >
+              {item.title}
+            </LocalizedLink>
+          </h3>
+          <p className="card__description" id={descriptionId}>
+            {item.description}
+          </p>
         </div>
-      </LocalizedLink>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Description

Updates the static-site homepage Quick Services cards so GA4 `click_text` contains only the service title instead of combining the title and supporting description.

### Ticket

This pull request resolves [#17944](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17944).

### Approach

- Moves each Quick Service link around the card title only.
- Uses a stretched-link pseudo-element so the full card remains clickable.
- Associates the visible supporting copy with the link through `aria-describedby`.
- Preserves the existing full-card hover and Grove focus states.
- Adds component coverage for link text, destination, and accessible descriptions.

### Steps to Test

1. Start the static site with `pnpm dev` from `packages/static-site`.
2. Open the homepage and find Quick Services.
3. Confirm clicking the title, icon, description, or card spacing for "Licenses & Permits" opens the licensing and certification guide.
4. In GTM Preview, confirm the click produces one event with `click_text` equal to `Licenses & Permits` and does not include `Apply for required business licenses`.
5. Tab to the card and confirm the full card has a visible focus outline.

### Notes

Validated with `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build`. A focused Playwright and axe check also confirmed the stretched-card interaction, accessible description, Grove focus outline, and no Quick Services accessibility violations.

Confirmed reduction in GA4 click events using Omnibug.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
