### PR TITLE
fix: add explicit cypress install to setup script

### DIFF
--- a/scripts/_install.sh
+++ b/scripts/_install.sh
@@ -384,6 +384,13 @@ echo "=== [6/7] Install dependencies and build ==="
 # ============================================================
 
 yarn install && yarn build || { echo "Root install or build failed."; exit 1; }
+
+# Cypress's postinstall hook normally downloads the binary during `yarn install`,
+# but Yarn 4 disables dependency lifecycle scripts by default (enableScripts: false).
+# Explicitly verify the binary is present to avoid confusing errors later.
+echo "Verifying Cypress binary..."
+yarn cypress install
+
 (
     cd packages/static-site
     pnpm install


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Noticed that my Cypress binary was missing while trying to run e2e tests locally, and found that even though Cypress is included in our `package.json`, running `yarn install` is not sufficient to ensure that Cypress is actually installed. 

To address this, we add `yarn cypress install` to the install script. If the binary is already present it returns instantly, and if it's missing it downloads it.

Previous developers likely had a leftover Cypress binary in ~/Library/Caches/Cypress/ from a older install or manually installed Cypress to bypass this error.


### Ticket

Have not created a ticket for this.



### Approach

I investigated with Claude and found out that Cypress is actually installed through postinstall scripts, which Yarn does not execute by default.

From [Cypress docs](https://docs.cypress.io/app/get-started/install-cypress):
> Cypress uses a postinstall script to download the Cypress binary into the [binary cache](https://docs.cypress.io/app/references/advanced-installation#Binary-cache). As a security hardening measure, package managers increasingly block dependency lifecycle scripts such as postinstall by default. When the script is blocked, the Cypress binary is not downloaded and Cypress will not run.

From [Yarn docs](https://yarnpkg.com/configuration/yarnrc#enableScripts) on `enableScripts`: 
>  Define whether to run postinstall scripts or not.
>
> If false (the default), Yarn will not execute the postinstall scripts from third-party packages when installing the project (workspaces will still see their postinstall scripts evaluated, as they're assumed to be safe if you're running an install within them).

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [ ] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
