### PR TITLE
feat: [AB#17939] 'Get Started' dropdown directs users to onboarding

### DIFF
--- a/packages/static-site/components/landing/HeaderAuthButtons.test.tsx
+++ b/packages/static-site/components/landing/HeaderAuthButtons.test.tsx
@@ -47,7 +47,7 @@ describe("HeaderAuthButtons", () => {
     );
     expect(screen.getByRole("link", { name: defaultProps.getStartedLabel })).toHaveAttribute(
       "href",
-      defaultProps.accountAppUrl,
+      `${defaultProps.accountAppUrl}/onboarding`,
     );
   });
 

--- a/packages/static-site/components/landing/HeaderAuthButtons.tsx
+++ b/packages/static-site/components/landing/HeaderAuthButtons.tsx
@@ -65,7 +65,7 @@ export const HeaderAuthButtons = ({
         {isOpen && (
           <ul className="usa-nav__auth-dropdown">
             <li>
-              <a href={accountAppUrl}>{getStartedLabel}</a>
+              <a href={`${accountAppUrl}/onboarding`}>{getStartedLabel}</a>
             </li>
           </ul>
         )}


### PR DESCRIPTION
## Description

Update the "Get Started" dropdown link in the static site header to direct users to the onboarding flow (`/onboarding`) instead of the My Account landing page.

### Ticket

This pull request resolves [#17939](https://dev.azure.com/NJInnovation/Business%20First%20Stop/_workitems/edit/17939).

### Approach

- Appended `/onboarding` to the `accountAppUrl` in the `HeaderAuthButtons` component's "Get Started" link. - Updated the corresponding test assertion.

### Steps to Test

1. Open the static site.
2. Click the "Get Started" dropdown in the header
    - The dropdown appears on every page
3. Verify the link points to `<accountAppUrl>/onboarding`

### Notes

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [X] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews