### PR TITLE
feat: [AB#17865] add terms and privacy policy page

### DIFF
--- a/content/src/pages/privacy-policy.md
+++ b/content/src/pages/privacy-policy.md
@@ -1,0 +1,98 @@
+---
+name: Terms & Privacy Policy
+slug: privacy-policy
+sub-heading-text: Business.NJ.gov is committed to protecting your privacy. This page explains how we collect, use, and protect information from visitors to Business.NJ.gov websites.
+meta-data: privacy policy terms cookies data collection opt-out Google Analytics Intercom
+heading-1: New Jersey Statewide Notices
+main-text-1: |-
+  * [State of New Jersey Legal Statement & Disclaimers](https://www.nj.gov/nj/legal.html)
+  * [State of New Jersey Privacy Notice](https://www.nj.gov/nj/privacy.html)
+
+  In addition to the New Jersey Legal Statement & Disclaimers and the New Jersey Privacy Notice, the information below summarizes how information from visitors to Business.NJ.gov websites is collected, used, and protected. We may collect personal and non-personal information you provide directly to us and information we or third-party service providers collect automatically whenever you interact with our sites. Included is a list of integrated web products on our sites, the types of data being collected, and how you can opt out of data collection.
+heading-2: Data Automatically Collected
+main-text-2: |-
+  Business.NJ.gov websites use cookies and identifiers from third-party partners such as Google Analytics to collect data for website functionality, analytics and measurement services, or for marketing and advertising purposes to deliver relevant features, content, and essential services the state provides.
+heading-3: Advertising Cookies
+main-text-3: |-
+  Business.NJ.gov may use "advertising cookies" to display advertisements that feature relevant topics, programs, and services to you, based on websites you have visited.
+heading-4: Persistent Cookies vs. Session Cookies
+main-text-4: |-
+  Some cookies, called session cookies, do not retain any information on your device or send information from your device when you visit a website. These cookies are deleted as soon as you close your browser window.
+
+  Persistent cookies are cookies that are stored on your device until you erase them, change your browser settings to block them, or they expire. Advertising cookies are persistent cookies.
+heading-5: Opt-Out Options for Persistent Advertising Cookies
+main-text-5: |-
+  If you want to opt out of Google's advertising cookies, there are options available to you to check and make changes to your browser settings and ad settings that can limit the types of data collected and ads you see on your desktop and mobile devices. These options are listed below:
+
+  1. Clear the cookies on your web browser. Most browsers allow you to manage how cookies are used when you visit websites, and to clear cookie data and browsing history. Browser settings may also allow you to set cookie preferences for websites. Check the settings for the particular browser in use.
+  2. Download and install the [Google Analytics Opt-Out Browser Add-on](https://tools.google.com/dlpage/gaoptout/) for your web browser. This add-on is compatible with Chrome, Safari, Firefox, and Microsoft Edge.
+  3. Control the ads you see or turn off ad personalization by updating your ad preferences through signing into your Google account and visiting [Google's Ad Settings](https://adssettings.google.com).
+  4. Opt out of receiving tailored online ads through your browser and mobile devices by visiting the [Network Advertising Initiative website](https://optout.networkadvertising.org/) for interest-based advertising.
+heading-6: Products Used on Business.NJ.gov Websites
+main-text-6: |-
+  ### Google Analytics and Google Tag Manager
+
+  **Purpose:** Used to determine how users engage with NJ.gov websites to build better features, provide services, and improve the user's experience.
+
+  **Data collected:** Anonymous/aggregated usage data and user statistics (age, gender, and interest categories) collected when you visit our website, including how often you visit, what pages you visit, links you click, and other actions you take on the site, such as submitting a form. Any personal data you choose to provide and submit via a form on our websites will not be shared with Google.
+
+  **Express opt-out:** [https://tools.google.com/dlpage/gaoptout/](https://tools.google.com/dlpage/gaoptout/)
+
+  ### Google Ads
+
+  **Purpose:** We and Google use cookies to track conversion rates and measure campaign performance when you click on a Google ad on a site you visit. We use this tool to raise awareness about state-provided information, programs, and services and increase traffic to our websites. We may use Google's remarketing features to target ads most relevant to you. Google does not sell any personal information to third parties.
+
+  **Data collected:** Anonymous/aggregated data collected when a user completes a specified action, such as a link click, form submission, or other events. Any personal data you choose to provide and submit via a form on our websites will not be shared with Google.
+
+  **Express opt-out:** [https://adssettings.google.com/authenticated](https://adssettings.google.com/authenticated)
+
+  ### Google Search Console
+
+  **Purpose:** Used to measure search engine traffic and see which search queries bring users to our site. We use this tool to make content improvements, which allows for better search results when users are looking to find information on NJ.gov sites.
+
+  **Data collected:** Data collected when you enter a phrase or keyword in the search engine box and when you click on a website link or ad in search results.
+
+  **Express opt-out:** If you have a Google account and are signed into it, Google may be able to link information that it collects from Google Site Search with information from your Google account. You can sign out of your Google account, or visit [Google's privacy policy](https://policies.google.com/privacy#infochoices) for information on opting out.
+
+  ### Intercom
+
+  **Purpose:** A live chat tool we use to improve the user experience by providing customer support services to answer questions asked and resolve issues discovered during a site visit.
+
+  **Data collected:** Data collected includes voluntary information and general usage of the tool, such as chat volume, customer satisfaction score, resolution rate, and other statistics.
+
+  **Express opt-out:** Users do not need to use the live chat feature on the website.
+heading-7: Data You Provide Directly to Us
+main-text-7: |-
+  You may voluntarily provide us with certain personal and non-personal information, which we use for:
+
+  **Authentication and security**
+
+  Personal contact and account information when you sign up for Navigator through creating a myNJ account.
+
+  Data collected: your name, email address, username, and password.
+
+  **Personalized content and features**
+
+  Business information is used to generate your step-by-step guide for doing business in New Jersey. This function enables you to form your business directly through our integrated API system and utilizes features that help you keep track of your business information.
+
+  Data collected: business information such as your business name, business location, industry, NAICS code, or other business details.
+
+  **Customer feedback and customer support**
+
+  Data collected: contact, account, or business information, and other information you choose to provide, such as when you submit a customer feedback survey, engage with the online chat, or [chat with a business expert](#open-chat).
+
+  *We may use your personal information to communicate with you, including, but not limited to, responding to your inquiries, fulfilling your requests, or sending information to you.*
+heading-8: Safeguarding and Protecting Your Information
+main-text-8: |-
+  Business.NJ.gov limits the collection of sensitive personal data via our websites and integrated web products. You may be asked to contact an agency representative via an official agency phone number if this information is needed to provide you with customer support. Should you receive such a contact, please note that your disclosure of such sensitive personal information is voluntary.
+
+  Sensitive personal information means any of the following data categories that merit special protection:
+
+  1. Credit, debit, or other payment card data subject to the Payment Card Industry Data Security Standards ("PCI DSS")
+  2. Patient, medical, or other protected health information regulated by the Health Insurance Portability and Accountability Act ("HIPAA")
+  3. Any other personal data of an EU citizen deemed to be in a "special category" (as identified in the EU General Data Protection Regulation or any successor directive or regulation)
+
+  As stated in the New Jersey Privacy Policy:
+
+  *We take all reasonable steps and precautions to protect the information you provide us on nj.gov from unauthorized access, disclosure, alteration, or destruction; however, this cannot be absolutely guaranteed. For more information on how we secure and protect your information, please visit [https://www.cyber.nj.gov/](https://www.cyber.nj.gov/).*
+---

--- a/content/src/spellcheck-exceptions.json
+++ b/content/src/spellcheck-exceptions.json
@@ -592,6 +592,7 @@
     "regardingobjectid",
     "registrationrequestid",
     "regreening",
+    "remarketing",
     "reoccuring",
     "reqs",
     "requestdate",

--- a/packages/static-site/app/[locale]/privacy-policy/page.test.tsx
+++ b/packages/static-site/app/[locale]/privacy-policy/page.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { loadPageBySlug } from "@/domain/content/loadContent";
+import PrivacyPolicyRoute, { generateMetadata } from "./page";
+
+const { name } = loadPageBySlug("privacy-policy");
+
+describe("generateMetadata", () => {
+  it("builds hreflang alternates for /privacy-policy", () => {
+    const metadata = generateMetadata();
+    expect(metadata.alternates?.canonical).toBe("/privacy-policy");
+  });
+});
+
+describe("PrivacyPolicyRoute", () => {
+  it("renders the privacy policy page for a supported locale", async () => {
+    render(
+      await PrivacyPolicyRoute({
+        params: Promise.resolve({ locale: "en-US" }),
+      }),
+    );
+
+    expect(screen.getByRole("heading", { level: 1, name })).toBeInTheDocument();
+  });
+});

--- a/packages/static-site/app/[locale]/privacy-policy/page.tsx
+++ b/packages/static-site/app/[locale]/privacy-policy/page.tsx
@@ -1,0 +1,58 @@
+/**
+ * Implements the standalone "Terms & Privacy Policy" page route.
+ *
+ * The page renders the same Markdown content as other guidance pages but lives
+ * outside the `(learn)` route group, so it stands on its own without the
+ * Plan/Start/Operate/Grow side navigation. Its Markdown source is loaded by
+ * slug and rendered through the shared `PageContent` renderer.
+ */
+
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import PageContent from "@/components/learn/PageContent";
+import { loadPages } from "@/domain/content/loadContent";
+import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
+import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
+
+/**
+ * Slug of the Markdown file backing this page (`content/src/pages/<slug>.md`).
+ */
+const PAGE_SLUG = "privacy-policy";
+
+interface PageParams {
+  readonly locale: AppLocale;
+}
+
+interface Props {
+  readonly params: Promise<PageParams>;
+}
+
+/**
+ * Generates metadata advertising hreflang alternates for the page.
+ *
+ * @returns Metadata containing canonical and alternate-language links.
+ */
+export const generateMetadata = (): Metadata => {
+  return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: `/${PAGE_SLUG}` }) };
+};
+
+const PrivacyPolicyRoute = async ({ params }: Props) => {
+  const { locale } = await params;
+
+  if (!hasAppLocale(locale)) {
+    notFound();
+  }
+
+  const page = loadPages().find((item) => item.slug === PAGE_SLUG);
+  if (!page) {
+    notFound();
+  }
+
+  return (
+    <div className="grid-container usa-section">
+      <PageContent page={page} />
+    </div>
+  );
+};
+
+export default PrivacyPolicyRoute;

--- a/packages/static-site/app/globals.css
+++ b/packages/static-site/app/globals.css
@@ -103,7 +103,10 @@ body:has(.page-not-found) .usa-footer__return-to-top {
   display: none;
 }
 
-.grid-container p {
+.grid-container p,
+.grid-container .usa-prose > p,
+.grid-container .usa-prose > ul li,
+.grid-container .usa-prose > ol li {
   max-width: unset;
 }
 

--- a/packages/static-site/app/sitemap.ts
+++ b/packages/static-site/app/sitemap.ts
@@ -55,7 +55,14 @@ const collectRoutePathnames = (): readonly string[] => {
     return category.children.map((page) => `/pages/${page.slug}`);
   });
 
-  return ["/", "/learn", "/our-software-and-reuse", ...categoryPathnames, ...contentPathnames];
+  return [
+    "/",
+    "/learn",
+    "/our-software-and-reuse",
+    "/privacy-policy",
+    ...categoryPathnames,
+    ...contentPathnames,
+  ];
 };
 
 /**

--- a/packages/static-site/components/learn/PageContent.tsx
+++ b/packages/static-site/components/learn/PageContent.tsx
@@ -84,7 +84,11 @@ const PageContent = ({ page }: Props) => {
                 </div>
               </div>
             )}
-            {section.body && <Markdown components={markdownComponents}>{section.body}</Markdown>}
+            {section.body && (
+              <div className="usa-prose">
+                <Markdown components={markdownComponents}>{section.body}</Markdown>
+              </div>
+            )}
             {section.linkText && section.linkUrl && (
               <a href={section.linkUrl} className="usa-button">
                 {section.linkText}

--- a/packages/static-site/domain/redirects/legacyRedirects.test.ts
+++ b/packages/static-site/domain/redirects/legacyRedirects.test.ts
@@ -280,3 +280,40 @@ describe("buildLegacyRedirects — bare /license splits from /license/*", () => 
     );
   });
 });
+
+describe("buildLegacyRedirects — terms & privacy policy", () => {
+  it("maps /terms to the standalone privacy policy page, permanently", () => {
+    const rule = find(buildLegacyRedirects(false), "/terms");
+    expect(rule?.destination).toBe("/privacy-policy");
+    expect(rule?.permanent).toBe(true);
+  });
+
+  it("maps /terms-of-use to the standalone privacy policy page", () => {
+    expect(find(buildLegacyRedirects(false), "/terms-of-use")?.destination).toBe("/privacy-policy");
+  });
+
+  it("maps /privacy to the standalone privacy policy page", () => {
+    expect(find(buildLegacyRedirects(false), "/privacy")?.destination).toBe("/privacy-policy");
+  });
+
+  it("maps the old /pages/[slug] URL to the standalone canonical page, permanently", () => {
+    const rule = find(buildLegacyRedirects(false), "/pages/privacy-policy");
+    expect(rule?.destination).toBe("/privacy-policy");
+    expect(rule?.permanent).toBe(true);
+  });
+
+  it("routes the /es-us Spanish source to the English page when multilingual is off", () => {
+    expect(find(buildLegacyRedirects(false), "/es-us/terms")?.destination).toBe("/privacy-policy");
+  });
+
+  it("routes the /es-us Spanish source to the /es-US page when multilingual is on", () => {
+    expect(find(buildLegacyRedirects(true), "/es-us/terms")?.destination).toBe(
+      "/es-US/privacy-policy",
+    );
+  });
+
+  it("orders the generated Spanish route before the /es-us catch-all", () => {
+    const rules = buildLegacyRedirects(false);
+    expect(indexOf(rules, "/es-us/terms")).toBeLessThan(indexOf(rules, "/es-us/:path*"));
+  });
+});

--- a/packages/static-site/domain/redirects/legacyRedirects.ts
+++ b/packages/static-site/domain/redirects/legacyRedirects.ts
@@ -138,6 +138,14 @@ const ONE_OFF_RULES: readonly InternalRule[] = [
   // The reuse page is a standalone route, not a /pages/[slug] page, but the slug
   // still resolves under that route (dynamicParams), so send it to the canonical URL.
   { source: "/pages/our-software-and-reuse", destination: "/our-software-and-reuse" },
+  // terms & privacy policy
+  { source: "/terms", destination: "/privacy-policy" },
+  { source: "/terms-of-use", destination: "/privacy-policy" },
+  { source: "/privacy", destination: "/privacy-policy" },
+  // The privacy policy is a standalone route, not a /pages/[slug] page, but the
+  // slug still resolves under that route (dynamicParams), so send it to the
+  // canonical URL.
+  { source: "/pages/privacy-policy", destination: "/privacy-policy" },
 ];
 
 /**

--- a/packages/static-site/messages/ar-US.json
+++ b/packages/static-site/messages/ar-US.json
@@ -182,9 +182,9 @@
         },
         {
           "link": {
-            "label": "المحتوى المنتج",
-            "href": "https://nj.gov/nj/privacy.html",
-            "isInternal": false,
+            "label": "الشروط وسياسة الخصوصية",
+            "href": "/privacy-policy",
+            "isInternal": true,
             "opensInNewTab": false
           }
         },

--- a/packages/static-site/messages/en-US.json
+++ b/packages/static-site/messages/en-US.json
@@ -192,9 +192,9 @@
         },
         {
           "link": {
-            "label": "Privacy Notice",
-            "href": "https://nj.gov/nj/privacy.html",
-            "isInternal": false,
+            "label": "Terms & Privacy Policy",
+            "href": "/privacy-policy",
+            "isInternal": true,
             "opensInNewTab": false
           }
         },

--- a/packages/static-site/messages/es-US.json
+++ b/packages/static-site/messages/es-US.json
@@ -192,9 +192,9 @@
         },
         {
           "link": {
-            "label": "Aviso de privacidad",
-            "href": "https://nj.gov/nj/privacy.html",
-            "isInternal": false,
+            "label": "Términos y Política de Privacidad",
+            "href": "/privacy-policy",
+            "isInternal": true,
             "opensInNewTab": false
           }
         },

--- a/packages/static-site/tests/accessibility/privacy-policy.a11y.spec.ts
+++ b/packages/static-site/tests/accessibility/privacy-policy.a11y.spec.ts
@@ -1,0 +1,66 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+import type { BrowserContext, Page } from "playwright";
+import { loadPageBySlug } from "@/domain/content/loadContent";
+import type { AppLocale } from "@/domain/i18n/locales";
+import { ENABLED_LOCALES } from "@/domain/i18n/locales";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+
+/**
+ * Defines the test context provided by Playwright.
+ */
+interface AccessibilityTestContext {
+  /** Browser page used by the test run. */
+  readonly page: Page;
+  /** Browser context, used to seed cookies before navigation. */
+  readonly context: BrowserContext;
+}
+
+/**
+ * Parameters for creating one locale-specific accessibility test.
+ */
+interface CreateLocaleAccessibilityTestParams {
+  /** Locale to evaluate in the browser accessibility audit. */
+  readonly locale: AppLocale;
+}
+
+/**
+ * Creates a Playwright accessibility test for one locale.
+ *
+ * This page nests Markdown `###` subheadings under a `heading-N` section (the
+ * four product entries under "Products Used on Business.NJ.gov Websites"), so
+ * it exercises axe's `heading-order` rule more deeply than other content-page
+ * audits.
+ */
+const createLocaleAccessibilityTest = ({ locale }: CreateLocaleAccessibilityTestParams) => {
+  return async ({ page, context }: AccessibilityTestContext) => {
+    const pageName = loadPageBySlug("privacy-policy").name;
+
+    // Suppress the preferred-language prompt modal so its open/animation state
+    // cannot race with the axe scan, which made this audit flaky.
+    await context.addCookies([
+      {
+        name: LANGUAGE_PROMPT_DISMISSED_COOKIE,
+        value: "true",
+        url: "http://127.0.0.1:3000",
+      },
+    ]);
+
+    await page.goto(`/${locale}/privacy-policy`);
+    await page.getByRole("heading", { level: 1, name: pageName }).waitFor();
+
+    // `color-contrast` is a pre-existing NJWDS banner/chrome issue present on
+    // every page (it also fails the homepage audit) and is outside this page's
+    // scope. Excluding it keeps this audit focused on this page's a11y.
+    const results = await new AxeBuilder({ page }).disableRules(["color-contrast"]).analyze();
+
+    expect(results.violations).toEqual([]);
+  };
+};
+
+for (const locale of ENABLED_LOCALES) {
+  test(
+    `privacy policy page has no automated WCAG violations for ${locale}`,
+    createLocaleAccessibilityTest({ locale }),
+  );
+}

--- a/packages/static-site/tests/e2e-english-only/redirects.e2e.spec.ts
+++ b/packages/static-site/tests/e2e-english-only/redirects.e2e.spec.ts
@@ -69,6 +69,36 @@ test.describe("Legacy redirects (English-only mode)", () => {
     expect(new URL(page.url()).pathname).toBe("/our-software-and-reuse");
   });
 
+  test("/terms redirects to the privacy policy page", async ({ page }) => {
+    const response = await page.goto("/terms");
+    expect(response?.status()).toBe(200);
+    expect(new URL(page.url()).pathname).toBe("/privacy-policy");
+  });
+
+  test("/terms-of-use redirects to the privacy policy page", async ({ page }) => {
+    const response = await page.goto("/terms-of-use");
+    expect(response?.status()).toBe(200);
+    expect(new URL(page.url()).pathname).toBe("/privacy-policy");
+  });
+
+  test("/privacy redirects to the privacy policy page", async ({ page }) => {
+    const response = await page.goto("/privacy");
+    expect(response?.status()).toBe(200);
+    expect(new URL(page.url()).pathname).toBe("/privacy-policy");
+  });
+
+  test("/privacy-policy renders directly (standalone route, no redirect)", async ({ page }) => {
+    const response = await page.goto("/privacy-policy");
+    expect(response?.status()).toBe(200);
+    expect(new URL(page.url()).pathname).toBe("/privacy-policy");
+  });
+
+  test("the old /pages/privacy-policy URL redirects to the standalone page", async ({ page }) => {
+    const response = await page.goto("/pages/privacy-policy");
+    expect(response?.status()).toBe(200);
+    expect(new URL(page.url()).pathname).toBe("/privacy-policy");
+  });
+
   test("a deliberately skipped legacy path still 404s", async ({ page }) => {
     const response = await page.goto("/search");
     expect(response?.status()).toBe(404);


### PR DESCRIPTION
## Description

Adds a standalone Terms & Privacy Policy page and updates references to it across the site.

### Ticket

This pull request resolves [#17865](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17865).

### Approach

- Added `content/src/pages/privacy-policy.md` with the policy content (cookies, Google Analytics/Ads/Search Console, Intercom, data collected, and safeguarding sections).
- Added a standalone route at `packages/static-site/app/[locale]/privacy-policy/page.tsx`, outside the `(learn)` route group so it renders without the Plan/Start/Operate/Grow side navigation, plus hreflang metadata.
- Added a page test and an accessibility spec for the new route.
- Added legacy redirects for `/terms`, `/terms-of-use`, `/privacy`, and `/pages/privacy-policy` to `/privacy-policy`, including locale-aware handling for `/es-us/terms`.
- Updated the sitemap to include `/privacy-policy`.
- Updated footer messages (en-US, es-US, ar-US) so "Terms & Privacy Policy" links internally to `/privacy-policy` instead of the external NJ privacy notice.

### Steps to Test

1. Visit `/privacy-policy` and confirm the page renders the policy content without side navigation.

2. Visit `/terms`, `/terms-of-use`, `/privacy`, and `/pages/privacy-policy` and confirm each redirects to `/privacy-policy`.

3. Check the site footer link now points to `/privacy-policy` internally.

4. Run the static-site test suite and the accessibility spec for this page.

### Notes

None.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews