### PR TITLE
fix: [AB#17959] stop hiding next task button on business structure

### DIFF
--- a/web/src/pages/tasks/[taskUrlSlug].tsx
+++ b/web/src/pages/tasks/[taskUrlSlug].tsx
@@ -12,13 +12,7 @@ import { useUserData } from "@/lib/data-hooks/useUserData";
 import { allowFormation } from "@/lib/domain-logic/allowFormation";
 import { getNextSeoTitle } from "@/lib/domain-logic/getNextSeoTitle";
 import { getUrlSlugs } from "@/lib/utils/roadmap-helpers";
-import {
-  businessStructureTaskId,
-  formationTaskId,
-  hasCompletedBusinessStructure,
-  HousingMunicipality,
-  Municipality,
-} from "@businessnjgovnavigator/shared";
+import { formationTaskId, HousingMunicipality, Municipality } from "@businessnjgovnavigator/shared";
 import {
   loadAllHousingMunicipalities,
   loadAllMunicipalities,
@@ -64,9 +58,6 @@ const TaskPage = (props: Props): ReactElement => {
       return undefined;
     }
 
-    const hideNextUrlSlug =
-      props.task.id === businessStructureTaskId && !hasCompletedBusinessStructure(business);
-
     return (
       <div
         className={`flex flex-row ${
@@ -84,7 +75,7 @@ const TaskPage = (props: Props): ReactElement => {
             <span className="margin-left-2"> {Config.taskDefaults.previousTaskButtonText}</span>
           </UnStyledButton>
         )}
-        {nextUrlSlug && !hideNextUrlSlug && (
+        {nextUrlSlug && (
           <UnStyledButton
             dataTestid={"nextUrlSlugButton"}
             onClick={(): void => {

--- a/web/test/pages/taskUrlSlug.test.tsx
+++ b/web/test/pages/taskUrlSlug.test.tsx
@@ -4,8 +4,6 @@ import {
   generateStep,
   generateTask,
   generateTaskLink,
-  operatingPhasesDisplayingBusinessStructurePrompt,
-  operatingPhasesNotDisplayingBusinessStructurePrompt,
   randomPublicFilingLegalType,
 } from "@/test/factories";
 import { mockPush, useMockRouter } from "@/test/mock/mockRouter";
@@ -28,7 +26,6 @@ import {
   LookupTaskAgencyById,
 } from "@businessnjgovnavigator/shared";
 import { getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
-import { businessStructureTaskId } from "@businessnjgovnavigator/shared/domain-logic/taskIds";
 import { createEmptyTaskDisplayContent, Task } from "@businessnjgovnavigator/shared/types";
 import * as materialUi from "@mui/material";
 import { useMediaQuery } from "@mui/material";
@@ -457,62 +454,6 @@ describe("task page", () => {
 
     expect(screen.queryByTestId("nextAndPreviousButtons")).not.toBeInTheDocument();
   });
-
-  it.each(operatingPhasesDisplayingBusinessStructurePrompt)(
-    "hides nextUrlSlug on business structure task when it's not marked as completed for %p operating phase",
-    (operatingPhase) => {
-      setLargeScreen(false);
-      renderPage(
-        generateTask({ id: businessStructureTaskId }),
-        generateBusiness({
-          profileData: generateProfileData({
-            operatingPhase,
-          }),
-          taskProgress: { [businessStructureTaskId]: "TO_DO" },
-        }),
-      );
-      expect(screen.queryByTestId("nextUrlSlugButton")).not.toBeInTheDocument();
-    },
-  );
-
-  // These phases never have a business structure task in their roadmap
-  it.each(
-    operatingPhasesNotDisplayingBusinessStructurePrompt.filter(
-      (operatingPhaseId) =>
-        operatingPhaseId !== "DOMESTIC_EMPLOYER" &&
-        operatingPhaseId !== "UP_AND_RUNNING_OWNING" &&
-        operatingPhaseId !== "UP_AND_RUNNING" &&
-        operatingPhaseId !== "GUEST_MODE_OWNING",
-    ),
-  )(
-    "shows nextUrlSlug on business structure task when it's not marked as completed for %p operating phase",
-    (operatingPhase) => {
-      const businessStructureTask = generateTask({
-        id: businessStructureTaskId,
-        urlSlug: "business-structure",
-        stepNumber: 1,
-        required: true,
-      });
-      const nextTask = generateTask({ urlSlug: "next-task", stepNumber: 2, required: true });
-      useMockRoadmap({
-        steps: [generateStep({ stepNumber: 1 }), generateStep({ stepNumber: 2 })],
-        tasks: [businessStructureTask, nextTask],
-      });
-
-      setLargeScreen(false);
-      renderPage(
-        businessStructureTask,
-        generateBusiness({
-          profileData: generateProfileData({
-            operatingPhase,
-          }),
-          taskProgress: { [businessStructureTaskId]: "COMPLETED" },
-        }),
-      );
-
-      expect(screen.getByTestId("nextUrlSlugButton")).toBeInTheDocument();
-    },
-  );
 
   describe("deferred location question", () => {
     const contentWithLocationSection =


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

We previously gated the formation task behind the business structure task, so we hid the next task button on the business structure page for users who hadn't completed it yet. Now that we've flattened the roadmap and removed the gate, we don't want to hide this button anymore.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to the URL for the board that owns it.
     Board routing is not a clean cutover; run `python3 scripts/fetch_ado_ticket.py <id>`
     or check scripts/ado-boards.json for the current cutover and exceptions list. -->

This pull request resolves [#17959](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17959).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

1. Onboard as a new business.
2. Go to the business structure task.
3. You should see a Next Task link on the bottom of the page.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
