### PR TITLE
fix: flaky cypress dropdown click race

### DIFF
--- a/web/cypress/support/page_objects/dashboardPage.ts
+++ b/web/cypress/support/page_objects/dashboardPage.ts
@@ -21,7 +21,7 @@ export class DashboardPage {
   };
 
   clickEditProfileInDropdown = () => {
-    this.getDropdown().first().should("be.visible").click({ force: true });
+    this.getDropdown().first().should("be.visible").and("be.enabled").click({ force: true });
     cy.get('[data-testid="nav-bar-popup-menu"]').should("be.visible");
     this.getProfileLinkInDropdown().first().should("be.visible").click({ force: true });
   };


### PR DESCRIPTION
## Description

CI intermittently failed `multiple-businesses.spec.ts` with a 20s timeout waiting for `[data-testid="nav-bar-popup-menu"]` after calling `clickEditProfileInDropdown()`. Investigation of the failing run (https://github.com/newjersey/navigator.business.nj.gov/actions/runs/30364129568) traced it to a race in the shared Cypress page object.

### Approach

`clickEditProfileInDropdown()` clicked the desktop dropdown button with `{ force: true }` before confirming the navbar had finished re-rendering out of its disabled `MINIMAL_WITH_DISABLED_DROPDOWN` variant (shown during onboarding/loading). `force: true` bypasses Cypress' disabled-element check, so the click could land on the stale disabled button and silently no-op, leaving the test to time out waiting for the popup menu that never opened.

Added a `.and("be.enabled")` retry-guard before the click so Cypress waits for the real, enabled dropdown button first. Kept `{ force: true }` on both clicks in this helper — removing it broke `guest.spec.ts` reproducibly in local testing, so it's still required there for a separate reason (likely a lingering overlay), which is out of scope for this fix.

No dependency, migration, or config changes.

### Steps to Test

1. `yarn services:up && yarn start:dev`
2. `cd web && CYPRESS_RANDOM_SEED=00g8p44i0my5g yarn cypress run --spec cypress/e2e/multiple-businesses.spec.ts` — replays the exact CI failing seed; should be 4/4 passing.
3. `yarn cypress run --spec cypress/e2e/dashboard.spec.ts` and `cypress/e2e/guest.spec.ts` — should remain 10/10 and 1/1 passing (these share the same helper).

### Notes

This was a flake, not a regression from any single commit. An automatic retry already passed on the same run. This change hardens the helper so the underlying race no longer surfaces as an occasional timeout.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews