### PR TITLE
fix: decap-cms-app ESM default export broke CMS init

### DIFF
--- a/web/src/pages/mgmt/cms.tsx
+++ b/web/src/pages/mgmt/cms.tsx
@@ -61,6 +61,7 @@ import TaxInputPreview from "@/lib/cms/previews/TaxInputPreview";
 import XrayRenewalCalendarEventPreview from "@/lib/cms/previews/XrayRenewalCalendarEventPreview";
 import XrayTaskPreview from "@/lib/cms/previews/XrayTaskPreview";
 import { useMountEffect } from "@/lib/utils/helpers";
+import type { CMS as CmsType } from "decap-cms-core";
 import { GetStaticPropsResult } from "next";
 import dynamic from "next/dynamic";
 import { ReactElement } from "react";
@@ -69,7 +70,16 @@ import SelectIndustryPreview from "@/lib/cms/previews/SelectIndustryPreview";
 import jsYaml from "js-yaml";
 
 const CMS_CONFIG = {};
-const Loading = (): ReactElement => {
+const Loading = ({ error }: { error?: Error | null }): ReactElement => {
+  if (error) {
+    return (
+      <div role="alert" className="min-h-screen flex items-center justify-center">
+        <p className="text-red-600 font-semibold text-xl">
+          Failed to load the CMS: {error.message}
+        </p>
+      </div>
+    );
+  }
   return (
     <div className="min-h-screen flex items-center justify-center">
       <p className="text-gray-500 font-semibold text-xl">Loading...</p>
@@ -77,34 +87,26 @@ const Loading = (): ReactElement => {
   );
 };
 const CMS = dynamic(
-  // @ts-expect-error: No type definition available
+  // @ts-expect-error: loader resolves void, not a component; decap mounts itself outside the React tree
   () => {
-    return import("decap-cms-app").then((CMS) => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      // @ts-expect-error: No type definition available
+    return import("decap-cms-app").then(({ default: CMS }) => {
+      // @ts-expect-error: decap-cms-core's InitOptions type omits the legacy CMS_CONFIG option
       CMS.init({ CMS_CONFIG });
-      // @ts-expect-error: No type definition available
+      // @ts-expect-error: decap-cms-core's CmsWidgetControlProps type omits setActiveStyle/setInactiveStyle, which decap passes at runtime
       CMS.registerWidget("write-once-read-only-no-space", WriteOnceReadOnlyNoSpaceControl);
-      // @ts-expect-error: No type definition available
+      // @ts-expect-error: decap-cms-core's CmsWidgetControlProps type omits setActiveStyle/setInactiveStyle, which decap passes at runtime
       CMS.registerWidget("no-space", NoSpaceControl);
-      // @ts-expect-error: No type definition available
       CMS.registerEditorComponent(ContextEditor);
-      // @ts-expect-error: No type definition available
       CMS.registerEditorComponent(AlertEditor);
-      // @ts-expect-error: No type definition available
       CMS.registerEditorComponent(Note);
-      // @ts-expect-error: No type definition available
       CMS.registerEditorComponent(CannabisLocationAlert);
-      // @ts-expect-error: No type definition available
       CMS.registerEditorComponent(LargeCallout);
-      // @ts-expect-error: No type definition available
       CMS.registerEditorComponent(MiniCallout);
-      // @ts-expect-error: No type definition available
       CMS.registerEditorComponent(IconWidgetEditor);
-      // @ts-expect-error: No type definition available
       // disables line wrapping in front-matter props
       CMS.registerCustomFormat("yaml", "yml", {
         fromFile: (text: string) => jsYaml.load(text),
+        // @ts-expect-error: decap-cms-core's Formatter type declares toFile's param as object, but decap passes the raw string here
         toFile: (value: string) =>
           jsYaml.dump(value, {
             lineWidth: -1,
@@ -230,30 +232,24 @@ const CMS = dynamic(
   { ssr: false, loading: Loading },
 );
 
-const registerAsTask = (CMS: typeof import("decap-cms-app"), names: string[]): void => {
+const registerAsTask = (CMS: CmsType, names: string[]): void => {
   for (const name of names) {
-    // @ts-expect-error: No type definition available
     CMS.registerPreviewTemplate(name, TaskPreview);
   }
 };
 
-const registerAsCannabisLicensePreview = (
-  CMS: typeof import("decap-cms-app"),
-  names: string[],
-): void => {
+const registerAsCannabisLicensePreview = (CMS: CmsType, names: string[]): void => {
   for (const name of names) {
-    // @ts-expect-error: No type definition available
     CMS.registerPreviewTemplate(name, CannabisLicensePreview);
   }
 };
 
 const registerPreview = (
-  CMS: typeof import("decap-cms-app"),
+  CMS: CmsType,
   name: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   preview: (props: any) => ReactElement,
 ): void => {
-  // @ts-expect-error: No type definition available
   CMS.registerPreviewTemplate(name, applyTheme(preview));
 };
 


### PR DESCRIPTION
## Description

Fixes `/mgmt/cms` (Decap CMS) getting stuck on "Loading..." forever after the React 19 upgrade.

The React 19 upgrade commit also bumped `decap-cms-app` 3.0.12 -> 3.15.1. That version added a `module` (ESM) entry point that the previous version lacked, so webpack started resolving the real ESM build instead of the UMD bundle. In the ESM build, the CMS API lives on the module's `default` export rather than on the namespace object itself, so the existing `import("decap-cms-app").then((CMS) => CMS.init(...))` call was calling `.init` on an object that no longer had it — the import silently rejected and Decap never bootstrapped. The `loading` component passed to `next/dynamic` also ignored the `error` prop, so the failure never reached the console.

### Approach

- Destructure `{ default: CMS }` from the `decap-cms-app` dynamic import instead of using the module namespace.
- Removed now-stale `@ts-expect-error` comments now that `decap-cms-app` ships a `.d.ts`, keeping only the ones still required by real gaps in `decap-cms-core`'s type declarations, with comments explaining each.
- Typed the `CMS` param on `registerAsTask`/`registerAsCannabisLicensePreview`/`registerPreview` as `CMS` from `decap-cms-core`.
- Updated the `Loading` placeholder to render the `error` from `next/dynamic` instead of spinning forever, so a future bootstrap failure is visible.
- No dependency changes; `decap-cms-app@3.15.1` is already the latest published version.

### Steps to Test

1. `yarn workspace @businessnjgovnavigator/web dev`
2. Visit `/mgmt/cms`
3. Confirm the page loads Decap's login screen (not "Loading...") and the browser console logs `decap-cms-core 3.17.1`
4. Log in and open a collection with a custom preview (e.g. Tasks) to confirm the preview pane renders
5. Save an entry to confirm the YAML round-trip still works

### Notes

Confirmed via Playwright against the dev environment that this was reproducible and that patching the default-export access fixes it live (Decap mounted `#nc-root` and rendered its login screen). Also confirmed `decap-cms-app@3.15.1` is npm's current `latest` tag, so no further version bump is available/needed.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews