### PR TITLE
fix: [AB#16176] repair Decap CMS previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -300,6 +300,7 @@
     "glob-parent": "6.0.2",
     "tar": "7.5.21",
     "ansi-regex": "5.0.1",
-    "trim-newlines": "5.0.0"
+    "trim-newlines": "5.0.0",
+    "react-is": "^19.2.0"
   }
 }

--- a/web/src/lib/cms/helpers/CmsUserDataProvider.tsx
+++ b/web/src/lib/cms/helpers/CmsUserDataProvider.tsx
@@ -1,0 +1,31 @@
+import { UserDataContext, UseUserDataResponse } from "@/contexts/userDataContext";
+import { UpdateQueue, UpdateQueueFactory } from "@/lib/UpdateQueue";
+import { UserData } from "@businessnjgovnavigator/shared/userData";
+import { ReactElement, ReactNode, useMemo } from "react";
+
+interface CmsUserDataProviderProps {
+  readonly children: ReactNode;
+}
+
+// Decap mounts previews in its own React root, outside the _app.tsx provider tree.
+// Previews needing populated data pass it via CMS_ONLY_fakeBusiness instead.
+export const CmsUserDataProvider = ({ children }: CmsUserDataProviderProps): ReactElement => {
+  const value = useMemo<UseUserDataResponse>(() => {
+    return {
+      userData: undefined,
+      business: undefined,
+      isLoading: true,
+      hasCompletedFetch: false,
+      error: undefined,
+      refresh: async (): Promise<void> => {},
+      updateQueue: undefined,
+      createUpdateQueue: async (userData: UserData): Promise<UpdateQueue> => {
+        return new UpdateQueueFactory(userData, async (): Promise<void> => {});
+      },
+      clearUserData: async (): Promise<void> => {},
+      clearUserDataError: (): void => {},
+    };
+  }, []);
+
+  return <UserDataContext.Provider value={value}>{children}</UserDataContext.Provider>;
+};

--- a/web/src/lib/cms/helpers/applyTheme.tsx
+++ b/web/src/lib/cms/helpers/applyTheme.tsx
@@ -1,3 +1,4 @@
+import { CmsUserDataProvider } from "@/lib/cms/helpers/CmsUserDataProvider";
 import { PreviewProps } from "@/lib/cms/helpers/previewHelpers";
 import { ThemeProvider } from "@mui/material";
 import { ReactElement } from "react";
@@ -8,6 +9,10 @@ type ReturnType = (props: PreviewProps) => ReactElement;
 export const applyTheme = (child: ReturnType): ReturnType => {
   // eslint-disable-next-line react/display-name
   return (props: PreviewProps): ReactElement => {
-    return <ThemeProvider theme={muiTheme}>{child(props)}</ThemeProvider>;
+    return (
+      <ThemeProvider theme={muiTheme}>
+        <CmsUserDataProvider>{child(props)}</CmsUserDataProvider>
+      </ThemeProvider>
+    );
   };
 };

--- a/web/src/lib/cms/previews/EmployerRatesPreview.tsx
+++ b/web/src/lib/cms/previews/EmployerRatesPreview.tsx
@@ -1,6 +1,11 @@
+import {
+  createDataFormErrorMap,
+  DataFormErrorMapContext,
+} from "@/contexts/dataFormErrorMapContext";
 import { PreviewProps } from "@/lib/cms/helpers/previewHelpers";
 import { usePreviewConfig } from "@/lib/cms/helpers/usePreviewConfig";
 import { usePreviewRef } from "@/lib/cms/helpers/usePreviewRef";
+import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
 import { ConfigContext } from "@businessnjgovnavigator/shared/contexts";
 import { ReactElement } from "react";
 import { EmployerRates } from "@/components/employer-rates/EmployerRates";
@@ -8,12 +13,15 @@ import { EmployerRates } from "@/components/employer-rates/EmployerRates";
 const EmployerRatesPreview = (props: PreviewProps): ReactElement => {
   const { config, setConfig } = usePreviewConfig(props);
   const ref = usePreviewRef(props);
+  const { state: formContextState } = useFormContextHelper(createDataFormErrorMap());
 
   return (
     <ConfigContext.Provider value={{ config, setOverrides: setConfig }}>
-      <div className="cms" ref={ref} style={{ margin: 40, pointerEvents: "none" }}>
-        <EmployerRates CMS_ONLY_enable_preview />
-      </div>
+      <DataFormErrorMapContext.Provider value={formContextState}>
+        <div className="cms" ref={ref} style={{ margin: 40, pointerEvents: "none" }}>
+          <EmployerRates CMS_ONLY_enable_preview />
+        </div>
+      </DataFormErrorMapContext.Provider>
     </ConfigContext.Provider>
   );
 };

--- a/web/src/lib/cms/previews/TaxAccessPreview.tsx
+++ b/web/src/lib/cms/previews/TaxAccessPreview.tsx
@@ -26,7 +26,7 @@ const TaxAccessPreview = (props: PreviewProps): ReactElement => {
             name="none"
             value="NONE"
             checked={errorPreview === "NONE"}
-            onClick={(): void => setErrorPreview("NONE")}
+            onChange={(): void => setErrorPreview("NONE")}
           />
           <label htmlFor="none">None</label>
         </div>
@@ -38,7 +38,7 @@ const TaxAccessPreview = (props: PreviewProps): ReactElement => {
             name="api"
             value="API"
             checked={errorPreview === "API"}
-            onClick={(): void => setErrorPreview("API")}
+            onChange={(): void => setErrorPreview("API")}
           />
           <label htmlFor="api">API error</label>
         </div>
@@ -50,7 +50,7 @@ const TaxAccessPreview = (props: PreviewProps): ReactElement => {
             name="unknown"
             value="UNKNOWN"
             checked={errorPreview === "UNKNOWN"}
-            onClick={(): void => setErrorPreview("UNKNOWN")}
+            onChange={(): void => setErrorPreview("UNKNOWN")}
           />
           <label htmlFor="unknown">Unknown error</label>
         </div>

--- a/web/src/pages/mgmt/cms.tsx
+++ b/web/src/pages/mgmt/cms.tsx
@@ -87,7 +87,6 @@ const Loading = ({ error }: { error?: Error | null }): ReactElement => {
   );
 };
 const CMS = dynamic(
-  // @ts-expect-error: loader resolves void, not a component; decap mounts itself outside the React tree
   () => {
     return import("decap-cms-app").then(({ default: CMS }) => {
       // @ts-expect-error: decap-cms-core's InitOptions type omits the legacy CMS_CONFIG option
@@ -227,6 +226,9 @@ const CMS = dynamic(
       registerPreview(CMS, "navigation-defaults", NavBarPreview);
 
       registerPreview(CMS, "calloutDefaults", LargeCalloutPreview);
+
+      // decap renders itself into #nc-root, outside the Next tree
+      return (): null => null;
     });
   },
   { ssr: false, loading: Loading },
@@ -234,13 +236,13 @@ const CMS = dynamic(
 
 const registerAsTask = (CMS: typeof CmsType, names: string[]): void => {
   for (const name of names) {
-    CMS.registerPreviewTemplate(name, TaskPreview);
+    registerPreview(CMS, name, TaskPreview);
   }
 };
 
 const registerAsCannabisLicensePreview = (CMS: typeof CmsType, names: string[]): void => {
   for (const name of names) {
-    CMS.registerPreviewTemplate(name, CannabisLicensePreview);
+    registerPreview(CMS, name, CannabisLicensePreview);
   }
 };
 

--- a/web/test/lib/cms/previews.test.tsx
+++ b/web/test/lib/cms/previews.test.tsx
@@ -1,0 +1,104 @@
+import { applyTheme } from "@/lib/cms/helpers/applyTheme";
+import { PreviewProps } from "@/lib/cms/helpers/previewHelpers";
+import { render, waitFor } from "@testing-library/react";
+import fs from "fs";
+import path from "path";
+import { ReactElement } from "react";
+
+jest.mock("@/lib/api-client/apiClient");
+jest.mock("@/lib/auth/sessionHelper");
+
+const PREVIEWS_DIR = path.join(__dirname, "..", "..", "..", "src", "lib", "cms", "previews");
+
+// Previews that branch on the entry slug; must match collection names in src/pages/mgmt/cms.tsx
+const SLUGS_BY_PREVIEW: Record<string, string[]> = {
+  "AnytimeActionTaxClearancePreview.tsx": [
+    "taxClearanceCertificate-step1",
+    "taxClearanceCertificate-step2",
+    "taxClearanceCertificate-step3",
+    "taxClearanceCertificate-shared",
+    "taxClearanceCertificate-download",
+  ],
+  "CannabisLicensePreview.tsx": [
+    "cannabisLicense-1",
+    "cannabisLicenseAnnual-2",
+    "cannabisLicenseConditional-2",
+  ],
+  "CannabisPriorityStatusPreview.tsx": ["cannabisPriority-1", "cannabisPriority-2"],
+  "CigaretteLicensePreview.tsx": [
+    "cigaretteLicense-step1",
+    "cigaretteLicense-step2",
+    "cigaretteLicense-step3",
+    "cigaretteLicense-step4",
+    "cigaretteLicense-shared",
+  ],
+  "PassengerTransportCdlPreview.tsx": [
+    "passenger-transport-cdl-tab1",
+    "passenger-transport-cdl-tab2",
+  ],
+};
+
+const previewFileNames = fs
+  .readdirSync(PREVIEWS_DIR)
+  .filter((fileName) => fileName.endsWith(".tsx"))
+  .sort();
+
+const slugAgnosticCases = previewFileNames
+  .filter((fileName) => !(fileName in SLUGS_BY_PREVIEW))
+  .map((fileName) => ({ fileName, slug: "preview-entry" }));
+
+const slugDrivenCases = previewFileNames
+  .filter((fileName) => fileName in SLUGS_BY_PREVIEW)
+  .flatMap((fileName) => SLUGS_BY_PREVIEW[fileName].map((slug) => ({ fileName, slug })));
+
+const createPreviewProps = (slug: string): PreviewProps => {
+  const data = { slug };
+  return {
+    entry: {
+      getIn: (): Record<string, unknown> => data,
+      toJS: (): Record<string, unknown> => data,
+    },
+    fieldsMetaData: {},
+    widgetFor: (): undefined => undefined,
+    widgetsFor: (): undefined => undefined,
+    getAsset: (): undefined => undefined,
+    window: window,
+    document: document,
+  };
+};
+
+const renderPreview = async (fileName: string, slug: string): Promise<HTMLElement> => {
+  const previewModule = await import(path.join(PREVIEWS_DIR, fileName));
+  const Preview = previewModule.default as (props: PreviewProps) => ReactElement;
+  const Themed = applyTheme(Preview);
+
+  const view = render(<Themed {...createPreviewProps(slug)} />);
+  // flush effects that kick off async work; setupTests turns act warnings into failures
+  await waitFor(() => view.container);
+
+  return view.container;
+};
+
+describe("cms previews", () => {
+  beforeAll(() => {
+    // jsdom does not implement createObjectURL; previews that render a blob need it
+    URL.createObjectURL = jest.fn(() => "blob:preview");
+    URL.revokeObjectURL = jest.fn();
+  });
+
+  it("finds preview components to test", () => {
+    expect(previewFileNames.length).toBeGreaterThan(0);
+  });
+
+  it.each(slugAgnosticCases)("renders $fileName", async ({ fileName, slug }) => {
+    await expect(renderPreview(fileName, slug)).resolves.toBeDefined();
+  });
+
+  // Slug-driven previews render nothing when no branch matches, so an empty render
+  // means the slug no longer lines up with the preview's branches.
+  it.each(slugDrivenCases)("renders $fileName for slug $slug", async ({ fileName, slug }) => {
+    // eslint-disable-next-line testing-library/render-result-naming-convention
+    const container = await renderPreview(fileName, slug);
+    expect(container.textContent?.length).toBeGreaterThan(0);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -32189,31 +32189,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:16.13.1, react-is@npm:^16.13.1, react-is@npm:^16.6.0, react-is@npm:^16.7.0":
-  version: 16.13.1
-  resolution: "react-is@npm:16.13.1"
-  checksum: 10/5aa564a1cde7d391ac980bedee21202fc90bdea3b399952117f54fb71a932af1e5902020144fb354b4690b2414a0c7aafe798eb617b76a3d441d956db7726fdf
-  languageName: node
-  linkType: hard
-
-"react-is@npm:^17.0.0, react-is@npm:^17.0.1, react-is@npm:^17.0.2":
-  version: 17.0.2
-  resolution: "react-is@npm:17.0.2"
-  checksum: 10/73b36281e58eeb27c9cc6031301b6ae19ecdc9f18ae2d518bdb39b0ac564e65c5779405d623f1df9abf378a13858b79442480244bd579968afc1faf9a2ce5e05
-  languageName: node
-  linkType: hard
-
-"react-is@npm:^17.0.1 || ^18.0.0, react-is@npm:^18.0.0, react-is@npm:^18.3.1":
-  version: 18.3.1
-  resolution: "react-is@npm:18.3.1"
-  checksum: 10/d5f60c87d285af24b1e1e7eaeb123ec256c3c8bdea7061ab3932e3e14685708221bf234ec50b21e10dd07f008f1b966a2730a0ce4ff67905b3872ff2042aec22
-  languageName: node
-  linkType: hard
-
-"react-is@npm:^19.0.0, react-is@npm:^19.2.4, react-is@npm:^19.2.6":
-  version: 19.2.7
-  resolution: "react-is@npm:19.2.7"
-  checksum: 10/ae0d3ae7638aa2fa2a82a78a817daf2806e57fa0aef357d07e1e8d1e9a301902e5967168e9334b5816db0df8fa980a725cd57569ba5a9e6e76a71e117b18be04
+"react-is@npm:^19.2.0":
+  version: 19.2.8
+  resolution: "react-is@npm:19.2.8"
+  checksum: 10/09d053ff36e0ba4d47164baf9eab1c7772791f0371aa92281f0e547e0f6a5a5c8a1eb939aadd1a08b3c565958dd63ee59c746b6ac0d5ccb14ad742ac0314ab15
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

The React 19 upgrade broke the Decap CMS preview pane. Preview templates mount in Decap's own React root at `#nc-root`, outside the provider tree from `_app.tsx`, so any preview rendering a component that calls `useUserData()` threw `useUserData must be used within a UserDataProvider` and blanked the pane. Two previews had additional React-19-specific breakage, and several previews were registered without the shared theme wrapper.

This PR restores preview rendering and adds a regression test that renders every preview component.

### Approach

- **`CmsUserDataProvider`** (new, `web/src/lib/cms/helpers/`): supplies an empty, loading-state `UserDataContext` value so components that call `useUserData()` render instead of throwing. Previews that need populated data continue to pass it explicitly via `CMS_ONLY_fakeBusiness`.
- **`applyTheme`** now wraps children in `CmsUserDataProvider` alongside the existing MUI `ThemeProvider`, so every preview routed through it gets both.
- **`cms.tsx`**: `registerAsTask` and `registerAsCannabisLicensePreview` called `CMS.registerPreviewTemplate` directly, bypassing `applyTheme`; both now go through the local `registerPreview` helper.
- **`TaxAccessPreview`**: the error-state radios used `onClick` handlers, which React 19 no longer fires for controlled radio selection; switched to `onChange`.
- **`EmployerRatesPreview`**: `EmployerRatesQuestions` consumes `DataFormErrorMapContext`; the preview now provides it via the existing `useFormContextHelper` / `createDataFormErrorMap` helpers.
- **`react-is`**: added a `^19.2.0` resolution, collapsing four duplicate versions (16.13.1 / 17.0.2 / 18.3.1 / 19.x) down to one.

### Steps to Test

1. `yarn start:dev` and sign in to the CMS at `/mgmt/cms`.
2. Open an entry in a **Tasks** collection. The preview pane should render styled content rather than a blank or unstyled pane, and the browser console should be free of  `useUserData must be used within a UserDataProvider` errors.
3. Open the **Tax Access** config entry and click through the None / API error /  Unknown error radios — each should select and swap the previewed error state.
4. Open the **Employer Rates** config entry and confirm the questions render.
5. Spot-check a handful of other collections for a rendered preview pane.

### Notes

`web/test/lib/cms/previews.test.tsx` is new: it walks `web/src/lib/cms/previews/`, renders each preview through `applyTheme`, and fails if one throws; so a future provider-shaped regression is caught in CI rather than by hand in the CMS UI. Previews that branch on the entry slug are enumerated in `SLUGS_BY_PREVIEW` and additionally asserted to render non-empty output; **that map must be kept in sync with the collection names in
`cms.tsx`** when slugs change.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews