### PR TITLE
fix: [AB#17957] repair stranded KMS ciphertext

### DIFF
--- a/.github/workflows/testing-deployment-trigger.yml
+++ b/.github/workflows/testing-deployment-trigger.yml
@@ -20,6 +20,8 @@ jobs:
     environment: testing
     env:
       AWS_REGION: ${{ vars.AWS_CRYPTO_CONTEXT_ORIGIN }}
+      AWS_CRYPTO_CONTEXT_ORIGIN: ${{ vars.AWS_CRYPTO_CONTEXT_ORIGIN }}
+      AWS_CRYPTO_CONTEXT_STAGE: ${{ vars.AWS_CRYPTO_CONTEXT_STAGE_DEV }}
       VPC_ID: ${{ vars.VPC_ID_AWS_DEV }}
       SUBNET_ID_01: ${{ vars.SUBNET_ID_01_AWS_DEV }}
       SUBNET_ID_02: ${{ vars.SUBNET_ID_02_AWS_DEV }}

--- a/api/cdk/lib/iamStack.ts
+++ b/api/cdk/lib/iamStack.ts
@@ -233,6 +233,7 @@ export class IamStack extends Stack {
         "dynamodb:UpdateItem",
         "dynamodb:DeleteItem",
         "dynamodb:PartiQLSelect",
+        "dynamodb:TransactWriteItems",
       ],
       resources: [
         `arn:aws:dynamodb:${this.region}:*:table/${USERS_TABLE}-${props.stage}`,

--- a/api/cdk/lib/lambdaStack.ts
+++ b/api/cdk/lib/lambdaStack.ts
@@ -339,7 +339,7 @@ export class LambdaStack extends Stack {
       entry: path.join(__dirname, "../../src/functions/migrateUsersVersion/app.ts"),
       handler: "handler",
       runtime: Runtime.NODEJS_22_X,
-      timeout: Duration.seconds(30),
+      timeout: Duration.minutes(4),
       memorySize: 1024,
       ephemeralStorageSize: Size.mebibytes(512),
       ...vpcProps,
@@ -352,6 +352,9 @@ export class LambdaStack extends Stack {
         AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY: awsCryptoTaxIdEncryptionKey,
         LEGACY_AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY: legacyAwsCryptoTaxIdEncryptionKey,
         AWS_CRYPTO_CONTEXT_TAX_ID_ENCRYPTION_PURPOSE: awsCryptoContextTaxIdEncryptionPurpose,
+        AWS_CRYPTO_TAX_ID_HASHING_KEY: awsCryptoTaxIdHashingKey,
+        AWS_CRYPTO_CONTEXT_TAX_ID_HASHING_PURPOSE: awsCryptoContextTaxIdHashingPurpose,
+        AWS_CRYPTO_TAX_ID_ENCRYPTED_HASHING_SALT: awsCryptoTaxIdHashingSalt,
       },
     });
 

--- a/api/cdk/lib/monitoringStack.ts
+++ b/api/cdk/lib/monitoringStack.ts
@@ -49,12 +49,6 @@ export class MonitoringStack extends Stack {
       `/aws/lambda/businessnjgov-api-v2-${props.stage}-express`,
     );
 
-    const migrateUsersVersionLogGroup = logs.LogGroup.fromLogGroupName(
-      this,
-      "MigrateUsersVersionLogGroup",
-      `/aws/lambda/businessnjgov-api-v2-${props.stage}-migrateUsersVersion`,
-    );
-
     if (props.stage === "dev") {
       new logs.LogGroup(this, "ApiLogLocalGroup", {
         logGroupName: `/${NAVIGATOR_WEBSERVICE}/local/ApiLogs`,
@@ -115,23 +109,14 @@ export class MonitoringStack extends Stack {
       },
     );
 
-    const migrationFailureMetricFilter = new logs.MetricFilter(
-      this,
-      "MigrationFailureMetricFilter",
-      {
-        logGroup: migrateUsersVersionLogGroup,
-        filterName: `MigrationFailureCount-${props.stage}`,
-        metricNamespace: "BFS/Navigator/Lambda",
-        metricName: "MigrateUserVersionsFailures",
-        filterPattern: logs.FilterPattern.literal('"MigrateUserVersions Failed"'),
-        metricValue: "1",
-        defaultValue: 0,
-      },
-    );
-
-    const migrationFailureMetric = migrationFailureMetricFilter.metric({
+    const migrationFailureMetric = new cloudwatch.Metric({
+      namespace: "AWS/Lambda",
+      metricName: "Errors",
       statistic: "Sum",
       period: Duration.seconds(300),
+      dimensionsMap: {
+        FunctionName: `businessnjgov-api-v2-${props.stage}-migrateUsersVersion`,
+      },
     });
 
     this.migrationLambdaTopic = new sns.Topic(this, "migrationLambdaTopic", {
@@ -166,13 +151,14 @@ export class MonitoringStack extends Stack {
       metric: migrationFailureMetric,
       threshold: 1,
       evaluationPeriods: 1,
-      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      alarmDescription: `Alarm when the MigrateUserVersions failure count exceeds the threshold for ${props.stage}`,
+      alarmDescription: `Alarm when MigrateUserVersions reports an invocation error for ${props.stage}`,
     });
 
     migrationFailureAlarm.addAlarmAction(
       new cloudwatch_actions.SnsAction(migrateUserVersionErrorTopic),
+      new cloudwatch_actions.SnsAction(this.migrationLambdaTopic),
     );
     migrationFailureAlarm.applyRemovalPolicy(RemovalPolicy.RETAIN);
 

--- a/api/cdk/test/iamStack.test.ts
+++ b/api/cdk/test/iamStack.test.ts
@@ -164,6 +164,7 @@ describe("IamStack", () => {
                 "dynamodb:UpdateItem",
                 "dynamodb:DeleteItem",
                 "dynamodb:PartiQLSelect",
+                "dynamodb:TransactWriteItems",
               ],
               Effect: "Allow",
               Resource: Match.anyValue(),

--- a/api/cdk/test/lambdaStack.test.ts
+++ b/api/cdk/test/lambdaStack.test.ts
@@ -69,10 +69,14 @@ describe("LambdaStack", () => {
       template.hasResourceProperties("AWS::Lambda::Function", {
         FunctionName: Match.stringLikeRegexp("businessnjgov-api-v2-local-migrateUsersVersion"),
         Runtime: "nodejs22.x",
+        Timeout: 240,
         Environment: {
           Variables: Match.objectLike({
             USERS_TABLE: "users-table-local",
             BUSINESSES_TABLE: "businesses-table-local",
+            AWS_CRYPTO_TAX_ID_HASHING_KEY: Match.anyValue(),
+            AWS_CRYPTO_CONTEXT_TAX_ID_HASHING_PURPOSE: Match.anyValue(),
+            AWS_CRYPTO_TAX_ID_ENCRYPTED_HASHING_SALT: Match.anyValue(),
           }),
         },
       });

--- a/api/cdk/test/monitoringStack.test.ts
+++ b/api/cdk/test/monitoringStack.test.ts
@@ -1,0 +1,41 @@
+import { App } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { MonitoringStack } from "../lib/monitoringStack";
+
+describe("MonitoringStack migration alarm", () => {
+  it("uses native Lambda errors and notifies operators and the kill switch", () => {
+    const app = new App();
+    const stack = new MonitoringStack(app, "TestMonitoringStack", { stage: "local" });
+    const alarms = Template.fromStack(stack).findResources("AWS::CloudWatch::Alarm", {
+      Properties: {
+        AlarmName: "bfs-migrate-userVersions-failures-local",
+      },
+    });
+    const alarm = Object.values(alarms)[0].Properties;
+
+    expect(alarm).toMatchObject({
+      Namespace: "AWS/Lambda",
+      MetricName: "Errors",
+      Statistic: "Sum",
+      Threshold: 1,
+      EvaluationPeriods: 1,
+      ComparisonOperator: "GreaterThanOrEqualToThreshold",
+      Dimensions: [
+        {
+          Name: "FunctionName",
+          Value: "businessnjgov-api-v2-local-migrateUsersVersion",
+        },
+      ],
+    });
+    expect(alarm.AlarmActions).toEqual(
+      expect.arrayContaining([
+        {
+          Ref: expect.stringContaining("MigrateUserVersionErrorTopic"),
+        },
+        {
+          Ref: expect.stringContaining("migrationLambdaTopic"),
+        },
+      ]),
+    );
+  });
+});

--- a/api/scripts/generateUserSchemaFile.ts
+++ b/api/scripts/generateUserSchemaFile.ts
@@ -15,7 +15,7 @@ import path from "node:path";
 
 const migrationFilePath = path.resolve(
   __dirname,
-  "../src/db/migrations/v192_fix_confirmation_email_sent_typo.ts",
+  "../src/db/migrations/v193_rotate_stranded_legacy_kms_fields.ts",
 );
 
 const tsconfigPath = path.resolve(__dirname, "../tsconfig.json");

--- a/api/scripts/printUserZodSchema.ts
+++ b/api/scripts/printUserZodSchema.ts
@@ -25,7 +25,7 @@
  * ```
  */
 
-import { v192UserDataSchema, withNoBase64Check } from "@db/zodSchema/zodSchemas";
+import { v193UserDataSchema, withNoBase64Check } from "@db/zodSchema/zodSchemas";
 import { generateTsSourceFromCompiler } from "./userSchemaCompiler";
 import { generateTsSourceFromZod, generateZodSource } from "./userSchemaGenerator";
 import { highlight } from "cli-highlight";
@@ -34,12 +34,12 @@ import { z } from "zod";
 
 const migrationFilePath = path.resolve(
   __dirname,
-  "../src/db/migrations/v192_fix_confirmation_email_sent_typo.ts",
+  "../src/db/migrations/v193_rotate_stranded_legacy_kms_fields.ts",
 );
 
 const tsconfigPath = path.resolve(__dirname, "../tsconfig.json");
 
-const finalZodSchema = withNoBase64Check(v192UserDataSchema);
+const finalZodSchema = withNoBase64Check(v193UserDataSchema);
 const shouldPrintZod = process.argv.includes("--zod");
 const shouldPrintJson = process.argv.includes("--json");
 const shouldPrintTsZod = process.argv.includes("--ts-zod");
@@ -53,10 +53,10 @@ if (modeCount !== 1) {
 }
 
 if (shouldPrintZod) {
-  const source = generateZodSource(v192UserDataSchema);
+  const source = generateZodSource(v193UserDataSchema);
   console.log(highlight(source, { language: "typescript" }));
 } else if (shouldPrintTsZod) {
-  const source = generateTsSourceFromZod(v192UserDataSchema);
+  const source = generateTsSourceFromZod(v193UserDataSchema);
   console.log(highlight(source, { language: "typescript" }));
 } else if (shouldPrintTs) {
   const source = generateTsSourceFromCompiler(migrationFilePath, tsconfigPath);

--- a/api/scripts/userSchemaCompiler.ts
+++ b/api/scripts/userSchemaCompiler.ts
@@ -1,6 +1,6 @@
 /**
  * TypeScript Compiler API utilities for generating a `UserData` interface
- * by fully expanding the `v192UserData` type from the migration source.
+ * by fully expanding the `v193UserData` type from the migration source.
  *
  * This lives in `scripts/` (not `src/domain/`) because it depends on
  * `typescript` (a dev dependency) and `path`, neither of which are
@@ -110,7 +110,7 @@ export const serializeType = (checker: ts.TypeChecker, type: ts.Type, depth: num
 };
 
 /**
- * Uses the TypeScript Compiler API to resolve the `v192UserData` interface and
+ * Uses the TypeScript Compiler API to resolve the `v193UserData` interface and
  * recursively inline all referenced types into a single `interface UserData { ... }`.
  * @param migrationFilePath - Absolute path to the migration `.ts` file containing the type.
  * @param tsconfigPath - Absolute path to the `tsconfig.json` to use for compilation.
@@ -139,14 +139,14 @@ export const generateTsSourceFromCompiler = (
   ts.forEachChild(sourceFile, (node) => {
     if (
       (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) &&
-      node.name.text === "v192UserData"
+      node.name.text === "v193UserData"
     ) {
       userDataType = checker.getTypeAtLocation(node.name);
     }
   });
 
   if (!userDataType) {
-    throw new Error("Could not find v192UserData type");
+    throw new Error("Could not find v193UserData type");
   }
 
   const body = serializeType(checker, userDataType, 0);

--- a/api/src/api/decryptionRouter.test.ts
+++ b/api/src/api/decryptionRouter.test.ts
@@ -1,14 +1,15 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { decryptionRouterFactory } from "@api/decryptionRouter";
-import { CryptoClient } from "@domain/types";
+import { type CryptoClient } from "@domain/types";
 import { setupExpress } from "@libs/express";
-import { DummyLogWriter } from "@libs/logWriter";
-import { Express } from "express";
+import { DummyLogWriter, type LogWriterType } from "@libs/logWriter";
+import { type Express } from "express";
 import request from "supertest";
 
 describe("decryptionRouter", () => {
   let app: Express;
   let stubCryptoClient: jest.Mocked<CryptoClient>;
+  let logger: LogWriterType;
 
   beforeEach(async () => {
     jest.resetAllMocks();
@@ -23,8 +24,12 @@ describe("decryptionRouter", () => {
       hashValue: jest.fn(),
     };
 
+    logger = {
+      ...DummyLogWriter,
+      LogError: jest.fn(),
+    };
     app = setupExpress(false);
-    app.use(decryptionRouterFactory(stubCryptoClient, DummyLogWriter));
+    app.use(decryptionRouterFactory(stubCryptoClient, logger));
   });
 
   afterAll(async () => {
@@ -37,6 +42,25 @@ describe("decryptionRouter", () => {
     it("decrypts value", async () => {
       const response = await request(app).post(`/decrypt`).send({ encryptedValue: "sample-value" });
       expect(response.body).toEqual("decrypted sample-value");
+    });
+
+    it.each([
+      "unencryptedDataKey has not been set",
+      "AccessDeniedException",
+      "Invalid ciphertext",
+      "ThrottlingException",
+      "TimeoutError",
+      "Encryption Context does not match expected values",
+    ])("returns 500 when decryption fails with %s", async (message) => {
+      stubCryptoClient.decryptValue.mockRejectedValueOnce(new Error(message));
+
+      const response = await request(app).post("/decrypt").send({ encryptedValue: "ciphertext" });
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({ error: message });
+      expect(logger.LogError).toHaveBeenCalledWith(
+        expect.stringContaining(`Failed to decrypt value: ${message}`),
+      );
     });
   });
 });

--- a/api/src/api/decryptionRouter.ts
+++ b/api/src/api/decryptionRouter.ts
@@ -1,4 +1,4 @@
-import { CryptoClient } from "@domain/types";
+import { type CryptoClient } from "@domain/types";
 import { getDurationMs } from "@libs/logUtils";
 import type { LogWriterType } from "@libs/logWriter";
 import { Router } from "express";

--- a/api/src/api/userRouter.test.ts
+++ b/api/src/api/userRouter.test.ts
@@ -27,7 +27,7 @@ import {
   getSecondAnnualFiling,
   getThirdAnnualFiling,
 } from "@shared/test";
-import { UserData } from "@shared/userData";
+import { CURRENT_VERSION, UserData } from "@shared/userData";
 import { generateAnnualFilings, getLastCalledWith } from "@test/helpers";
 import dayjs from "dayjs";
 import { Express } from "express";
@@ -155,6 +155,33 @@ describe("userRouter", () => {
       expect(mockJwt.decode).toHaveBeenCalledWith("user-123-token");
       expect(response.status).toEqual(StatusCodes.OK);
       expect(response.body).toEqual(userData);
+    });
+
+    it("returns an outdated migration fallback without updating or persisting it", async () => {
+      const business = generateBusiness({
+        profileData: generateProfileData({ hashedTaxId: "some-hashed-tax-id" }),
+      });
+      const outdatedUserData = {
+        ...generateUserDataForBusiness(business),
+        version: CURRENT_VERSION - 1,
+      };
+      stubUnifiedDataClient.get.mockResolvedValue(outdatedUserData);
+      mockJwt.decode.mockReturnValue(cognitoPayload({ id: "123" }));
+
+      const response = await request(app)
+        .get("/users/123")
+        .set("Authorization", "Bearer user-123-token");
+
+      expect(response.status).toEqual(StatusCodes.OK);
+      expect(response.body.version).toBe(CURRENT_VERSION - 1);
+      expect(
+        response.body.businesses[outdatedUserData.currentBusinessId].profileData.hashedTaxId,
+      ).toBeUndefined();
+      expect(stubUpdateOperatingPhase).not.toHaveBeenCalled();
+      expect(stubUpdateRoadmapSidebarCards).not.toHaveBeenCalled();
+      expect(stubUpdateLicenseStatus).not.toHaveBeenCalled();
+      expect(stubXrayRegistrationStatus).not.toHaveBeenCalled();
+      expect(stubUnifiedDataClient.put).not.toHaveBeenCalled();
     });
 
     it("does not return a hashed tax ID to the frontend if present in profileData", async () => {

--- a/api/src/api/userRouter.ts
+++ b/api/src/api/userRouter.ts
@@ -22,7 +22,7 @@ import { getCurrentBusiness } from "@shared/domain-logic/getCurrentBusiness";
 import { modifyCurrentBusiness } from "@shared/domain-logic/modifyCurrentBusiness";
 import { createEmptyFormationFormData, FormationAddress } from "@shared/formationData";
 import { LicenseName, LicenseSearchNameAndAddress } from "@shared/license";
-import { Business, createEmptyUserData, UserData } from "@shared/userData";
+import { Business, createEmptyUserData, CURRENT_VERSION, UserData } from "@shared/userData";
 import { Request, Response, Router } from "express";
 import { StatusCodes } from "http-status-codes";
 import jwt from "jsonwebtoken";
@@ -217,13 +217,15 @@ export const userRouterFactory = (
       .get(requestedUserId)
       .then(async (userData: UserData) => {
         let updatedUserData = userData;
-        updatedUserData = await updateBusinessNameSearchIfNeeded(updatedUserData)
-          .then((userData) => updateOperatingPhase(userData))
-          .then((userData) => updateRoadmapSidebarCards(userData))
-          .then((userData) => asyncUpdateLicenseStatus(userData))
-          .then((userData) => asyncUpdateXrayStatus(userData));
+        if (userData.version >= CURRENT_VERSION) {
+          updatedUserData = await updateBusinessNameSearchIfNeeded(updatedUserData)
+            .then((userData) => updateOperatingPhase(userData))
+            .then((userData) => updateRoadmapSidebarCards(userData))
+            .then((userData) => asyncUpdateLicenseStatus(userData))
+            .then((userData) => asyncUpdateXrayStatus(userData));
 
-        await databaseClient.put(updatedUserData);
+          await databaseClient.put(updatedUserData);
+        }
 
         const sanitizedUserData = removeSensitiveData(updatedUserData);
         const status = StatusCodes.OK;

--- a/api/src/client/AwsCryptoFactory.test.ts
+++ b/api/src/client/AwsCryptoFactory.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as AWSCrypto from "@aws-crypto/client-node";
 import { AWSCryptoFactory, cryptoUtils } from "@client/AwsCryptoFactory";
-import { CryptoClient } from "@domain/types";
+import { type CryptoClient } from "@domain/types";
 import { TextEncoder } from "node:util";
 
 type AWSMockContext = {
@@ -13,13 +13,19 @@ type AWSMockContext = {
 type MockAWSCryptoType = {
   encryptValueCalledWith: string;
   decryptValueCalledWith: string;
+  encryptKeyringCalledWith: unknown;
+  decryptKeyringCalledWith: unknown;
+  decryptResult: {
+    error?: Error;
+    encryptionContext: AWSMockContext;
+  };
   optionsCalledWith: string;
   contextCalledWith: any;
   buildClient: (options: string) => {
     encrypt: (cmm: string, plaintext: string, op?: AWSMockContext) => Promise<any>;
     decrypt: (keyring: AWSCrypto.KeyringNode, value: string) => Promise<any>;
   };
-  KmsKeyringNode: () => void;
+  KmsKeyringNode: jest.Mock;
   CommitmentPolicy: any;
 };
 
@@ -35,6 +41,12 @@ describe("AWSCryptoFactory", () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+    mockAWSCrypto.decryptResult.error = undefined;
+    mockAWSCrypto.decryptResult.encryptionContext = {
+      stage: "some-stage",
+      purpose: "some-purpose",
+      origin: "some-origin",
+    };
     client = AWSCryptoFactory(
       "some-key",
       {
@@ -44,6 +56,58 @@ describe("AWSCryptoFactory", () => {
       },
       "some-application-salt",
     );
+  });
+
+  describe("keyrings", () => {
+    it("encrypts with only the current generator key", async () => {
+      await client.encryptValue("2323232");
+
+      expect(mockAWSCrypto.KmsKeyringNode.mock.calls[0][0]).toEqual({
+        generatorKeyId: "some-key",
+      });
+      expect(mockAWSCrypto.encryptKeyringCalledWith).toBe(
+        mockAWSCrypto.KmsKeyringNode.mock.instances[0],
+      );
+    });
+
+    it("decrypts with a strict current and legacy key allowlist", async () => {
+      const clientWithLegacyKey = AWSCryptoFactory(
+        "current-key",
+        {
+          stage: "some-stage",
+          purpose: "some-purpose",
+          origin: "some-origin",
+        },
+        undefined,
+        ["legacy-key"],
+      );
+
+      await clientWithLegacyKey.decryptValue("encrypted-value");
+
+      expect(mockAWSCrypto.KmsKeyringNode.mock.calls[3][0]).toEqual({
+        keyIds: ["current-key", "legacy-key"],
+      });
+      expect(mockAWSCrypto.decryptKeyringCalledWith).toBe(
+        mockAWSCrypto.KmsKeyringNode.mock.instances[3],
+      );
+    });
+
+    it("deduplicates configured decrypt keys", () => {
+      AWSCryptoFactory(
+        "current-key",
+        {
+          stage: "some-stage",
+          purpose: "some-purpose",
+          origin: "some-origin",
+        },
+        undefined,
+        ["", "current-key", "legacy-key", "legacy-key"],
+      );
+
+      expect(mockAWSCrypto.KmsKeyringNode.mock.calls[3][0]).toEqual({
+        keyIds: ["current-key", "legacy-key"],
+      });
+    });
   });
 
   it("calls encrypt with the correct value", async () => {
@@ -64,6 +128,88 @@ describe("AWSCryptoFactory", () => {
     const result = await client.decryptValue("encrypted-value");
     expect(result).toEqual("decrypted-value");
     expect(mockAWSCrypto.decryptValueCalledWith).toEqual("encrypted-value");
+  });
+
+  it.each([
+    ["an unsupported wrapping key", "unencryptedDataKey has not been set"],
+    ["malformed ciphertext", "Invalid ciphertext"],
+    ["missing KMS permissions", "AccessDeniedException"],
+    ["KMS throttling after SDK retries", "ThrottlingException"],
+    ["a KMS timeout after SDK retries", "TimeoutError"],
+  ])("propagates %s failures", async (_description, message) => {
+    mockAWSCrypto.decryptResult.error = new Error(message);
+
+    await expect(client.decryptValue("encrypted-value")).rejects.toThrow(message);
+  });
+
+  it("rejects ciphertext with an unexpected encryption context", async () => {
+    mockAWSCrypto.decryptResult.encryptionContext = {
+      stage: "another-stage",
+      purpose: "some-purpose",
+      origin: "some-origin",
+    };
+
+    await expect(client.decryptValue("encrypted-value")).rejects.toThrow(
+      "Encryption Context does not match expected values",
+    );
+  });
+
+  it("accepts an explicitly configured decrypt-only encryption context", async () => {
+    const clientWithLegacyContext = AWSCryptoFactory(
+      "some-key",
+      {
+        stage: "some-stage",
+        purpose: "some-purpose",
+        origin: "some-origin",
+      },
+      undefined,
+      [],
+      [
+        {
+          stage: "",
+          purpose: "some-purpose",
+          origin: "",
+        },
+      ],
+    );
+    mockAWSCrypto.decryptResult.encryptionContext = {
+      stage: "",
+      purpose: "some-purpose",
+      origin: "",
+    };
+
+    await expect(clientWithLegacyContext.decryptValue("encrypted-value")).resolves.toBe(
+      "decrypted-value",
+    );
+  });
+
+  it("requires every value in a decrypt-only encryption context to match", async () => {
+    const clientWithLegacyContext = AWSCryptoFactory(
+      "some-key",
+      {
+        stage: "some-stage",
+        purpose: "some-purpose",
+        origin: "some-origin",
+      },
+      undefined,
+      [],
+      [
+        {
+          stage: "",
+          purpose: "some-purpose",
+          origin: "",
+        },
+      ],
+    );
+    mockAWSCrypto.decryptResult.encryptionContext = {
+      stage: "",
+      purpose: "another-purpose",
+      origin: "",
+    };
+
+    await expect(clientWithLegacyContext.decryptValue("encrypted-value")).rejects.toThrow(
+      "Encryption Context does not match expected values",
+    );
   });
 
   describe("hashValue", () => {
@@ -156,6 +302,16 @@ jest.mock("@aws-crypto/client-node", (): MockAWSCryptoType => {
   return {
     encryptValueCalledWith: "",
     decryptValueCalledWith: "",
+    encryptKeyringCalledWith: undefined,
+    decryptKeyringCalledWith: undefined,
+    decryptResult: {
+      error: undefined,
+      encryptionContext: {
+        stage: "some-stage",
+        purpose: "some-purpose",
+        origin: "some-origin",
+      },
+    },
     optionsCalledWith: "",
     contextCalledWith: undefined,
     CommitmentPolicy: { REQUIRE_ENCRYPT_REQUIRE_DECRYPT: "REQUIRE_ENCRYPT_REQUIRE_DECRYPT" },
@@ -163,6 +319,7 @@ jest.mock("@aws-crypto/client-node", (): MockAWSCryptoType => {
       this.optionsCalledWith = options;
       // eslint-disable-next-line unicorn/consistent-function-scoping
       const encrypt = (cmm: string, plaintext: string, op?: AWSMockContext): any => {
+        this.encryptKeyringCalledWith = cmm;
         this.encryptValueCalledWith = plaintext;
         this.contextCalledWith = { ...op };
         return Promise.resolve(plaintext).then((): any => {
@@ -172,23 +329,23 @@ jest.mock("@aws-crypto/client-node", (): MockAWSCryptoType => {
       // eslint-disable-next-line unicorn/consistent-function-scoping
       const decrypt = (keyring: AWSCrypto.KeyringNode, value: string): any => {
         const encoder = new TextEncoder();
+        this.decryptKeyringCalledWith = keyring;
         this.decryptValueCalledWith = value;
+        if (this.decryptResult.error) {
+          return Promise.reject(this.decryptResult.error);
+        }
         return Promise.resolve(value).then((): any => {
           return {
             plaintext: encoder.encode("decrypted-value"),
             messageHeader: {
-              encryptionContext: {
-                stage: "some-stage",
-                purpose: "some-purpose",
-                origin: "some-origin",
-              },
+              encryptionContext: this.decryptResult.encryptionContext,
             },
           };
         });
       };
       return { encrypt, decrypt };
     },
-    KmsKeyringNode: function MockKeyRingNode(): any {},
+    KmsKeyringNode: jest.fn(function MockKeyRingNode(): any {}),
   };
 });
 

--- a/api/src/client/AwsCryptoFactory.ts
+++ b/api/src/client/AwsCryptoFactory.ts
@@ -1,16 +1,21 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const AWSCrypto = require("@aws-crypto/client-node");
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
-import { CryptoClient } from "@domain/types";
-import { NonSharedBuffer } from "node:buffer";
+import { type CryptoClient } from "@domain/types";
+import { type NonSharedBuffer } from "node:buffer";
 import * as crypto from "node:crypto";
 import { TextDecoder } from "node:util";
 
-type Context = {
-  stage: string;
-  purpose: string;
-  origin: string;
-};
+export interface EncryptionContext {
+  readonly stage: string;
+  readonly purpose: string;
+  readonly origin: string;
+}
+
+const contextMatches = (
+  actualContext: Record<string, string>,
+  expectedContext: EncryptionContext,
+): boolean => Object.entries(expectedContext).every(([key, value]) => actualContext[key] === value);
 
 export const cryptoUtils: { pbkdf2: typeof crypto.pbkdf2 } = {
   pbkdf2: (
@@ -27,18 +32,23 @@ export const cryptoUtils: { pbkdf2: typeof crypto.pbkdf2 } = {
 
 export const AWSCryptoFactory = (
   generatorKeyId: string,
-  context: Context,
+  context: EncryptionContext,
   encryptedHashingSalt?: string,
+  decryptOnlyKeyIds: readonly string[] = [],
+  decryptOnlyContexts: readonly EncryptionContext[] = [],
 ): CryptoClient => {
   const { encrypt, decrypt } = AWSCrypto.buildClient(
     AWSCrypto.CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT,
   );
-  const keyring = new AWSCrypto.KmsKeyringNode({ generatorKeyId });
+  const encryptKeyring = new AWSCrypto.KmsKeyringNode({ generatorKeyId });
+  const decryptKeyring = new AWSCrypto.KmsKeyringNode({
+    keyIds: [...new Set([generatorKeyId, ...decryptOnlyKeyIds].filter(Boolean))],
+  });
 
   const decoder = new TextDecoder();
 
   const encryptValue = async (plainTextValue: string): Promise<string> => {
-    const { result } = await encrypt(keyring, plainTextValue, {
+    const { result } = await encrypt(encryptKeyring, plainTextValue, {
       encryptionContext: context,
     });
     const base64Value = toBase64(result);
@@ -48,14 +58,17 @@ export const AWSCryptoFactory = (
   const decryptValue = async (encryptedValue: string): Promise<string> => {
     const bufferedValue = fromBase64(encryptedValue);
 
-    const { plaintext, messageHeader } = await decrypt(keyring, bufferedValue);
+    const { plaintext, messageHeader } = await decrypt(decryptKeyring, bufferedValue);
 
     const { encryptionContext } = messageHeader;
 
-    for (const [key, value] of Object.entries(context)) {
-      if (encryptionContext[key] !== value) {
-        throw new Error("Encryption Context does not match expected values");
-      }
+    const acceptedContexts = [context, ...decryptOnlyContexts];
+    if (
+      !acceptedContexts.some((acceptedContext) =>
+        contextMatches(encryptionContext, acceptedContext),
+      )
+    ) {
+      throw new Error("Encryption Context does not match expected values");
     }
 
     const decodedValue = decoder.decode(plaintext);

--- a/api/src/db/DynamoBusinessDataClient.ts
+++ b/api/src/db/DynamoBusinessDataClient.ts
@@ -1,14 +1,34 @@
-import { AttributeValue, QueryCommand, QueryCommandInput } from "@aws-sdk/client-dynamodb";
+import {
+  type AttributeValue,
+  QueryCommand,
+  type QueryCommandInput,
+} from "@aws-sdk/client-dynamodb";
 import {
   DeleteCommand,
-  DynamoDBDocumentClient,
+  type DynamoDBDocumentClient,
   GetCommand,
   PutCommand,
 } from "@aws-sdk/lib-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
-import { BusinessesDataClient } from "@domain/types";
-import { LogWriterType } from "@libs/logWriter";
-import { Business } from "@shared/userData";
+import { type BusinessesDataClient } from "@domain/types";
+import { type LogWriterType } from "@libs/logWriter";
+import { type Business } from "@shared/userData";
+
+export const createBusinessDataItem = (businessData: Business): Record<string, unknown> => {
+  const businessName = businessData.profileData.businessName;
+  const naicsCode = businessData.profileData.naicsCode;
+  const hasBusinessName = businessName && businessName !== "";
+
+  return {
+    businessId: businessData.id,
+    industry: businessData.profileData.industryId,
+    hashedTaxId: businessData.profileData.hashedTaxId,
+    data: businessData,
+    businessName: businessName === "" ? undefined : businessName,
+    naicsCode: naicsCode === "" ? undefined : naicsCode,
+    businessNamePartition: hasBusinessName ? "businessName" : undefined,
+  };
+};
 
 export const DynamoBusinessDataClient = (
   db: DynamoDBDocumentClient,
@@ -125,20 +145,9 @@ export const DynamoBusinessDataClient = (
   };
 
   const put = async (businessData: Business): Promise<Business> => {
-    const businessName = businessData.profileData.businessName;
-    const naicsCode = businessData.profileData.naicsCode;
-    const hasBusinessName = businessName && businessName !== "";
     const params = {
       TableName: tableName,
-      Item: {
-        businessId: businessData.id,
-        industry: businessData.profileData.industryId,
-        hashedTaxId: businessData.profileData.hashedTaxId,
-        data: businessData,
-        businessName: businessName === "" ? undefined : businessData.profileData.businessName,
-        naicsCode: naicsCode === "" ? undefined : businessData.profileData.naicsCode,
-        businessNamePartition: hasBusinessName ? "businessName" : undefined,
-      },
+      Item: createBusinessDataItem(businessData),
     };
     return db.send(new PutCommand(params)).then(() => {
       return businessData;

--- a/api/src/db/DynamoDataClient.test.ts
+++ b/api/src/db/DynamoDataClient.test.ts
@@ -4,12 +4,14 @@ import { dynamoDbTranslateConfig } from "@db/config/dynamoDbConfig";
 import { DynamoBusinessDataClient } from "@db/DynamoBusinessDataClient";
 import { DynamoUserDataClient } from "@db/DynamoUserDataClient";
 import {
-  BusinessesDataClient,
-  DatabaseClient,
-  UserDataClient,
+  type BusinessesDataClient,
+  type DatabaseClient,
+  MigrationConflictError,
+  type MigrationDataClient,
+  type UserDataClient,
   type CryptoClient,
 } from "@domain/types";
-import { DummyLogWriter, LogWriterType } from "@libs/logWriter";
+import { DummyLogWriter, type LogWriterType } from "@libs/logWriter";
 
 import { DynamoDataClient } from "@db/DynamoDataClient";
 
@@ -20,7 +22,7 @@ import {
   generateTaxFilingData,
   generateUserDataForBusiness,
 } from "@shared/test";
-import { CURRENT_VERSION, UserData } from "@shared/userData";
+import { CURRENT_VERSION, type UserData } from "@shared/userData";
 import dayjs from "dayjs";
 import { getConfigValue } from "@libs/ssmUtils";
 import { parseUserData } from "@db/zodSchema/zodSchemas";
@@ -52,6 +54,7 @@ describe("User and Business Migration with DynamoDataClient", () => {
   let logger: LogWriterType;
   let dynamoUsersDataClient: UserDataClient;
   let cryptoClient: CryptoClient;
+  let migrationDataClient: jest.Mocked<MigrationDataClient>;
 
   let dynamoDataClient: DatabaseClient;
 
@@ -100,12 +103,19 @@ describe("User and Business Migration with DynamoDataClient", () => {
       usersDbConfig.tableName,
       logger,
     );
+    migrationDataClient = {
+      migrateAndPut: jest.fn(async (input) => ({
+        ...input,
+        version: CURRENT_VERSION,
+      })),
+    };
 
     dynamoDataClient = DynamoDataClient(
       dynamoUsersDataClient,
       dynamoBusinessesDataClient,
       logger,
       isKillSwitchOn,
+      migrationDataClient,
     );
     (dynamoBusinessesDataClient.put as jest.Mock) = jest.fn();
     (dynamoUsersDataClient.put as jest.Mock) = jest.fn();
@@ -126,36 +136,23 @@ describe("User and Business Migration with DynamoDataClient", () => {
 
     expect(result.success).toBe(true);
     expect(result.migratedCount).toBeGreaterThan(0);
-    expect(dynamoBusinessesDataClient.put).toHaveBeenCalledTimes(1);
-    const businessId = userData.businesses[userData.currentBusinessId].id;
-    expect(dynamoBusinessesDataClient.put).toHaveBeenCalledWith(
-      expect.objectContaining({ id: businessId }),
-    );
-    expect(logger.LogInfo).toHaveBeenCalledWith(
-      expect.stringContaining(`Processed user ${userData.user.id} in the user data table`),
-    );
-    expect(logger.LogInfo).toHaveBeenCalledWith(
-      expect.stringContaining(`Updated business ${businessId} for user ${userData.user.id}`),
-    );
-    expect(logger.LogInfo).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `Processed business with ID ${businessId} for user ${userData.user.id}`,
-      ),
-    );
+    expect(migrationDataClient.migrateAndPut).toHaveBeenCalledWith(userData);
+    expect(dynamoBusinessesDataClient.put).not.toHaveBeenCalled();
+    expect(dynamoUsersDataClient.put).not.toHaveBeenCalled();
     expect(logger.LogInfo).toHaveBeenCalledWith(expect.stringContaining("Migration complete"));
   });
 
-  it("should log an error when no businesses are found for a user", async () => {
-    userData.businesses = {};
+  it("should atomically migrate a user with no businesses", async () => {
+    const userWithNoBusinesses = { ...userData, businesses: {} };
 
     jest.spyOn(dynamoUsersDataClient, "getUsersWithOutdatedVersion").mockResolvedValueOnce({
-      usersToMigrate: [userData],
+      usersToMigrate: [userWithNoBusinesses],
       nextToken: undefined,
     });
 
     await dynamoDataClient.migrateOutdatedVersionUsers();
 
-    expect(logger.LogInfo).toHaveBeenCalledWith(`No businesses found for user ${userData.user.id}`);
+    expect(migrationDataClient.migrateAndPut).toHaveBeenCalledWith(userWithNoBusinesses);
     expect(dynamoBusinessesDataClient.put).not.toHaveBeenCalled();
   });
 
@@ -193,10 +190,6 @@ describe("User and Business Migration with DynamoDataClient", () => {
     const userDataBatch2 = generateUserData();
     const userDataBatch3 = generateUserData();
 
-    const businessId1 = userDataBatch1.businesses[userDataBatch1.currentBusinessId].id;
-    const businessId2 = userDataBatch2.businesses[userDataBatch2.currentBusinessId].id;
-    const businessId3 = userDataBatch3.businesses[userDataBatch3.currentBusinessId].id;
-
     const nextTokenBatch1: string = "nextTokenBatch1";
     const nextTokenBatch2: string = "nextTokenBatch2";
     jest
@@ -217,41 +210,7 @@ describe("User and Business Migration with DynamoDataClient", () => {
 
     const result = await dynamoDataClient.migrateOutdatedVersionUsers();
     expect(result.migratedCount).toBe(3);
-    expect(logger.LogInfo).toHaveBeenCalledWith(
-      expect.stringContaining(`Processed user ${userDataBatch1.user.id} in the user data table`),
-    );
-    expect(logger.LogInfo).toHaveBeenCalledWith(
-      expect.stringContaining(`Updated business ${businessId1} for user ${userDataBatch1.user.id}`),
-    );
-    expect(logger.LogInfo).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `Processed business with ID ${businessId1} for user ${userDataBatch1.user.id}`,
-      ),
-    );
-
-    expect(logger.LogInfo).toHaveBeenCalledWith(
-      expect.stringContaining(`Processed user ${userDataBatch2.user.id} in the user data table`),
-    );
-    expect(logger.LogInfo).toHaveBeenCalledWith(
-      expect.stringContaining(`Updated business ${businessId2} for user ${userDataBatch2.user.id}`),
-    );
-    expect(logger.LogInfo).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `Processed business with ID ${businessId2} for user ${userDataBatch2.user.id}`,
-      ),
-    );
-
-    expect(logger.LogInfo).toHaveBeenCalledWith(
-      expect.stringContaining(`Processed user ${userDataBatch3.user.id} in the user data table`),
-    );
-    expect(logger.LogInfo).toHaveBeenCalledWith(
-      expect.stringContaining(`Updated business ${businessId3} for user ${userDataBatch3.user.id}`),
-    );
-    expect(logger.LogInfo).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `Processed business with ID ${businessId3} for user ${userDataBatch3.user.id}`,
-      ),
-    );
+    expect(migrationDataClient.migrateAndPut).toHaveBeenCalledTimes(3);
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Migration complete"));
     expect(dynamoUsersDataClient.getUsersWithOutdatedVersion).toHaveBeenCalledTimes(3);
     expect(dynamoUsersDataClient.getUsersWithOutdatedVersion).toHaveBeenCalledWith(
@@ -341,6 +300,7 @@ describe("User and Business Migration with DynamoDataClient", () => {
       dynamoBusinessesDataClient,
       logger,
       isKillSwitchOnTruePath,
+      migrationDataClient,
     );
     const putBusinessesSpy = jest.spyOn(dynamoBusinessesDataClient, "put");
     const putUsersSpy = jest.spyOn(dynamoUsersDataClient, "put");
@@ -351,6 +311,94 @@ describe("User and Business Migration with DynamoDataClient", () => {
     expect(putBusinessesSpy).not.toHaveBeenCalled();
     expect(putUsersSpy).not.toHaveBeenCalled();
     expect(logger.LogInfo).toHaveBeenCalledWith("Migration halted: kill switch is ON");
+  });
+
+  it("returns the unchanged stored record when request-time migration fails", async () => {
+    const outdatedUser = { ...generateUserData(), version: CURRENT_VERSION - 1 };
+    jest.spyOn(dynamoUsersDataClient, "get").mockResolvedValueOnce(outdatedUser);
+    migrationDataClient.migrateAndPut.mockRejectedValueOnce(new Error("KMS unavailable"));
+
+    await expect(dynamoDataClient.get(outdatedUser.user.id)).resolves.toEqual(outdatedUser);
+    expect(dynamoUsersDataClient.put).not.toHaveBeenCalled();
+    expect(dynamoBusinessesDataClient.put).not.toHaveBeenCalled();
+    expect(logger.LogError).toHaveBeenCalledWith(
+      `Request-time migration failed from version ${
+        CURRENT_VERSION - 1
+      } to ${CURRENT_VERSION}: KMS unavailable`,
+    );
+  });
+
+  it("returns the unchanged stored record when the request-time kill switch is on", async () => {
+    const outdatedUser = { ...generateUserData(), version: CURRENT_VERSION - 1 };
+    jest.spyOn(dynamoUsersDataClient, "get").mockResolvedValueOnce(outdatedUser);
+    dynamoDataClient = DynamoDataClient(
+      dynamoUsersDataClient,
+      dynamoBusinessesDataClient,
+      logger,
+      isKillSwitchOnTruePath,
+      migrationDataClient,
+    );
+
+    await expect(dynamoDataClient.get(outdatedUser.user.id)).resolves.toEqual(outdatedUser);
+    expect(migrationDataClient.migrateAndPut).not.toHaveBeenCalled();
+  });
+
+  it("stops the scheduled migration after the first terminal user failure", async () => {
+    const first = generateUserData();
+    const second = generateUserData();
+    jest.spyOn(dynamoUsersDataClient, "getUsersWithOutdatedVersion").mockResolvedValueOnce({
+      usersToMigrate: [first, second],
+      nextToken: undefined,
+    });
+    migrationDataClient.migrateAndPut.mockRejectedValueOnce(new Error("AccessDeniedException"));
+
+    const result = await dynamoDataClient.migrateOutdatedVersionUsers();
+
+    expect(result).toEqual({ success: false, error: "AccessDeniedException" });
+    expect(migrationDataClient.migrateAndPut).toHaveBeenCalledTimes(1);
+    expect(logger.LogError).toHaveBeenCalledWith(
+      `Scheduled migration failed for user ${first.user.id} from version ${first.version} to ${CURRENT_VERSION}: AccessDeniedException`,
+    );
+  });
+
+  it("continues scheduled migration after a retryable transaction conflict", async () => {
+    const first = generateUserData();
+    const second = generateUserData();
+    jest.spyOn(dynamoUsersDataClient, "getUsersWithOutdatedVersion").mockResolvedValueOnce({
+      usersToMigrate: [first, second],
+      nextToken: undefined,
+    });
+    migrationDataClient.migrateAndPut.mockRejectedValueOnce(new MigrationConflictError());
+
+    const result = await dynamoDataClient.migrateOutdatedVersionUsers();
+
+    expect(result).toEqual({ success: true, migratedCount: 1 });
+    expect(migrationDataClient.migrateAndPut).toHaveBeenCalledTimes(2);
+    expect(logger.LogInfo).toHaveBeenCalledWith(
+      "Skipped migration because the user record changed concurrently",
+    );
+    expect(logger.LogError).not.toHaveBeenCalledWith(
+      expect.stringContaining("Scheduled migration failed"),
+    );
+  });
+
+  it("stops successfully between users when the Lambda time budget is exhausted", async () => {
+    const first = generateUserData();
+    const second = generateUserData();
+    jest.spyOn(dynamoUsersDataClient, "getUsersWithOutdatedVersion").mockResolvedValueOnce({
+      usersToMigrate: [first, second],
+      nextToken: undefined,
+    });
+    const canStartNextUser = jest.fn().mockReturnValueOnce(true).mockReturnValueOnce(false);
+
+    const result = await dynamoDataClient.migrateOutdatedVersionUsers({ canStartNextUser });
+
+    expect(result).toEqual({ success: true, migratedCount: 1 });
+    expect(migrationDataClient.migrateAndPut).toHaveBeenCalledTimes(1);
+    expect(migrationDataClient.migrateAndPut).toHaveBeenCalledWith(first);
+    expect(logger.LogInfo).toHaveBeenCalledWith(
+      "Migration paused before Lambda timeout; remaining users will retry",
+    );
   });
 
   it("should call parseUserData when zod_parsing_on feature flag is true", async () => {

--- a/api/src/db/DynamoDataClient.ts
+++ b/api/src/db/DynamoDataClient.ts
@@ -1,6 +1,13 @@
-import { BusinessesDataClient, DatabaseClient, UserDataClient } from "@domain/types";
-import { LogWriterType } from "@libs/logWriter";
-import { Business, CURRENT_VERSION, UserData } from "@shared/userData";
+import {
+  type BusinessesDataClient,
+  type DatabaseClient,
+  MigrationConflictError,
+  type MigrationDataClient,
+  type MigrationRunOptions,
+  type UserDataClient,
+} from "@domain/types";
+import { type LogWriterType } from "@libs/logWriter";
+import { type Business, CURRENT_VERSION, type UserData } from "@shared/userData";
 import { chunk } from "lodash";
 import { parseUserData } from "@db/zodSchema/zodSchemas";
 import { getConfigValue } from "@libs/ssmUtils";
@@ -10,13 +17,18 @@ export const DynamoDataClient = (
   businessesDataClient: BusinessesDataClient,
   logger: LogWriterType,
   isKillSwitchOn: () => Promise<boolean>,
+  migrationDataClient?: MigrationDataClient,
 ): DatabaseClient => {
   const MAX_SAFE_MIGRATION_COUNT = 5000;
-  const migrateOutdatedVersionUsers = async (): Promise<{
+  const migrateOutdatedVersionUsers = async (
+    options?: MigrationRunOptions,
+  ): Promise<{
     success: boolean;
     migratedCount?: number;
     error?: string;
   }> => {
+    const canStartNextUser = options?.canStartNextUser ?? ((): boolean => true);
+
     try {
       let nextToken: string | undefined = undefined;
       let migratedCount = 0;
@@ -46,11 +58,14 @@ export const DynamoDataClient = (
             return { success: true, migratedCount };
           }
 
-          await processBatch(batch, isZodParsingOn);
-          migratedCount += batch.length;
+          const batchResult = await processBatch(batch, isZodParsingOn, canStartNextUser);
+          migratedCount += batchResult.migratedCount;
           logger.LogInfo(
-            `Processed batch of ${batch.length} users. Total migrated so far: ${migratedCount}`,
+            `Completed ${batchResult.migratedCount} migrations in this batch. Total migrated so far: ${migratedCount}`,
           );
+          if (batchResult.stoppedForTime) {
+            return { success: true, migratedCount };
+          }
         }
         nextToken = newNextToken;
       } while (nextToken);
@@ -68,27 +83,71 @@ export const DynamoDataClient = (
   const processBatch = async (
     usersToMigrate: UserData[],
     isZodParsingOn: string,
-  ): Promise<void> => {
-    const results = await Promise.allSettled(
-      usersToMigrate.map(async (user) => {
-        await updateUserAndBusinesses(user);
-        logger.LogInfo(`Migrated user ${user.user.id} to version ${CURRENT_VERSION}`);
-        if (isZodParsingOn === "true") {
-          parseUserData(logger, user);
-        }
-      }),
-    );
+    canStartNextUser: () => boolean,
+  ): Promise<{ migratedCount: number; stoppedForTime: boolean }> => {
+    if (!migrationDataClient) {
+      throw new Error("Migration data client is required for coordinated migrations");
+    }
 
-    for (const [index, result] of results.entries()) {
-      const user = usersToMigrate[index];
-      if (result.status === "rejected") {
-        logger.LogError(`Failed to migrate user ${user.user.id}: ${result.reason}`);
+    let migratedCount = 0;
+    for (const user of usersToMigrate) {
+      if (!canStartNextUser()) {
+        logger.LogInfo("Migration paused before Lambda timeout; remaining users will retry");
+        return { migratedCount, stoppedForTime: true };
       }
+
+      try {
+        const migratedUser = await migrationDataClient.migrateAndPut(user);
+        migratedCount += 1;
+        logger.LogInfo(`Migrated user to version ${CURRENT_VERSION}`);
+        if (isZodParsingOn === "true") {
+          parseUserData(logger, migratedUser);
+        }
+      } catch (error) {
+        if (error instanceof MigrationConflictError) {
+          logger.LogInfo("Skipped migration because the user record changed concurrently");
+          continue;
+        }
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.LogError(
+          `Scheduled migration failed for user ${user.user.id} from version ${user.version} to ${CURRENT_VERSION}: ${errorMessage}`,
+        );
+        throw error;
+      }
+    }
+
+    return { migratedCount, stoppedForTime: false };
+  };
+
+  const migrateForRequest = async (sourceUserData: UserData): Promise<UserData> => {
+    if (sourceUserData.version >= CURRENT_VERSION) {
+      return sourceUserData;
+    }
+
+    if (await isKillSwitchOn()) {
+      logger.LogInfo("Request-time migration skipped: kill switch is ON");
+      return sourceUserData;
+    }
+
+    if (!migrationDataClient) {
+      logger.LogError("Request-time migration failed: migration data client is not configured");
+      return sourceUserData;
+    }
+
+    try {
+      return await migrationDataClient.migrateAndPut(sourceUserData);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.LogError(
+        `Request-time migration failed from version ${sourceUserData.version} to ${CURRENT_VERSION}: ${errorMessage}`,
+      );
+      return sourceUserData;
     }
   };
 
   const get = async (userId: string): Promise<UserData> => {
-    return await userDataClient.get(userId);
+    const sourceUserData = await userDataClient.get(userId);
+    return await migrateForRequest(sourceUserData);
   };
 
   const updateUserAndBusinesses = async (userData: UserData): Promise<void> => {
@@ -126,6 +185,12 @@ export const DynamoDataClient = (
 
   const put = async (userData: UserData): Promise<UserData> => {
     try {
+      if (userData.version < CURRENT_VERSION) {
+        if (!migrationDataClient) {
+          throw new Error("Migration data client is required for coordinated migrations");
+        }
+        return await migrationDataClient.migrateAndPut(userData);
+      }
       await updateUserAndBusinesses(userData);
       return userData;
     } catch (error) {
@@ -136,7 +201,8 @@ export const DynamoDataClient = (
   };
 
   const findByEmail = async (email: string): Promise<UserData | undefined> => {
-    return await userDataClient.findByEmail(email);
+    const sourceUserData = await userDataClient.findByEmail(email);
+    return sourceUserData ? await migrateForRequest(sourceUserData) : undefined;
   };
   const findUserByBusinessName = async (businessName: string): Promise<UserData | undefined> => {
     try {
@@ -146,7 +212,7 @@ export const DynamoDataClient = (
         return undefined;
       }
       const userId = business.userId;
-      const user = await userDataClient.get(userId);
+      const user = await get(userId);
       if (!user) {
         logger.LogInfo(`No user found for business: ${businessName}`);
         return undefined;
@@ -167,9 +233,7 @@ export const DynamoDataClient = (
         logger.LogInfo(`No Businesses Found with prefix: ${prefix}`);
         return [];
       }
-      const users = await Promise.all(
-        businesses.map((business) => userDataClient.get(business.userId)),
-      );
+      const users = await Promise.all(businesses.map((business) => get(business.userId)));
 
       return users as UserData[];
     } catch (error) {

--- a/api/src/db/DynamoMigrationDataClient.test.ts
+++ b/api/src/db/DynamoMigrationDataClient.test.ts
@@ -1,0 +1,144 @@
+import { type DynamoDBDocumentClient, TransactWriteCommand } from "@aws-sdk/lib-dynamodb";
+import { DynamoMigrationDataClient } from "@db/DynamoMigrationDataClient";
+import {
+  MigrationConflictError,
+  type MigrationDataClient,
+  type UserDataClient,
+} from "@domain/types";
+import {
+  generateBusiness,
+  generateProfileData,
+  generateUser,
+  generateUserData,
+} from "@shared/test";
+import { CURRENT_VERSION, type UserData } from "@shared/userData";
+
+const usersTableName = "users-table";
+const businessesTableName = "businesses-table";
+
+const generateOutdatedUser = (businessCount = 2): UserData => {
+  const userId = "migration-user";
+  const businesses = Object.fromEntries(
+    Array.from({ length: businessCount }, (_, index) => {
+      const businessId = `${userId}-business-${index}`;
+      return [
+        businessId,
+        generateBusiness({
+          id: businessId,
+          userId,
+          version: CURRENT_VERSION - 1,
+          profileData: generateProfileData({ businessName: `Business ${index}` }),
+        }),
+      ];
+    }),
+  );
+
+  return generateUserData({
+    user: generateUser({ id: userId }),
+    version: CURRENT_VERSION - 1,
+    currentBusinessId: Object.keys(businesses)[0],
+    businesses,
+  });
+};
+
+const migrateUser = (source: UserData): UserData => ({
+  ...source,
+  version: CURRENT_VERSION,
+  businesses: Object.fromEntries(
+    Object.entries(source.businesses).map(([id, business]) => [
+      id,
+      { ...business, version: CURRENT_VERSION },
+    ]),
+  ),
+});
+
+describe("DynamoMigrationDataClient", () => {
+  let send: jest.Mock;
+  let userDataClient: jest.Mocked<UserDataClient>;
+
+  beforeEach(() => {
+    send = jest.fn().mockResolvedValue({});
+    userDataClient = {
+      get: jest.fn(),
+      findByEmail: jest.fn(),
+      put: jest.fn(),
+      migrateToLatest: jest.fn(async (source) => migrateUser(source)),
+      getNeedNewsletterUsers: jest.fn(),
+      getNeedTaxIdEncryptionUsers: jest.fn(),
+      getUsersWithOutdatedVersion: jest.fn(),
+    };
+  });
+
+  const makeClient = (): MigrationDataClient =>
+    DynamoMigrationDataClient({
+      db: { send } as unknown as DynamoDBDocumentClient,
+      userDataClient,
+      usersTableName,
+      businessesTableName,
+    });
+
+  it("writes the user and every business in one conditional transaction", async () => {
+    const source = generateOutdatedUser();
+
+    const result = await makeClient().migrateAndPut(source);
+
+    expect(result.version).toBe(CURRENT_VERSION);
+    expect(send).toHaveBeenCalledTimes(1);
+    const command = send.mock.calls[0][0] as TransactWriteCommand;
+    expect(command.input.TransactItems).toHaveLength(3);
+    expect(command.input.TransactItems?.[0].Put).toMatchObject({
+      TableName: usersTableName,
+      ConditionExpression: "#data = :sourceData",
+      ExpressionAttributeValues: { ":sourceData": source },
+      Item: { userId: source.user.id, version: CURRENT_VERSION },
+    });
+    expect(command.input.TransactItems?.slice(1).map((item) => item.Put?.TableName)).toEqual([
+      businessesTableName,
+      businessesTableName,
+    ]);
+    expect(
+      command.input.TransactItems?.slice(1).map((item) => item.Put?.Item?.data.version),
+    ).toEqual([CURRENT_VERSION, CURRENT_VERSION]);
+  });
+
+  it("does not write when any field migration fails", async () => {
+    const source = generateOutdatedUser();
+    const original = structuredClone(source);
+    userDataClient.migrateToLatest.mockRejectedValueOnce(new Error("KMS unavailable"));
+
+    await expect(makeClient().migrateAndPut(source)).rejects.toThrow("KMS unavailable");
+
+    expect(send).not.toHaveBeenCalled();
+    expect(source).toEqual(original);
+  });
+
+  it("classifies a conditional transaction cancellation as concurrent migration", async () => {
+    send.mockRejectedValueOnce({
+      name: "TransactionCanceledException",
+      CancellationReasons: [{ Code: "ConditionalCheckFailed" }],
+    });
+
+    await expect(makeClient().migrateAndPut(generateOutdatedUser())).rejects.toBeInstanceOf(
+      MigrationConflictError,
+    );
+  });
+
+  it("classifies a transaction collision as a retryable migration conflict", async () => {
+    send.mockRejectedValueOnce({
+      name: "TransactionCanceledException",
+      CancellationReasons: [{ Code: "None" }, { Code: "TransactionConflict" }],
+    });
+
+    await expect(makeClient().migrateAndPut(generateOutdatedUser())).rejects.toBeInstanceOf(
+      MigrationConflictError,
+    );
+  });
+
+  it("rejects users that exceed DynamoDB's 100-item transaction limit", async () => {
+    await expect(makeClient().migrateAndPut(generateOutdatedUser(100))).rejects.toThrow(
+      "Cannot atomically migrate user with more than 99 businesses",
+    );
+    expect(userDataClient.migrateToLatest).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/db/DynamoMigrationDataClient.ts
+++ b/api/src/db/DynamoMigrationDataClient.ts
@@ -1,0 +1,104 @@
+import {
+  type DynamoDBDocumentClient,
+  TransactWriteCommand,
+  type TransactWriteCommandInput,
+} from "@aws-sdk/lib-dynamodb";
+import { createBusinessDataItem } from "@db/DynamoBusinessDataClient";
+import { createUserDataItem } from "@db/DynamoUserDataClient";
+import {
+  MigrationConflictError,
+  type MigrationDataClient,
+  type UserDataClient,
+} from "@domain/types";
+import { type UserData } from "@shared/userData";
+
+const MAX_TRANSACTION_BUSINESSES = 99;
+
+interface DynamoMigrationDataClientProps {
+  readonly db: DynamoDBDocumentClient;
+  readonly userDataClient: UserDataClient;
+  readonly usersTableName: string;
+  readonly businessesTableName: string;
+}
+
+const isMigrationConflict = (error: unknown): boolean => {
+  if (!error || typeof error !== "object" || !("name" in error)) {
+    return false;
+  }
+
+  const cancellationReasons =
+    "CancellationReasons" in error && Array.isArray(error.CancellationReasons)
+      ? error.CancellationReasons
+      : [];
+
+  return (
+    error.name === "TransactionCanceledException" &&
+    (cancellationReasons[0]?.Code === "ConditionalCheckFailed" ||
+      cancellationReasons.some((reason) => reason?.Code === "TransactionConflict"))
+  );
+};
+
+const businessPut = (
+  business: UserData["businesses"][string],
+  tableName: string,
+): NonNullable<TransactWriteCommandInput["TransactItems"]>[number] => ({
+  Put: {
+    TableName: tableName,
+    Item: createBusinessDataItem(business),
+  },
+});
+
+export const DynamoMigrationDataClient = ({
+  db,
+  userDataClient,
+  usersTableName,
+  businessesTableName,
+}: DynamoMigrationDataClientProps): MigrationDataClient => {
+  const migrateAndPut = async (sourceUserData: UserData): Promise<UserData> => {
+    const sourceBusinessCount = Object.keys(sourceUserData.businesses ?? {}).length;
+    if (sourceBusinessCount > MAX_TRANSACTION_BUSINESSES) {
+      throw new Error(
+        `Cannot atomically migrate user with more than ${MAX_TRANSACTION_BUSINESSES} businesses`,
+      );
+    }
+
+    const migratedUserData = await userDataClient.migrateToLatest(sourceUserData);
+    const migratedBusinesses = Object.values(migratedUserData.businesses);
+    if (migratedBusinesses.length > MAX_TRANSACTION_BUSINESSES) {
+      throw new Error(
+        `Cannot atomically migrate user with more than ${MAX_TRANSACTION_BUSINESSES} businesses`,
+      );
+    }
+
+    const transactItems: NonNullable<TransactWriteCommandInput["TransactItems"]> = [
+      {
+        Put: {
+          TableName: usersTableName,
+          Item: createUserDataItem(migratedUserData),
+          ConditionExpression: "#data = :sourceData",
+          ExpressionAttributeNames: {
+            "#data": "data",
+          },
+          ExpressionAttributeValues: {
+            ":sourceData": sourceUserData,
+          },
+        },
+      },
+      ...migratedBusinesses.map((business) => businessPut(business, businessesTableName)),
+    ];
+
+    try {
+      await db.send(new TransactWriteCommand({ TransactItems: transactItems }));
+    } catch (error) {
+      if (isMigrationConflict(error)) {
+        throw new MigrationConflictError();
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Atomic migration transaction failed: ${message}`, { cause: error });
+    }
+
+    return migratedUserData;
+  };
+
+  return { migrateAndPut };
+};

--- a/api/src/db/DynamoUserDataClient.ts
+++ b/api/src/db/DynamoUserDataClient.ts
@@ -1,13 +1,17 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ExecuteStatementCommand, QueryCommand, QueryCommandInput } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  ExecuteStatementCommand,
+  QueryCommand,
+  type QueryCommandInput,
+} from "@aws-sdk/client-dynamodb";
+import { type DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
 import { Migrations } from "@db/migrations/migrations";
-import { type CryptoClient, UserDataClient } from "@domain/types";
-import { LogWriterType } from "@libs/logWriter";
-import { CURRENT_VERSION, UserData } from "@shared/userData";
-import { MigrationClients } from "@db/migrations/types";
+import { type MigrationClients } from "@db/migrations/types";
+import { type CryptoClient, type UserDataClient } from "@domain/types";
+import { type LogWriterType } from "@libs/logWriter";
+import { CURRENT_VERSION, type UserData } from "@shared/userData";
 
 const marshallOptions = {
   // Whether to automatically convert empty strings, blobs, and sets to `null`.
@@ -24,6 +28,14 @@ const unmarshallOptions = {
 };
 
 export const dynamoDbTranslateConfig = { marshallOptions, unmarshallOptions };
+
+export const createUserDataItem = (userData: UserData): Record<string, unknown> => ({
+  userId: userData.user.id,
+  email: userData.user.email,
+  data: userData,
+  version: userData.version,
+});
+
 export const DynamoUserDataClient = (
   db: DynamoDBDocumentClient,
   cryptoClient: CryptoClient,
@@ -31,35 +43,30 @@ export const DynamoUserDataClient = (
   logger: LogWriterType,
   migrationClients?: Omit<MigrationClients, "cryptoClient">,
 ): UserDataClient => {
-  const migrateData = async (data: UserData, logger: LogWriterType): Promise<any> => {
+  const migrateToLatest = async (data: UserData): Promise<UserData> => {
     const logId = logger.GetId();
     const dataVersion = data.version ?? CURRENT_VERSION;
     const migrationsToRun = Migrations.slice(dataVersion);
-    let migratedData = data;
+    let migratedData = structuredClone(data);
     for (const migration of migrationsToRun) {
       try {
         logger.LogInfo(
-          `Database Migration - Id:${logId} - Upgrading ${data.user.id} from ${
-            migratedData.version
-          } to ${Number(migratedData.version) + 1}`,
+          `Database Migration - Id:${logId} - Upgrading from ${migratedData.version} to ${
+            Number(migratedData.version) + 1
+          }`,
         );
         migratedData = await Promise.resolve(
-          migration(migratedData, { cryptoClient, ...migrationClients }),
+          migration(migratedData, { cryptoClient, ...migrationClients, logger }),
         );
       } catch (error) {
         logger.LogError(
-          `Database Migration Error - Id:${logId} - Error: ${error} - Data: ${JSON.stringify(
-            migratedData,
-          )}`,
+          `Database Migration Error - Id:${logId} - Failed upgrading to ${
+            Number(migratedData.version) + 1
+          } - Error: ${error}`,
         );
+        throw error;
       }
     }
-    return { ...migratedData, version: CURRENT_VERSION };
-  };
-
-  const doMigration = async (data: UserData): Promise<UserData> => {
-    const migratedData = await migrateData(data, logger);
-    await put(migratedData);
     return migratedData;
   };
 
@@ -79,7 +86,7 @@ export const DynamoUserDataClient = (
         if (!result.Items || result.Items.length === 0) {
           return;
         }
-        return doMigration(unmarshall(result.Items[0], unmarshallOptions).data);
+        return unmarshall(result.Items[0], unmarshallOptions).data;
       })
       .catch((error) => {
         console.log(error);
@@ -102,7 +109,7 @@ export const DynamoUserDataClient = (
           logger.LogInfo(`User with ID ${userId} not found in table ${tableName}`);
           throw new Error("Not found");
         }
-        return await doMigration(result.Item.data);
+        return result.Item.data;
       })
       .catch((error) => {
         throw error;
@@ -110,20 +117,14 @@ export const DynamoUserDataClient = (
   };
 
   const put = async (userData: UserData): Promise<UserData> => {
-    const migratedData = await migrateData(userData, logger);
     const params = {
       TableName: tableName,
-      Item: {
-        userId: migratedData.user.id,
-        email: migratedData.user.email,
-        data: migratedData,
-        version: migratedData.version,
-      },
+      Item: createUserDataItem(userData),
     };
     return db
       .send(new PutCommand(params))
       .then(() => {
-        return migratedData;
+        return userData;
       })
       .catch((error) => {
         throw error;
@@ -169,8 +170,7 @@ export const DynamoUserDataClient = (
     const { Items = [] } = await db.send(new ExecuteStatementCommand({ Statement: statement }));
     return await Promise.all(
       Items.map(async (object: any): Promise<UserData> => {
-        const data = unmarshall(object).data;
-        return await doMigration(data);
+        return unmarshall(object).data;
       }),
     );
   };
@@ -178,6 +178,7 @@ export const DynamoUserDataClient = (
   return {
     get,
     put,
+    migrateToLatest,
     findByEmail,
     getNeedNewsletterUsers,
     getNeedTaxIdEncryptionUsers,

--- a/api/src/db/dynamoUserDataMigration.test.ts
+++ b/api/src/db/dynamoUserDataMigration.test.ts
@@ -7,8 +7,8 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
 import { dynamoDbTranslateConfig, DynamoUserDataClient } from "@db/DynamoUserDataClient";
-import { type CryptoClient, UserDataClient } from "@domain/types";
-import { DummyLogWriter, LogWriterType } from "@libs/logWriter";
+import { type CryptoClient, type UserDataClient } from "@domain/types";
+import { DummyLogWriter, type LogWriterType } from "@libs/logWriter";
 import * as sharedUserData from "@shared/userData";
 
 function setupMockSharedUserData(): typeof sharedUserData {
@@ -29,6 +29,8 @@ jest.mock("@db/migrations/migrations", () => {
 const dbConfig = {
   tableName: "users-table-test",
 };
+
+let laterMigrationRan = false;
 
 const makeParams = (data: any): { TableName: string; Item: any } => {
   return {
@@ -53,6 +55,7 @@ describe("DynamoUserDataClient Migrations", () => {
   let logger: LogWriterType;
 
   beforeEach(async () => {
+    laterMigrationRan = false;
     client = DynamoDBDocumentClient.from(new DynamoDBClient(config), dynamoDbTranslateConfig);
     cryptoClient = {
       encryptValue: jest.fn(),
@@ -64,9 +67,9 @@ describe("DynamoUserDataClient Migrations", () => {
     await insertOldData();
   });
 
-  it("migrates and saves data from initial state", async () => {
-    // before migration
-    expect(await getDbItem("v0-id")).toEqual({
+  it("migrates a cloned initial record without persisting it", async () => {
+    const source = await dynamoUserDataClient.get("v0-id");
+    expect(source).toEqual({
       user: {
         id: "v0-id",
       },
@@ -74,8 +77,7 @@ describe("DynamoUserDataClient Migrations", () => {
       version: 0,
     });
 
-    // get does a migration
-    expect(await dynamoUserDataClient.get("v0-id")).toEqual({
+    expect(await dynamoUserDataClient.migrateToLatest(source)).toEqual({
       user: {
         id: "v0-id",
       },
@@ -84,54 +86,45 @@ describe("DynamoUserDataClient Migrations", () => {
       version: 2,
     });
 
-    // now db field is migrated
     expect(await getDbItem("v0-id")).toEqual({
       user: {
         id: "v0-id",
       },
-      v0FieldRenamed: "some-v0-value",
+      v0Field: "some-v0-value",
+      version: 0,
+    });
+  });
+
+  it("stops at the first failed migration without mutating or stamping the source", async () => {
+    const source = await dynamoUserDataClient.get("failing-v0-id");
+    const original = structuredClone(source);
+
+    await expect(dynamoUserDataClient.migrateToLatest(source)).rejects.toThrow(
+      "v0 migration failed",
+    );
+
+    expect(laterMigrationRan).toBe(false);
+    expect(source).toEqual(original);
+    expect(await getDbItem("failing-v0-id")).toEqual(original);
+  });
+
+  it("migrates data from v1 through the pure migration method", async () => {
+    const source = await dynamoUserDataClient.get("v1-id");
+    expect(await dynamoUserDataClient.migrateToLatest(source)).toEqual({
+      user: {
+        id: "v1-id",
+      },
+      v0FieldRenamed: "some-v1-data",
       newV2Field: "",
       version: 2,
     });
   });
 
-  it("migrates data from v1 state on get", async () => {
-    expect(await getDbItem("v1-id")).toEqual({
-      user: {
-        id: "v1-id",
-      },
-      v0FieldRenamed: "some-v1-data",
-      version: 1,
-    });
-
-    expect(await dynamoUserDataClient.get("v1-id")).toEqual({
-      user: {
-        id: "v1-id",
-      },
-      v0FieldRenamed: "some-v1-data",
-      newV2Field: "",
-      version: 2,
-    });
-  });
-
-  it("migrates data on put", async () => {
+  it("puts the supplied version without running migrations", async () => {
     const v1Data = await getDbItem("v1-id");
-    expect(v1Data).toEqual({
-      user: {
-        id: "v1-id",
-      },
-      v0FieldRenamed: "some-v1-data",
-      version: 1,
-    });
 
-    expect(await dynamoUserDataClient.put(v1Data)).toEqual({
-      user: {
-        id: "v1-id",
-      },
-      v0FieldRenamed: "some-v1-data",
-      newV2Field: "",
-      version: 2,
-    });
+    expect(await dynamoUserDataClient.put(v1Data)).toEqual(v1Data);
+    expect(await getDbItem("v1-id")).toEqual(v1Data);
   });
 
   it("does not migrate data when in most recent schema", async () => {
@@ -145,7 +138,7 @@ describe("DynamoUserDataClient Migrations", () => {
     });
   });
 
-  it("adds current version to inserted data", async () => {
+  it("does not synthesize a version while persisting", async () => {
     const v2Data = {
       user: {
         id: "v2-id",
@@ -157,18 +150,12 @@ describe("DynamoUserDataClient Migrations", () => {
     // @ts-ignore
     await dynamoUserDataClient.put(v2Data);
 
-    expect(await getDbItem("v2-id")).toEqual({
-      user: {
-        id: "v2-id",
-      },
-      v0FieldRenamed: "some-v2-data",
-      newV2Field: "some-value",
-      version: 2,
-    });
+    expect(await getDbItem("v2-id")).toEqual(v2Data);
   });
 
   const insertOldData = async (): Promise<void> => {
     await client.send(new PutCommand(makeParams(v0Data)));
+    await client.send(new PutCommand(makeParams(failingV0Data)));
     await client.send(new PutCommand(makeParams(v1Data)));
     await client.send(new PutCommand(makeParams(v2Data)));
   };
@@ -227,6 +214,14 @@ const v1Data = {
   version: 1,
 };
 
+const failingV0Data = {
+  user: {
+    id: "failing-v0-id",
+  },
+  v0Field: "fail",
+  version: 0,
+};
+
 const v2Data = {
   user: {
     id: "v2-id",
@@ -237,6 +232,10 @@ const v2Data = {
 };
 
 function migrate_v0_to_v1(data: v0): v1 {
+  if (data.v0Field === "fail") {
+    throw new Error("v0 migration failed");
+  }
+
   const { v0Field, ...rest } = data;
   return {
     ...rest,
@@ -246,6 +245,7 @@ function migrate_v0_to_v1(data: v0): v1 {
 }
 
 function migrate_v1_to_v2(data: v1): v2 {
+  laterMigrationRan = true;
   return {
     ...data,
     newV2Field: "",

--- a/api/src/db/migrations/migrations.test.ts
+++ b/api/src/db/migrations/migrations.test.ts
@@ -163,7 +163,9 @@ describe("migrations", () => {
       let user: unknown = generateV0UserData({});
       try {
         for (const func of Migrations) {
-          user = await Promise.resolve(func(user, { cryptoClient }));
+          user = await Promise.resolve(
+            func(user, { cryptoClient, newHashingClient: cryptoClient }),
+          );
         }
       } catch (error) {
         logger.LogError(`Dynamo User Migration Test Error - Error: ${error} - Data: ${user}`);
@@ -184,7 +186,9 @@ describe("migrations", () => {
 
       try {
         for (const func of Migrations) {
-          migratedUser = await Promise.resolve(func(migratedUser, { cryptoClient }));
+          migratedUser = await Promise.resolve(
+            func(migratedUser, { cryptoClient, newHashingClient: cryptoClient }),
+          );
         }
       } catch (error) {
         logger.LogError(

--- a/api/src/db/migrations/migrations.ts
+++ b/api/src/db/migrations/migrations.ts
@@ -165,7 +165,7 @@ import { migrate_v161_to_v162 } from "@db/migrations/v162_add_hashed_taxid_to_us
 import { migrate_v162_to_v163 } from "@db/migrations/v163_waste_transport_to_waste_data";
 import { migrate_v163_to_v164 } from "@db/migrations/v164_track_tax_clearance_primary_business";
 import { migrate_v164_to_v165 } from "@db/migrations/v165_add_last_updated_iso_to_xray_registration_data";
-import { MigrationClients } from "@db/migrations/types";
+import { type MigrationClients } from "@db/migrations/types";
 import { migrate_v165_to_v166 } from "@db/migrations/v166_add_roadmap_task_data";
 import { migrate_v166_to_v167 } from "@db/migrations/v167_update_agent_number_or_manual_options";
 import { migrate_v167_to_v168 } from "@db/migrations/v168_add_cigarette_license_data";
@@ -193,6 +193,7 @@ import { migrate_v188_to_v189 } from "@db/migrations/v189_update_env_task_id";
 import { migrate_v189_to_v190 } from "@db/migrations/v190_remove_hidden_fundings_and_certifications";
 import { migrate_v190_to_v191 } from "@db/migrations/v191_rotate_new_kms_keys";
 import { migrate_v191_to_v192 } from "@db/migrations/v192_fix_confirmation_email_sent_typo";
+import { migrate_v192_to_v193 } from "@db/migrations/v193_rotate_stranded_legacy_kms_fields";
 
 // Effectively (data: v_UserData, clients: MigrationClients) => v_UserData | Promise<v_UserData>
 export type MigrationFunction = (data: any, clients: MigrationClients) => any;
@@ -390,6 +391,7 @@ export const Migrations: MigrationFunction[] = [
   migrate_v189_to_v190,
   migrate_v190_to_v191,
   migrate_v191_to_v192,
+  migrate_v192_to_v193,
 ];
 
-export { generatev192UserData as CURRENT_GENERATOR } from "@db/migrations/v192_fix_confirmation_email_sent_typo";
+export { generatev193UserData as CURRENT_GENERATOR } from "@db/migrations/v193_rotate_stranded_legacy_kms_fields";

--- a/api/src/db/migrations/types.ts
+++ b/api/src/db/migrations/types.ts
@@ -1,7 +1,8 @@
 import { type CryptoClient } from "@domain/types";
+import { type LogWriterType } from "@libs/logWriter";
 
 export interface MigrationClients {
   cryptoClient: CryptoClient;
-  legacyTaxIdCryptoClient?: CryptoClient;
   newHashingClient?: CryptoClient;
+  logger?: Pick<LogWriterType, "LogError">;
 }

--- a/api/src/db/migrations/v191_rotate_new_kms_keys.test.ts
+++ b/api/src/db/migrations/v191_rotate_new_kms_keys.test.ts
@@ -1,0 +1,135 @@
+import {
+  generatev190Business,
+  generatev190ProfileData,
+  generatev190UserData,
+} from "@db/migrations/v190_remove_hidden_fundings_and_certifications";
+import { migrate_v190_to_v191 } from "@db/migrations/v191_rotate_new_kms_keys";
+import {
+  generatev191Business,
+  generatev191ProfileData,
+  generatev191UserData,
+} from "@db/migrations/v191_rotate_new_kms_keys";
+import { migrate_v191_to_v192 } from "@db/migrations/v192_fix_confirmation_email_sent_typo";
+import { type CryptoClient } from "@domain/types";
+
+const makeCryptoClient = (): jest.Mocked<CryptoClient> => ({
+  decryptValue: jest.fn(async (value) => `plain:${value}`),
+  encryptValue: jest.fn(async (value) => `current:${value}`),
+  hashValue: jest.fn(),
+});
+
+describe("migrate_v190_to_v191 hashing", () => {
+  it("retries hashing up to three total attempts", async () => {
+    const cryptoClient = makeCryptoClient();
+    const hashingClient = makeCryptoClient();
+    const logger = { LogError: jest.fn() };
+    hashingClient.hashValue
+      .mockRejectedValueOnce(new Error("temporary hashing failure"))
+      .mockRejectedValueOnce(new Error("temporary hashing failure"))
+      .mockResolvedValueOnce("hashed-tax-id");
+    const userData = generatev190UserData({
+      businesses: {
+        first: generatev190Business({
+          id: "first",
+          profileData: generatev190ProfileData({ encryptedTaxId: "encrypted-tax-id" }),
+        }),
+      },
+    });
+
+    const result = await migrate_v190_to_v191(userData, {
+      cryptoClient,
+      newHashingClient: hashingClient,
+      logger,
+    });
+
+    expect(result.businesses.first.profileData.hashedTaxId).toBe("hashed-tax-id");
+    expect(hashingClient.hashValue).toHaveBeenCalledTimes(3);
+    expect(logger.LogError).toHaveBeenCalledTimes(2);
+    expect(logger.LogError).toHaveBeenLastCalledWith(
+      expect.stringContaining("attempt 2 of 3: Error: temporary hashing failure"),
+    );
+  });
+
+  it("fails the migration after the third hashing failure", async () => {
+    const cryptoClient = makeCryptoClient();
+    const hashingClient = makeCryptoClient();
+    const logger = { LogError: jest.fn() };
+    hashingClient.hashValue.mockRejectedValue(new Error("terminal hashing failure"));
+    const userData = generatev190UserData({
+      businesses: {
+        first: generatev190Business({
+          id: "first",
+          profileData: generatev190ProfileData({ encryptedTaxId: "encrypted-tax-id" }),
+        }),
+      },
+    });
+
+    await expect(
+      migrate_v190_to_v191(userData, {
+        cryptoClient,
+        newHashingClient: hashingClient,
+        logger,
+      }),
+    ).rejects.toThrow("terminal hashing failure");
+    expect(hashingClient.hashValue).toHaveBeenCalledTimes(3);
+    expect(logger.LogError).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("migrate_v191_to_v192 hashing", () => {
+  it("retries hashing up to three total attempts", async () => {
+    const cryptoClient = makeCryptoClient();
+    const hashingClient = makeCryptoClient();
+    const logger = { LogError: jest.fn() };
+    hashingClient.hashValue
+      .mockRejectedValueOnce(new Error("temporary hashing failure"))
+      .mockRejectedValueOnce(new Error("temporary hashing failure"))
+      .mockResolvedValueOnce("hashed-tax-id");
+    const userData = generatev191UserData({
+      businesses: {
+        first: generatev191Business({
+          id: "first",
+          profileData: generatev191ProfileData({ encryptedTaxId: "encrypted-tax-id" }),
+        }),
+      },
+    });
+
+    const result = await migrate_v191_to_v192(userData, {
+      cryptoClient,
+      newHashingClient: hashingClient,
+      logger,
+    });
+
+    expect(result.businesses.first.profileData.hashedTaxId).toBe("hashed-tax-id");
+    expect(hashingClient.hashValue).toHaveBeenCalledTimes(3);
+    expect(logger.LogError).toHaveBeenCalledTimes(2);
+    expect(logger.LogError).toHaveBeenLastCalledWith(
+      expect.stringContaining("attempt 2 of 3: Error: temporary hashing failure"),
+    );
+  });
+
+  it("fails the migration after the third hashing failure", async () => {
+    const cryptoClient = makeCryptoClient();
+    const hashingClient = makeCryptoClient();
+    const logger = { LogError: jest.fn() };
+    hashingClient.hashValue.mockRejectedValue(new Error("terminal hashing failure"));
+    const userData = generatev191UserData({
+      businesses: {
+        first: generatev191Business({
+          id: "first",
+          profileData: generatev191ProfileData({ encryptedTaxId: "encrypted-tax-id" }),
+        }),
+      },
+    });
+
+    await expect(
+      migrate_v191_to_v192(userData, {
+        cryptoClient,
+        newHashingClient: hashingClient,
+        logger,
+      }),
+    ).rejects.toThrow("terminal hashing failure");
+    expect(hashingClient.hashValue).toHaveBeenCalledTimes(3);
+    expect(logger.LogError).toHaveBeenCalledTimes(3);
+  });
+});

--- a/api/src/db/migrations/v192_fix_confirmation_email_sent_typo.ts
+++ b/api/src/db/migrations/v192_fix_confirmation_email_sent_typo.ts
@@ -7,21 +7,49 @@ import {
 import { randomInt } from "@shared/intHelpers";
 import { type MigrationClients } from "@db/migrations/types";
 
+const decryptField = async (
+  fieldName: string,
+  encryptedValue: string,
+  clients: MigrationClients,
+): Promise<string> => {
+  try {
+    return await clients.cryptoClient.decryptValue(encryptedValue);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Migration v192 failed to decrypt ${fieldName}: ${message}`, {
+      cause: error,
+    });
+  }
+};
+
+const encryptField = async (
+  fieldName: string,
+  plaintext: string,
+  clients: MigrationClients,
+): Promise<string> => {
+  try {
+    return await clients.cryptoClient.encryptValue(plaintext);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Migration v192 failed to encrypt ${fieldName}: ${message}`, {
+      cause: error,
+    });
+  }
+};
+
 const reEncryptDeptOfLaborEin = async (
   encryptedValue: string | undefined,
   clients: MigrationClients,
 ): Promise<string> => {
   if (encryptedValue === "" || !encryptedValue) return "";
 
-  if (!clients.legacyTaxIdCryptoClient) {
-    throw new Error("legacyTaxIdCryptoClient is required");
-  }
-
-  const plaintext = await clients.legacyTaxIdCryptoClient.decryptValue(encryptedValue);
-  return await clients.cryptoClient.encryptValue(plaintext);
+  const fieldName = "profileData.deptOfLaborEin";
+  const plaintext = await decryptField(fieldName, encryptedValue, clients);
+  return await encryptField(fieldName, plaintext, clients);
 };
 
 const reEncryptValue = async (
+  fieldName: string,
   encryptedValue: string | undefined,
   clients: MigrationClients,
 ): Promise<string | undefined> => {
@@ -29,12 +57,31 @@ const reEncryptValue = async (
     return encryptedValue;
   }
 
-  if (!clients.legacyTaxIdCryptoClient) {
-    throw new Error("legacyTaxIdCryptoClient is required");
+  const plaintext = await decryptField(fieldName, encryptedValue, clients);
+  return await encryptField(fieldName, plaintext, clients);
+};
+
+const hashTaxId = async (plaintext: string, clients: MigrationClients): Promise<string> => {
+  if (!clients.newHashingClient) {
+    throw new Error("newHashingClient is required");
   }
 
-  const plaintext = await clients.legacyTaxIdCryptoClient.decryptValue(encryptedValue);
-  return await clients.cryptoClient.encryptValue(plaintext);
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      return await clients.newHashingClient.hashValue(plaintext);
+    } catch (error) {
+      lastError = error;
+      clients.logger?.LogError(
+        `Migration v192 failed to hash profileData.encryptedTaxId on attempt ${attempt} of 3: ${error}`,
+      );
+    }
+  }
+  const message = lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(
+    `Migration v192 failed to hash profileData.encryptedTaxId after 3 attempts: ${message}`,
+    { cause: lastError },
+  );
 };
 
 const reEncryptAndHashTaxId = async (
@@ -51,19 +98,12 @@ const reEncryptAndHashTaxId = async (
     };
   }
 
-  if (!clients.legacyTaxIdCryptoClient) {
-    throw new Error("legacyTaxIdCryptoClient is required");
-  }
-
-  if (!clients.newHashingClient) {
-    throw new Error("newHashingClient is required");
-  }
-
-  const plaintext = await clients.legacyTaxIdCryptoClient.decryptValue(encryptedTaxId);
+  const fieldName = "profileData.encryptedTaxId";
+  const plaintext = await decryptField(fieldName, encryptedTaxId, clients);
 
   return {
-    encryptedTaxId: await clients.cryptoClient.encryptValue(plaintext),
-    hashedTaxId: await clients.newHashingClient.hashValue(plaintext),
+    encryptedTaxId: await encryptField(fieldName, plaintext, clients),
+    hashedTaxId: await hashTaxId(plaintext, clients),
   };
 };
 
@@ -125,11 +165,16 @@ const migrate_v191Business_to_v192Business = async (
   );
 
   const cigaretteEncryptedTaxId = await reEncryptValue(
+    "cigaretteLicenseData.encryptedTaxId",
     business.cigaretteLicenseData?.encryptedTaxId,
     clients,
   );
 
-  const encryptedTaxPin = await reEncryptValue(business.profileData.encryptedTaxPin, clients);
+  const encryptedTaxPin = await reEncryptValue(
+    "profileData.encryptedTaxPin",
+    business.profileData.encryptedTaxPin,
+    clients,
+  );
 
   const encryptedDeptOfLaborEin = await reEncryptDeptOfLaborEin(
     business.profileData.deptOfLaborEin,

--- a/api/src/db/migrations/v193_rotate_stranded_legacy_kms_fields.test.ts
+++ b/api/src/db/migrations/v193_rotate_stranded_legacy_kms_fields.test.ts
@@ -1,0 +1,131 @@
+import {
+  generatev192Business,
+  generatev192CigaretteLicenseData,
+  generatev192ProfileData,
+  generatev192TaxClearanceCertificateData,
+  generatev192UserData,
+  type v192TaxClearanceCertificateData,
+} from "@db/migrations/v192_fix_confirmation_email_sent_typo";
+import { migrate_v192_to_v193 } from "@db/migrations/v193_rotate_stranded_legacy_kms_fields";
+import { type MigrationClients } from "@db/migrations/types";
+import { type CryptoClient } from "@domain/types";
+
+const makeCryptoClient = (): jest.Mocked<CryptoClient> => ({
+  decryptValue: jest.fn(async (value) => `plain:${value}`),
+  encryptValue: jest.fn(async (value) => `current:${value}`),
+  hashValue: jest.fn(),
+});
+
+describe("migrate_v192_to_v193", () => {
+  let cryptoClient: jest.Mocked<CryptoClient>;
+  let clients: MigrationClients;
+
+  beforeEach(() => {
+    cryptoClient = makeCryptoClient();
+    clients = { cryptoClient };
+  });
+
+  it("requires migration clients", async () => {
+    await expect(migrate_v192_to_v193(generatev192UserData({}))).rejects.toThrow(
+      "Migration v193 requires migration clients",
+    );
+  });
+
+  it("rotates all six encrypted fields and updates every business version", async () => {
+    const taxClearanceData = {
+      ...generatev192TaxClearanceCertificateData({}),
+      encryptedTaxId: "tax-clearance-tax-id",
+      encryptedTaxPin: "tax-clearance-tax-pin",
+    } as v192TaxClearanceCertificateData & {
+      encryptedTaxId: string;
+      encryptedTaxPin: string;
+    };
+    const userData = generatev192UserData({
+      version: 192,
+      businesses: {
+        first: generatev192Business({
+          id: "first",
+          version: 192,
+          profileData: generatev192ProfileData({
+            encryptedTaxId: "profile-tax-id",
+            encryptedTaxPin: "profile-tax-pin",
+            deptOfLaborEin: "dol-ein",
+          }),
+          cigaretteLicenseData: generatev192CigaretteLicenseData({
+            encryptedTaxId: "cigarette-tax-id",
+            paymentInfo: { confirmationEmailSent: true },
+          }),
+          taxClearanceCertificateData: taxClearanceData,
+        }),
+        second: generatev192Business({ id: "second", version: 192 }),
+      },
+    });
+
+    const result = await migrate_v192_to_v193(userData, clients);
+    const first = result.businesses.first;
+
+    expect(result.version).toBe(193);
+    expect(first.version).toBe(193);
+    expect(result.businesses.second.version).toBe(193);
+    expect(first.profileData.encryptedTaxId).toBe("current:plain:profile-tax-id");
+    expect(first.profileData.encryptedTaxPin).toBe("current:plain:profile-tax-pin");
+    expect(first.profileData.deptOfLaborEin).toBe("current:plain:dol-ein");
+    expect(first.cigaretteLicenseData?.encryptedTaxId).toBe("current:plain:cigarette-tax-id");
+    expect(first.cigaretteLicenseData?.paymentInfo?.confirmationEmailSent).toBe(true);
+    expect(first.taxClearanceCertificateData?.encryptedTaxId).toBe(
+      "current:plain:tax-clearance-tax-id",
+    );
+    expect(first.taxClearanceCertificateData?.encryptedTaxPin).toBe(
+      "current:plain:tax-clearance-tax-pin",
+    );
+  });
+
+  it("leaves missing encrypted fields empty", async () => {
+    const userData = generatev192UserData({
+      businesses: {
+        first: generatev192Business({
+          id: "first",
+          profileData: generatev192ProfileData({
+            encryptedTaxId: undefined,
+            encryptedTaxPin: undefined,
+            deptOfLaborEin: "",
+          }),
+          cigaretteLicenseData: undefined,
+          taxClearanceCertificateData: undefined,
+        }),
+      },
+    });
+
+    const result = await migrate_v192_to_v193(userData, clients);
+
+    expect(result.businesses.first.profileData.encryptedTaxId).toBeUndefined();
+    expect(result.businesses.first.profileData.encryptedTaxPin).toBeUndefined();
+    expect(result.businesses.first.profileData.deptOfLaborEin).toBe("");
+  });
+
+  it.each([
+    ["decrypt", "AccessDeniedException"],
+    ["decrypt", "unencryptedDataKey has not been set"],
+    ["decrypt", "Invalid ciphertext"],
+    ["decrypt", "ThrottlingException"],
+    ["decrypt", "TimeoutError"],
+    ["encrypt", "KMS encryption failed"],
+  ])("rejects without mutating source data when %s fails with %s", async (operation, message) => {
+    const userData = generatev192UserData({
+      businesses: {
+        first: generatev192Business({
+          id: "first",
+          profileData: generatev192ProfileData({ encryptedTaxId: "encrypted-value" }),
+        }),
+      },
+    });
+    const original = structuredClone(userData);
+    const method = operation === "decrypt" ? cryptoClient.decryptValue : cryptoClient.encryptValue;
+    method.mockRejectedValueOnce(new Error(message));
+
+    await expect(migrate_v192_to_v193(userData, clients)).rejects.toThrow(
+      `Migration v193 failed to ${operation} profileData.encryptedTaxId: ${message}`,
+    );
+    expect(userData).toEqual(original);
+  });
+});

--- a/api/src/db/migrations/v193_rotate_stranded_legacy_kms_fields.ts
+++ b/api/src/db/migrations/v193_rotate_stranded_legacy_kms_fields.ts
@@ -1,53 +1,12 @@
-import {
-  v190Business,
-  v190BusinessUser,
-  v190UserData,
-} from "@db/migrations/v190_remove_hidden_fundings_and_certifications";
+import type {
+  v192Business,
+  v192BusinessUser,
+  v192UserData,
+} from "@db/migrations/v192_fix_confirmation_email_sent_typo";
 import { randomInt } from "@shared/intHelpers";
 import { type MigrationClients } from "@db/migrations/types";
 
-const decryptField = async (
-  fieldName: string,
-  encryptedValue: string,
-  clients: MigrationClients,
-): Promise<string> => {
-  try {
-    return await clients.cryptoClient.decryptValue(encryptedValue);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Migration v191 failed to decrypt ${fieldName}: ${message}`, {
-      cause: error,
-    });
-  }
-};
-
-const encryptField = async (
-  fieldName: string,
-  plaintext: string,
-  clients: MigrationClients,
-): Promise<string> => {
-  try {
-    return await clients.cryptoClient.encryptValue(plaintext);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Migration v191 failed to encrypt ${fieldName}: ${message}`, {
-      cause: error,
-    });
-  }
-};
-
-const reEncryptDeptOfLaborEin = async (
-  encryptedValue: string | undefined,
-  clients: MigrationClients,
-): Promise<string> => {
-  if (encryptedValue === "" || !encryptedValue) return "";
-
-  const fieldName = "profileData.deptOfLaborEin";
-  const plaintext = await decryptField(fieldName, encryptedValue, clients);
-  return await encryptField(fieldName, plaintext, clients);
-};
-
-const reEncryptValue = async (
+const rotateField = async (
   fieldName: string,
   encryptedValue: string | undefined,
   clients: MigrationClients,
@@ -56,67 +15,37 @@ const reEncryptValue = async (
     return encryptedValue;
   }
 
-  const plaintext = await decryptField(fieldName, encryptedValue, clients);
-  return await encryptField(fieldName, plaintext, clients);
-};
-
-const hashTaxId = async (plaintext: string, clients: MigrationClients): Promise<string> => {
-  if (!clients.newHashingClient) {
-    throw new Error("newHashingClient is required");
+  let plaintext: string;
+  try {
+    plaintext = await clients.cryptoClient.decryptValue(encryptedValue);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Migration v193 failed to decrypt ${fieldName}: ${message}`, {
+      cause: error,
+    });
   }
 
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= 3; attempt += 1) {
-    try {
-      return await clients.newHashingClient.hashValue(plaintext);
-    } catch (error) {
-      lastError = error;
-      clients.logger?.LogError(
-        `Migration v191 failed to hash profileData.encryptedTaxId on attempt ${attempt} of 3: ${error}`,
-      );
-    }
+  try {
+    return await clients.cryptoClient.encryptValue(plaintext);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Migration v193 failed to encrypt ${fieldName}: ${message}`, {
+      cause: error,
+    });
   }
-  const message = lastError instanceof Error ? lastError.message : String(lastError);
-  throw new Error(
-    `Migration v191 failed to hash profileData.encryptedTaxId after 3 attempts: ${message}`,
-    { cause: lastError },
-  );
 };
 
-const reEncryptAndHashTaxId = async (
-  encryptedTaxId: string | undefined,
-  clients: MigrationClients,
-): Promise<{
-  encryptedTaxId: string | undefined;
-  hashedTaxId: string | undefined;
-}> => {
-  if (!encryptedTaxId) {
-    return {
-      encryptedTaxId,
-      hashedTaxId: undefined,
-    };
-  }
-
-  const fieldName = "profileData.encryptedTaxId";
-  const plaintext = await decryptField(fieldName, encryptedTaxId, clients);
-
-  return {
-    encryptedTaxId: await encryptField(fieldName, plaintext, clients),
-    hashedTaxId: await hashTaxId(plaintext, clients),
-  };
-};
-
-export const migrate_v190_to_v191 = async (
-  userData: v190UserData,
+export const migrate_v192_to_v193 = async (
+  userData: v192UserData,
   clients?: MigrationClients,
-): Promise<v191UserData> => {
+): Promise<v193UserData> => {
   if (!clients) {
-    throw new Error("Migration v191 requires migration clients");
+    throw new Error("Migration v193 requires migration clients");
   }
 
   const migratedBusinesses = await Promise.all(
     Object.values(userData.businesses).map(async (business) => {
-      const migratedBusiness = await migrate_v190Business_to_v191Business(business, clients);
+      const migratedBusiness = await migrate_v192Business_to_v193Business(business, clients);
 
       return [migratedBusiness.id, migratedBusiness] as const;
     }),
@@ -124,53 +53,82 @@ export const migrate_v190_to_v191 = async (
 
   return {
     ...userData,
-    user: migrate_v190BusinessUser_to_v191BusinessUser(userData.user),
+    user: migrate_v192BusinessUser_to_v193BusinessUser(userData.user),
     businesses: Object.fromEntries(migratedBusinesses),
-    version: 191,
+    version: 193,
   };
 };
 
-const migrate_v190BusinessUser_to_v191BusinessUser = (
-  user: v190BusinessUser,
-): v191BusinessUser => ({
+const migrate_v192BusinessUser_to_v193BusinessUser = (
+  user: v192BusinessUser,
+): v193BusinessUser => ({
   ...user,
 });
 
-const migrate_v190Business_to_v191Business = async (
-  business: v190Business,
+type LegacyTaxClearanceCertificateData = {
+  encryptedTaxId?: string;
+  encryptedTaxPin?: string;
+};
+
+const migrate_v192Business_to_v193Business = async (
+  business: v192Business,
   clients: MigrationClients,
-): Promise<v191Business> => {
-  const { encryptedTaxId, hashedTaxId } = await reEncryptAndHashTaxId(
+): Promise<v193Business> => {
+  const encryptedTaxId = await rotateField(
+    "profileData.encryptedTaxId",
     business.profileData.encryptedTaxId,
     clients,
   );
 
-  const cigaretteEncryptedTaxId = await reEncryptValue(
+  const cigaretteEncryptedTaxId = await rotateField(
     "cigaretteLicenseData.encryptedTaxId",
     business.cigaretteLicenseData?.encryptedTaxId,
     clients,
   );
 
-  const encryptedTaxPin = await reEncryptValue(
+  const encryptedTaxPin = await rotateField(
     "profileData.encryptedTaxPin",
     business.profileData.encryptedTaxPin,
     clients,
   );
 
-  const encryptedDeptOfLaborEin = await reEncryptDeptOfLaborEin(
+  const encryptedDeptOfLaborEin = await rotateField(
+    "profileData.deptOfLaborEin",
     business.profileData.deptOfLaborEin,
+    clients,
+  );
+
+  // These fields exist in stored records but were omitted from the v191/v192 type tree.
+  const legacyTaxClearance = business.taxClearanceCertificateData as
+    | (typeof business.taxClearanceCertificateData & LegacyTaxClearanceCertificateData)
+    | undefined;
+  const taxClearanceEncryptedTaxId = await rotateField(
+    "taxClearanceCertificateData.encryptedTaxId",
+    legacyTaxClearance?.encryptedTaxId,
+    clients,
+  );
+  const taxClearanceEncryptedTaxPin = await rotateField(
+    "taxClearanceCertificateData.encryptedTaxPin",
+    legacyTaxClearance?.encryptedTaxPin,
     clients,
   );
 
   return {
     ...business,
+    version: 193,
     profileData: {
       ...business.profileData,
       encryptedTaxId,
-      hashedTaxId,
       encryptedTaxPin,
-      deptOfLaborEin: encryptedDeptOfLaborEin,
+      deptOfLaborEin: encryptedDeptOfLaborEin ?? "",
     },
+    taxClearanceCertificateData: business.taxClearanceCertificateData
+      ? {
+          ...business.taxClearanceCertificateData,
+          encryptedTaxId: taxClearanceEncryptedTaxId,
+          encryptedTaxPin: taxClearanceEncryptedTaxPin,
+        }
+      : business.taxClearanceCertificateData,
     cigaretteLicenseData: business.cigaretteLicenseData
       ? {
           ...business.cigaretteLicenseData,
@@ -180,87 +138,87 @@ const migrate_v190Business_to_v191Business = async (
   };
 };
 
-export interface v191IndustrySpecificData {
+export interface v193IndustrySpecificData {
   liquorLicense: boolean;
   requiresCpa: boolean | undefined;
   homeBasedBusiness?: boolean | undefined;
   providesStaffingService: boolean;
   certifiedInteriorDesigner: boolean;
   realEstateAppraisalManagement: boolean;
-  cannabisLicenseType: v191CannabisLicenseType;
+  cannabisLicenseType: v193CannabisLicenseType;
   cannabisMicrobusiness: boolean | undefined;
   constructionRenovationPlan: boolean | undefined;
-  carService: v191CarServiceType | undefined;
+  carService: v193CarServiceType | undefined;
   interstateTransport: boolean | undefined;
   interstateLogistics: boolean | undefined;
   interstateMoving: boolean | undefined;
   isChildcareForSixOrMore: boolean | undefined;
   petCareHousing: boolean | undefined;
   willSellPetCareItems: boolean | undefined;
-  constructionType: v191ConstructionType;
-  residentialConstructionType: v191ResidentialConstructionType;
-  employmentPersonnelServiceType: v191EmploymentAndPersonnelServicesType;
-  employmentPlacementType: v191EmploymentPlacementType;
-  propertyLeaseType: v191PropertyLeaseType;
+  constructionType: v193ConstructionType;
+  residentialConstructionType: v193ResidentialConstructionType;
+  employmentPersonnelServiceType: v193EmploymentAndPersonnelServicesType;
+  employmentPlacementType: v193EmploymentPlacementType;
+  propertyLeaseType: v193PropertyLeaseType;
   hasThreeOrMoreRentalUnits: boolean | undefined;
   publicWorksContractor: boolean | undefined;
 }
 
-export type v191PropertyLeaseType = "SHORT_TERM_RENTAL" | "LONG_TERM_RENTAL" | "BOTH" | undefined;
+export type v193PropertyLeaseType = "SHORT_TERM_RENTAL" | "LONG_TERM_RENTAL" | "BOTH" | undefined;
 
-// ---------------- v191 types ----------------
-type v191TaskProgress = "TO_DO" | "COMPLETED";
-type v191OnboardingFormProgress = "UNSTARTED" | "COMPLETED";
-type v191ABExperience = "ExperienceA" | "ExperienceB";
+// ---------------- v193 types ----------------
+type v193TaskProgress = "TO_DO" | "COMPLETED";
+type v193OnboardingFormProgress = "UNSTARTED" | "COMPLETED";
+type v193ABExperience = "ExperienceA" | "ExperienceB";
 
-export interface v191UserData {
-  user: v191BusinessUser;
+export interface v193UserData {
+  user: v193BusinessUser;
   version: number;
   lastUpdatedISO: string;
   dateCreatedISO: string;
   versionWhenCreated: number;
-  businesses: Record<string, v191Business>;
+  businesses: Record<string, v193Business>;
   currentBusinessId: string;
 }
 
-export interface v191Business {
+export interface v193Business {
   id: string;
   dateCreatedISO: string;
   lastUpdatedISO: string;
   dateDeletedISO: string;
-  profileData: v191ProfileData;
-  onboardingFormProgress: v191OnboardingFormProgress;
-  taskProgress: Record<string, v191TaskProgress>;
+  profileData: v193ProfileData;
+  onboardingFormProgress: v193OnboardingFormProgress;
+  taskProgress: Record<string, v193TaskProgress>;
   taskItemChecklist: Record<string, boolean>;
-  licenseData: v191LicenseData | undefined;
-  preferences: v191Preferences;
-  taxFilingData: v191TaxFilingData;
-  formationData: v191FormationData;
-  environmentData: v191EnvironmentData | undefined;
-  xrayRegistrationData: v191XrayData | undefined;
-  crtkData: v191CrtkData | undefined;
-  roadmapTaskData: v191RoadmapTaskData;
-  taxClearanceCertificateData: v191TaxClearanceCertificateData | undefined;
-  cigaretteLicenseData: v191CigaretteLicenseData | undefined;
+  licenseData: v193LicenseData | undefined;
+  preferences: v193Preferences;
+  taxFilingData: v193TaxFilingData;
+  formationData: v193FormationData;
+  environmentData: v193EnvironmentData | undefined;
+  xrayRegistrationData: v193XrayData | undefined;
+  crtkData: v193CrtkData | undefined;
+  roadmapTaskData: v193RoadmapTaskData;
+  taxClearanceCertificateData: v193TaxClearanceCertificateData | undefined;
+  cigaretteLicenseData: v193CigaretteLicenseData | undefined;
   version: number;
   versionWhenCreated: number;
   userId: string;
 }
 
-export interface v191RoadmapTaskData {
+export interface v193RoadmapTaskData {
   manageBusinessVehicles?: boolean;
   passengerTransportSchoolBus?: boolean;
   passengerTransportSixteenOrMorePassengers?: boolean;
 }
 
-export interface v191ProfileData extends v191IndustrySpecificData {
-  businessPersona: v191BusinessPersona;
+export interface v193ProfileData extends v193IndustrySpecificData {
+  businessPersona: v193BusinessPersona;
   businessName: string;
   responsibleOwnerName: string;
   tradeName: string;
   industryId: string | undefined;
   legalStructureId: string | undefined;
-  municipality: v191Municipality | undefined;
+  municipality: v193Municipality | undefined;
   dateOfFormation: string | undefined;
   entityId: string | undefined;
   employerId: string | undefined;
@@ -268,19 +226,19 @@ export interface v191ProfileData extends v191IndustrySpecificData {
   hashedTaxId: string | undefined;
   encryptedTaxId: string | undefined;
   notes: string;
-  documents: v191ProfileDocuments;
+  documents: v193ProfileDocuments;
   ownershipTypeIds: string[];
   existingEmployees: string | undefined;
   taxPin: string | undefined;
   encryptedTaxPin: string | undefined;
   sectorId: string | undefined;
   naicsCode: string;
-  foreignBusinessTypeIds: v191ForeignBusinessTypeId[];
+  foreignBusinessTypeIds: v193ForeignBusinessTypeId[];
   nexusDbaName: string;
-  operatingPhase: v191OperatingPhase;
+  operatingPhase: v193OperatingPhase;
   nonEssentialRadioAnswers: Record<string, boolean | undefined>;
   elevatorOwningBusiness: boolean | undefined;
-  communityAffairsAddress?: v191CommunityAffairsAddress;
+  communityAffairsAddress?: v193CommunityAffairsAddress;
   plannedRenovationQuestion: boolean | undefined;
   raffleBingoGames: boolean | undefined;
   businessOpenMoreThanTwoYears: boolean | undefined;
@@ -288,36 +246,36 @@ export interface v191ProfileData extends v191IndustrySpecificData {
   deptOfLaborEin: string;
 }
 
-export type v191CommunityAffairsAddress = {
+export type v193CommunityAffairsAddress = {
   streetAddress1: string;
   streetAddress2?: string;
-  municipality: v191Municipality;
+  municipality: v193Municipality;
 };
 
-export type v191BusinessUser = {
+export type v193BusinessUser = {
   name?: string;
   email: string;
   id: string;
   receiveNewsletter: boolean;
   userTesting: boolean;
   receiveUpdatesAndReminders: boolean;
-  externalStatus: v191ExternalStatus;
+  externalStatus: v193ExternalStatus;
   myNJUserKey?: string;
   intercomHash?: string;
-  abExperience: v191ABExperience;
+  abExperience: v193ABExperience;
   accountCreationSource: string;
   contactSharingWithAccountCreationPartner: boolean;
   phoneNumber?: string;
 };
 
-export interface v191ProfileDocuments {
+export interface v193ProfileDocuments {
   formationDoc: string;
   standingDoc: string;
   certifiedDoc: string;
 }
 
-type v191BusinessPersona = "STARTING" | "OWNING" | "FOREIGN" | undefined;
-type v191OperatingPhase =
+type v193BusinessPersona = "STARTING" | "OWNING" | "FOREIGN" | undefined;
+type v193OperatingPhase =
   | "GUEST_MODE"
   | "GUEST_MODE_WITH_BUSINESS_STRUCTURE"
   | "GUEST_MODE_OWNING"
@@ -330,18 +288,18 @@ type v191OperatingPhase =
   | "DOMESTIC_EMPLOYER"
   | undefined;
 
-export type v191CannabisLicenseType = "CONDITIONAL" | "ANNUAL" | undefined;
-export type v191CarServiceType = "STANDARD" | "HIGH_CAPACITY" | "BOTH" | undefined;
-export type v191ConstructionType = "RESIDENTIAL" | "COMMERCIAL_OR_INDUSTRIAL" | "BOTH" | undefined;
-export type v191ResidentialConstructionType =
+export type v193CannabisLicenseType = "CONDITIONAL" | "ANNUAL" | undefined;
+export type v193CarServiceType = "STANDARD" | "HIGH_CAPACITY" | "BOTH" | undefined;
+export type v193ConstructionType = "RESIDENTIAL" | "COMMERCIAL_OR_INDUSTRIAL" | "BOTH" | undefined;
+export type v193ResidentialConstructionType =
   | "NEW_HOME_CONSTRUCTION"
   | "HOME_RENOVATIONS"
   | "BOTH"
   | undefined;
-export type v191EmploymentAndPersonnelServicesType = "JOB_SEEKERS" | "EMPLOYERS" | undefined;
-export type v191EmploymentPlacementType = "TEMPORARY" | "PERMANENT" | "BOTH" | undefined;
+export type v193EmploymentAndPersonnelServicesType = "JOB_SEEKERS" | "EMPLOYERS" | undefined;
+export type v193EmploymentPlacementType = "TEMPORARY" | "PERMANENT" | "BOTH" | undefined;
 
-type v191ForeignBusinessTypeId =
+type v193ForeignBusinessTypeId =
   | "employeeOrContractorInNJ"
   | "officeInNJ"
   | "propertyInNJ"
@@ -351,54 +309,54 @@ type v191ForeignBusinessTypeId =
   | "transactionsInNJ"
   | "none";
 
-export type v191Municipality = {
+export type v193Municipality = {
   name: string;
   displayName: string;
   county: string;
   id: string;
 };
 
-type v191TaxFilingState = "SUCCESS" | "FAILED" | "UNREGISTERED" | "PENDING" | "API_ERROR";
-type v191TaxFilingErrorFields = "businessName" | "formFailure";
+type v193TaxFilingState = "SUCCESS" | "FAILED" | "UNREGISTERED" | "PENDING" | "API_ERROR";
+type v193TaxFilingErrorFields = "businessName" | "formFailure";
 
-export type v191TaxFilingData = {
-  state?: v191TaxFilingState;
+export type v193TaxFilingData = {
+  state?: v193TaxFilingState;
   lastUpdatedISO?: string;
   registeredISO?: string;
-  errorField?: v191TaxFilingErrorFields;
+  errorField?: v193TaxFilingErrorFields;
   businessName?: string;
-  filings: v191TaxFilingCalendarEvent[];
+  filings: v193TaxFilingCalendarEvent[];
 };
 
-export type v191CalendarEvent = {
+export type v193CalendarEvent = {
   readonly dueDate: string; // YYYY-MM-DD
   readonly calendarEventType: "TAX-FILING" | "LICENSE";
 };
 
-export interface v191TaxFilingCalendarEvent extends v191CalendarEvent {
+export interface v193TaxFilingCalendarEvent extends v193CalendarEvent {
   readonly identifier: string;
   readonly calendarEventType: "TAX-FILING";
 }
 
-export type v191LicenseSearchAddress = {
+export type v193LicenseSearchAddress = {
   addressLine1: string;
   addressLine2: string;
   zipCode: string;
 };
 
-export interface v191LicenseSearchNameAndAddress extends v191LicenseSearchAddress {
+export interface v193LicenseSearchNameAndAddress extends v193LicenseSearchAddress {
   name: string;
 }
 
-export type v191LicenseDetails = {
-  nameAndAddress: v191LicenseSearchNameAndAddress;
-  licenseStatus: v191LicenseStatus;
+export type v193LicenseDetails = {
+  nameAndAddress: v193LicenseSearchNameAndAddress;
+  licenseStatus: v193LicenseStatus;
   expirationDateISO: string | undefined;
   lastUpdatedISO: string;
-  checklistItems: v191LicenseStatusItem[];
+  checklistItems: v193LicenseStatusItem[];
 };
 
-const v191taskIdLicenseNameMapping = {
+const v193taskIdLicenseNameMapping = {
   "apply-for-shop-license": "Cosmetology and Hairstyling-Shop",
   "appraiser-license": "Real Estate Appraisers-Appraisal Management Company",
   "architect-license": "Architecture-Certificate of Authorization",
@@ -416,19 +374,19 @@ const v191taskIdLicenseNameMapping = {
   "telemarketing-license": "Telemarketers",
 } as const;
 
-type v191LicenseTaskID = keyof typeof v191taskIdLicenseNameMapping;
+type v193LicenseTaskID = keyof typeof v193taskIdLicenseNameMapping;
 
-export type v191LicenseName = (typeof v191taskIdLicenseNameMapping)[v191LicenseTaskID];
+export type v193LicenseName = (typeof v193taskIdLicenseNameMapping)[v193LicenseTaskID];
 
-type v191Licenses = Partial<Record<v191LicenseName, v191LicenseDetails>>;
+type v193Licenses = Partial<Record<v193LicenseName, v193LicenseDetails>>;
 
-export type v191LicenseData = {
+export type v193LicenseData = {
   lastUpdatedISO: string;
-  licenses?: v191Licenses;
+  licenses?: v193Licenses;
 };
 
-export type v191Preferences = {
-  roadmapOpenSections: v191SectionType[];
+export type v193Preferences = {
+  roadmapOpenSections: v193SectionType[];
   roadmapOpenSteps: number[];
   visibleSidebarCards: string[];
   isCalendarFullView: boolean;
@@ -438,14 +396,14 @@ export type v191Preferences = {
   isNonProfitFromFunding?: boolean;
 };
 
-export type v191LicenseStatusItem = {
+export type v193LicenseStatusItem = {
   title: string;
-  status: v191CheckoffStatus;
+  status: v193CheckoffStatus;
 };
 
-type v191CheckoffStatus = "ACTIVE" | "PENDING" | "UNKNOWN";
+type v193CheckoffStatus = "ACTIVE" | "PENDING" | "UNKNOWN";
 
-type v191LicenseStatus =
+type v193LicenseStatus =
   | "ACTIVE"
   | "PENDING"
   | "UNKNOWN"
@@ -459,7 +417,7 @@ type v191LicenseStatus =
   | "VOLUNTARY_SURRENDER"
   | "WITHDRAWN";
 
-const v191LicenseStatuses: v191LicenseStatus[] = [
+const v193LicenseStatuses: v193LicenseStatus[] = [
   "ACTIVE",
   "PENDING",
   "UNKNOWN",
@@ -474,25 +432,25 @@ const v191LicenseStatuses: v191LicenseStatus[] = [
   "WITHDRAWN",
 ];
 
-const v191SectionNames = ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"] as const;
-export type v191SectionType = (typeof v191SectionNames)[number];
+const v193SectionNames = ["PLAN", "START", "DOMESTIC_EMPLOYER_SECTION"] as const;
+export type v193SectionType = (typeof v193SectionNames)[number];
 
-export type v191ExternalStatus = {
-  newsletter?: v191NewsletterResponse;
-  userTesting?: v191UserTestingResponse;
+export type v193ExternalStatus = {
+  newsletter?: v193NewsletterResponse;
+  userTesting?: v193UserTestingResponse;
 };
 
-export interface v191NewsletterResponse {
+export interface v193NewsletterResponse {
   success?: boolean;
-  status: v191NewsletterStatus;
+  status: v193NewsletterStatus;
 }
 
-export interface v191UserTestingResponse {
+export interface v193UserTestingResponse {
   success?: boolean;
-  status: v191UserTestingStatus;
+  status: v193UserTestingStatus;
 }
 
-type v191NewsletterStatus = (typeof newsletterStatusList)[number];
+type v193NewsletterStatus = (typeof newsletterStatusList)[number];
 
 const externalStatusList = [
   "SUCCESS",
@@ -503,7 +461,7 @@ const externalStatusList = [
 
 const userTestingStatusList = [...externalStatusList] as const;
 
-type v191UserTestingStatus = (typeof userTestingStatusList)[number];
+type v193UserTestingStatus = (typeof userTestingStatusList)[number];
 
 const newsletterStatusList = [
   ...externalStatusList,
@@ -515,7 +473,7 @@ const newsletterStatusList = [
   "QUESTION_WARNING",
 ] as const;
 
-type v191NameAvailabilityStatus =
+type v193NameAvailabilityStatus =
   | "AVAILABLE"
   | "DESIGNATOR_ERROR"
   | "SPECIAL_CHARACTER_ERROR"
@@ -523,33 +481,33 @@ type v191NameAvailabilityStatus =
   | "RESTRICTED_ERROR"
   | undefined;
 
-export interface v191NameAvailabilityResponse {
-  status: v191NameAvailabilityStatus;
+export interface v193NameAvailabilityResponse {
+  status: v193NameAvailabilityStatus;
   similarNames: string[];
   invalidWord?: string;
 }
 
-export interface v191NameAvailability extends v191NameAvailabilityResponse {
+export interface v193NameAvailability extends v193NameAvailabilityResponse {
   lastUpdatedTimeStamp: string;
 }
 
-export interface v191FormationData {
-  formationFormData: v191FormationFormData;
-  businessNameAvailability: v191NameAvailability | undefined;
-  dbaBusinessNameAvailability: v191NameAvailability | undefined;
-  formationResponse: v191FormationSubmitResponse | undefined;
-  getFilingResponse: v191GetFilingResponse | undefined;
+export interface v193FormationData {
+  formationFormData: v193FormationFormData;
+  businessNameAvailability: v193NameAvailability | undefined;
+  dbaBusinessNameAvailability: v193NameAvailability | undefined;
+  formationResponse: v193FormationSubmitResponse | undefined;
+  getFilingResponse: v193GetFilingResponse | undefined;
   completedFilingPayment: boolean;
   lastVisitedPageIndex: number;
 }
 
-type v191InFormInBylaws = "IN_BYLAWS" | "IN_FORM" | undefined;
-type v191HowToProceedOptions = "DIFFERENT_NAME" | "KEEP_NAME" | "CANCEL_NAME";
+type v193InFormInBylaws = "IN_BYLAWS" | "IN_FORM" | undefined;
+type v193HowToProceedOptions = "DIFFERENT_NAME" | "KEEP_NAME" | "CANCEL_NAME";
 
-export interface v191FormationFormData extends v191FormationAddress {
+export interface v193FormationFormData extends v193FormationAddress {
   readonly businessName: string;
   readonly businessNameConfirmation: boolean | undefined;
-  readonly businessSuffix: v191BusinessSuffix | undefined;
+  readonly businessSuffix: v193BusinessSuffix | undefined;
   readonly businessTotalStock: string;
   readonly businessStartDate: string; // YYYY-MM-DD
   readonly businessPurpose: string;
@@ -563,13 +521,13 @@ export interface v191FormationFormData extends v191FormationAddress {
   readonly canMakeDistribution: boolean | undefined;
   readonly makeDistributionTerms: string;
   readonly hasNonprofitBoardMembers: boolean | undefined;
-  readonly nonprofitBoardMemberQualificationsSpecified: v191InFormInBylaws;
+  readonly nonprofitBoardMemberQualificationsSpecified: v193InFormInBylaws;
   readonly nonprofitBoardMemberQualificationsTerms: string;
-  readonly nonprofitBoardMemberRightsSpecified: v191InFormInBylaws;
+  readonly nonprofitBoardMemberRightsSpecified: v193InFormInBylaws;
   readonly nonprofitBoardMemberRightsTerms: string;
-  readonly nonprofitTrusteesMethodSpecified: v191InFormInBylaws;
+  readonly nonprofitTrusteesMethodSpecified: v193InFormInBylaws;
   readonly nonprofitTrusteesMethodTerms: string;
-  readonly nonprofitAssetDistributionSpecified: v191InFormInBylaws;
+  readonly nonprofitAssetDistributionSpecified: v193InFormInBylaws;
   readonly nonprofitAssetDistributionTerms: string;
   readonly additionalProvisions: string[] | undefined;
   readonly agentType: "MYSELF" | "AUTHORIZED_REP" | "PROFESSIONAL_SERVICE";
@@ -582,10 +540,10 @@ export interface v191FormationFormData extends v191FormationAddress {
   readonly agentOfficeAddressZipCode: string;
   readonly agentUseAccountInfo: boolean;
   readonly agentUseBusinessAddress: boolean;
-  readonly members: v191FormationMember[] | undefined;
-  readonly incorporators: v191FormationIncorporator[] | undefined;
-  readonly signers: v191FormationSigner[] | undefined;
-  readonly paymentType: v191PaymentType;
+  readonly members: v193FormationMember[] | undefined;
+  readonly incorporators: v193FormationIncorporator[] | undefined;
+  readonly signers: v193FormationSigner[] | undefined;
+  readonly paymentType: v193PaymentType;
   readonly annualReportNotification: boolean;
   readonly corpWatchNotification: boolean;
   readonly officialFormationDocument: boolean;
@@ -594,41 +552,41 @@ export interface v191FormationFormData extends v191FormationAddress {
   readonly contactFirstName: string;
   readonly contactLastName: string;
   readonly contactPhoneNumber: string;
-  readonly foreignStateOfFormation: v191StateObject | undefined;
+  readonly foreignStateOfFormation: v193StateObject | undefined;
   readonly foreignDateOfFormation: string | undefined; // YYYY-MM-DD
-  readonly foreignGoodStandingFile: v191ForeignGoodStandingFileObject | undefined;
+  readonly foreignGoodStandingFile: v193ForeignGoodStandingFileObject | undefined;
   readonly legalType: string;
   readonly willPracticeLaw: boolean | undefined;
   readonly isVeteranNonprofit: boolean | undefined;
   readonly checkNameReservation: boolean | undefined;
-  readonly howToProceed: v191HowToProceedOptions;
+  readonly howToProceed: v193HowToProceedOptions;
 }
 
-export type v191ForeignGoodStandingFileObject = {
+export type v193ForeignGoodStandingFileObject = {
   Extension: "PDF" | "PNG";
   Content: string;
 };
 
-export type v191StateObject = {
+export type v193StateObject = {
   shortCode: string;
   name: string;
 };
 
-export interface v191FormationAddress {
+export interface v193FormationAddress {
   readonly addressLine1: string;
   readonly addressLine2: string;
   readonly addressCity?: string;
-  readonly addressState?: v191StateObject;
-  readonly addressMunicipality?: v191Municipality;
+  readonly addressState?: v193StateObject;
+  readonly addressMunicipality?: v193Municipality;
   readonly addressProvince?: string;
   readonly addressZipCode: string;
   readonly addressCountry?: string;
-  readonly businessLocationType: v191FormationBusinessLocationType | undefined;
+  readonly businessLocationType: v193FormationBusinessLocationType | undefined;
 }
 
-type v191FormationBusinessLocationType = "US" | "INTL" | "NJ";
+type v193FormationBusinessLocationType = "US" | "INTL" | "NJ";
 
-type v191SignerTitle =
+type v193SignerTitle =
   | "Authorized Representative"
   | "Authorized Partner"
   | "Incorporator"
@@ -638,19 +596,19 @@ type v191SignerTitle =
   | "Chairman of the Board"
   | "CEO";
 
-export interface v191FormationSigner {
+export interface v193FormationSigner {
   readonly name: string;
   readonly signature: boolean;
-  readonly title: v191SignerTitle;
+  readonly title: v193SignerTitle;
 }
 
-export interface v191FormationIncorporator extends v191FormationSigner, v191FormationAddress {}
+export interface v193FormationIncorporator extends v193FormationSigner, v193FormationAddress {}
 
-export interface v191FormationMember extends v191FormationAddress {
+export interface v193FormationMember extends v193FormationAddress {
   readonly name: string;
 }
 
-type v191PaymentType = "CC" | "ACH" | undefined;
+type v193PaymentType = "CC" | "ACH" | undefined;
 
 const llcBusinessSuffix = [
   "LLC",
@@ -708,24 +666,24 @@ export const AllBusinessSuffixes = [
   ...nonprofitBusinessSuffix,
 ] as const;
 
-type v191BusinessSuffix = (typeof AllBusinessSuffixes)[number];
+type v193BusinessSuffix = (typeof AllBusinessSuffixes)[number];
 
-export type v191FormationSubmitResponse = {
+export type v193FormationSubmitResponse = {
   success: boolean;
   token: string | undefined;
   formationId: string | undefined;
   redirect: string | undefined;
-  errors: v191FormationSubmitError[];
+  errors: v193FormationSubmitError[];
   lastUpdatedISO: string | undefined;
 };
 
-export type v191FormationSubmitError = {
+export type v193FormationSubmitError = {
   field: string;
   type: "FIELD" | "UNKNOWN" | "RESPONSE";
   message: string;
 };
 
-export type v191GetFilingResponse = {
+export type v193GetFilingResponse = {
   success: boolean;
   entityId: string;
   transactionDate: string;
@@ -735,38 +693,38 @@ export type v191GetFilingResponse = {
   certifiedDoc: string;
 };
 
-export interface v191EnvironmentData {
-  questionnaireData?: v191QuestionnaireData;
+export interface v193EnvironmentData {
+  questionnaireData?: v193QuestionnaireData;
   submitted?: boolean;
   emailSent?: boolean;
 }
 
-export type v191QuestionnaireData = {
-  air: v191AirData;
-  land: v191LandData;
-  waste: v191WasteData;
-  drinkingWater: v191DrinkingWaterData;
-  wasteWater: v191WasteWaterData;
+export type v193QuestionnaireData = {
+  air: v193AirData;
+  land: v193LandData;
+  waste: v193WasteData;
+  drinkingWater: v193DrinkingWaterData;
+  wasteWater: v193WasteWaterData;
 };
 
-export type v191AirFieldIds =
+export type v193AirFieldIds =
   | "emitPollutants"
   | "emitEmissions"
   | "constructionActivities"
   | "noAir";
 
-export type v191AirData = Record<v191AirFieldIds, boolean>;
+export type v193AirData = Record<v193AirFieldIds, boolean>;
 
-export type v191LandFieldIds =
+export type v193LandFieldIds =
   | "takeOverExistingBiz"
   | "propertyAssessment"
   | "constructionActivities"
   | "siteImprovementWasteLands"
   | "noLand";
 
-export type v191LandData = Record<v191LandFieldIds, boolean>;
+export type v193LandData = Record<v193LandFieldIds, boolean>;
 
-export type v191WasteFieldIds =
+export type v193WasteFieldIds =
   | "transportWaste"
   | "hazardousMedicalWaste"
   | "compostWaste"
@@ -774,18 +732,18 @@ export type v191WasteFieldIds =
   | "constructionDebris"
   | "noWaste";
 
-export type v191WasteData = Record<v191WasteFieldIds, boolean>;
+export type v193WasteData = Record<v193WasteFieldIds, boolean>;
 
-export type v191DrinkingWaterFieldIds =
+export type v193DrinkingWaterFieldIds =
   | "ownWell"
   | "combinedWellCapacity"
   | "wellDrilled"
   | "potableWater"
   | "noDrinkingWater";
 
-export type v191DrinkingWaterData = Record<v191DrinkingWaterFieldIds, boolean>;
+export type v193DrinkingWaterData = Record<v193DrinkingWaterFieldIds, boolean>;
 
-export type v191WasteWaterFieldIds =
+export type v193WasteWaterFieldIds =
   | "sanitaryWaste"
   | "industrialWaste"
   | "localSewage"
@@ -797,9 +755,9 @@ export type v191WasteWaterFieldIds =
   | "takeoverIndustrialStormWaterPermit"
   | "noWasteWater";
 
-export type v191WasteWaterData = Record<v191WasteWaterFieldIds, boolean>;
+export type v193WasteWaterData = Record<v193WasteWaterFieldIds, boolean>;
 
-export type v191CrtkBusinessDetails = {
+export type v193CrtkBusinessDetails = {
   businessName: string;
   addressLine1: string;
   city: string;
@@ -807,9 +765,9 @@ export type v191CrtkBusinessDetails = {
   ein?: string | undefined;
 };
 
-export type v191CrtkSearchResult = "FOUND" | "NOT_FOUND";
+export type v193CrtkSearchResult = "FOUND" | "NOT_FOUND";
 
-export interface v191CrtkEntry {
+export interface v193CrtkEntry {
   businessName?: string;
   streetAddress?: string;
   city?: string;
@@ -828,7 +786,7 @@ export interface v191CrtkEntry {
   receivedDate?: string;
 }
 
-export interface v191CrtkEmailMetadata {
+export interface v193CrtkEmailMetadata {
   username: string;
   email: string;
   businessName: string;
@@ -841,29 +799,31 @@ export interface v191CrtkEmailMetadata {
   materialOrProducts: string;
 }
 
-export type v191CrtkData = {
+export type v193CrtkData = {
   lastUpdatedISO: string;
-  crtkBusinessDetails?: v191CrtkBusinessDetails;
-  crtkSearchResult: v191CrtkSearchResult;
-  crtkEntry: v191CrtkEntry;
+  crtkBusinessDetails?: v193CrtkBusinessDetails;
+  crtkSearchResult: v193CrtkSearchResult;
+  crtkEntry: v193CrtkEntry;
   crtkEmailSent?: boolean;
 };
 
-export type v191TaxClearanceCertificateData = {
+export type v193TaxClearanceCertificateData = {
   requestingAgencyId: string | undefined;
   businessName: string | undefined;
   addressLine1: string | undefined;
   addressLine2: string | undefined;
   addressCity: string | undefined;
-  addressState?: v191StateObject | undefined;
+  addressState?: v193StateObject | undefined;
   addressZipCode?: string | undefined;
   taxId: string | undefined;
+  encryptedTaxId: string | undefined;
   taxPin: string | undefined;
+  encryptedTaxPin: string | undefined;
   hasPreviouslyReceivedCertificate: boolean | undefined;
   lastUpdatedISO: string | undefined;
 };
 
-export type v191CigaretteLicenseData = {
+export type v193CigaretteLicenseData = {
   businessName?: string;
   responsibleOwnerName?: string;
   tradeName?: string;
@@ -872,13 +832,13 @@ export type v191CigaretteLicenseData = {
   addressLine1?: string;
   addressLine2?: string;
   addressCity?: string;
-  addressState?: v191StateObject;
+  addressState?: v193StateObject;
   addressZipCode?: string;
   mailingAddressIsTheSame?: boolean;
   mailingAddressLine1?: string;
   mailingAddressLine2?: string;
   mailingAddressCity?: string;
-  mailingAddressState?: v191StateObject;
+  mailingAddressState?: v193StateObject;
   mailingAddressZipCode?: string;
   contactName?: string;
   contactPhoneNumber?: string;
@@ -889,35 +849,35 @@ export type v191CigaretteLicenseData = {
   signerRelationship?: string;
   signature?: boolean;
   lastUpdatedISO?: string;
-  paymentInfo?: v191CigaretteLicensePaymentInfo;
+  paymentInfo?: v193CigaretteLicensePaymentInfo;
 };
 
-export type v191CigaretteLicensePaymentInfo = {
+export type v193CigaretteLicensePaymentInfo = {
   token?: string;
   paymentComplete?: boolean;
   orderId?: number;
   orderStatus?: string;
   orderTimestamp?: string;
-  confirmationEmailsent?: boolean;
+  confirmationEmailSent?: boolean;
 };
 
-export type v191XrayData = {
-  facilityDetails?: v191FacilityDetails;
-  machines?: v191MachineDetails[];
-  status?: v191XrayRegistrationStatus;
+export type v193XrayData = {
+  facilityDetails?: v193FacilityDetails;
+  machines?: v193MachineDetails[];
+  status?: v193XrayRegistrationStatus;
   expirationDate?: string;
   deactivationDate?: string;
   lastUpdatedISO?: string;
 };
 
-export type v191FacilityDetails = {
+export type v193FacilityDetails = {
   businessName: string;
   addressLine1: string;
   addressLine2?: string;
   addressZipCode: string;
 };
 
-export type v191MachineDetails = {
+export type v193MachineDetails = {
   name?: string;
   registrationNumber?: string;
   roomId?: string;
@@ -928,35 +888,35 @@ export type v191MachineDetails = {
   annualFee?: number;
 };
 
-export type v191XrayRegistrationStatusResponse = {
-  machines: v191MachineDetails[];
-  status: v191XrayRegistrationStatus;
+export type v193XrayRegistrationStatusResponse = {
+  machines: v193MachineDetails[];
+  status: v193XrayRegistrationStatus;
   expirationDate?: string;
   deactivationDate?: string;
 };
 
-export type v191XrayRegistrationStatus = "ACTIVE" | "EXPIRED" | "INACTIVE";
+export type v193XrayRegistrationStatus = "ACTIVE" | "EXPIRED" | "INACTIVE";
 
-// ---------------- v191 generators ----------------
+// ---------------- v193 generators ----------------
 
-export const generatev191UserData = (overrides: Partial<v191UserData>): v191UserData => {
+export const generatev193UserData = (overrides: Partial<v193UserData>): v193UserData => {
   return {
-    user: generatev191BusinessUser({}),
-    version: 191,
+    user: generatev193BusinessUser({}),
+    version: 193,
     lastUpdatedISO: "",
     dateCreatedISO: "",
     versionWhenCreated: 141,
     businesses: {
-      "123": generatev191Business({ id: "123" }),
+      "123": generatev193Business({ id: "123" }),
     },
     currentBusinessId: "",
     ...overrides,
   };
 };
 
-export const generatev191BusinessUser = (
-  overrides: Partial<v191BusinessUser>,
-): v191BusinessUser => {
+export const generatev193BusinessUser = (
+  overrides: Partial<v193BusinessUser>,
+): v193BusinessUser => {
   return {
     name: `some-name-${randomInt()}`,
     email: `some-email-${randomInt()}@example.com`,
@@ -980,9 +940,9 @@ export const generatev191BusinessUser = (
   };
 };
 
-export const generatev191RoadmapTaskData = (
-  overrides: Partial<v191RoadmapTaskData>,
-): v191RoadmapTaskData => {
+export const generatev193RoadmapTaskData = (
+  overrides: Partial<v193RoadmapTaskData>,
+): v193RoadmapTaskData => {
   return {
     manageBusinessVehicles: undefined,
     passengerTransportSchoolBus: undefined,
@@ -991,8 +951,8 @@ export const generatev191RoadmapTaskData = (
   };
 };
 
-export const generatev191Business = (overrides: Partial<v191Business>): v191Business => {
-  const profileData = generatev191ProfileData({});
+export const generatev193Business = (overrides: Partial<v193Business>): v193Business => {
+  const profileData = generatev193ProfileData({});
 
   return {
     id: `some-id-${randomInt()}`,
@@ -1000,35 +960,35 @@ export const generatev191Business = (overrides: Partial<v191Business>): v191Busi
     lastUpdatedISO: "",
     dateDeletedISO: "",
     profileData: profileData,
-    preferences: generatev191Preferences({}),
-    formationData: generatev191FormationData({}, profileData.legalStructureId ?? ""),
+    preferences: generatev193Preferences({}),
+    formationData: generatev193FormationData({}, profileData.legalStructureId ?? ""),
     onboardingFormProgress: "UNSTARTED",
-    taxClearanceCertificateData: generatev191TaxClearanceCertificateData({}),
-    cigaretteLicenseData: generatev191CigaretteLicenseData({}),
+    taxClearanceCertificateData: generatev193TaxClearanceCertificateData({}),
+    cigaretteLicenseData: generatev193CigaretteLicenseData({}),
     taskProgress: {
       "business-structure": "TO_DO",
     },
     taskItemChecklist: {
       "general-dvob": false,
     },
-    roadmapTaskData: generatev191RoadmapTaskData({}),
+    roadmapTaskData: generatev193RoadmapTaskData({}),
     licenseData: undefined,
-    taxFilingData: generatev191TaxFilingData({}),
+    taxFilingData: generatev193TaxFilingData({}),
     environmentData: undefined,
     xrayRegistrationData: undefined,
     crtkData: undefined,
     userId: `some-id-${randomInt()}`,
-    version: 191,
+    version: 193,
     versionWhenCreated: -1,
     ...overrides,
   };
 };
 
-export const generatev191ProfileData = (overrides: Partial<v191ProfileData>): v191ProfileData => {
+export const generatev193ProfileData = (overrides: Partial<v193ProfileData>): v193ProfileData => {
   const id = `some-id-${randomInt()}`;
   const persona = randomInt() % 2 ? "STARTING" : "OWNING";
   return {
-    ...generatev191IndustrySpecificData({}),
+    ...generatev193IndustrySpecificData({}),
     businessPersona: persona,
     businessName: `some-business-name-${randomInt()}`,
     industryId: "restaurant",
@@ -1069,9 +1029,9 @@ export const generatev191ProfileData = (overrides: Partial<v191ProfileData>): v1
   };
 };
 
-export const generatev191IndustrySpecificData = (
-  overrides: Partial<v191IndustrySpecificData>,
-): v191IndustrySpecificData => {
+export const generatev193IndustrySpecificData = (
+  overrides: Partial<v193IndustrySpecificData>,
+): v193IndustrySpecificData => {
   return {
     liquorLicense: false,
     requiresCpa: false,
@@ -1100,7 +1060,7 @@ export const generatev191IndustrySpecificData = (
   };
 };
 
-export const generatev191Preferences = (overrides: Partial<v191Preferences>): v191Preferences => {
+export const generatev193Preferences = (overrides: Partial<v193Preferences>): v193Preferences => {
   return {
     roadmapOpenSections: ["PLAN", "START"],
     roadmapOpenSteps: [],
@@ -1114,12 +1074,12 @@ export const generatev191Preferences = (overrides: Partial<v191Preferences>): v1
   };
 };
 
-export const generatev191FormationData = (
-  overrides: Partial<v191FormationData>,
+export const generatev193FormationData = (
+  overrides: Partial<v193FormationData>,
   legalStructureId: string,
-): v191FormationData => {
+): v193FormationData => {
   return {
-    formationFormData: generatev191FormationFormData({}, legalStructureId),
+    formationFormData: generatev193FormationFormData({}, legalStructureId),
     formationResponse: undefined,
     getFilingResponse: undefined,
     completedFilingPayment: false,
@@ -1130,15 +1090,15 @@ export const generatev191FormationData = (
   };
 };
 
-export const generatev191FormationFormData = (
-  overrides: Partial<v191FormationFormData>,
+export const generatev193FormationFormData = (
+  overrides: Partial<v193FormationFormData>,
   legalStructureId: string,
-): v191FormationFormData => {
+): v193FormationFormData => {
   const isCorp = legalStructureId
     ? ["s-corporation", "c-corporation"].includes(legalStructureId)
     : false;
 
-  return <v191FormationFormData>{
+  return <v193FormationFormData>{
     businessName: `some-business-name-${randomInt()}`,
     businessNameConfirmation: true,
     businessSuffix: "LLC",
@@ -1151,7 +1111,7 @@ export const generatev191FormationFormData = (
     addressState: { shortCode: "123", name: "new-jersey" },
     addressZipCode: `some-agent-office-zipcode-${randomInt()}`,
     addressCountry: `some-county`,
-    addressMunicipality: generatev191Municipality({}),
+    addressMunicipality: generatev193Municipality({}),
     addressProvince: "",
     withdrawals: `some-withdrawals-text-${randomInt()}`,
     combinedInvestment: `some-combinedInvestment-text-${randomInt()}`,
@@ -1185,7 +1145,7 @@ export const generatev191FormationFormData = (
     agentUseBusinessAddress: !!(randomInt() % 2),
     signers: [],
     members:
-      legalStructureId === "limited-liability-partnership" ? [] : [generatev191FormationMember({})],
+      legalStructureId === "limited-liability-partnership" ? [] : [generatev193FormationMember({})],
     incorporators: undefined,
     paymentType: randomInt() % 2 ? "ACH" : "CC",
     annualReportNotification: !!(randomInt() % 2),
@@ -1210,9 +1170,9 @@ export const generatev191FormationFormData = (
   };
 };
 
-export const generatev191Municipality = (
-  overrides: Partial<v191Municipality>,
-): v191Municipality => {
+export const generatev193Municipality = (
+  overrides: Partial<v193Municipality>,
+): v193Municipality => {
   return {
     displayName: `some-display-name-${randomInt()}`,
     name: `some-name-${randomInt()}`,
@@ -1222,9 +1182,9 @@ export const generatev191Municipality = (
   };
 };
 
-export const generatev191FormationMember = (
-  overrides: Partial<v191FormationMember>,
-): v191FormationMember => {
+export const generatev193FormationMember = (
+  overrides: Partial<v193FormationMember>,
+): v193FormationMember => {
   return {
     name: `some-name`,
     addressLine1: `addr1-${randomInt(3)}`,
@@ -1238,9 +1198,9 @@ export const generatev191FormationMember = (
   };
 };
 
-export const generatev191TaxFilingData = (
-  overrides: Partial<v191TaxFilingData>,
-): v191TaxFilingData => {
+export const generatev193TaxFilingData = (
+  overrides: Partial<v193TaxFilingData>,
+): v193TaxFilingData => {
   return {
     state: undefined,
     businessName: undefined,
@@ -1252,22 +1212,22 @@ export const generatev191TaxFilingData = (
   };
 };
 
-export const generatev191LicenseDetails = (
-  overrides: Partial<v191LicenseDetails>,
-): v191LicenseDetails => {
+export const generatev193LicenseDetails = (
+  overrides: Partial<v193LicenseDetails>,
+): v193LicenseDetails => {
   return {
-    nameAndAddress: generatev191LicenseSearchNameAndAddress({}),
-    licenseStatus: getRandomv191LicenseStatus(),
+    nameAndAddress: generatev193LicenseSearchNameAndAddress({}),
+    licenseStatus: getRandomv193LicenseStatus(),
     expirationDateISO: "some-expiration-iso",
     lastUpdatedISO: "some-last-updated",
-    checklistItems: [generatev191LicenseStatusItem()],
+    checklistItems: [generatev193LicenseStatusItem()],
     ...overrides,
   };
 };
 
-const generatev191LicenseSearchNameAndAddress = (
-  overrides: Partial<v191LicenseSearchNameAndAddress>,
-): v191LicenseSearchNameAndAddress => {
+const generatev193LicenseSearchNameAndAddress = (
+  overrides: Partial<v193LicenseSearchNameAndAddress>,
+): v193LicenseSearchNameAndAddress => {
   return {
     name: `some-name`,
     addressLine1: `addr1-${randomInt(3)}`,
@@ -1277,21 +1237,21 @@ const generatev191LicenseSearchNameAndAddress = (
   };
 };
 
-const generatev191LicenseStatusItem = (): v191LicenseStatusItem => {
+const generatev193LicenseStatusItem = (): v193LicenseStatusItem => {
   return {
     title: `some-title-${randomInt()}`,
     status: "ACTIVE",
   };
 };
 
-export const getRandomv191LicenseStatus = (): v191LicenseStatus => {
-  const randomIndex = Math.floor(Math.random() * v191LicenseStatuses.length);
-  return v191LicenseStatuses[randomIndex];
+export const getRandomv193LicenseStatus = (): v193LicenseStatus => {
+  const randomIndex = Math.floor(Math.random() * v193LicenseStatuses.length);
+  return v193LicenseStatuses[randomIndex];
 };
 
-export const generatev191TaxClearanceCertificateData = (
-  overrides: Partial<v191TaxClearanceCertificateData>,
-): v191TaxClearanceCertificateData => {
+export const generatev193TaxClearanceCertificateData = (
+  overrides: Partial<v193TaxClearanceCertificateData>,
+): v193TaxClearanceCertificateData => {
   return {
     requestingAgencyId: "",
     businessName: `some-business-name-${randomInt()}`,
@@ -1301,16 +1261,18 @@ export const generatev191TaxClearanceCertificateData = (
     addressState: undefined,
     addressZipCode: randomInt(5).toString(),
     taxId: `${randomInt(12)}`,
+    encryptedTaxId: `some-encrypted-tax-id-${randomInt()}`,
     taxPin: randomInt(4).toString(),
+    encryptedTaxPin: `some-encrypted-tax-pin-${randomInt()}`,
     hasPreviouslyReceivedCertificate: undefined,
     lastUpdatedISO: "",
     ...overrides,
   };
 };
 
-export const generatev191CigaretteLicenseData = (
-  overrides: Partial<v191CigaretteLicenseData>,
-): v191CigaretteLicenseData => {
+export const generatev193CigaretteLicenseData = (
+  overrides: Partial<v193CigaretteLicenseData>,
+): v193CigaretteLicenseData => {
   const taxId = randomInt(12).toString();
   const maskingCharacter = "*";
   return {
@@ -1343,19 +1305,19 @@ export const generatev191CigaretteLicenseData = (
   };
 };
 
-export const generatev191EnvironmentQuestionnaireData = ({
+export const generatev193EnvironmentQuestionnaireData = ({
   airOverrides,
   landOverrides,
   wasteOverrides,
   drinkingWaterOverrides,
   wasteWaterOverrides,
 }: {
-  airOverrides?: Partial<v191AirData>;
-  landOverrides?: Partial<v191LandData>;
-  wasteOverrides?: Partial<v191WasteData>;
-  drinkingWaterOverrides?: Partial<v191DrinkingWaterData>;
-  wasteWaterOverrides?: Partial<v191WasteWaterData>;
-}): v191QuestionnaireData => {
+  airOverrides?: Partial<v193AirData>;
+  landOverrides?: Partial<v193LandData>;
+  wasteOverrides?: Partial<v193WasteData>;
+  drinkingWaterOverrides?: Partial<v193DrinkingWaterData>;
+  wasteWaterOverrides?: Partial<v193WasteWaterData>;
+}): v193QuestionnaireData => {
   return {
     air: {
       emitPollutants: false,

--- a/api/src/db/zodSchema/zodSchemas.test.ts
+++ b/api/src/db/zodSchema/zodSchemas.test.ts
@@ -1,27 +1,27 @@
 import {
-  generatev192Business,
-  generatev192BusinessUser,
-  generatev192CigaretteLicenseData,
-  generatev192EnvironmentQuestionnaireData,
-  generatev192FormationMember,
-  generatev192LicenseDetails,
-  generatev192Municipality,
-  generatev192Preferences,
-  generatev192TaxClearanceCertificateData,
-  generatev192TaxFilingData,
-  generatev192UserData,
-} from "@db/migrations/v192_fix_confirmation_email_sent_typo";
+  generatev193Business,
+  generatev193BusinessUser,
+  generatev193CigaretteLicenseData,
+  generatev193EnvironmentQuestionnaireData,
+  generatev193FormationMember,
+  generatev193LicenseDetails,
+  generatev193Municipality,
+  generatev193Preferences,
+  generatev193TaxClearanceCertificateData,
+  generatev193TaxFilingData,
+  generatev193UserData,
+} from "@db/migrations/v193_rotate_stranded_legacy_kms_fields";
 import {
   parseUserData,
-  v192FormationMemberSchema,
-  v192MunicipalitySchema,
-  v192PreferencesSchema,
-  v192QuestionnaireDataSchema,
-  v192TaxClearanceCertificateDataSchema,
-  v192TaxFilingDataSchema,
-  v192UserDataSchema,
+  v193FormationMemberSchema,
+  v193MunicipalitySchema,
+  v193PreferencesSchema,
+  v193QuestionnaireDataSchema,
+  v193TaxClearanceCertificateDataSchema,
+  v193TaxFilingDataSchema,
+  v193UserDataSchema,
 } from "@db/zodSchema/zodSchemas";
-import { LogWriterType } from "@libs/logWriter";
+import { type LogWriterType } from "@libs/logWriter";
 import {
   AGENT_EMAIL_MAX_CHAR,
   AGENT_NAME_MAX_CHAR,
@@ -36,7 +36,7 @@ import {
   CONTACT_LAST_NAME_MAX_CHAR,
   SIGNER_NAME_MAX_CHAR,
 } from "@shared/formationData";
-import { UserData } from "@businessnjgovnavigator/shared";
+import { type UserData } from "@businessnjgovnavigator/shared";
 
 jest.mock("@db/zodSchema/zodSchemas", () => {
   const actual = jest.requireActual("@db/zodSchema/zodSchemas");
@@ -88,7 +88,7 @@ describe("Zod Schema validation", () => {
   let safeParseSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    safeParseSpy = jest.spyOn(v192UserDataSchema, "safeParse");
+    safeParseSpy = jest.spyOn(v193UserDataSchema, "safeParse");
   });
 
   afterEach(() => {
@@ -110,7 +110,7 @@ describe("Zod Schema validation", () => {
     });
 
     it("logs success when parsing succeeds", () => {
-      const validUserData = generatev192UserData({});
+      const validUserData = generatev193UserData({});
 
       parseUserData(mockLogger, validUserData as unknown as UserData);
 
@@ -145,9 +145,9 @@ describe("Zod Schema validation", () => {
     });
 
     it("QuestionnaireDataSchema should pass for valid data", () => {
-      const validData = generatev192EnvironmentQuestionnaireData({});
+      const validData = generatev193EnvironmentQuestionnaireData({});
 
-      const result = v192QuestionnaireDataSchema.safeParse(validData);
+      const result = v193QuestionnaireDataSchema.safeParse(validData);
 
       expect(result.success).toBe(true);
     });
@@ -155,15 +155,15 @@ describe("Zod Schema validation", () => {
     it("QuestionnaireDataSchema should not pass for invalid data", () => {
       const invalidData = {};
 
-      const result = v192QuestionnaireDataSchema.safeParse(invalidData);
+      const result = v193QuestionnaireDataSchema.safeParse(invalidData);
 
       expect(result.success).toBe(false);
     });
 
     it("MuncipialitySchema should pass for valid data", () => {
-      const validData = generatev192Municipality({});
+      const validData = generatev193Municipality({});
 
-      const result = v192MunicipalitySchema.safeParse(validData);
+      const result = v193MunicipalitySchema.safeParse(validData);
 
       expect(result.success).toBe(true);
     });
@@ -171,15 +171,15 @@ describe("Zod Schema validation", () => {
     it("MuncipialitySchema should not pass for invalid data", () => {
       const invalidData = {};
 
-      const result = v192MunicipalitySchema.safeParse(invalidData);
+      const result = v193MunicipalitySchema.safeParse(invalidData);
 
       expect(result.success).toBe(false);
     });
 
     it("TaxFilingSchema should pass for valid data", () => {
-      const validData = generatev192TaxFilingData({});
+      const validData = generatev193TaxFilingData({});
 
-      const result = v192TaxFilingDataSchema.safeParse(validData);
+      const result = v193TaxFilingDataSchema.safeParse(validData);
 
       expect(result.success).toBe(true);
     });
@@ -187,23 +187,23 @@ describe("Zod Schema validation", () => {
     it("TaxFilingSchema should not pass for invalid data", () => {
       const invalidData = {};
 
-      const result = v192TaxFilingDataSchema.safeParse(invalidData);
+      const result = v193TaxFilingDataSchema.safeParse(invalidData);
 
       expect(result.success).toBe(false);
     });
 
     it("TaxClearanceSchema should pass for valid data", () => {
-      const validData = generatev192TaxClearanceCertificateData({});
+      const validData = generatev193TaxClearanceCertificateData({});
 
-      const result = v192TaxClearanceCertificateDataSchema.safeParse(validData);
+      const result = v193TaxClearanceCertificateDataSchema.safeParse(validData);
 
       expect(result.success).toBe(true);
     });
 
     it("PreferencesSchema should pass for valid data", () => {
-      const validData = generatev192Preferences({});
+      const validData = generatev193Preferences({});
 
-      const result = v192PreferencesSchema.safeParse(validData);
+      const result = v193PreferencesSchema.safeParse(validData);
 
       expect(result.success).toBe(true);
     });
@@ -211,15 +211,15 @@ describe("Zod Schema validation", () => {
     it("PreferencesSchema should not pass for invalid data", () => {
       const invalidData = {};
 
-      const result = v192PreferencesSchema.safeParse(invalidData);
+      const result = v193PreferencesSchema.safeParse(invalidData);
 
       expect(result.success).toBe(false);
     });
 
     it("FormationMemberSchema should pass for valid data", () => {
-      const validData = generatev192FormationMember({});
+      const validData = generatev193FormationMember({});
 
-      const result = v192FormationMemberSchema.safeParse(validData);
+      const result = v193FormationMemberSchema.safeParse(validData);
 
       expect(result.success).toBe(true);
     });
@@ -227,39 +227,39 @@ describe("Zod Schema validation", () => {
     it("FormationMemberSchema should not pass for invalid data", () => {
       const invalidData = {};
 
-      const result = v192FormationMemberSchema.safeParse(invalidData);
+      const result = v193FormationMemberSchema.safeParse(invalidData);
 
       expect(result.success).toBe(false);
     });
 
-    it("v192UserDataSchema should pass for valid data", () => {
+    it("v193UserDataSchema should pass for valid data", () => {
       safeParseSpy.mockRestore();
-      const validData = generatev192UserData({});
+      const validData = generatev193UserData({});
 
-      const result = v192UserDataSchema.safeParse(validData);
+      const result = v193UserDataSchema.safeParse(validData);
 
       expect(result.success).toBe(true);
     });
 
-    it("v192UserDataSchema should pass for  license valid data", () => {
+    it("v193UserDataSchema should pass for  license valid data", () => {
       safeParseSpy.mockRestore();
-      const validData = generatev192UserData({
+      const validData = generatev193UserData({
         businesses: {
-          "123": generatev192Business({
+          "123": generatev193Business({
             id: "123",
             licenseData: {
               lastUpdatedISO: "",
               licenses: {
-                ["Pharmacy-Pharmacy"]: generatev192LicenseDetails({}),
+                ["Pharmacy-Pharmacy"]: generatev193LicenseDetails({}),
               },
             },
           }),
         },
       });
       expect(() => {
-        v192UserDataSchema.parse(validData);
+        v193UserDataSchema.parse(validData);
       }).not.toThrow();
-      const result = v192UserDataSchema.safeParse(validData);
+      const result = v193UserDataSchema.safeParse(validData);
       expect(result.success).toBe(true);
     });
 
@@ -267,30 +267,30 @@ describe("Zod Schema validation", () => {
       safeParseSpy.mockRestore();
       const invalidData = {};
 
-      const result = v192UserDataSchema.safeParse(invalidData);
+      const result = v193UserDataSchema.safeParse(invalidData);
 
       expect(result.success).toBe(false);
     });
 
-    it("v192UserDataSchema should pass with all fields populated", () => {
+    it("v193UserDataSchema should pass with all fields populated", () => {
       safeParseSpy.mockRestore();
 
       const comprehensiveLicenseData = {
         lastUpdatedISO: "2024-01-01T00:00:00.000Z",
         licenses: {
-          "Pharmacy-Pharmacy": generatev192LicenseDetails({}),
-          "Accountancy-Firm Registration": generatev192LicenseDetails({
+          "Pharmacy-Pharmacy": generatev193LicenseDetails({}),
+          "Accountancy-Firm Registration": generatev193LicenseDetails({
             licenseStatus: "EXPIRED",
             expirationDateISO: "2023-12-31T00:00:00.000Z",
           }),
-          "Health Club Services": generatev192LicenseDetails({
+          "Health Club Services": generatev193LicenseDetails({
             licenseStatus: "PENDING",
           }),
         },
       };
 
       const comprehensiveEnvironmentData = {
-        questionnaireData: generatev192EnvironmentQuestionnaireData({
+        questionnaireData: generatev193EnvironmentQuestionnaireData({
           airOverrides: {
             emitPollutants: true,
             emitEmissions: true,
@@ -341,12 +341,12 @@ describe("Zod Schema validation", () => {
         lastUpdatedISO: "2024-01-01T00:00:00.000Z",
       };
 
-      const comprehensiveBusiness = generatev192Business({
+      const comprehensiveBusiness = generatev193Business({
         id: "business-123",
         licenseData: comprehensiveLicenseData,
         environmentData: comprehensiveEnvironmentData,
         xrayRegistrationData: comprehensiveXrayData,
-        taxClearanceCertificateData: generatev192TaxClearanceCertificateData({
+        taxClearanceCertificateData: generatev193TaxClearanceCertificateData({
           requestingAgencyId: "agency-001",
           businessName: "Comprehensive Test Business",
           addressLine1: "456 Business Ave",
@@ -362,7 +362,7 @@ describe("Zod Schema validation", () => {
           hasPreviouslyReceivedCertificate: true,
           lastUpdatedISO: "2024-01-01T00:00:00.000Z",
         }),
-        cigaretteLicenseData: generatev192CigaretteLicenseData({
+        cigaretteLicenseData: generatev193CigaretteLicenseData({
           businessName: "Tobacco Shop LLC",
           responsibleOwnerName: "John Doe",
           signature: true,
@@ -380,20 +380,20 @@ describe("Zod Schema validation", () => {
         },
       });
 
-      const secondBusiness = generatev192Business({
+      const secondBusiness = generatev193Business({
         id: "business-456",
         licenseData: {
           lastUpdatedISO: "2024-02-01T00:00:00.000Z",
           licenses: {
-            Telemarketers: generatev192LicenseDetails({
+            Telemarketers: generatev193LicenseDetails({
               licenseStatus: "ACTIVE",
             }),
           },
         },
       });
 
-      const comprehensiveUserData = generatev192UserData({
-        user: generatev192BusinessUser({
+      const comprehensiveUserData = generatev193UserData({
+        user: generatev193BusinessUser({
           name: "Jane Smith",
           email: "jane.smith@example.com",
           id: "user-789",
@@ -428,23 +428,23 @@ describe("Zod Schema validation", () => {
         dateCreatedISO: "2023-06-01T08:00:00.000Z",
       });
 
-      const result = v192UserDataSchema.safeParse(comprehensiveUserData);
+      const result = v193UserDataSchema.safeParse(comprehensiveUserData);
 
       expect(result.success).toBe(true);
     });
 
-    it("v192UserDataSchema should pass with only required fields (no optional data)", () => {
+    it("v193UserDataSchema should pass with only required fields (no optional data)", () => {
       safeParseSpy.mockRestore();
 
-      const minimalUserData = generatev192UserData({
-        user: generatev192BusinessUser({
+      const minimalUserData = generatev193UserData({
+        user: generatev193BusinessUser({
           name: undefined,
           myNJUserKey: undefined,
           intercomHash: undefined,
           phoneNumber: undefined,
         }),
         businesses: {
-          "business-minimal": generatev192Business({
+          "business-minimal": generatev193Business({
             id: "business-minimal",
             licenseData: undefined,
             environmentData: undefined,
@@ -458,23 +458,23 @@ describe("Zod Schema validation", () => {
         currentBusinessId: "business-minimal",
       });
 
-      const result = v192UserDataSchema.safeParse(minimalUserData);
+      const result = v193UserDataSchema.safeParse(minimalUserData);
 
       expect(result.success).toBe(true);
     });
 
-    it("v192UserDataSchema should pass when interstate transport is not in the object", () => {
+    it("v193UserDataSchema should pass when interstate transport is not in the object", () => {
       safeParseSpy.mockRestore();
 
-      const userDataWithoutInterstateTransport = generatev192UserData({
-        user: generatev192BusinessUser({
+      const userDataWithoutInterstateTransport = generatev193UserData({
+        user: generatev193BusinessUser({
           name: undefined,
           myNJUserKey: undefined,
           intercomHash: undefined,
           phoneNumber: undefined,
         }),
         businesses: {
-          "business-minimal": generatev192Business({
+          "business-minimal": generatev193Business({
             id: "business-minimal",
             licenseData: undefined,
             environmentData: undefined,
@@ -493,23 +493,23 @@ describe("Zod Schema validation", () => {
       expect(
         userDataWithoutInterstateTransport.businesses["business-minimal"].profileData,
       ).not.toHaveProperty("interstateTransport");
-      const result = v192UserDataSchema.safeParse(userDataWithoutInterstateTransport);
+      const result = v193UserDataSchema.safeParse(userDataWithoutInterstateTransport);
 
       expect(result.success).toBe(true);
     });
 
-    it("v192UserDataSchema should pass when address country is not in the object", () => {
+    it("v193UserDataSchema should pass when address country is not in the object", () => {
       safeParseSpy.mockRestore();
 
-      const minimalUserData = generatev192UserData({
-        user: generatev192BusinessUser({
+      const minimalUserData = generatev193UserData({
+        user: generatev193BusinessUser({
           name: undefined,
           myNJUserKey: undefined,
           intercomHash: undefined,
           phoneNumber: undefined,
         }),
         businesses: {
-          "business-minimal": generatev192Business({
+          "business-minimal": generatev193Business({
             id: "business-minimal",
             licenseData: undefined,
             environmentData: undefined,
@@ -544,22 +544,22 @@ describe("Zod Schema validation", () => {
         userDataWithoutAddressCountry.businesses["business-minimal"].formationData
           .formationFormData,
       ).not.toHaveProperty("addressCountry");
-      const result = v192UserDataSchema.safeParse(userDataWithoutAddressCountry);
+      const result = v193UserDataSchema.safeParse(userDataWithoutAddressCountry);
       expect(result.success).toBe(true);
     });
 
     it("max character tests", () => {
       safeParseSpy.mockRestore();
 
-      const userDataWithMaxOverLimits = generatev192UserData({
-        user: generatev192BusinessUser({
+      const userDataWithMaxOverLimits = generatev193UserData({
+        user: generatev193BusinessUser({
           name: undefined,
           myNJUserKey: undefined,
           intercomHash: undefined,
           phoneNumber: undefined,
         }),
         businesses: {
-          "business-minimal": generatev192Business({
+          "business-minimal": generatev193Business({
             id: "business-minimal",
             licenseData: undefined,
             environmentData: undefined,
@@ -612,7 +612,7 @@ describe("Zod Schema validation", () => {
         },
       };
 
-      const result = v192UserDataSchema.safeParse(userDataOverMaxLimits);
+      const result = v193UserDataSchema.safeParse(userDataOverMaxLimits);
 
       expect(result?.error?.issues).toEqual(
         expect.arrayContaining([
@@ -793,15 +793,15 @@ describe("Zod Schema validation", () => {
     it("base64 encoding tests", () => {
       safeParseSpy.mockRestore();
 
-      const userDataWithBase64Encoding = generatev192UserData({
-        user: generatev192BusinessUser({
+      const userDataWithBase64Encoding = generatev193UserData({
+        user: generatev193BusinessUser({
           name: generateLongBase64String(),
           myNJUserKey: undefined,
           intercomHash: undefined,
           phoneNumber: undefined,
         }),
         businesses: {
-          "business-minimal": generatev192Business({
+          "business-minimal": generatev193Business({
             id: "business-minimal",
             licenseData: undefined,
             environmentData: undefined,
@@ -816,7 +816,7 @@ describe("Zod Schema validation", () => {
       });
 
       const actual = jest.requireActual("@db/zodSchema/zodSchemas");
-      const schemaWithBase64Check = actual.withNoBase64Check(actual.v192UserDataSchema);
+      const schemaWithBase64Check = actual.withNoBase64Check(actual.v193UserDataSchema);
       const result = schemaWithBase64Check.safeParse(userDataWithBase64Encoding);
 
       expect(result.success).toBe(false);
@@ -825,34 +825,34 @@ describe("Zod Schema validation", () => {
 
   describe("withNoBase64Check tests", () => {
     let withNoBase64Check: <T>(schema: T) => T;
-    let actualv192UserDataSchema: typeof v192UserDataSchema;
+    let actualv193UserDataSchema: typeof v193UserDataSchema;
 
     beforeEach(() => {
       jest.restoreAllMocks();
       const actual = jest.requireActual("@db/zodSchema/zodSchemas");
       withNoBase64Check = actual.withNoBase64Check;
-      actualv192UserDataSchema = actual.v192UserDataSchema;
+      actualv193UserDataSchema = actual.v193UserDataSchema;
     });
 
     describe("valid data without base64 encoding", () => {
       it("should pass validation for normal user data", () => {
-        const validUserData = generatev192UserData({
-          user: generatev192BusinessUser({
+        const validUserData = generatev193UserData({
+          user: generatev193BusinessUser({
             name: "John Doe",
             email: "john@example.com",
             phoneNumber: "555-123-4567",
           }),
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(validUserData);
 
         expect(result.success).toBe(true);
       });
 
       it("should pass validation for user data with all optional fields populated", () => {
-        const validUserData = generatev192UserData({
-          user: generatev192BusinessUser({
+        const validUserData = generatev193UserData({
+          user: generatev193BusinessUser({
             name: "Jane Smith",
             email: "jane.smith@example.com",
             phoneNumber: "555-987-6543",
@@ -860,47 +860,47 @@ describe("Zod Schema validation", () => {
             intercomHash: "intercom-hash-abc",
           }),
           businesses: {
-            "business-123": generatev192Business({
+            "business-123": generatev193Business({
               id: "business-123",
               licenseData: {
                 lastUpdatedISO: "2024-01-01T00:00:00.000Z",
                 licenses: {
-                  "Pharmacy-Pharmacy": generatev192LicenseDetails({}),
+                  "Pharmacy-Pharmacy": generatev193LicenseDetails({}),
                 },
               },
             }),
           },
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(validUserData);
 
         expect(result.success).toBe(true);
       });
 
       it("should pass validation for short strings", () => {
-        const validUserData = generatev192UserData({
-          user: generatev192BusinessUser({
+        const validUserData = generatev193UserData({
+          user: generatev193BusinessUser({
             name: "Bob",
             email: "b@x.com",
           }),
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(validUserData);
 
         expect(result.success).toBe(true);
       });
 
       it("should pass validation for strings with special characters", () => {
-        const validUserData = generatev192UserData({
-          user: generatev192BusinessUser({
+        const validUserData = generatev193UserData({
+          user: generatev193BusinessUser({
             name: "O'Brien-Smith Jr.",
             email: "obrien+test@example.com",
           }),
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(validUserData);
 
         expect(result.success).toBe(true);
@@ -910,13 +910,13 @@ describe("Zod Schema validation", () => {
     describe("base64 encoded data in various fields", () => {
       it("should fail validation for base64 in user name", () => {
         const base64Name = generateLongBase64String();
-        const userData = generatev192UserData({
-          user: generatev192BusinessUser({
+        const userData = generatev193UserData({
+          user: generatev193BusinessUser({
             name: base64Name,
           }),
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(userData);
 
         expect(result.success).toBe(false);
@@ -927,19 +927,19 @@ describe("Zod Schema validation", () => {
 
       it("should fail validation for base64 in business name", () => {
         const base64BusinessName = generateLongBase64String();
-        const userData = generatev192UserData({
+        const userData = generatev193UserData({
           businesses: {
-            "business-123": generatev192Business({
+            "business-123": generatev193Business({
               id: "business-123",
               profileData: {
-                ...generatev192Business({}).profileData,
+                ...generatev193Business({}).profileData,
                 businessName: base64BusinessName,
               },
             }),
           },
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(userData);
 
         expect(result.success).toBe(false);
@@ -957,11 +957,11 @@ describe("Zod Schema validation", () => {
 
       it("should fail validation for base64 in formation form data address", () => {
         const base64Address = generateLongBase64String();
-        const business = generatev192Business({
+        const business = generatev193Business({
           id: "business-123",
         });
 
-        const userData = generatev192UserData({
+        const userData = generatev193UserData({
           businesses: {
             "business-123": {
               ...business,
@@ -973,7 +973,7 @@ describe("Zod Schema validation", () => {
           },
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(userData);
 
         expect(result.success).toBe(false);
@@ -988,18 +988,18 @@ describe("Zod Schema validation", () => {
 
       it("should fail validation for base64 in nested cigarette license data", () => {
         const base64TradeName = generateLongBase64String();
-        const userData = generatev192UserData({
+        const userData = generatev193UserData({
           businesses: {
-            "business-123": generatev192Business({
+            "business-123": generatev193Business({
               id: "business-123",
-              cigaretteLicenseData: generatev192CigaretteLicenseData({
+              cigaretteLicenseData: generatev193CigaretteLicenseData({
                 tradeName: base64TradeName,
               }),
             }),
           },
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(userData);
 
         expect(result.success).toBe(false);
@@ -1015,18 +1015,18 @@ describe("Zod Schema validation", () => {
 
       it("should fail validation for base64 in tax clearance certificate data", () => {
         const base64BusinessName = generateLongBase64String();
-        const userData = generatev192UserData({
+        const userData = generatev193UserData({
           businesses: {
-            "business-123": generatev192Business({
+            "business-123": generatev193Business({
               id: "business-123",
-              taxClearanceCertificateData: generatev192TaxClearanceCertificateData({
+              taxClearanceCertificateData: generatev193TaxClearanceCertificateData({
                 businessName: base64BusinessName,
               }),
             }),
           },
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(userData);
 
         expect(result.success).toBe(false);
@@ -1045,13 +1045,13 @@ describe("Zod Schema validation", () => {
         const base64WithDoublePadding = generateLongBase64String("double");
         expect(base64WithDoublePadding).toMatch(/==$/); // Ends with ==
 
-        const userData = generatev192UserData({
-          user: generatev192BusinessUser({
+        const userData = generatev193UserData({
+          user: generatev193BusinessUser({
             name: base64WithDoublePadding,
           }),
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(userData);
 
         expect(result.success).toBe(false);
@@ -1062,13 +1062,13 @@ describe("Zod Schema validation", () => {
         expect(base64WithSinglePadding).toMatch(/[^=]=$/); // Ends with single =
         expect(base64WithSinglePadding).not.toMatch(/==$/); // But not ==
 
-        const userData = generatev192UserData({
-          user: generatev192BusinessUser({
+        const userData = generatev193UserData({
+          user: generatev193BusinessUser({
             name: base64WithSinglePadding,
           }),
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(userData);
 
         expect(result.success).toBe(false);
@@ -1077,19 +1077,19 @@ describe("Zod Schema validation", () => {
       it("should fail validation for long base64 encoded strings", () => {
         const base64LongString = generateLongBase64String();
 
-        const userData = generatev192UserData({
+        const userData = generatev193UserData({
           businesses: {
-            "business-123": generatev192Business({
+            "business-123": generatev193Business({
               id: "business-123",
               profileData: {
-                ...generatev192Business({}).profileData,
+                ...generatev193Business({}).profileData,
                 notes: base64LongString,
               },
             }),
           },
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(userData);
 
         expect(result.success).toBe(false);
@@ -1099,22 +1099,22 @@ describe("Zod Schema validation", () => {
         const base64Name = generateLongBase64String();
         const base64BusinessName = generateLongBase64String();
 
-        const userData = generatev192UserData({
-          user: generatev192BusinessUser({
+        const userData = generatev193UserData({
+          user: generatev193BusinessUser({
             name: base64Name,
           }),
           businesses: {
-            "business-123": generatev192Business({
+            "business-123": generatev193Business({
               id: "business-123",
               profileData: {
-                ...generatev192Business({}).profileData,
+                ...generatev193Business({}).profileData,
                 businessName: base64BusinessName,
               },
             }),
           },
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(userData);
 
         expect(result.success).toBe(false);
@@ -1127,13 +1127,13 @@ describe("Zod Schema validation", () => {
 
     describe("edge cases and boundary conditions", () => {
       it("should handle strings that are exactly 20 characters and not base64", () => {
-        const userData = generatev192UserData({
-          user: generatev192BusinessUser({
+        const userData = generatev193UserData({
+          user: generatev193BusinessUser({
             name: "Exactly 20 Chars!!",
           }),
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(userData);
 
         expect(result.success).toBe(true);
@@ -1143,13 +1143,13 @@ describe("Zod Schema validation", () => {
         const base64String = generateLongBase64String();
         const whitespaceWrapped = `  ${base64String}  `;
 
-        const userData = generatev192UserData({
-          user: generatev192BusinessUser({
+        const userData = generatev193UserData({
+          user: generatev193BusinessUser({
             name: whitespaceWrapped,
           }),
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(userData);
 
         expect(result.success).toBe(false);
@@ -1158,21 +1158,21 @@ describe("Zod Schema validation", () => {
       it("should pass for strings that look like base64 but have wrong length", () => {
         const notBase64 = "abcdefghijklmnopqrstu";
 
-        const userData = generatev192UserData({
-          user: generatev192BusinessUser({
+        const userData = generatev193UserData({
+          user: generatev193BusinessUser({
             name: notBase64,
           }),
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(userData);
 
         expect(result.success).toBe(true);
       });
 
       it("should handle undefined optional fields", () => {
-        const userData = generatev192UserData({
-          user: generatev192BusinessUser({
+        const userData = generatev193UserData({
+          user: generatev193BusinessUser({
             name: undefined,
             myNJUserKey: undefined,
             intercomHash: undefined,
@@ -1180,26 +1180,26 @@ describe("Zod Schema validation", () => {
           }),
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(userData);
 
         expect(result.success).toBe(true);
       });
 
       it("should handle empty strings", () => {
-        const userData = generatev192UserData({
+        const userData = generatev193UserData({
           businesses: {
-            "business-123": generatev192Business({
+            "business-123": generatev193Business({
               id: "business-123",
               profileData: {
-                ...generatev192Business({}).profileData,
+                ...generatev193Business({}).profileData,
                 notes: "",
               },
             }),
           },
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(userData);
 
         expect(result.success).toBe(true);
@@ -1213,7 +1213,7 @@ describe("Zod Schema validation", () => {
           },
         };
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(invalidUserData);
 
         expect(result.success).toBe(false);
@@ -1221,11 +1221,11 @@ describe("Zod Schema validation", () => {
 
       it("should fail for base64 in array of strings (formation additional provisions)", () => {
         const base64Provision = generateLongBase64String();
-        const business = generatev192Business({
+        const business = generatev193Business({
           id: "business-123",
         });
 
-        const userData = generatev192UserData({
+        const userData = generatev193UserData({
           businesses: {
             "business-123": {
               ...business,
@@ -1244,7 +1244,7 @@ describe("Zod Schema validation", () => {
           },
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(userData);
 
         expect(result.success).toBe(false);
@@ -1262,13 +1262,13 @@ describe("Zod Schema validation", () => {
       it("should pass for URL-safe base64 with dashes and underscores (not detected as base64)", () => {
         const base64UrlSafe = "aGVsbG8gd29ybGQgdGhpcyBpcyBhIHRlc3QgZm9yIGJhc2U2NA";
 
-        const userData = generatev192UserData({
-          user: generatev192BusinessUser({
+        const userData = generatev193UserData({
+          user: generatev193BusinessUser({
             name: base64UrlSafe,
           }),
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(userData);
 
         expect(result.success).toBe(true);
@@ -1277,13 +1277,13 @@ describe("Zod Schema validation", () => {
       it("should handle base64 with various character combinations", () => {
         const base64WithSpecialChars = generateLongBase64String();
 
-        const userData = generatev192UserData({
-          user: generatev192BusinessUser({
+        const userData = generatev193UserData({
+          user: generatev193BusinessUser({
             name: base64WithSpecialChars,
           }),
         });
 
-        const schemaWithBase64Check = withNoBase64Check(actualv192UserDataSchema);
+        const schemaWithBase64Check = withNoBase64Check(actualv193UserDataSchema);
         const result = schemaWithBase64Check.safeParse(userData);
 
         expect(result.success).toBe(false);

--- a/api/src/db/zodSchema/zodSchemas.ts
+++ b/api/src/db/zodSchema/zodSchemas.ts
@@ -1,52 +1,52 @@
-import {
-  v192FacilityDetails,
-  v192MachineDetails,
-  v192QuestionnaireData,
-  v192StateObject,
-  v192TaxClearanceCertificateData,
-  v192XrayData,
-  v192XrayRegistrationStatusResponse,
-  v192GetFilingResponse,
-  v192FormationSubmitError,
-  v192FormationSubmitResponse,
-  v192FormationSigner,
-  v192ForeignGoodStandingFileObject,
-  v192UserTestingResponse,
-  v192NewsletterResponse,
-  v192ExternalStatus,
-  v192CalendarEvent,
-  v192LicenseSearchAddress,
-  v192TaxFilingCalendarEvent,
-  v192LicenseSearchNameAndAddress,
-  v192TaxFilingData,
-  v192LicenseDetails,
-  v192Municipality,
-  v192ProfileDocuments,
-  v192BusinessUser,
-  v192CommunityAffairsAddress,
-  v192RoadmapTaskData,
-  v192FormationAddress,
-  v192LicenseData,
-  v192Preferences,
-  v192LicenseStatusItem,
-  v192FormationMember,
-  v192NameAvailability,
-  v192NameAvailabilityResponse,
-  v192IndustrySpecificData,
-  v192ProfileData,
-  v192FormationFormData,
-  v192FormationData,
-  v192Business,
-  v192UserData,
-  v192CrtkData,
-  v192CrtkEmailMetadata,
-  v192CrtkEntry,
-  v192CrtkBusinessDetails,
-  v192CigaretteLicensePaymentInfo,
-  v192CigaretteLicenseData,
-  v192EnvironmentData,
-} from "@db/migrations/v192_fix_confirmation_email_sent_typo";
-import { LogWriterType } from "@libs/logWriter";
+import type {
+  v193FacilityDetails,
+  v193MachineDetails,
+  v193QuestionnaireData,
+  v193StateObject,
+  v193TaxClearanceCertificateData,
+  v193XrayData,
+  v193XrayRegistrationStatusResponse,
+  v193GetFilingResponse,
+  v193FormationSubmitError,
+  v193FormationSubmitResponse,
+  v193FormationSigner,
+  v193ForeignGoodStandingFileObject,
+  v193UserTestingResponse,
+  v193NewsletterResponse,
+  v193ExternalStatus,
+  v193CalendarEvent,
+  v193LicenseSearchAddress,
+  v193TaxFilingCalendarEvent,
+  v193LicenseSearchNameAndAddress,
+  v193TaxFilingData,
+  v193LicenseDetails,
+  v193Municipality,
+  v193ProfileDocuments,
+  v193BusinessUser,
+  v193CommunityAffairsAddress,
+  v193RoadmapTaskData,
+  v193FormationAddress,
+  v193LicenseData,
+  v193Preferences,
+  v193LicenseStatusItem,
+  v193FormationMember,
+  v193NameAvailability,
+  v193NameAvailabilityResponse,
+  v193IndustrySpecificData,
+  v193ProfileData,
+  v193FormationFormData,
+  v193FormationData,
+  v193Business,
+  v193UserData,
+  v193CrtkData,
+  v193CrtkEmailMetadata,
+  v193CrtkEntry,
+  v193CrtkBusinessDetails,
+  v193CigaretteLicensePaymentInfo,
+  v193CigaretteLicenseData,
+  v193EnvironmentData,
+} from "@db/migrations/v193_rotate_stranded_legacy_kms_fields";
+import { type LogWriterType } from "@libs/logWriter";
 import {
   AGENT_EMAIL_MAX_CHAR,
   AGENT_NAME_MAX_CHAR,
@@ -61,8 +61,8 @@ import {
   CONTACT_LAST_NAME_MAX_CHAR,
   SIGNER_NAME_MAX_CHAR,
 } from "@shared/formationData";
-import { UserData } from "@shared/userData";
-import { z, ZodTypeAny } from "zod";
+import { type UserData } from "@shared/userData";
+import { z, type ZodTypeAny } from "zod";
 
 // Zod 4.4 requires an explicit optional wrapper to accept omitted object keys.
 // Keep the legacy migration type as a required property whose value may be undefined.
@@ -121,7 +121,7 @@ export const withNoBase64Check = <T extends ZodTypeAny>(schema: T): T => {
 };
 
 export const parseUserData = (logger: LogWriterType, userData: UserData): void => {
-  const schemaWithBase64Check = withNoBase64Check(v192UserDataSchema);
+  const schemaWithBase64Check = withNoBase64Check(v193UserDataSchema);
   const result = schemaWithBase64Check.safeParse(userData);
 
   if (result.success) {
@@ -135,9 +135,9 @@ export const parseUserData = (logger: LogWriterType, userData: UserData): void =
   }
 };
 
-export const v192XrayRegistrationStatusSchema = z.enum(["ACTIVE", "EXPIRED", "INACTIVE"]);
+export const v193XrayRegistrationStatusSchema = z.enum(["ACTIVE", "EXPIRED", "INACTIVE"]);
 
-export const v192WasteWaterFieldIdsSchema = z.enum([
+export const v193WasteWaterFieldIdsSchema = z.enum([
   "sanitaryWaste",
   "industrialWaste",
   "localSewage",
@@ -150,13 +150,13 @@ export const v192WasteWaterFieldIdsSchema = z.enum([
   "noWasteWater",
 ]);
 
-export const v192WasteWaterDataSchema = z.object(
+export const v193WasteWaterDataSchema = z.object(
   Object.fromEntries(
-    v192WasteWaterFieldIdsSchema.options.map((key) => [key, z.boolean()]),
-  ) as Record<(typeof v192WasteWaterFieldIdsSchema.options)[number], z.ZodBoolean>,
+    v193WasteWaterFieldIdsSchema.options.map((key) => [key, z.boolean()]),
+  ) as Record<(typeof v193WasteWaterFieldIdsSchema.options)[number], z.ZodBoolean>,
 );
 
-export const v192DrinkingWaterFieldIdsSchema = z.enum([
+export const v193DrinkingWaterFieldIdsSchema = z.enum([
   "ownWell",
   "combinedWellCapacity",
   "wellDrilled",
@@ -164,13 +164,13 @@ export const v192DrinkingWaterFieldIdsSchema = z.enum([
   "noDrinkingWater",
 ]);
 
-export const v192DrinkingWaterDataSchema = z.object(
+export const v193DrinkingWaterDataSchema = z.object(
   Object.fromEntries(
-    v192DrinkingWaterFieldIdsSchema.options.map((key) => [key, z.boolean()]),
-  ) as Record<(typeof v192DrinkingWaterFieldIdsSchema.options)[number], z.ZodBoolean>,
+    v193DrinkingWaterFieldIdsSchema.options.map((key) => [key, z.boolean()]),
+  ) as Record<(typeof v193DrinkingWaterFieldIdsSchema.options)[number], z.ZodBoolean>,
 );
 
-export const v192WasteFieldIdsSchema = z.enum([
+export const v193WasteFieldIdsSchema = z.enum([
   "transportWaste",
   "hazardousMedicalWaste",
   "compostWaste",
@@ -179,14 +179,14 @@ export const v192WasteFieldIdsSchema = z.enum([
   "noWaste",
 ]);
 
-export const v192WasteDataSchema = z.object(
-  Object.fromEntries(v192WasteFieldIdsSchema.options.map((key) => [key, z.boolean()])) as Record<
-    (typeof v192WasteFieldIdsSchema.options)[number],
+export const v193WasteDataSchema = z.object(
+  Object.fromEntries(v193WasteFieldIdsSchema.options.map((key) => [key, z.boolean()])) as Record<
+    (typeof v193WasteFieldIdsSchema.options)[number],
     z.ZodBoolean
   >,
 );
 
-export const v192LandFieldIdsSchema = z.enum([
+export const v193LandFieldIdsSchema = z.enum([
   "takeOverExistingBiz",
   "propertyAssessment",
   "constructionActivities",
@@ -194,28 +194,28 @@ export const v192LandFieldIdsSchema = z.enum([
   "noLand",
 ]);
 
-export const v192LandDataSchema = z.object(
-  Object.fromEntries(v192LandFieldIdsSchema.options.map((key) => [key, z.boolean()])) as Record<
-    (typeof v192LandFieldIdsSchema.options)[number],
+export const v193LandDataSchema = z.object(
+  Object.fromEntries(v193LandFieldIdsSchema.options.map((key) => [key, z.boolean()])) as Record<
+    (typeof v193LandFieldIdsSchema.options)[number],
     z.ZodBoolean
   >,
 );
 
-export const v192AirFieldIdsSchema = z.enum([
+export const v193AirFieldIdsSchema = z.enum([
   "emitPollutants",
   "emitEmissions",
   "constructionActivities",
   "noAir",
 ]);
 
-export const v192AirDataSchema = z.object(
-  Object.fromEntries(v192AirFieldIdsSchema.options.map((key) => [key, z.boolean()])) as Record<
-    (typeof v192AirFieldIdsSchema.options)[number],
+export const v193AirDataSchema = z.object(
+  Object.fromEntries(v193AirFieldIdsSchema.options.map((key) => [key, z.boolean()])) as Record<
+    (typeof v193AirFieldIdsSchema.options)[number],
     z.ZodBoolean
   >,
 );
 
-export const v192PaymentTypeSchema = optionalUndefined(z.enum(["CC", "ACH"]));
+export const v193PaymentTypeSchema = optionalUndefined(z.enum(["CC", "ACH"]));
 
 export const llcBusinessSuffixSchema = z.enum([
   "LLC",
@@ -277,11 +277,11 @@ export const AllBusinessSuffixesSchema = [
   ...nonprofitBusinessSuffixSchema.options,
 ] as const;
 
-export const v192BusinessSuffixSchema = z.enum(AllBusinessSuffixesSchema);
+export const v193BusinessSuffixSchema = z.enum(AllBusinessSuffixesSchema);
 
-export const v192FormationBusinessLocationTypeSchema = z.enum(["US", "INTL", "NJ"] as const);
+export const v193FormationBusinessLocationTypeSchema = z.enum(["US", "INTL", "NJ"] as const);
 
-export const v192SignerTitleSchema = z.enum([
+export const v193SignerTitleSchema = z.enum([
   "Authorized Representative",
   "Authorized Partner",
   "Incorporator",
@@ -292,9 +292,9 @@ export const v192SignerTitleSchema = z.enum([
   "CEO",
 ] as const);
 
-export const v192InFormInBylawsSchema = optionalUndefined(z.enum(["IN_BYLAWS", "IN_FORM"]));
+export const v193InFormInBylawsSchema = optionalUndefined(z.enum(["IN_BYLAWS", "IN_FORM"]));
 
-export const v192HowToProceedOptionsSchema = z.enum([
+export const v193HowToProceedOptionsSchema = z.enum([
   "DIFFERENT_NAME",
   "KEEP_NAME",
   "CANCEL_NAME",
@@ -309,7 +309,7 @@ export const externalStatusListSchema = z.enum([
 
 export const userTestingStatusListSchema = z.enum(externalStatusListSchema.options);
 
-export const v192UserTestingStatusSchema = z.enum(userTestingStatusListSchema.options);
+export const v193UserTestingStatusSchema = z.enum(userTestingStatusListSchema.options);
 
 export const newsletterStatusListSchema = z.enum([
   ...externalStatusListSchema.options,
@@ -321,7 +321,7 @@ export const newsletterStatusListSchema = z.enum([
   "QUESTION_WARNING",
 ]);
 
-export const v192NameAvailabilityStatusSchema = z.enum([
+export const v193NameAvailabilityStatusSchema = z.enum([
   "AVAILABLE",
   "DESIGNATOR_ERROR",
   "SPECIAL_CHARACTER_ERROR",
@@ -329,17 +329,17 @@ export const v192NameAvailabilityStatusSchema = z.enum([
   "RESTRICTED_ERROR",
 ]);
 
-export const v192NewsletterStatusSchema = z.enum(newsletterStatusListSchema.options);
+export const v193NewsletterStatusSchema = z.enum(newsletterStatusListSchema.options);
 
-export const v192SectionTypeSchema = z.enum([
+export const v193SectionTypeSchema = z.enum([
   "PLAN",
   "START",
   "DOMESTIC_EMPLOYER_SECTION",
 ] as const);
 
-export const v192CheckoffStatusSchema = z.enum(["ACTIVE", "PENDING", "UNKNOWN"] as const);
+export const v193CheckoffStatusSchema = z.enum(["ACTIVE", "PENDING", "UNKNOWN"] as const);
 
-export const v192LicenseStatusSchema = z.enum([
+export const v193LicenseStatusSchema = z.enum([
   "ACTIVE",
   "PENDING",
   "UNKNOWN",
@@ -354,20 +354,20 @@ export const v192LicenseStatusSchema = z.enum([
   "WITHDRAWN",
 ] as const);
 
-export const v192PropertyLeaseTypeSchema = optionalUndefined(
+export const v193PropertyLeaseTypeSchema = optionalUndefined(
   z.enum(["SHORT_TERM_RENTAL", "LONG_TERM_RENTAL", "BOTH"]),
 );
 
-export const v192TaskProgressSchema = z.enum(["TO_DO", "COMPLETED"] as const);
+export const v193TaskProgressSchema = z.enum(["TO_DO", "COMPLETED"] as const);
 
-export const v192OnboardingFormProgressSchema = z.enum(["UNSTARTED", "COMPLETED"] as const);
+export const v193OnboardingFormProgressSchema = z.enum(["UNSTARTED", "COMPLETED"] as const);
 
-export const v192ABExperienceSchema = z.enum(["ExperienceA", "ExperienceB"] as const);
+export const v193ABExperienceSchema = z.enum(["ExperienceA", "ExperienceB"] as const);
 
-export const v192BusinessPersonaSchema = optionalUndefined(
+export const v193BusinessPersonaSchema = optionalUndefined(
   z.enum(["STARTING", "OWNING", "FOREIGN"]),
 );
-export const v192OperatingPhaseSchema = optionalUndefined(
+export const v193OperatingPhaseSchema = optionalUndefined(
   z.enum([
     "GUEST_MODE",
     "GUEST_MODE_WITH_BUSINESS_STRUCTURE",
@@ -382,24 +382,24 @@ export const v192OperatingPhaseSchema = optionalUndefined(
   ] as const),
 );
 
-export const v192CannabisLicenseTypeSchema = optionalUndefined(z.enum(["CONDITIONAL", "ANNUAL"]));
-export const v192CarServiceTypeSchema = optionalUndefined(
+export const v193CannabisLicenseTypeSchema = optionalUndefined(z.enum(["CONDITIONAL", "ANNUAL"]));
+export const v193CarServiceTypeSchema = optionalUndefined(
   z.enum(["STANDARD", "HIGH_CAPACITY", "BOTH"]),
 );
-export const v192ConstructionTypeSchema = optionalUndefined(
+export const v193ConstructionTypeSchema = optionalUndefined(
   z.enum(["RESIDENTIAL", "COMMERCIAL_OR_INDUSTRIAL", "BOTH"]),
 );
-export const v192ResidentialConstructionTypeSchema = optionalUndefined(
+export const v193ResidentialConstructionTypeSchema = optionalUndefined(
   z.enum(["NEW_HOME_CONSTRUCTION", "HOME_RENOVATIONS", "BOTH"]),
 );
-export const v192EmploymentAndPersonnelServicesTypeSchema = optionalUndefined(
+export const v193EmploymentAndPersonnelServicesTypeSchema = optionalUndefined(
   z.enum(["JOB_SEEKERS", "EMPLOYERS"]),
 );
-export const v192EmploymentPlacementTypeSchema = optionalUndefined(
+export const v193EmploymentPlacementTypeSchema = optionalUndefined(
   z.enum(["TEMPORARY", "PERMANENT", "BOTH"]),
 );
 
-export const v192ForeignBusinessTypeIdSchema = z.enum([
+export const v193ForeignBusinessTypeIdSchema = z.enum([
   "employeeOrContractorInNJ",
   "officeInNJ",
   "propertyInNJ",
@@ -410,17 +410,17 @@ export const v192ForeignBusinessTypeIdSchema = z.enum([
   "none",
 ] as const);
 
-export const v192TaxFilingStateSchema = z.enum([
+export const v193TaxFilingStateSchema = z.enum([
   "SUCCESS",
   "FAILED",
   "UNREGISTERED",
   "PENDING",
   "API_ERROR",
 ] as const);
-export const v192TaxFilingErrorFieldsSchema = z.enum(["businessName", "formFailure"] as const);
+export const v193TaxFilingErrorFieldsSchema = z.enum(["businessName", "formFailure"] as const);
 
 // Plain object mapping for license names
-const v192taskIdLicenseNameMapping = {
+const v193taskIdLicenseNameMapping = {
   "apply-for-shop-license": "Cosmetology and Hairstyling-Shop",
   "appraiser-license": "Real Estate Appraisers-Appraisal Management Company",
   "architect-license": "Architecture-Certificate of Authorization",
@@ -438,7 +438,7 @@ const v192taskIdLicenseNameMapping = {
   "telemarketing-license": "Telemarketers",
 } as const;
 
-export const v192taskIdLicenseNameMappingSchema = z.object({
+export const v193taskIdLicenseNameMappingSchema = z.object({
   "apply-for-shop-license": z.literal("Cosmetology and Hairstyling-Shop"),
   "appraiser-license": z.literal("Real Estate Appraisers-Appraisal Management Company"),
   "architect-license": z.literal("Architecture-Certificate of Authorization"),
@@ -462,12 +462,12 @@ export const v192taskIdLicenseNameMappingSchema = z.object({
   "telemarketing-license": z.literal("Telemarketers"),
 } as const);
 
-export const v192LicenseTaskIDSchema = z.enum(
-  Object.keys(v192taskIdLicenseNameMapping) as [string, ...string[]],
+export const v193LicenseTaskIDSchema = z.enum(
+  Object.keys(v193taskIdLicenseNameMapping) as [string, ...string[]],
 );
 
-export const v192LicenseNameSchema = z.enum(
-  Object.values(v192taskIdLicenseNameMapping) as [string, ...string[]],
+export const v193LicenseNameSchema = z.enum(
+  Object.values(v193taskIdLicenseNameMapping) as [string, ...string[]],
 );
 z.enum([
   "ACTIVE",
@@ -483,21 +483,21 @@ z.enum([
   "VOLUNTARY_SURRENDER",
   "WITHDRAWN",
 ] as const);
-export const v192SectionNamesSchema = z.enum([
+export const v193SectionNamesSchema = z.enum([
   "PLAN",
   "START",
   "DOMESTIC_EMPLOYER_SECTION",
 ] as const);
 
-export const v192QuestionnaireDataSchema: z.ZodType<v192QuestionnaireData> = z.object({
-  air: v192AirDataSchema,
-  land: v192LandDataSchema,
-  waste: v192WasteDataSchema,
-  drinkingWater: v192DrinkingWaterDataSchema,
-  wasteWater: v192WasteWaterDataSchema,
+export const v193QuestionnaireDataSchema: z.ZodType<v193QuestionnaireData> = z.object({
+  air: v193AirDataSchema,
+  land: v193LandDataSchema,
+  waste: v193WasteDataSchema,
+  drinkingWater: v193DrinkingWaterDataSchema,
+  wasteWater: v193WasteWaterDataSchema,
 });
 
-export const v192MachineDetailsSchema: z.ZodType<v192MachineDetails> = z.object({
+export const v193MachineDetailsSchema: z.ZodType<v193MachineDetails> = z.object({
   name: z.string().optional(),
   registrationNumber: z.string().optional(),
   roomId: z.string().optional(),
@@ -508,31 +508,31 @@ export const v192MachineDetailsSchema: z.ZodType<v192MachineDetails> = z.object(
   annualFee: z.number().optional(),
 });
 
-export const v192XrayRegistrationStatusResponseSchema: z.ZodType<v192XrayRegistrationStatusResponse> =
+export const v193XrayRegistrationStatusResponseSchema: z.ZodType<v193XrayRegistrationStatusResponse> =
   z.object({
-    machines: z.array(v192MachineDetailsSchema),
-    status: v192XrayRegistrationStatusSchema,
+    machines: z.array(v193MachineDetailsSchema),
+    status: v193XrayRegistrationStatusSchema,
     expirationDate: z.string().optional(),
     deactivationDate: z.string().optional(),
   });
 
-export const v192FacilityDetailsSchema: z.ZodType<v192FacilityDetails> = z.object({
+export const v193FacilityDetailsSchema: z.ZodType<v193FacilityDetails> = z.object({
   businessName: z.string(),
   addressLine1: z.string(),
   addressLine2: z.string().optional(),
   addressZipCode: z.string(),
 });
 
-export const v192XrayDataSchema: z.ZodType<v192XrayData> = z.object({
-  facilityDetails: v192FacilityDetailsSchema.optional(),
-  machines: z.array(v192MachineDetailsSchema).optional(),
-  status: v192XrayRegistrationStatusSchema.optional(),
+export const v193XrayDataSchema: z.ZodType<v193XrayData> = z.object({
+  facilityDetails: v193FacilityDetailsSchema.optional(),
+  machines: z.array(v193MachineDetailsSchema).optional(),
+  status: v193XrayRegistrationStatusSchema.optional(),
   expirationDate: z.string().optional(),
   deactivationDate: z.string().optional(),
   lastUpdatedISO: z.string().optional(),
 });
 
-export const v192CigaretteLicensePaymentInfoSchema: z.ZodType<v192CigaretteLicensePaymentInfo> =
+export const v193CigaretteLicensePaymentInfoSchema: z.ZodType<v193CigaretteLicensePaymentInfo> =
   z.object({
     token: z.string().optional(),
     paymentComplete: z.boolean().optional(),
@@ -542,12 +542,12 @@ export const v192CigaretteLicensePaymentInfoSchema: z.ZodType<v192CigaretteLicen
     confirmationEmailSent: z.boolean().optional(),
   });
 
-export const v192StateObjectSchema: z.ZodType<v192StateObject> = z.object({
+export const v193StateObjectSchema: z.ZodType<v193StateObject> = z.object({
   shortCode: z.string(),
   name: z.string(),
 });
 
-export const v192CigaretteLicenseDataSchema: z.ZodType<v192CigaretteLicenseData> = z.object({
+export const v193CigaretteLicenseDataSchema: z.ZodType<v193CigaretteLicenseData> = z.object({
   businessName: z.string().optional(),
   responsibleOwnerName: z.string().optional(),
   tradeName: z.string().optional(),
@@ -556,13 +556,13 @@ export const v192CigaretteLicenseDataSchema: z.ZodType<v192CigaretteLicenseData>
   addressLine1: z.string().optional(),
   addressLine2: z.string().optional(),
   addressCity: z.string().optional(),
-  addressState: v192StateObjectSchema.optional(),
+  addressState: v193StateObjectSchema.optional(),
   addressZipCode: z.string().optional(),
   mailingAddressIsTheSame: z.boolean().optional(),
   mailingAddressLine1: z.string().optional(),
   mailingAddressLine2: z.string().optional(),
   mailingAddressCity: z.string().optional(),
-  mailingAddressState: v192StateObjectSchema.optional(),
+  mailingAddressState: v193StateObjectSchema.optional(),
   mailingAddressZipCode: z.string().optional(),
   contactName: z.string().optional(),
   contactPhoneNumber: z.string().optional(),
@@ -573,31 +573,33 @@ export const v192CigaretteLicenseDataSchema: z.ZodType<v192CigaretteLicenseData>
   signerRelationship: z.string().optional(),
   signature: z.boolean().optional(),
   lastUpdatedISO: z.string().optional(),
-  paymentInfo: v192CigaretteLicensePaymentInfoSchema.optional(),
+  paymentInfo: v193CigaretteLicensePaymentInfoSchema.optional(),
 });
 
-export const v192TaxClearanceCertificateDataSchema: z.ZodType<v192TaxClearanceCertificateData> =
+export const v193TaxClearanceCertificateDataSchema: z.ZodType<v193TaxClearanceCertificateData> =
   z.object({
     requestingAgencyId: optionalUndefined(z.string()),
     businessName: optionalUndefined(z.string()),
     addressLine1: optionalUndefined(z.string()),
     addressLine2: optionalUndefined(z.string()),
     addressCity: optionalUndefined(z.string()),
-    addressState: v192StateObjectSchema.optional(),
+    addressState: v193StateObjectSchema.optional(),
     addressZipCode: z.string().optional(),
     taxId: optionalUndefined(z.string()),
+    encryptedTaxId: optionalUndefined(z.string()),
     taxPin: optionalUndefined(z.string()),
+    encryptedTaxPin: optionalUndefined(z.string()),
     hasPreviouslyReceivedCertificate: optionalUndefined(z.boolean()),
     lastUpdatedISO: optionalUndefined(z.string()),
   });
 
-export const v192EnvironmentDataSchema: z.ZodType<v192EnvironmentData> = z.object({
-  questionnaireData: v192QuestionnaireDataSchema.optional(),
+export const v193EnvironmentDataSchema: z.ZodType<v193EnvironmentData> = z.object({
+  questionnaireData: v193QuestionnaireDataSchema.optional(),
   submitted: z.boolean().optional(),
   emailSent: z.boolean().optional(),
 });
 
-export const v192GetFilingResponseSchema: z.ZodType<v192GetFilingResponse> = z.object({
+export const v193GetFilingResponseSchema: z.ZodType<v193GetFilingResponse> = z.object({
   success: z.boolean(),
   entityId: z.string(),
   transactionDate: z.string(), // ISO 8601 date string
@@ -607,148 +609,148 @@ export const v192GetFilingResponseSchema: z.ZodType<v192GetFilingResponse> = z.o
   certifiedDoc: z.string(),
 });
 
-export const v192FormationSubmitErrorSchema: z.ZodType<v192FormationSubmitError> = z.object({
+export const v193FormationSubmitErrorSchema: z.ZodType<v193FormationSubmitError> = z.object({
   field: z.string(),
   type: z.enum(["FIELD", "UNKNOWN", "RESPONSE"]),
   message: z.string(),
 });
 
-export const v192FormationSubmitResponseSchema: z.ZodType<v192FormationSubmitResponse> = z.object({
+export const v193FormationSubmitResponseSchema: z.ZodType<v193FormationSubmitResponse> = z.object({
   success: z.boolean(),
   token: optionalUndefined(z.string()),
   formationId: optionalUndefined(z.string()),
   redirect: optionalUndefined(z.string()),
-  errors: z.array(v192FormationSubmitErrorSchema),
+  errors: z.array(v193FormationSubmitErrorSchema),
   lastUpdatedISO: optionalUndefined(z.string()),
 });
 
-export const v192FormationSignerSchema = z.object({
+export const v193FormationSignerSchema = z.object({
   name: z.string().max(SIGNER_NAME_MAX_CHAR, {
     message: `signer name cannot exceed ${SIGNER_NAME_MAX_CHAR} characters`,
   }),
   signature: z.boolean(),
-  title: v192SignerTitleSchema,
-}) satisfies z.ZodType<v192FormationSigner>;
+  title: v193SignerTitleSchema,
+}) satisfies z.ZodType<v193FormationSigner>;
 
-export const v192ForeignGoodStandingFileObjectSchema: z.ZodType<v192ForeignGoodStandingFileObject> =
+export const v193ForeignGoodStandingFileObjectSchema: z.ZodType<v193ForeignGoodStandingFileObject> =
   z.object({
     Extension: z.enum(["PDF", "PNG"]),
     Content: z.string(),
   });
 
-export const v192NameAvailabilityResponseSchema = z.object({
-  status: optionalUndefined(v192NameAvailabilityStatusSchema),
+export const v193NameAvailabilityResponseSchema = z.object({
+  status: optionalUndefined(v193NameAvailabilityStatusSchema),
   similarNames: z.array(z.string()),
   invalidWord: z.string().optional(),
-}) satisfies z.ZodType<v192NameAvailabilityResponse>;
+}) satisfies z.ZodType<v193NameAvailabilityResponse>;
 
-export const v192NameAvailabilitySchema = v192NameAvailabilityResponseSchema.extend({
+export const v193NameAvailabilitySchema = v193NameAvailabilityResponseSchema.extend({
   lastUpdatedTimeStamp: z.string(),
-}) satisfies z.ZodType<v192NameAvailability>;
+}) satisfies z.ZodType<v193NameAvailability>;
 
-export const v192NewsletterResponseSchema: z.ZodType<v192NewsletterResponse> = z.object({
+export const v193NewsletterResponseSchema: z.ZodType<v193NewsletterResponse> = z.object({
   success: z.boolean().optional(),
-  status: v192NewsletterStatusSchema,
+  status: v193NewsletterStatusSchema,
 });
 
-export const v192UserTestingResponseSchema: z.ZodType<v192UserTestingResponse> = z.object({
+export const v193UserTestingResponseSchema: z.ZodType<v193UserTestingResponse> = z.object({
   success: z.boolean().optional(),
-  status: v192UserTestingStatusSchema,
+  status: v193UserTestingStatusSchema,
 });
 
-export const v192ExternalStatusSchema: z.ZodType<v192ExternalStatus> = z.object({
-  newsletter: v192NewsletterResponseSchema.optional(),
-  userTesting: v192UserTestingResponseSchema.optional(),
+export const v193ExternalStatusSchema: z.ZodType<v193ExternalStatus> = z.object({
+  newsletter: v193NewsletterResponseSchema.optional(),
+  userTesting: v193UserTestingResponseSchema.optional(),
 });
 
-export const v192CalendarEventSchema = z.object({
+export const v193CalendarEventSchema = z.object({
   dueDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, {
     message: "dueDate must be in YYYY-MM-DD format",
   }),
   calendarEventType: z.enum(["TAX-FILING", "LICENSE"]),
-}) satisfies z.ZodType<v192CalendarEvent>;
+}) satisfies z.ZodType<v193CalendarEvent>;
 
-export const v192LicenseSearchAddressSchema = z.object({
+export const v193LicenseSearchAddressSchema = z.object({
   addressLine1: z.string(),
   addressLine2: z.string(),
   zipCode: z.string(),
-}) satisfies z.ZodType<v192LicenseSearchAddress>;
+}) satisfies z.ZodType<v193LicenseSearchAddress>;
 
-export const v192TaxFilingCalendarEventSchema = v192CalendarEventSchema
+export const v193TaxFilingCalendarEventSchema = v193CalendarEventSchema
   .extend({
     identifier: z.string(),
     calendarEventType: z.literal("TAX-FILING"), // override enum to fixed value
   })
-  .readonly() satisfies z.ZodType<v192TaxFilingCalendarEvent>;
+  .readonly() satisfies z.ZodType<v193TaxFilingCalendarEvent>;
 
-export const v192LicenseSearchNameAndAddressSchema = v192LicenseSearchAddressSchema.extend({
+export const v193LicenseSearchNameAndAddressSchema = v193LicenseSearchAddressSchema.extend({
   name: z.string(),
-}) satisfies z.ZodType<v192LicenseSearchNameAndAddress>;
+}) satisfies z.ZodType<v193LicenseSearchNameAndAddress>;
 
-export const v192TaxFilingDataSchema: z.ZodType<v192TaxFilingData> = z.object({
-  state: v192TaxFilingStateSchema.optional(),
+export const v193TaxFilingDataSchema: z.ZodType<v193TaxFilingData> = z.object({
+  state: v193TaxFilingStateSchema.optional(),
   lastUpdatedISO: z.string().optional(),
   registeredISO: z.string().optional(),
-  errorField: v192TaxFilingErrorFieldsSchema.optional(),
+  errorField: v193TaxFilingErrorFieldsSchema.optional(),
   businessName: z.string().optional(),
-  filings: z.array(v192TaxFilingCalendarEventSchema),
+  filings: z.array(v193TaxFilingCalendarEventSchema),
 });
 
-export const v192MunicipalitySchema: z.ZodType<v192Municipality> = z.object({
+export const v193MunicipalitySchema: z.ZodType<v193Municipality> = z.object({
   name: z.string(),
   displayName: z.string(),
   county: z.string(),
   id: z.string(),
 });
 
-export const v192LicenseStatusItemSchema: z.ZodType<v192LicenseStatusItem> = z.object({
+export const v193LicenseStatusItemSchema: z.ZodType<v193LicenseStatusItem> = z.object({
   title: z.string(),
-  status: v192CheckoffStatusSchema,
+  status: v193CheckoffStatusSchema,
 });
 
-export const v192LicenseDetailsSchema: z.ZodType<v192LicenseDetails> = z.object({
-  nameAndAddress: v192LicenseSearchNameAndAddressSchema,
-  licenseStatus: v192LicenseStatusSchema,
+export const v193LicenseDetailsSchema: z.ZodType<v193LicenseDetails> = z.object({
+  nameAndAddress: v193LicenseSearchNameAndAddressSchema,
+  licenseStatus: v193LicenseStatusSchema,
   expirationDateISO: optionalUndefined(z.string()),
   lastUpdatedISO: z.string(),
-  checklistItems: z.array(v192LicenseStatusItemSchema),
+  checklistItems: z.array(v193LicenseStatusItemSchema),
 });
 
-export const v192CommunityAffairsAddressSchema: z.ZodType<v192CommunityAffairsAddress> = z.object({
+export const v193CommunityAffairsAddressSchema: z.ZodType<v193CommunityAffairsAddress> = z.object({
   streetAddress1: z.string(),
   streetAddress2: z.string().optional(),
-  municipality: v192MunicipalitySchema,
+  municipality: v193MunicipalitySchema,
 });
 
-export const v192BusinessUserSchema: z.ZodType<v192BusinessUser> = z.object({
+export const v193BusinessUserSchema: z.ZodType<v193BusinessUser> = z.object({
   name: z.string().optional(),
   email: z.string(),
   id: z.string(),
   receiveNewsletter: z.boolean(),
   userTesting: z.boolean(),
   receiveUpdatesAndReminders: z.boolean(),
-  externalStatus: v192ExternalStatusSchema,
+  externalStatus: v193ExternalStatusSchema,
   myNJUserKey: z.string().optional(),
   intercomHash: z.string().optional(),
-  abExperience: v192ABExperienceSchema,
+  abExperience: v193ABExperienceSchema,
   accountCreationSource: z.string(),
   contactSharingWithAccountCreationPartner: z.boolean(),
   phoneNumber: z.string().optional(),
 });
 
-export const v192ProfileDocumentsSchema: z.ZodType<v192ProfileDocuments> = z.object({
+export const v193ProfileDocumentsSchema: z.ZodType<v193ProfileDocuments> = z.object({
   formationDoc: z.string(),
   standingDoc: z.string(),
   certifiedDoc: z.string(),
 });
 
-export const v192RoadmapTaskDataSchema: z.ZodType<v192RoadmapTaskData> = z.object({
+export const v193RoadmapTaskDataSchema: z.ZodType<v193RoadmapTaskData> = z.object({
   manageBusinessVehicles: z.boolean().optional(),
   passengerTransportSchoolBus: z.boolean().optional(),
   passengerTransportSixteenOrMorePassengers: z.boolean().optional(),
 });
 
-export const v192FormationAddressSchema = z.object({
+export const v193FormationAddressSchema = z.object({
   addressLine1: z.string().max(BUSINESS_ADDRESS_LINE_1_MAX_CHAR, {
     message: `address line 1 cannot exceed ${BUSINESS_ADDRESS_LINE_1_MAX_CHAR} characters`,
   }),
@@ -761,8 +763,8 @@ export const v192FormationAddressSchema = z.object({
       message: `address city cannot exceed ${BUSINESS_ADDRESS_CITY_MAX_CHAR} characters`,
     })
     .optional(),
-  addressState: v192StateObjectSchema.optional(),
-  addressMunicipality: v192MunicipalitySchema.optional(),
+  addressState: v193StateObjectSchema.optional(),
+  addressMunicipality: v193MunicipalitySchema.optional(),
   addressProvince: z
     .string()
     .max(BUSINESS_ADDRESS_PROVINCE_MAX_CHAR, {
@@ -771,56 +773,56 @@ export const v192FormationAddressSchema = z.object({
     .optional(),
   addressZipCode: z.string(),
   addressCountry: z.string().optional(),
-  businessLocationType: optionalUndefined(v192FormationBusinessLocationTypeSchema),
-}) satisfies z.ZodType<v192FormationAddress>;
+  businessLocationType: optionalUndefined(v193FormationBusinessLocationTypeSchema),
+}) satisfies z.ZodType<v193FormationAddress>;
 
-export const v192FormationMemberSchema = v192FormationAddressSchema
+export const v193FormationMemberSchema = v193FormationAddressSchema
   .extend({
     name: z.string(),
   })
-  .readonly() satisfies z.ZodType<v192FormationMember>;
+  .readonly() satisfies z.ZodType<v193FormationMember>;
 
-export const v192FormationIncorporatorSchema = z
+export const v193FormationIncorporatorSchema = z
   .object({
-    ...v192FormationSignerSchema.shape,
-    ...v192FormationAddressSchema.shape,
+    ...v193FormationSignerSchema.shape,
+    ...v193FormationAddressSchema.shape,
   })
   .readonly();
 
-export const v192IndustrySpecificDataSchema = z.object({
+export const v193IndustrySpecificDataSchema = z.object({
   liquorLicense: z.boolean(),
   requiresCpa: optionalUndefined(z.boolean()),
   homeBasedBusiness: z.boolean().optional(),
   providesStaffingService: z.boolean(),
   certifiedInteriorDesigner: z.boolean(),
   realEstateAppraisalManagement: z.boolean(),
-  cannabisLicenseType: v192CannabisLicenseTypeSchema,
+  cannabisLicenseType: v193CannabisLicenseTypeSchema,
   cannabisMicrobusiness: optionalUndefined(z.boolean()),
   constructionRenovationPlan: optionalUndefined(z.boolean()),
-  carService: v192CarServiceTypeSchema,
+  carService: v193CarServiceTypeSchema,
   interstateTransport: optionalUndefined(z.boolean()),
   interstateLogistics: optionalUndefined(z.boolean()),
   interstateMoving: optionalUndefined(z.boolean()),
   isChildcareForSixOrMore: optionalUndefined(z.boolean()),
   petCareHousing: optionalUndefined(z.boolean()),
   willSellPetCareItems: optionalUndefined(z.boolean()),
-  constructionType: v192ConstructionTypeSchema,
-  residentialConstructionType: v192ResidentialConstructionTypeSchema,
-  employmentPersonnelServiceType: v192EmploymentAndPersonnelServicesTypeSchema,
-  employmentPlacementType: v192EmploymentPlacementTypeSchema,
-  propertyLeaseType: v192PropertyLeaseTypeSchema,
+  constructionType: v193ConstructionTypeSchema,
+  residentialConstructionType: v193ResidentialConstructionTypeSchema,
+  employmentPersonnelServiceType: v193EmploymentAndPersonnelServicesTypeSchema,
+  employmentPlacementType: v193EmploymentPlacementTypeSchema,
+  propertyLeaseType: v193PropertyLeaseTypeSchema,
   hasThreeOrMoreRentalUnits: optionalUndefined(z.boolean()),
   publicWorksContractor: optionalUndefined(z.boolean()),
-}) satisfies z.ZodType<v192IndustrySpecificData>;
+}) satisfies z.ZodType<v193IndustrySpecificData>;
 
-export const v192ProfileDataSchema = v192IndustrySpecificDataSchema.extend({
-  businessPersona: v192BusinessPersonaSchema,
+export const v193ProfileDataSchema = v193IndustrySpecificDataSchema.extend({
+  businessPersona: v193BusinessPersonaSchema,
   businessName: z.string(),
   responsibleOwnerName: z.string(),
   tradeName: z.string(),
   industryId: optionalUndefined(z.string()),
   legalStructureId: optionalUndefined(z.string()),
-  municipality: optionalUndefined(v192MunicipalitySchema),
+  municipality: optionalUndefined(v193MunicipalitySchema),
   dateOfFormation: optionalUndefined(z.string()),
   entityId: optionalUndefined(z.string()),
   employerId: optionalUndefined(z.string()),
@@ -828,31 +830,31 @@ export const v192ProfileDataSchema = v192IndustrySpecificDataSchema.extend({
   hashedTaxId: optionalUndefined(z.string()),
   encryptedTaxId: optionalUndefined(z.string()),
   notes: z.string(),
-  documents: v192ProfileDocumentsSchema,
+  documents: v193ProfileDocumentsSchema,
   ownershipTypeIds: z.array(z.string()),
   existingEmployees: optionalUndefined(z.string()),
   taxPin: optionalUndefined(z.string()),
   encryptedTaxPin: optionalUndefined(z.string()),
   sectorId: optionalUndefined(z.string()),
   naicsCode: z.string(),
-  foreignBusinessTypeIds: z.array(v192ForeignBusinessTypeIdSchema),
+  foreignBusinessTypeIds: z.array(v193ForeignBusinessTypeIdSchema),
   nexusDbaName: z.string(),
-  operatingPhase: v192OperatingPhaseSchema,
+  operatingPhase: v193OperatingPhaseSchema,
   nonEssentialRadioAnswers: z.record(z.string(), optionalUndefined(z.boolean())),
   elevatorOwningBusiness: optionalUndefined(z.boolean()),
-  communityAffairsAddress: v192CommunityAffairsAddressSchema.optional(),
+  communityAffairsAddress: v193CommunityAffairsAddressSchema.optional(),
   plannedRenovationQuestion: optionalUndefined(z.boolean()),
   raffleBingoGames: optionalUndefined(z.boolean()),
   businessOpenMoreThanTwoYears: optionalUndefined(z.boolean()),
   employerAccessRegistration: optionalUndefined(z.boolean()),
   deptOfLaborEin: z.string(),
-}) satisfies z.ZodType<v192ProfileData>;
+}) satisfies z.ZodType<v193ProfileData>;
 
-export const v192FormationFormDataSchema = v192FormationAddressSchema
+export const v193FormationFormDataSchema = v193FormationAddressSchema
   .extend({
     businessName: z.string(),
     businessNameConfirmation: optionalUndefined(z.boolean()),
-    businessSuffix: optionalUndefined(v192BusinessSuffixSchema),
+    businessSuffix: optionalUndefined(v193BusinessSuffixSchema),
     businessTotalStock: z.string(),
     businessStartDate: z.string(), // YYYY-MM-DD
     businessPurpose: z.string(),
@@ -866,13 +868,13 @@ export const v192FormationFormDataSchema = v192FormationAddressSchema
     canMakeDistribution: optionalUndefined(z.boolean()),
     makeDistributionTerms: z.string(),
     hasNonprofitBoardMembers: optionalUndefined(z.boolean()),
-    nonprofitBoardMemberQualificationsSpecified: v192InFormInBylawsSchema,
+    nonprofitBoardMemberQualificationsSpecified: v193InFormInBylawsSchema,
     nonprofitBoardMemberQualificationsTerms: z.string(),
-    nonprofitBoardMemberRightsSpecified: v192InFormInBylawsSchema,
+    nonprofitBoardMemberRightsSpecified: v193InFormInBylawsSchema,
     nonprofitBoardMemberRightsTerms: z.string(),
-    nonprofitTrusteesMethodSpecified: v192InFormInBylawsSchema,
+    nonprofitTrusteesMethodSpecified: v193InFormInBylawsSchema,
     nonprofitTrusteesMethodTerms: z.string(),
-    nonprofitAssetDistributionSpecified: v192InFormInBylawsSchema,
+    nonprofitAssetDistributionSpecified: v193InFormInBylawsSchema,
     nonprofitAssetDistributionTerms: z.string(),
     additionalProvisions: optionalUndefined(z.array(z.string())),
     agentType: z.enum(["MYSELF", "AUTHORIZED_REP", "PROFESSIONAL_SERVICE"]),
@@ -895,10 +897,10 @@ export const v192FormationFormDataSchema = v192FormationAddressSchema
     agentOfficeAddressZipCode: z.string(),
     agentUseAccountInfo: z.boolean(),
     agentUseBusinessAddress: z.boolean(),
-    members: optionalUndefined(z.array(v192FormationMemberSchema)),
-    incorporators: optionalUndefined(z.array(v192FormationIncorporatorSchema)),
-    signers: optionalUndefined(z.array(v192FormationSignerSchema.readonly())),
-    paymentType: v192PaymentTypeSchema,
+    members: optionalUndefined(z.array(v193FormationMemberSchema)),
+    incorporators: optionalUndefined(z.array(v193FormationIncorporatorSchema)),
+    signers: optionalUndefined(z.array(v193FormationSignerSchema.readonly())),
+    paymentType: v193PaymentTypeSchema,
     annualReportNotification: z.boolean(),
     corpWatchNotification: z.boolean(),
     officialFormationDocument: z.boolean(),
@@ -911,40 +913,40 @@ export const v192FormationFormDataSchema = v192FormationAddressSchema
       message: `contact last name cannot exceed ${CONTACT_LAST_NAME_MAX_CHAR} characters`,
     }),
     contactPhoneNumber: z.string(),
-    foreignStateOfFormation: optionalUndefined(v192StateObjectSchema),
+    foreignStateOfFormation: optionalUndefined(v193StateObjectSchema),
     foreignDateOfFormation: optionalUndefined(z.string()), // YYYY-MM-DD
-    foreignGoodStandingFile: optionalUndefined(v192ForeignGoodStandingFileObjectSchema),
+    foreignGoodStandingFile: optionalUndefined(v193ForeignGoodStandingFileObjectSchema),
     legalType: z.string(),
     willPracticeLaw: optionalUndefined(z.boolean()),
     isVeteranNonprofit: optionalUndefined(z.boolean()),
     checkNameReservation: optionalUndefined(z.boolean()),
-    howToProceed: v192HowToProceedOptionsSchema,
+    howToProceed: v193HowToProceedOptionsSchema,
   })
-  .readonly() satisfies z.ZodType<v192FormationFormData>;
+  .readonly() satisfies z.ZodType<v193FormationFormData>;
 
-export const v192FormationDataSchema: z.ZodType<v192FormationData> = z.object({
-  formationFormData: v192FormationFormDataSchema,
-  businessNameAvailability: optionalUndefined(v192NameAvailabilitySchema),
-  dbaBusinessNameAvailability: optionalUndefined(v192NameAvailabilitySchema),
-  formationResponse: optionalUndefined(v192FormationSubmitResponseSchema),
-  getFilingResponse: optionalUndefined(v192GetFilingResponseSchema),
+export const v193FormationDataSchema: z.ZodType<v193FormationData> = z.object({
+  formationFormData: v193FormationFormDataSchema,
+  businessNameAvailability: optionalUndefined(v193NameAvailabilitySchema),
+  dbaBusinessNameAvailability: optionalUndefined(v193NameAvailabilitySchema),
+  formationResponse: optionalUndefined(v193FormationSubmitResponseSchema),
+  getFilingResponse: optionalUndefined(v193GetFilingResponseSchema),
   completedFilingPayment: z.boolean(),
   lastVisitedPageIndex: z.number(),
 });
 
-export const v192LicensesSchema = z.object(
+export const v193LicensesSchema = z.object(
   Object.fromEntries(
-    v192LicenseNameSchema.options.map((name) => [name, v192LicenseDetailsSchema.optional()]),
-  ) as Record<string, z.ZodOptional<typeof v192LicenseDetailsSchema>>,
+    v193LicenseNameSchema.options.map((name) => [name, v193LicenseDetailsSchema.optional()]),
+  ) as Record<string, z.ZodOptional<typeof v193LicenseDetailsSchema>>,
 );
 
-export const v192LicenseDataSchema: z.ZodType<v192LicenseData> = z.object({
+export const v193LicenseDataSchema: z.ZodType<v193LicenseData> = z.object({
   lastUpdatedISO: z.string(),
-  licenses: v192LicensesSchema.optional(),
+  licenses: v193LicensesSchema.optional(),
 });
 
-export const v192PreferencesSchema: z.ZodType<v192Preferences> = z.object({
-  roadmapOpenSections: z.array(v192SectionTypeSchema),
+export const v193PreferencesSchema: z.ZodType<v193Preferences> = z.object({
+  roadmapOpenSections: z.array(v193SectionTypeSchema),
   roadmapOpenSteps: z.array(z.number()),
   visibleSidebarCards: z.array(z.string()),
   isCalendarFullView: z.boolean(),
@@ -954,7 +956,7 @@ export const v192PreferencesSchema: z.ZodType<v192Preferences> = z.object({
   isNonProfitFromFunding: z.boolean().optional(),
 });
 
-export const v192CrtkBusinessDetailsSchema: z.ZodType<v192CrtkBusinessDetails> = z.object({
+export const v193CrtkBusinessDetailsSchema: z.ZodType<v193CrtkBusinessDetails> = z.object({
   businessName: z.string(),
   addressLine1: z.string(),
   city: z.string(),
@@ -962,9 +964,9 @@ export const v192CrtkBusinessDetailsSchema: z.ZodType<v192CrtkBusinessDetails> =
   ein: z.string().optional(),
 });
 
-export const v192CrtkSearchResultSchema = z.enum(["FOUND", "NOT_FOUND"]);
+export const v193CrtkSearchResultSchema = z.enum(["FOUND", "NOT_FOUND"]);
 
-export const v192CrtkEntrySchema: z.ZodType<v192CrtkEntry> = z.object({
+export const v193CrtkEntrySchema: z.ZodType<v193CrtkEntry> = z.object({
   businessName: z.string().optional(),
   streetAddress: z.string().optional(),
   city: z.string().optional(),
@@ -983,7 +985,7 @@ export const v192CrtkEntrySchema: z.ZodType<v192CrtkEntry> = z.object({
   receivedDate: z.string().optional(),
 });
 
-export const v192CrtkEmailMetadataSchema: z.ZodType<v192CrtkEmailMetadata> = z.object({
+export const v193CrtkEmailMetadataSchema: z.ZodType<v193CrtkEmailMetadata> = z.object({
   username: z.string(),
   email: z.email(),
   businessName: z.string(),
@@ -996,44 +998,44 @@ export const v192CrtkEmailMetadataSchema: z.ZodType<v192CrtkEmailMetadata> = z.o
   materialOrProducts: z.string(),
 });
 
-export const v192CrtkDataSchema: z.ZodType<v192CrtkData> = z.object({
+export const v193CrtkDataSchema: z.ZodType<v193CrtkData> = z.object({
   lastUpdatedISO: z.string(),
-  crtkBusinessDetails: v192CrtkBusinessDetailsSchema.optional(),
-  crtkSearchResult: z.union([v192CrtkSearchResultSchema]),
-  crtkEntry: v192CrtkEntrySchema,
+  crtkBusinessDetails: v193CrtkBusinessDetailsSchema.optional(),
+  crtkSearchResult: z.union([v193CrtkSearchResultSchema]),
+  crtkEntry: v193CrtkEntrySchema,
   crtkEmailSent: z.boolean().optional(),
 });
 
-export const v192BusinessSchema: z.ZodType<v192Business> = z.object({
+export const v193BusinessSchema: z.ZodType<v193Business> = z.object({
   id: z.string(),
   dateCreatedISO: z.string(),
   lastUpdatedISO: z.string(),
   dateDeletedISO: z.string(),
-  profileData: v192ProfileDataSchema,
-  onboardingFormProgress: v192OnboardingFormProgressSchema,
-  taskProgress: z.record(z.string(), v192TaskProgressSchema),
+  profileData: v193ProfileDataSchema,
+  onboardingFormProgress: v193OnboardingFormProgressSchema,
+  taskProgress: z.record(z.string(), v193TaskProgressSchema),
   taskItemChecklist: z.record(z.string(), z.boolean()),
-  licenseData: optionalUndefined(v192LicenseDataSchema),
-  preferences: v192PreferencesSchema,
-  taxFilingData: v192TaxFilingDataSchema,
-  formationData: v192FormationDataSchema,
-  environmentData: optionalUndefined(v192EnvironmentDataSchema),
-  xrayRegistrationData: optionalUndefined(v192XrayDataSchema),
-  crtkData: optionalUndefined(v192CrtkDataSchema),
-  roadmapTaskData: v192RoadmapTaskDataSchema,
-  taxClearanceCertificateData: optionalUndefined(v192TaxClearanceCertificateDataSchema),
-  cigaretteLicenseData: optionalUndefined(v192CigaretteLicenseDataSchema),
+  licenseData: optionalUndefined(v193LicenseDataSchema),
+  preferences: v193PreferencesSchema,
+  taxFilingData: v193TaxFilingDataSchema,
+  formationData: v193FormationDataSchema,
+  environmentData: optionalUndefined(v193EnvironmentDataSchema),
+  xrayRegistrationData: optionalUndefined(v193XrayDataSchema),
+  crtkData: optionalUndefined(v193CrtkDataSchema),
+  roadmapTaskData: v193RoadmapTaskDataSchema,
+  taxClearanceCertificateData: optionalUndefined(v193TaxClearanceCertificateDataSchema),
+  cigaretteLicenseData: optionalUndefined(v193CigaretteLicenseDataSchema),
   version: z.number(),
   versionWhenCreated: z.number(),
   userId: z.string(),
 });
 
-export const v192UserDataSchema: z.ZodType<v192UserData> = z.object({
-  user: v192BusinessUserSchema,
+export const v193UserDataSchema: z.ZodType<v193UserData> = z.object({
+  user: v193BusinessUserSchema,
   version: z.number(),
   lastUpdatedISO: z.string(),
   dateCreatedISO: z.string(),
   versionWhenCreated: z.number(),
-  businesses: z.record(z.string(), v192BusinessSchema),
+  businesses: z.record(z.string(), v193BusinessSchema),
   currentBusinessId: z.string(),
 });

--- a/api/src/domain/newsletter/addNewsletterBatch.test.ts
+++ b/api/src/domain/newsletter/addNewsletterBatch.test.ts
@@ -15,6 +15,7 @@ describe("addNewsletterBatch", () => {
     stubUserDataClient = {
       get: jest.fn(),
       put: jest.fn(),
+      migrateToLatest: jest.fn(),
       findByEmail: jest.fn(),
       getNeedNewsletterUsers: jest.fn(),
       getNeedTaxIdEncryptionUsers: jest.fn(),

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -71,7 +71,7 @@ export interface MessageData {
   dateCreated: string;
 }
 export interface DatabaseClient {
-  migrateOutdatedVersionUsers: () => Promise<{
+  migrateOutdatedVersionUsers: (options?: MigrationRunOptions) => Promise<{
     success: boolean;
     migratedCount?: number;
     error?: string;
@@ -84,16 +84,32 @@ export interface DatabaseClient {
   findBusinessesByHashedTaxId: (hashedTaxId: string) => Promise<Business[]>;
 }
 
+export interface MigrationRunOptions {
+  readonly canStartNextUser: () => boolean;
+}
+
 export interface UserDataClient {
   get: (userId: string) => Promise<UserData>;
   findByEmail: (email: string) => Promise<UserData | undefined>;
   put: (userData: UserData) => Promise<UserData>;
+  migrateToLatest: (userData: UserData) => Promise<UserData>;
   getNeedNewsletterUsers: () => Promise<UserData[]>;
   getNeedTaxIdEncryptionUsers: () => Promise<UserData[]>;
   getUsersWithOutdatedVersion: (
     latestVersion: number,
     nextToken?: string,
   ) => Promise<{ usersToMigrate: UserData[]; nextToken?: string }>;
+}
+
+export interface MigrationDataClient {
+  migrateAndPut: (userData: UserData) => Promise<UserData>;
+}
+
+export class MigrationConflictError extends Error {
+  constructor() {
+    super("User data changed during migration");
+    this.name = "MigrationConflictError";
+  }
 }
 
 export interface BusinessesDataClient {

--- a/api/src/domain/user/encryptTaxIdBatch.test.ts
+++ b/api/src/domain/user/encryptTaxIdBatch.test.ts
@@ -15,6 +15,7 @@ describe("encryptTaxIdBatch", () => {
     stubUserDataClient = {
       get: jest.fn(),
       put: jest.fn(),
+      migrateToLatest: jest.fn(),
       findByEmail: jest.fn(),
       getNeedNewsletterUsers: jest.fn(),
       getNeedTaxIdEncryptionUsers: jest.fn(),

--- a/api/src/functions/config.ts
+++ b/api/src/functions/config.ts
@@ -12,6 +12,17 @@ export const LEGACY_AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY =
   process.env.LEGACY_AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY || "";
 export const AWS_CRYPTO_CONTEXT_TAX_ID_ENCRYPTION_PURPOSE =
   process.env.AWS_CRYPTO_CONTEXT_TAX_ID_ENCRYPTION_PURPOSE || "";
+// Testing deployments omitted both values after the CircleCI-to-GitHub Actions migration.
+export const AWS_CRYPTO_TAX_ID_DECRYPT_ONLY_CONTEXTS =
+  STAGE === "testing"
+    ? [
+        {
+          stage: "",
+          purpose: AWS_CRYPTO_CONTEXT_TAX_ID_ENCRYPTION_PURPOSE,
+          origin: "",
+        },
+      ]
+    : [];
 export const AWS_CRYPTO_TAX_ID_HASHING_KEY = process.env.AWS_CRYPTO_TAX_ID_HASHING_KEY || "";
 export const AWS_CRYPTO_TAX_ID_ENCRYPTED_HASHING_SALT =
   process.env.AWS_CRYPTO_TAX_ID_ENCRYPTED_HASHING_SALT || "";

--- a/api/src/functions/express/app.ts
+++ b/api/src/functions/express/app.ts
@@ -65,6 +65,7 @@ import { WebserviceLicenseStatusProcessorClient } from "@client/webservice/Webse
 import { createDynamoDbClient } from "@db/config/dynamoDbConfig";
 import { DynamoBusinessDataClient } from "@db/DynamoBusinessDataClient";
 import { DynamoDataClient } from "@db/DynamoDataClient";
+import { DynamoMigrationDataClient } from "@db/DynamoMigrationDataClient";
 import { DynamoUserDataClient } from "@db/DynamoUserDataClient";
 import { HealthCheckMethod } from "@domain/types";
 import { updateSidebarCards } from "@domain/updateSidebarCards";
@@ -80,6 +81,7 @@ import {
   AWS_CRYPTO_CONTEXT_TAX_ID_HASHING_PURPOSE,
   AWS_CRYPTO_TAX_ID_ENCRYPTED_HASHING_SALT,
   AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY,
+  AWS_CRYPTO_TAX_ID_DECRYPT_ONLY_CONTEXTS,
   LEGACY_AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY,
   AWS_CRYPTO_TAX_ID_HASHING_KEY,
   BUSINESSES_TABLE,
@@ -310,21 +312,19 @@ const ABC_ETP_API_ACCOUNT = process.env.ABC_ETP_API_ACCOUNT || "";
 const ABC_ETP_API_KEY = process.env.ABC_ETP_API_KEY || "";
 const ABC_ETP_API_BASE_URL = process.env.ABC_ETP_API_BASE_URL || "";
 
-const LegacyAWSTaxIDEncryptionClient = isLocal
-  ? new MockCryptoClient()
-  : AWSCryptoFactory(LEGACY_AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY, {
-      stage: AWS_CRYPTO_CONTEXT_STAGE,
-      purpose: AWS_CRYPTO_CONTEXT_TAX_ID_ENCRYPTION_PURPOSE,
-      origin: AWS_CRYPTO_CONTEXT_ORIGIN,
-    });
-
 const AWSTaxIDEncryptionClient = isLocal
   ? new MockCryptoClient()
-  : AWSCryptoFactory(AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY, {
-      stage: AWS_CRYPTO_CONTEXT_STAGE,
-      purpose: AWS_CRYPTO_CONTEXT_TAX_ID_ENCRYPTION_PURPOSE,
-      origin: AWS_CRYPTO_CONTEXT_ORIGIN,
-    });
+  : AWSCryptoFactory(
+      AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY,
+      {
+        stage: AWS_CRYPTO_CONTEXT_STAGE,
+        purpose: AWS_CRYPTO_CONTEXT_TAX_ID_ENCRYPTION_PURPOSE,
+        origin: AWS_CRYPTO_CONTEXT_ORIGIN,
+      },
+      undefined,
+      [LEGACY_AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY],
+      AWS_CRYPTO_TAX_ID_DECRYPT_ONLY_CONTEXTS,
+    );
 
 const AWSTaxIDHashingClient = isLocal
   ? new MockCryptoClient()
@@ -365,16 +365,22 @@ const userDataClient = DynamoUserDataClient(
   USERS_TABLE,
   dataLogger,
   {
-    legacyTaxIdCryptoClient: LegacyAWSTaxIDEncryptionClient,
     newHashingClient: AWSTaxIDHashingClient,
   },
 );
 const businessesDataClient = DynamoBusinessDataClient(dynamoDb, BUSINESSES_TABLE, dataLogger);
+const migrationDataClient = DynamoMigrationDataClient({
+  db: dynamoDb,
+  userDataClient,
+  usersTableName: USERS_TABLE,
+  businessesTableName: BUSINESSES_TABLE,
+});
 const dynamoDataClient = DynamoDataClient(
   userDataClient,
   businessesDataClient,
   dataLogger,
   isKillSwitchOn,
+  migrationDataClient,
 );
 
 const taxFilingInterface = taxFilingsInterfaceFactory(taxFilingClient);

--- a/api/src/functions/migrateUsersVersion/app.test.ts
+++ b/api/src/functions/migrateUsersVersion/app.test.ts
@@ -1,0 +1,63 @@
+import { AWSCryptoFactory } from "@client/AwsCryptoFactory";
+import { createDynamoDbClient } from "@db/config/dynamoDbConfig";
+import { DynamoBusinessDataClient } from "@db/DynamoBusinessDataClient";
+import { DynamoDataClient } from "@db/DynamoDataClient";
+import { DynamoMigrationDataClient } from "@db/DynamoMigrationDataClient";
+import { DynamoUserDataClient } from "@db/DynamoUserDataClient";
+import { handler } from "@functions/migrateUsersVersion/app";
+import { isKillSwitchOn } from "@libs/ssmUtils";
+
+jest.mock("@client/AwsCryptoFactory");
+jest.mock("@db/config/dynamoDbConfig");
+jest.mock("@db/DynamoBusinessDataClient");
+jest.mock("@db/DynamoDataClient");
+jest.mock("@db/DynamoMigrationDataClient");
+jest.mock("@db/DynamoUserDataClient");
+jest.mock("@libs/ssmUtils");
+
+describe("migrateUsersVersion handler", () => {
+  const migrateOutdatedVersionUsers = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (isKillSwitchOn as jest.Mock).mockResolvedValue(false);
+    (createDynamoDbClient as jest.Mock).mockReturnValue({});
+    (AWSCryptoFactory as jest.Mock).mockReturnValue({});
+    (DynamoUserDataClient as jest.Mock).mockReturnValue({});
+    (DynamoBusinessDataClient as jest.Mock).mockReturnValue({});
+    (DynamoMigrationDataClient as jest.Mock).mockReturnValue({});
+    (DynamoDataClient as jest.Mock).mockReturnValue({ migrateOutdatedVersionUsers });
+  });
+
+  it("throws so Lambda Errors alarms and activates the kill switch", async () => {
+    migrateOutdatedVersionUsers.mockResolvedValue({
+      success: false,
+      error: "AccessDeniedException",
+    });
+
+    await expect(handler()).rejects.toThrow("AccessDeniedException");
+  });
+
+  it("resolves when every user migration succeeds", async () => {
+    migrateOutdatedVersionUsers.mockResolvedValue({
+      success: true,
+      migratedCount: 3,
+    });
+
+    await expect(handler()).resolves.toBeUndefined();
+    expect(DynamoMigrationDataClient).toHaveBeenCalled();
+  });
+
+  it("stops starting users when the Lambda reaches its shutdown buffer", async () => {
+    migrateOutdatedVersionUsers.mockResolvedValue({
+      success: true,
+      migratedCount: 1,
+    });
+    const getRemainingTimeInMillis = jest.fn().mockReturnValue(30_000);
+
+    await handler(undefined, { getRemainingTimeInMillis });
+
+    const options = migrateOutdatedVersionUsers.mock.calls[0][0];
+    expect(options.canStartNextUser()).toBe(false);
+  });
+});

--- a/api/src/functions/migrateUsersVersion/app.ts
+++ b/api/src/functions/migrateUsersVersion/app.ts
@@ -2,6 +2,7 @@ import { AWSCryptoFactory } from "@client/AwsCryptoFactory";
 import { createDynamoDbClient } from "@db/config/dynamoDbConfig";
 import { DynamoBusinessDataClient } from "@db/DynamoBusinessDataClient";
 import { DynamoDataClient } from "@db/DynamoDataClient";
+import { DynamoMigrationDataClient } from "@db/DynamoMigrationDataClient";
 import { DynamoUserDataClient } from "@db/DynamoUserDataClient";
 import {
   AWS_CRYPTO_CONTEXT_ORIGIN,
@@ -9,6 +10,7 @@ import {
   AWS_CRYPTO_CONTEXT_TAX_ID_ENCRYPTION_PURPOSE,
   AWS_CRYPTO_CONTEXT_TAX_ID_HASHING_PURPOSE,
   AWS_CRYPTO_TAX_ID_ENCRYPTED_HASHING_SALT,
+  AWS_CRYPTO_TAX_ID_DECRYPT_ONLY_CONTEXTS,
   AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY,
   AWS_CRYPTO_TAX_ID_HASHING_KEY,
   BUSINESSES_TABLE,
@@ -21,7 +23,13 @@ import {
 import { ConsoleLogWriter, LogWriter } from "@libs/logWriter";
 import { isKillSwitchOn } from "@libs/ssmUtils";
 
-export const handler = async (): Promise<void> => {
+const MIGRATION_SHUTDOWN_BUFFER_MS = 30_000;
+
+interface LambdaTimeContext {
+  getRemainingTimeInMillis(): number;
+}
+
+export const handler = async (_event?: unknown, context?: LambdaTimeContext): Promise<void> => {
   const isLocal = STAGE === "local";
 
   const logger = isLocal
@@ -34,17 +42,17 @@ export const handler = async (): Promise<void> => {
   }
 
   const dynamoDb = createDynamoDbClient(IS_DOCKER, DYNAMO_OFFLINE_PORT);
-  const AWSTaxIDEncryptionClient = AWSCryptoFactory(AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY, {
-    stage: AWS_CRYPTO_CONTEXT_STAGE,
-    purpose: AWS_CRYPTO_CONTEXT_TAX_ID_ENCRYPTION_PURPOSE,
-    origin: AWS_CRYPTO_CONTEXT_ORIGIN,
-  });
-
-  const LegacyAWSTaxIDEncryptionClient = AWSCryptoFactory(LEGACY_AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY, {
-    stage: AWS_CRYPTO_CONTEXT_STAGE,
-    purpose: AWS_CRYPTO_CONTEXT_TAX_ID_ENCRYPTION_PURPOSE,
-    origin: AWS_CRYPTO_CONTEXT_ORIGIN,
-  });
+  const AWSTaxIDEncryptionClient = AWSCryptoFactory(
+    AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY,
+    {
+      stage: AWS_CRYPTO_CONTEXT_STAGE,
+      purpose: AWS_CRYPTO_CONTEXT_TAX_ID_ENCRYPTION_PURPOSE,
+      origin: AWS_CRYPTO_CONTEXT_ORIGIN,
+    },
+    undefined,
+    [LEGACY_AWS_CRYPTO_TAX_ID_ENCRYPTION_KEY],
+    AWS_CRYPTO_TAX_ID_DECRYPT_ONLY_CONTEXTS,
+  );
 
   const AWSTaxIDHashingClient = AWSCryptoFactory(
     AWS_CRYPTO_TAX_ID_HASHING_KEY,
@@ -62,17 +70,29 @@ export const handler = async (): Promise<void> => {
     USERS_TABLE,
     logger,
     {
-      legacyTaxIdCryptoClient: LegacyAWSTaxIDEncryptionClient,
       newHashingClient: AWSTaxIDHashingClient,
     },
   );
 
   const businessesDataClient = DynamoBusinessDataClient(dynamoDb, BUSINESSES_TABLE, logger);
+  const migrationDataClient = DynamoMigrationDataClient({
+    db: dynamoDb,
+    userDataClient,
+    usersTableName: USERS_TABLE,
+    businessesTableName: BUSINESSES_TABLE,
+  });
   const dynamoDataClient = DynamoDataClient(
     userDataClient,
     businessesDataClient,
     logger,
     isKillSwitchOn,
+    migrationDataClient,
   );
-  await dynamoDataClient.migrateOutdatedVersionUsers();
+  const result = await dynamoDataClient.migrateOutdatedVersionUsers({
+    canStartNextUser: () =>
+      !context || context.getRemainingTimeInMillis() > MIGRATION_SHUTDOWN_BUFFER_MS,
+  });
+  if (!result.success) {
+    throw new Error(result.error ?? "User migration failed");
+  }
 };

--- a/content/src/spellcheck-exceptions.json
+++ b/content/src/spellcheck-exceptions.json
@@ -391,6 +391,7 @@
     "Middlesex",
     "Mikie",
     "milestonevp",
+    "Millis",
     "Millville",
     "minh",
     "Miniwarehouses",

--- a/shared/src/userData.ts
+++ b/shared/src/userData.ts
@@ -45,7 +45,7 @@ export interface Business {
   readonly crtkData: CrtkData | undefined;
 }
 
-export const CURRENT_VERSION = 192;
+export const CURRENT_VERSION = 193;
 
 export const createEmptyBusiness = ({
   userId,


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

`POST /api/decrypt` can return HTTP 500 with `{"error":"unencryptedDataKey has not been set"}` when a user reveals a tax ID or another protected identifier that was encrypted before the stage-specific KMS key rotation.

A prior KMS rotation introduced a current key per stage. Some ciphertext remained wrapped by the legacy key. `AWSCryptoFactory` currently uses one generator keyring for encryption and decryption. A strict single-key keyring
discards encrypted data keys wrapped by any other key before calling KMS, so a current-only client cannot decrypt legacy ciphertext and a legacy-only client cannot decrypt ciphertext already rotated to the current key.

The migration runner compounds the incident. It catches individual migration errors, continues the chain, forces `CURRENT_VERSION`, and persists the result. This can remove a partially migrated record from future version scans.

User data is duplicated across one users-table item containing embedded businesses and separate businesses-table projections. There are no DynamoDB Streams synchronizing these copies. Existing migration writes can therefore
advance the users-table version while leaving one or more business projections unchanged.

The production `migrateUsersVersion` Lambda is enabled every five minutes during its daily window. Recent CloudWatch metrics show every invocation failing. Its deployed environment omits the hashing key, hashing purpose, and hashing salt read by the handler.

This PR restores access to those values and provides a safe path for the scheduled user migration to converge every affected record onto the current key. It also closes a separate migration failure mode that could mark a partially migrated record as current and prevent the scheduler from ever finding it again.

### Ticket

This pull request resolves [#17957](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17957).

### What failed beyond `/api/decrypt`

The HTTP 500 was the most visible symptom, but it was only one point in a larger failure chain:

1. **Some protected fields became unreadable while others still worked.** The failure was field-specific, not necessarily user-specific. A user could have one value wrapped by the legacy key and another wrapped by the current key, so revealing one tax identifier could succeed while another returned `unencryptedDataKey has not been set`. The error did not by itself mean that KMS rejected access or that the ciphertext had been corrupted. It meant the local keyring discarded every encrypted data key in that ciphertext before making a KMS request.
2. **The v191 and v192 migrations could disagree with the ciphertext they received.** v191 decrypted with a legacy-only client and re-encrypted with the current key. v192 repeated the crypto work but still decrypted with the legacy-only client. If v191 succeeded, v192 could immediately fail because it was being asked to decrypt newly current-wrapped ciphertext with the wrong strict keyring. Records created on a newer version could begin with current-wrapped ciphertext and encounter the same legacy-only mismatch.
3. **A migration error could become permanent record state.** The old migration runner caught an individual migration exception, logged it, continued the chain, and returned the record with `CURRENT_VERSION` forced onto it. The subsequent write could therefore persist an incompletely transformed record as current. Scheduled scans select records by version, so that record would no longer be selected for another attempt even though one or more protected fields still required repair.
4. **The failure log exposed too much data without reliably identifying the failing operation.** The old catch block serialized the full in-memory user record. That could put email addresses, ciphertext, and unrelated user data into a migration error while still leaving operators to infer which field and crypto phase had failed. This PR replaces that with migration, field, attempt, version, and persistence-phase context without logging plaintext, ciphertext, tax identifiers, email addresses, or complete records.
5. **The users table and businesses table could diverge.** The users-table item was written first, followed by separate business projection writes. A later business write failure was logged and swallowed. That could leave the canonical user stamped current while one or more business-table projections remained on an older schema or retained old ciphertext.
6. **The scheduled repair path had an independent configuration failure.** The Lambda's CDK environment omitted the hashing key, hashing purpose, and hashing salt required by v191 and v192. A record that reached the hashing step could fail with `Salt must be provided`, even after its KMS decryption issue was fixed.
7. **Scheduled failures did not reliably become Lambda failures.** Per-user work used `Promise.allSettled`, rejected users were logged, the outer migration method converted thrown errors into `{ success: false }`, and the handler did not rethrow that result. CloudWatch could therefore see a successful Lambda invocation even when no affected user was repaired.
8. **The existing alarm watched for a message that was never emitted.** Its metric filter matched `"MigrateUserVersions Failed"`, while the relevant code logged messages such as `"MigrateData Failed"` or `"Failed to migrate user"`. A persistent migration failure could therefore avoid both the operator alert and the automatic kill-switch path.
9. **Testing had two authenticated encryption contexts.** Before the CircleCI-to-GitHub Actions deployment migration, testing inherited the dev encryption context: `stage=dev`, `purpose=tax_id_encryption`, and `origin=us-east-1`. The GitHub Actions workflow kept the testing application stage but omitted `AWS_CRYPTO_CONTEXT_STAGE` and `AWS_CRYPTO_CONTEXT_ORIGIN`, so the deployed Lambdas expected empty values and newer testing ciphertext was written with that empty context. Once the compatible keyring found the affected legacy encrypted data key, the existing post-decryption validation correctly rejected its historical dev context.
10. **The request-time fallback retried migration through the GET route.** The data client caught the v193 failure and returned the unchanged v192 record as designed. The user GET route then ran its ordinary derived updates and unconditionally called `put()`, which attempted v193 a second time and surfaced the same failure as HTTP 500. Returning an unchanged record only preserves availability if the caller also avoids mutating and persisting that outdated fallback.

Together, those behaviors created a feedback loop: a key or authenticated-context mismatch could prevent decryption, the migration framework could hide that failure by advancing the version anyway, the two table representations could disagree, the request fallback could retry the failed migration, and the scheduled process could continue reporting successful invocations without making the record eligible for repair again.

### KMS background

Navigator uses the [AWS Encryption SDK's envelope-encryption model](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/how-it-works.html):

1. The SDK generates a one-time data key and uses it to encrypt the sensitive value.
2. KMS encrypts, or "wraps," that data key with a customer managed KMS key (CMK).
3. The resulting ciphertext stores the encrypted value, the wrapped encrypted data key, the wrapping key's identifier, and the encryption context.
4. During decryption, the [AWS KMS keyring](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/use-kms-keyring.html) first selects an encrypted data key whose wrapping key is allowed. Only after that selection does it ask KMS to unwrap the data key.

Before this change, Navigator used one strict keyring configured with only the current key for both encryption and decryption. Ciphertext written with the legacy key still contained a valid encrypted data key, but the keyring rejected it because its wrapping key was not configured. With no acceptable encrypted data key left, the Encryption SDK raised `unencryptedDataKey has not been set` before making a KMS request.

This distinction matters operationally:

- `unencryptedDataKey has not been set` means the local keyring could not find an allowed encrypted data key in the ciphertext.
- An IAM, disabled-key, throttling, or KMS availability error means the keyring found a configured key and the subsequent KMS operation failed.
- Malformed ciphertext or an unexpected [encryption context](https://docs.aws.amazon.com/kms/latest/developerguide/encrypt_context.html) must fail closed; it is not a signal to skip that field and mark the record migrated. Deployment verification showed one exact, explainable exception in testing: a historical workflow omission created a second known context. This PR allowlists that complete historical context rather than weakening validation generally.

#### Terms used in this PR

- **Plaintext:** the original tax ID, tax PIN, or employer identifier. Plaintext must never be written to logs or stored directly.
- **Data key:** a short-lived symmetric key generated for encrypting a value. AWS explains the distinction between plaintext and encrypted copies in its [data key documentation](https://docs.aws.amazon.com/kms/latest/developerguide/data-keys.html).
- **Encrypted data key (EDK):** the data key after a KMS key wraps it. The EDK can be stored alongside ciphertext because KMS authorization is still required to unwrap it.
- **Wrapping key or KMS key:** the stage-specific customer managed key that encrypts the data key. This PR calls the previous wrapping key the legacy key and the replacement the current key.
- **Generator key:** the keyring's KMS key used when creating new ciphertext. Only the current key may be a generator after this change.
- **Keyring:** the Encryption SDK component that decides which keys may create EDKs during encryption and which EDKs may be considered during decryption.
- **Encryption context:** authenticated, non-secret metadata describing the stage, purpose, and origin of the ciphertext. Navigator verifies those values after decrypting so ciphertext created for a different context cannot be silently accepted.
- **Primary encryption context:** the exact stage, purpose, and origin used for new ciphertext. Encryption always uses this context.
- **Decrypt-only encryption context:** a complete historical stage, purpose, and origin combination that may be accepted during convergence but is never used for new encryption.
- **Ciphertext message:** the serialized Encryption SDK output containing the encrypted value, EDK metadata, encryption context, and algorithm information. AWS documents those components in the [Encryption SDK message format](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/message-format.html).

### A concrete mixed-key example

Consider a hypothetical v191 user with two businesses after the original rotation:

- Business A's profile tax ID is still wrapped by the legacy key.
- Business A's tax PIN was updated later and is wrapped by the current key.
- Business B's tax-clearance tax ID is still wrapped by the legacy key because that field was omitted from the earlier migration type tree.

Before this PR:

1. The current-only runtime client could decrypt the tax PIN but rejected both legacy-wrapped tax IDs before calling KMS.
2. The legacy-only migration client could decrypt the tax IDs but rejected the current-wrapped tax PIN.
3. Because migration operates on the whole user, either single-key client eventually encountered a field it could not accept.
4. The old runner could catch that failure, force the root record to the latest version, and persist it. A later scheduled scan then saw the version as current and skipped the user even though the fields remained mixed.
5. If the users-table write succeeded and a later business projection write failed, the two tables could disagree about both schema version and ciphertext.

After this PR, the decryption allowlist accepts both expected wrapping keys, every affected field is rotated in memory, and the users-table item plus all business projections commit in one transaction. The record moves forward only when the complete migration unit succeeds.

### Approach

#### Keep encryption current-only while allowing compatible decryption

`AWSCryptoFactory` now creates separate keyrings for the two directions:

- Encryption uses only the current stage CMK as the generator key. New ciphertext cannot be wrapped by the legacy key.
- Decryption uses a strict allowlist containing the full ARNs of the current and legacy stage CMKs. It does not accept arbitrary KMS keys.

The same crypto client can therefore decrypt a record containing either generation of ciphertext while continuing to produce current-key-only ciphertext. Encryption-context validation remains in place after decryption.

This intentionally does not configure one encryption keyring with both keys. The Encryption SDK can use [multi-keyrings](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/use-multi-keyring.html) to wrap a data key under a generator key and additional child keys during encryption. That is useful when new ciphertext should carry multiple EDKs, but it is the wrong contract here because the legacy key must be decrypt-only. Separate direction-specific keyrings make the asymmetry explicit: write with exactly one current key, read with exactly two allowlisted keys during convergence.

The decrypt keyring is also deliberately not a discovery keyring. Restricting it to full current and legacy CMK ARNs prevents Navigator from accepting ciphertext merely because the Lambda role happens to have access to some other KMS key.

The Encryption SDK reuses its regional KMS clients, and the AWS SDK performs its [standard retry behavior with exponential backoff](https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html) with three total attempts. This PR does not add a second retry layer around those network calls. The local tax-ID hashing step is retried up to three total attempts and logs each failed attempt with migration and field context.

Ciphertext already wrapped by the current key may be decrypted and re-encrypted once by the catch-up migration. Avoiding those one-time KMS calls would require additional ciphertext inspection and branching without changing the final state, so it is intentionally outside this repair.

#### Preserve exact encryption-context compatibility in testing

The testing workflow now restores `AWS_CRYPTO_CONTEXT_STAGE` from the dev context variable and explicitly supplies `AWS_CRYPTO_CONTEXT_ORIGIN`. New testing ciphertext therefore returns to the historical primary context: `dev`, `tax_id_encryption`, and `us-east-1`.

`AWSCryptoFactory` can also receive explicit decrypt-only contexts. After KMS decrypts a message, the complete header context must match either the primary context or one complete decrypt-only context. Values cannot be mixed across allowed contexts, and there are no wildcard stage, purpose, or origin values.

Only `STAGE=testing` receives the historical GitHub Actions context with empty stage and origin. This covers both legacy-key/dev-context records and current-key/empty-context records created during the workflow gap. v193 re-encrypts either form with the current key and corrected primary context, so the exception converges existing data instead of creating more empty-context ciphertext. Staging and production do not receive this compatibility context.

This remains distinct from a discovery keyring or disabled context validation. A ciphertext must use an allowlisted full KMS key ARN and one exact accepted context combination.

#### Repair the migration chain before adding v193

Adding only a v193 migration would not repair users whose stored version is older than v192. Navigator runs migrations in order, so a v190 record must successfully complete v191 and v192 before v193 can execute.

| Stored version | Required path after deployment | Reason |
| --- | --- | --- |
| v190 or earlier | Existing migrations through v190, then v191, v192, and v193 | Migrations cannot be skipped. v190 itself does not use KMS, but v191 and v192 require the repaired clients and fail-fast runner. |
| v191 | v192, then v193 | The record may already contain a mixture of legacy- and current-wrapped fields. |
| v192 | v193 | The catch-up migration re-enrolls records already stamped current by the previous runner and rotates fields omitted earlier. |
| v193 | No migration | New writes already use the current key, and the record is outside the scheduler's outdated-version scan. |

This PR updates the existing migration path so that:

- the compatible crypto client and hashing client are available to the migrations that need them;
- the scheduled Lambda receives the hashing key, purpose, and salt that were missing from its environment;
- migrations stop immediately at the first failure;
- the runner no longer catches an error, continues later migrations, and force-stamps `CURRENT_VERSION`; and
- migration work occurs on a copy, so a failed migration leaves the stored source record unchanged.

This makes older records able to reach v193 and keeps failed records eligible for the next scheduled attempt.

#### Use v193 as a complete catch-up rotation

The v193 migration decrypts with the current-plus-legacy allowlist and re-encrypts with the current key for every persisted field affected by the rotation:

- `profileData.encryptedTaxId`
- `profileData.encryptedTaxPin`
- `profileData.deptOfLaborEin`
- `cigaretteLicenseData.encryptedTaxId`
- `taxClearanceCertificateData.encryptedTaxId`
- `taxClearanceCertificateData.encryptedTaxPin`

The tax-clearance fields are included because runtime code can persist them, even though the v191 and v192 versioned type trees did not declare them.

All affected fields in all of a user's businesses must succeed in memory. A missing optional field remains absent. A malformed value, unsupported wrapping key, exhausted KMS error, encryption error, or exhausted hash error fails the whole user migration; the code does not preserve the bad field while advancing the record's version.

#### Commit the user and all business projections atomically

Navigator stores each user's businesses in two places:

- embedded in the users-table item; and
- as separate items in the businesses table.

There is no DynamoDB Stream synchronizing those copies. Updating the users item first and then writing businesses individually could therefore leave the user at v193 while one or more business projections remained on an older version.

Successful request-time and scheduled migrations now use one `TransactWriteItems` call containing the users-table put and every corresponding businesses-table put. DynamoDB commits all of those writes or none of them.

The users-table put is conditional on the exact source snapshot read before migration. If another request changes that record first, DynamoDB cancels the transaction, no migration writes commit, and the newer record remains authoritative. That concurrency conflict is expected contention and is retried on a later pass; it is not treated as a terminal data or infrastructure failure.

Existing drift in a businesses-table projection does not block repair. The users-table snapshot remains canonical and overwrites each projection as part of the successful transaction.

DynamoDB limits a transaction to 100 items, so one user and at most 99 businesses can be migrated as one unit. A record above that limit is a terminal failure requiring operator attention rather than a partial write.

#### Preserve request-time availability

Reading a user record may attempt a migration, but a migration problem must not turn the application read itself into an outage.

Request-time and scheduled migration share the same transformation and atomic transaction, but they have different responsibilities at the outer boundary. The request path protects application availability, so failure returns the unchanged stored record. The scheduled path owns convergence and operational detection, so a persistent terminal failure must stop the backfill, alert the team, and activate the kill switch instead of quietly moving to the next user.

If the migration kill switch is enabled, request-time migration is skipped and the unchanged stored record is returned. If a request-time migration fails:

- no migration data is written;
- the failure is logged with source version, target version, failed field or persistence phase, and the root error; and
- the unchanged stored record is returned to the caller.

Request-time logs do not serialize the user record or include an email address, plaintext, ciphertext, tax identifier, or user identifier. Request-time failures also do not directly activate the kill switch. The scheduled Lambda is the circuit-breaker owner and will encounter persistent failures independently.

Deployment verification exposed one additional caller responsibility. When `databaseClient.get()` returns an unchanged record below `CURRENT_VERSION`, the user GET route now recognizes that version as a migration fallback, sanitizes it, and returns HTTP 200 without running derived business-name, operating-phase, sidebar, license, or x-ray updates and without calling `put()`. A successfully migrated current record continues through the ordinary update-and-save path.

#### Stop and alert on scheduled terminal failures

The scheduled migration distinguishes retryable contention from a terminal failure:

- A transaction conflict is logged and skipped so a later scheduled pass can retry the newer record.
- A terminal field, record, KMS, hashing, configuration, permission, or persistence failure stops processing and fails the Lambda invocation.

The terminal scheduled log includes the opaque DynamoDB user key and non-sensitive migration context so an operator can locate the record. It does not include the email address, plaintext, ciphertext, tax identifiers, or full record.

The Lambda timeout is increased to four minutes. It stops starting another user when less than 30 seconds remain, exits successfully, and leaves the remaining users for the next scheduled invocation. This prevents normal KMS workload duration from looking like a structural migration failure.

Monitoring now alarms on the native `AWS/Lambda` `Errors` metric for the migration function instead of matching a log phrase the function did not emit. The first failed invocation publishes to both the existing operator-alert topic and the existing migration kill-switch topic. That path alerts the team and enables the SSM migration kill switch automatically.

The Lambda role retains its existing access to both configured KMS keys and receives the DynamoDB transaction permission required by the new atomic write path.

### Why this is the smallest deployable vertical slice

The runtime keyring change is the smallest code change that restores `POST /api/decrypt` for legacy ciphertext, but it is not independently sufficient to resolve the incident for existing users:

1. **Records must converge off the legacy key.** Leaving permanent dual-key decryption in place would make the legacy key an indefinite runtime dependency and leave the affected data unmigrated.
2. **Older records cannot jump directly to v193.** The ordered migration chain must be able to complete v191 and v192 first, including their crypto and hashing work.
3. **The old runner could permanently strand failures.** A catch-up migration is unsafe if an earlier failure can still be swallowed and the record stamped current.
4. **A user is duplicated across two tables.** Rotating sensitive fields while advancing only one copy can create a partially migrated record, so the persistence boundary must be atomic.
5. **The scheduled Lambda is the recovery mechanism.** It needs the same crypto and hashing configuration, enough execution time, the necessary IAM permissions, and a reliable terminal-failure signal.
6. **A terminal failure must stop the backfill.** Continuing after a malformed record or structural KMS problem risks repeating partial or invalid work across the database. The existing alarm and kill-switch path must therefore be connected to real Lambda failures.
7. **Known testing contexts must converge without weakening context authentication.** Correcting the workflow alone would make empty-context ciphertext unreadable, while keeping the empty primary context would continue producing incorrectly scoped ciphertext. The exact decrypt-only context provides the compatibility window needed to rewrite both populations correctly.
8. **Read fallback must survive the full HTTP request path.** Catching migration inside the data client is insufficient if the route immediately writes the outdated record and retries the same migration. The route-level version guard is part of the availability boundary.

These concerns span crypto configuration, migration logic, persistence, versioned schemas, Lambda infrastructure, IAM, monitoring, and tests, but they form one operational path: read legacy ciphertext, safely transform the whole migration unit, commit it once, and stop visibly if that cannot be done. Removing any one of those pieces would either fail to reach affected records, permit partial migration, or leave the scheduled repair unable to run safely.

Much of the apparent diff is also required by the repository's migration architecture rather than by new product behavior. Each migration carries a complete versioned TypeScript type tree, and the version bump must remain consistent with the migration registry, shared `CURRENT_VERSION`, Zod schemas, and schema-generation tooling. The runtime behavior remains narrowly limited to the KMS compatibility and migration-safety path described above.

### Failure behavior after this PR

| Condition | Request-time behavior | Scheduled behavior |
| --- | --- | --- |
| Value is wrapped by the current key | Decrypt and continue | Rotate once and continue |
| Value is wrapped by the configured legacy key | Decrypt and continue | Rotate to the current key |
| Testing value uses the corrected `dev` / `tax_id_encryption` / `us-east-1` context | Decrypt and continue | Rotate once with the corrected primary context |
| Testing value uses the known empty-stage and empty-origin context | Decrypt and continue through the testing-only compatibility context | Rotate to the corrected primary context |
| Wrapping key is not configured | Return the unchanged record and log context | Fail the invocation and activate the alert/kill-switch path |
| KMS permission, key-state, throttling, timeout, or availability failure after SDK retries | Return the unchanged record and log context | Fail the invocation and activate the alert/kill-switch path |
| Malformed ciphertext or any non-allowlisted encryption context | Return the sanitized unchanged record without a follow-up write and log context | Fail the invocation and activate the alert/kill-switch path |
| Re-encryption fails after SDK retries | Return the unchanged record and log context | Fail the invocation and activate the alert/kill-switch path |
| Hashing fails after three total attempts | Return the unchanged record and log each attempt | Fail the invocation and activate the alert/kill-switch path |
| Source record changes before the transaction commits | Return the unchanged source read | Skip as retryable contention; reconsider the newer record later |
| Lambda approaches its timeout between users | Not applicable | Stop cleanly; resume remaining users on the next invocation |

### Steps to Test

Automated verification completed for this branch:

1. Run `CI=true ./scripts/pre-commit.sh`.
   - Formatting, linting, type checking, builds, spellcheck, and configured unit suites pass.
2. Start the repository services and development application.
   - The local web and API applications start successfully.
3. Run the configured Cypress end-to-end suite against the development stack.
   - The affected user workflows pass.
   - One unrelated dashboard interaction timed out in the full run and then passed repeatedly in an isolated seeded rerun.
4. Run the API and CDK suites independently.
   - Crypto/keyring, migration, transaction, Lambda, IAM, and monitoring coverage passes.
5. Run `git diff --check`.
   - No whitespace errors are reported.
6. Run the lead PR review workflow.
   - No pebbles or boulders remain.

The focused tests cover:

- current-only encryption and strict current-plus-legacy decryption;
- encryption-context mismatch and malformed/decryption failure propagation;
- exact decrypt-only context acceptance and rejection when any stage, purpose, or origin value differs;
- failures representing unconfigured keys, IAM/KMS errors, exhausted encryption errors, and exhausted hashing errors;
- hashing success after retry and failure after the final attempt;
- fail-fast migration ordering and unchanged source data on failure;
- rotation of every affected field across multiple businesses;
- one conditional transaction for the user and all business projections;
- no write when any field fails;
- retryable transaction conflicts and terminal transaction failures;
- request-time fallback to the sanitized unchanged stored record, including a route-level assertion that no derived updater or follow-up write runs;
- scheduled Lambda failure propagation and timeout-aware clean stopping; and
- native Lambda error alarming to the operator and kill-switch topics.

Follow-up verification after the testing deployment ran 176 API/CDK suites with 971 passing tests, then reran the 93 tests covering the crypto factory, data client, and user route after the fallback correction. API type checking, linting, formatting, documentation spellcheck, and `git diff --check` also pass.

### Deployment verification

The following checks require deployed AWS resources and should be completed in dev before production rollout:

1. Confirm the current and legacy key settings are full stage-specific CMK ARNs and that the Lambda role has the intended least-privilege KMS access.
2. Encrypt a new value and verify its ciphertext contains only the current wrapping key and the intended primary encryption context.
3. Verify `POST /api/decrypt` can decrypt representative ciphertext wrapped by both the current and legacy keys with their expected contexts.
4. Exercise representative v190, v191, and v192 records through v193.
5. Run a real DynamoDB transaction for a user with multiple business projections, including an intentionally drifted projection.
6. Confirm a failed field leaves both tables unchanged.
7. Confirm a conditional transaction conflict commits nothing and does not activate the kill switch.
8. Confirm a scheduled terminal failure raises the Lambda `Errors` metric, alerts operators, and enables the migration kill switch.

The testing deployment has now verified the failure and corrective crypto path against deployed AWS resources:

1. The deployed express and migration Lambdas both had empty `AWS_CRYPTO_CONTEXT_STAGE` and `AWS_CRYPTO_CONTEXT_ORIGIN` values.
2. The affected v192 record's ciphertext header used the legacy testing key with `dev`, `tax_id_encryption`, and `us-east-1`.
3. The updated client decrypted that real ciphertext, re-encrypted the plaintext with the current testing key and corrected primary context, and decrypted the result successfully. The check did not persist plaintext or ciphertext, and the source record remained at v192.
4. CloudWatch logs confirmed the availability bug's two phases in one request: `get()` logged and caught the first v193 context failure, then the GET route's follow-up `put()` retried v193 and produced the HTTP 500. The route regression test now covers the no-update, no-write fallback behavior.

DynamoDB Local in this repository does not implement `TransactWriteItems`, so the command shape and behavior are covered by unit tests while the real transaction remains a dev deployment check. The affected legacy-key ciphertext and a generated current-key ciphertext have now been exercised with the deployed testing keys. Equivalent staging and production key/context verification remains a rollout check and cannot be proven by the local test environment.

### Rollout and rollback

This migration is forward-only after any v193 record is persisted. Rolling the entire application back to the previous v192 implementation would restore the migration runner that can swallow failures and force the version forward.

If a rollback is required after migration begins:

- enable the migration kill switch to stop additional work; and
- retain the compatible decrypt keyring, fail-fast migration runner, and request-time fallback while rolling forward with a corrective deployment.

The legacy key must remain enabled and authorized for decryption until a verified scan confirms no legacy-wrapped ciphertext remains.

### Notes and follow-up work

The following improvements are intentionally deferred because they are broader than this KMS repair:

- Reject ordinary writes when a stale browser submits a schema version older than the stored users-table version. The migration transaction protects against writes that happen before it commits, but a browser that loaded v192 can still save after v193 and downgrade the record.
- Redesign users-table and businesses-table projection synchronization around DynamoDB Streams.
- Remove legacy-key decryption only after a verified zero-legacy-ciphertext scan.
- Generalize migration-framework cleanup beyond the paths required to reach v193.
- Improve migration throughput, dashboards, and structured tracing beyond the contextual non-PII logs required for this repair.
- Replace the legacy Serverless-style hashing-salt placeholder with CDK-native SSM retrieval across all hash producers, followed by a coordinated rehash of existing records.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts`
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews


