### PR TITLE
feat: [AB#17867] add continue exploring option to all login modals

### DIFF
--- a/content/src/fieldConfig/self-registration.json
+++ b/content/src/fieldConfig/self-registration.json
@@ -1,6 +1,5 @@
 {
   "selfRegistration": {
-    "continueWithoutSaving": "Continue without saving",
     "errorTextGeneric": "Something went wrong. Try again later.",
     "errorTextEmailsNotMatching": "Email addresses must match and be valid.",
     "accountSuccessSnackbarTitleExistingAccount": "Your myNewJersey Account is Linked",
@@ -21,13 +20,14 @@
     "closeButtonText": "Cancel",
     "updatesAndRemindersCheckboxLabel": "I want to receive updates and reminders by email.",
     "newsletterCheckboxLabel": "I want to receive the Business.NJ.gov email newsletter.",
-    "needsAccountModalTitle": "Link with myNewJersey to Save Your Progress",
-    "needsAccountModalButtonText": "Link with myNewJersey",
+    "needsAccountModalTitle": "Do You Want to Save Your Progress?",
+    "needsAccountModalBody": "Create a secure myNewJersey account to save your information, or continue as a guest and we won't save anything.",
+    "needsAccountModalButtonText": "Create My Free Account",
+    "continueExploringButtonText": "Continue Exploring",
     "accountSuccessSnackbarBody": "You can now save your progress, access more features, and edit your business profile.",
     "accountSuccessSnackbarTitle": "Welcome to your Business.NJ.gov account!",
     "errorTextFullNameSpecialCharacter": "Full name may only contain letters, numbers, spaces, and these five characters: , . - ' _",
     "errorTextFullNameStartWithLetter": "Full name must start with a letter.",
-    "needsAccountModalBody": "To use this feature, you need to complete your registration with the State of New Jersey's secure login system, MyNewJersey. This will ensure your privacy, and allow you to come back any time.",
     "phoneNumberFieldLabelOptional": "(Optional)"
   }
 }

--- a/web/decap-config/collections/12-misc.yml
+++ b/web/decap-config/collections/12-misc.yml
@@ -658,7 +658,11 @@ collections:
                 }
               - { label: Submit Button Text, name: submitButtonText, widget: string }
               - { label: Close Button Text, name: closeButtonText, widget: string }
-              - { label: Continue without Saving, name: continueWithoutSaving, widget: string }
+              - {
+                  label: Continue Exploring Button,
+                  name: continueExploringButtonText,
+                  widget: string,
+                }
               - { label: Error - Full name is required, name: errorTextFullName, widget: string }
               - {
                   label: Error - Full name contains special characters,

--- a/web/src/components/auth/NeedsAccountModal.test.tsx
+++ b/web/src/components/auth/NeedsAccountModal.test.tsx
@@ -22,28 +22,18 @@ describe("<NeedsAccount Modal />", () => {
   });
 
   const setShowNeedsAccountModal = jest.fn();
-  const setUserWantsToContinueWithoutSaving = jest.fn();
-  const setShowContinueWithoutSaving = jest.fn();
 
   const setupHookWithAuth = ({
     isAuthenticated,
     showNeedsAccountModal,
-    showContinueWithoutSaving,
-    userWantsToContinueWithoutSaving,
   }: {
     isAuthenticated: IsAuthenticated;
     showNeedsAccountModal?: boolean;
-    showContinueWithoutSaving?: boolean;
-    userWantsToContinueWithoutSaving?: boolean;
   }): void => {
     render(
       withNeedsAccountContext(<NeedsAccountModal />, isAuthenticated, {
         showNeedsAccountModal: showNeedsAccountModal ?? true,
-        showContinueWithoutSaving: showContinueWithoutSaving ?? false,
-        userWantsToContinueWithoutSaving: userWantsToContinueWithoutSaving ?? false,
         setShowNeedsAccountModal: setShowNeedsAccountModal,
-        setShowContinueWithoutSaving: setShowContinueWithoutSaving,
-        setUserWantsToContinueWithoutSaving: setUserWantsToContinueWithoutSaving,
       }),
     );
   };
@@ -60,9 +50,15 @@ describe("<NeedsAccount Modal />", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("returns user to previous page when modal is closed", () => {
+  it("hides the modal when close button is clicked", () => {
     setupHookWithAuth({ isAuthenticated: IsAuthenticated.FALSE });
     fireEvent.click(screen.getByLabelText("close"));
+    expect(setShowNeedsAccountModal).toHaveBeenCalledWith(false);
+  });
+
+  it("hides the modal when the continue exploring exploring button is clicked", () => {
+    setupHookWithAuth({ isAuthenticated: IsAuthenticated.FALSE });
+    fireEvent.click(screen.getByText(Config.selfRegistration.continueExploringButtonText));
     expect(setShowNeedsAccountModal).toHaveBeenCalledWith(false);
   });
 
@@ -91,24 +87,5 @@ describe("<NeedsAccount Modal />", () => {
       screen.getByText(markdownToText(Config.selfRegistration.needsAccountModalSubText)),
     );
     expect(mockPush).toHaveBeenCalledWith(ROUTES.login);
-  });
-
-  it("displays the 'continue without saving' button when showContinueWithoutSaving is true", () => {
-    setupHookWithAuth({
-      isAuthenticated: IsAuthenticated.FALSE,
-      showNeedsAccountModal: true,
-      showContinueWithoutSaving: true,
-    });
-    expect(screen.getByText(Config.selfRegistration.continueWithoutSaving)).toBeInTheDocument();
-  });
-
-  it("sets userWantsToContinueWithoutSaving to true when 'continue without saving' is clicked", () => {
-    setupHookWithAuth({
-      isAuthenticated: IsAuthenticated.FALSE,
-      showNeedsAccountModal: true,
-      showContinueWithoutSaving: true,
-    });
-    fireEvent.click(screen.getByText(Config.selfRegistration.continueWithoutSaving));
-    expect(setUserWantsToContinueWithoutSaving).toHaveBeenCalledWith(true);
   });
 });

--- a/web/src/components/auth/NeedsAccountModal.tsx
+++ b/web/src/components/auth/NeedsAccountModal.tsx
@@ -16,13 +16,8 @@ import { ReactElement, useContext } from "react";
 export const NeedsAccountModal = (): ReactElement => {
   const { business } = useUserData();
   const router = useRouter();
-  const {
-    isAuthenticated,
-    showNeedsAccountModal,
-    showContinueWithoutSaving,
-    setShowNeedsAccountModal,
-    setUserWantsToContinueWithoutSaving,
-  } = useContext(NeedsAccountContext);
+  const { isAuthenticated, showNeedsAccountModal, setShowNeedsAccountModal } =
+    useContext(NeedsAccountContext);
   const { Config } = useConfig();
   const loginPageEnabled = process.env.FEATURE_LOGIN_PAGE === "true";
 
@@ -62,19 +57,17 @@ export const NeedsAccountModal = (): ReactElement => {
             <PrimaryButton isColor="primary" isFullWidthOnDesktop onClick={linkToAccountSetup}>
               {Config.selfRegistration.needsAccountModalButtonText}
             </PrimaryButton>
-            {showContinueWithoutSaving && (
-              <SecondaryButton
-                isColor="primary"
-                className={"margin-top-05"}
-                isFullWidthOnDesktop
-                onClick={() => {
-                  setUserWantsToContinueWithoutSaving(true);
-                  setShowNeedsAccountModal(false);
-                }}
-              >
-                {Config.selfRegistration.continueWithoutSaving}
-              </SecondaryButton>
-            )}
+            <SecondaryButton
+              isColor="primary"
+              className={"margin-top-05"}
+              isFullWidthOnDesktop
+              onClick={() => {
+                analytics.event.guest_modal.click.continue_exploring();
+                setShowNeedsAccountModal(false);
+              }}
+            >
+              {Config.selfRegistration.continueExploringButtonText}
+            </SecondaryButton>
           </div>
 
           <hr className="margin-y-3 margin-x-neg-4" />

--- a/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/Requirements.test.tsx
+++ b/web/src/components/tasks/anytime-action/tax-clearance-certificate/steps/Requirements.test.tsx
@@ -29,10 +29,6 @@ describe("Requirements", () => {
             setShowNeedsAccountSnackbar: jest.fn(),
             registrationStatus: undefined,
             setRegistrationStatus: jest.fn(),
-            showContinueWithoutSaving: false,
-            setShowContinueWithoutSaving: jest.fn(),
-            userWantsToContinueWithoutSaving: false,
-            setUserWantsToContinueWithoutSaving: jest.fn(),
           }}
         >
           <Requirements setStepIndex={mockSetStepIndex} />

--- a/web/src/components/tasks/cigarette-license/GeneralInfo.test.tsx
+++ b/web/src/components/tasks/cigarette-license/GeneralInfo.test.tsx
@@ -1,9 +1,9 @@
+import { GeneralInfo } from "@/components/tasks/cigarette-license/GeneralInfo";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useMockProfileData } from "@/test/mock/mockUseUserData";
 import { ConfigContext, getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { GeneralInfo } from "@/components/tasks/cigarette-license/GeneralInfo";
 
 jest.mock("@/lib/data-hooks/useUserData", () => ({ useUserData: jest.fn() }));
 
@@ -29,10 +29,6 @@ describe("General Info", () => {
             setShowNeedsAccountSnackbar: jest.fn(),
             registrationStatus: undefined,
             setRegistrationStatus: jest.fn(),
-            showContinueWithoutSaving: false,
-            setShowContinueWithoutSaving: jest.fn(),
-            userWantsToContinueWithoutSaving: false,
-            setUserWantsToContinueWithoutSaving: jest.fn(),
           }}
         >
           <GeneralInfo setStepIndex={mockSetStepIndex} />

--- a/web/src/components/tasks/environment-questionnaire/EnvQuestionnaireStepper.tsx
+++ b/web/src/components/tasks/environment-questionnaire/EnvQuestionnaireStepper.tsx
@@ -42,12 +42,7 @@ export const EnvQuestionnaireStepper = (): ReactElement => {
   const envContext = useContext(EnvRequirementsContext);
   const { updateQueue } = useUserData();
 
-  const {
-    isAuthenticated,
-    setShowNeedsAccountModal,
-    setShowContinueWithoutSaving,
-    userWantsToContinueWithoutSaving,
-  } = useContext(NeedsAccountContext);
+  const { isAuthenticated, setShowNeedsAccountModal } = useContext(NeedsAccountContext);
 
   type EnvRequirementsStepNames =
     | "Instructions"
@@ -155,18 +150,13 @@ export const EnvQuestionnaireStepper = (): ReactElement => {
       categoryName,
     );
 
-    const userNotAuthAndDoesNotWantToSave =
-      envContext.state.stepIndex === 0 &&
-      isAuthenticated === IsAuthenticated.FALSE &&
-      userWantsToContinueWithoutSaving === false;
-
-    if (userNotAuthAndDoesNotWantToSave) {
+    if (envContext.state.stepIndex === 0 && isAuthenticated === IsAuthenticated.FALSE) {
       updateQueue
         ?.queuePreferences({ returnToLink: ROUTES.environmentRequirements })
         .updateInBackground();
-      setShowContinueWithoutSaving(true);
       setShowNeedsAccountModal(true);
     }
+
     envContext.setStepIndex(newStep);
   };
 
@@ -280,25 +270,16 @@ export const EnvQuestionnaireStepper = (): ReactElement => {
           isRightMarginRemoved
           isColor="accent-cooler"
           onClick={() => {
-            if (
-              envContext.state.stepIndex === 0 &&
-              isAuthenticated === IsAuthenticated.FALSE &&
-              userWantsToContinueWithoutSaving === false
-            ) {
+            if (envContext.state.stepIndex === 0 && isAuthenticated === IsAuthenticated.FALSE) {
               updateQueue
                 ?.queuePreferences({ returnToLink: ROUTES.environmentRequirements })
                 .updateInBackground();
-              setShowContinueWithoutSaving(true);
               analytics.event.gen_guidance_stepper_save_modal_displayed.appears.general_guidance_save_modal_displayed();
               setShowNeedsAccountModal(true);
               envContext.setStepIndex(envContext.state.stepIndex + 1);
               return;
             }
             if (envContext.state.stepIndex < 5) {
-              if (userWantsToContinueWithoutSaving === true && envContext.state.stepIndex === 1) {
-                analytics.event.gen_guidance_stepper_continue_without_saving.click.general_guidance_continue_wo_saving();
-              }
-
               envContext.setStepIndex(envContext.state.stepIndex + 1);
             }
             if (envContext.state.stepIndex === 5) {

--- a/web/src/components/tasks/environment-questionnaire/EnvRequirements.test.tsx
+++ b/web/src/components/tasks/environment-questionnaire/EnvRequirements.test.tsx
@@ -49,7 +49,6 @@ describe("<EnvRequirements />", () => {
   });
 
   const setShowNeedsAccountModal = jest.fn();
-  const setShowContinueWithoutSaving = jest.fn();
   const existingEmail = "emailInUserData@email.com";
 
   const renderComponent = (environmentData?: Partial<EnvironmentData>): void => {
@@ -75,10 +74,8 @@ describe("<EnvRequirements />", () => {
 
   const renderComponentWithNeedsAccountContext = ({
     isAuthenticated,
-    userWantsToContinueWithoutSaving,
   }: {
     isAuthenticated?: boolean;
-    userWantsToContinueWithoutSaving?: boolean;
   }): void => {
     render(
       withNeedsAccountContext(
@@ -88,8 +85,6 @@ describe("<EnvRequirements />", () => {
         isAuthenticated ? IsAuthenticated.TRUE : IsAuthenticated.FALSE,
         {
           setShowNeedsAccountModal: setShowNeedsAccountModal,
-          setShowContinueWithoutSaving: setShowContinueWithoutSaving,
-          userWantsToContinueWithoutSaving: userWantsToContinueWithoutSaving ?? false,
         },
       ),
     );
@@ -122,22 +117,6 @@ describe("<EnvRequirements />", () => {
           return expect(setShowNeedsAccountModal).toHaveBeenCalledWith(true);
         });
         expect(currentBusiness().preferences.returnToLink).toEqual(ROUTES.environmentRequirements);
-      });
-
-      it("sets showContinueWithoutSaving to true when on the first step, is not authenticated and user hasn't clicked continue without saving", async () => {
-        renderComponentWithNeedsAccountContext({});
-        startQuestionnaire();
-        await waitFor(() => {
-          return expect(setShowContinueWithoutSaving).toHaveBeenCalledWith(true);
-        });
-      });
-
-      it("doesn't open 'Needs Account' modal when continueWithoutSaving is true", async () => {
-        renderComponentWithNeedsAccountContext({ userWantsToContinueWithoutSaving: true });
-        startQuestionnaire();
-        await waitFor(() => {
-          return expect(setShowNeedsAccountModal).not.toHaveBeenCalled();
-        });
       });
     });
 

--- a/web/src/contexts/needsAccountContext.ts
+++ b/web/src/contexts/needsAccountContext.ts
@@ -8,12 +8,6 @@ export interface NeedsAccountContextType {
   showNeedsAccountSnackbar: boolean;
   showNeedsAccountModal: boolean;
 
-  showContinueWithoutSaving: boolean;
-  setShowContinueWithoutSaving: (value: boolean) => void;
-
-  userWantsToContinueWithoutSaving: boolean;
-  setUserWantsToContinueWithoutSaving: (value: boolean) => void;
-
   setRegistrationStatus: (value: RegistrationStatus | undefined) => void;
   setShowNeedsAccountSnackbar: (value: boolean) => void;
   setShowNeedsAccountModal: (value: boolean) => void;
@@ -23,10 +17,6 @@ export const NeedsAccountContext = createContext<NeedsAccountContextType>({
   isAuthenticated: IsAuthenticated.UNKNOWN,
   registrationStatus: undefined,
   showNeedsAccountSnackbar: false,
-  showContinueWithoutSaving: false,
-  setShowContinueWithoutSaving: () => {},
-  userWantsToContinueWithoutSaving: false,
-  setUserWantsToContinueWithoutSaving: () => {},
   setRegistrationStatus: () => {},
   setShowNeedsAccountSnackbar: () => {},
   showNeedsAccountModal: false,

--- a/web/src/lib/cms/previews/SelfRegistrationPreview.tsx
+++ b/web/src/lib/cms/previews/SelfRegistrationPreview.tsx
@@ -59,10 +59,6 @@ const SelfRegistrationPreview = (props: PreviewProps): ReactElement => {
         setShowNeedsAccountModal: () => {
           setModalOpen(true);
         },
-        showContinueWithoutSaving: true,
-        setShowContinueWithoutSaving: () => {},
-        userWantsToContinueWithoutSaving: true,
-        setUserWantsToContinueWithoutSaving: () => {},
       }}
     >
       <ConfigContext.Provider value={{ config, setOverrides: setConfig }}>

--- a/web/src/lib/utils/analytics.ts
+++ b/web/src/lib/utils/analytics.ts
@@ -60,7 +60,6 @@ type EventType =
   | "env_help_dep_opened"
   | "env_help_responses_opened"
   | "env_save_progress_prompted"
-  | "env_continue_without_auth"
   | "env_contact_info_engaged"
   | string;
 
@@ -110,7 +109,6 @@ const eventMap: Record<EventType, string> = {
   env_help_dep_opened: "env_help_dep_opened",
   env_help_responses_opened: "env_help_responses_opened",
   env_save_progress_prompted: "env_save_progress_prompted",
-  env_continue_without_auth: "env_continue_without_auth",
   env_contact_info_engaged: "env_contact_info_engaged",
 };
 
@@ -176,7 +174,8 @@ type Clicked =
   | "unlinked_myNJ_account"
   | "get_unlinked_myNJ_account_modal"
   | "link_your_myNJ_account"
-  | "close_NeedsAccountModal";
+  | "close_NeedsAccountModal"
+  | "continue_exploring_button";
 
 type OnSiteSection =
   | "landing_page"
@@ -772,6 +771,16 @@ export default {
             legacy_event_category: "guest_modal",
             legacy_event_label: "close_NeedsAccountModal",
             clicked: "close_NeedsAccountModal",
+            item: "guest_modal",
+          });
+        },
+        continue_exploring: () => {
+          eventRunner.track({
+            event: "account_clicks",
+            legacy_event_action: "click",
+            legacy_event_category: "guest_modal",
+            legacy_event_label: "continue_exploring",
+            clicked: "continue_exploring_button",
             item: "guest_modal",
           });
         },
@@ -2976,18 +2985,6 @@ export default {
             legacy_event_action: "mouseover",
             legacy_event_category: "environmental_requirements_contact",
             legacy_event_label: "contact_info_hovered",
-          });
-        },
-      },
-    },
-    gen_guidance_stepper_continue_without_saving: {
-      click: {
-        general_guidance_continue_wo_saving: () => {
-          eventRunner.track({
-            event: "env_continue_without_auth",
-            legacy_event_action: "click",
-            legacy_event_category: "environmental_requirements_save",
-            legacy_event_label: "continue_without_saving_clicked",
           });
         },
       },

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -16,9 +16,9 @@ import { UpdateQueueContext } from "@/contexts/updateQueueContext";
 import { UserDataErrorContext } from "@/contexts/userDataErrorContext";
 import { UpdateQueue } from "@/lib/UpdateQueue";
 import { authReducer } from "@/lib/auth/AuthContext";
-import { UserDataProvider } from "@/lib/data-hooks/UserDataProvider";
 import { getActiveUser } from "@/lib/auth/sessionHelper";
 import { onGuestSignIn, onSignIn } from "@/lib/auth/signinHelper";
+import { UserDataProvider } from "@/lib/data-hooks/UserDataProvider";
 import { insertIndustryContent } from "@/lib/domain-logic/starterKits";
 import MuiTheme from "@/lib/muiTheme";
 import { UserDataStorageFactory } from "@/lib/storage/UserDataStorage";
@@ -68,10 +68,6 @@ const App = ({ Component, pageProps }: AppProps): ReactElement => {
   const [showNeedsAccountSnackbar, setShowNeedsAccountSnackbar] = useState<boolean>(false);
   const [showNeedsAccountModal, setShowNeedsAccountModal] = useState<boolean>(false);
   const [showRemoveBusinessModal, setShowRemoveBusinessModal] = useState<boolean>(false);
-
-  const [showContinueWithoutSaving, setShowContinueWithoutSaving] = useState<boolean>(false);
-  const [userWantsToContinueWithoutSaving, setUserWantsToContinueWithoutSaving] =
-    useState<boolean>(false);
 
   const [contextualInfo, setContextualInfo] = useState<ContextualInfo>({
     isVisible: false,
@@ -271,10 +267,6 @@ const App = ({ Component, pageProps }: AppProps): ReactElement => {
                                 setRegistrationStatus: setRegistrationStatusInStateAndStorage,
                                 setShowNeedsAccountSnackbar,
                                 setShowNeedsAccountModal: setShowNeedsAccountModalAndSendAnalytics,
-                                showContinueWithoutSaving,
-                                setShowContinueWithoutSaving,
-                                userWantsToContinueWithoutSaving,
-                                setUserWantsToContinueWithoutSaving,
                               }}
                             >
                               <RemoveBusinessContext.Provider

--- a/web/stories/Molecules/textfields/OneEncryptedFieldTextField.stories.tsx
+++ b/web/stories/Molecules/textfields/OneEncryptedFieldTextField.stories.tsx
@@ -34,10 +34,6 @@ const Template = () => {
           setShowNeedsAccountSnackbar: () => {},
           showNeedsAccountModal: false,
           setShowNeedsAccountModal: () => {},
-          showContinueWithoutSaving: false,
-          setShowContinueWithoutSaving: () => {},
-          userWantsToContinueWithoutSaving: false,
-          setUserWantsToContinueWithoutSaving: () => {},
         }}
       >
         <ConfigContext.Provider value={{ config, setOverrides: setConfig }}>

--- a/web/stories/Molecules/textfields/TextFieldLabels.stories.tsx
+++ b/web/stories/Molecules/textfields/TextFieldLabels.stories.tsx
@@ -80,10 +80,6 @@ const Template = () => {
             setShowNeedsAccountSnackbar: () => {},
             showNeedsAccountModal: false,
             setShowNeedsAccountModal: () => {},
-            showContinueWithoutSaving: false,
-            setShowContinueWithoutSaving: () => {},
-            userWantsToContinueWithoutSaving: false,
-            setUserWantsToContinueWithoutSaving: () => {},
           }}
         >
           <ConfigContext.Provider value={{ config: Config, setOverrides: setConfig }}>

--- a/web/stories/Molecules/textfields/TwoEncryptedFieldTextField.stories.tsx
+++ b/web/stories/Molecules/textfields/TwoEncryptedFieldTextField.stories.tsx
@@ -35,10 +35,6 @@ const Template = () => {
           setShowNeedsAccountSnackbar: () => {},
           showNeedsAccountModal: false,
           setShowNeedsAccountModal: () => {},
-          showContinueWithoutSaving: false,
-          setShowContinueWithoutSaving: () => {},
-          userWantsToContinueWithoutSaving: false,
-          setUserWantsToContinueWithoutSaving: () => {},
         }}
       >
         <ConfigContext.Provider value={{ config, setOverrides: setConfig }}>

--- a/web/test/helpers/helpers-formation.tsx
+++ b/web/test/helpers/helpers-formation.tsx
@@ -81,8 +81,6 @@ type PreparePageParams = {
   task?: Task;
   isAuthenticated?: IsAuthenticated;
   setShowNeedsAccountModal?: (value: boolean) => void;
-  setShowContinueWithoutSaving?: (value: boolean) => void;
-  setUserWantsToContinueWithoutSaving?: (value: boolean) => void;
   user?: Partial<BusinessUser>;
 };
 
@@ -93,8 +91,6 @@ export const preparePage = ({
   task,
   isAuthenticated,
   setShowNeedsAccountModal,
-  setShowContinueWithoutSaving,
-  setUserWantsToContinueWithoutSaving,
   user,
 }: PreparePageParams): FormationPageHelpers => {
   const profileData = generateFormationProfileData({ ...business.profileData });
@@ -148,10 +144,6 @@ export const preparePage = ({
       {
         showNeedsAccountModal: false,
         setShowNeedsAccountModal: setShowNeedsAccountModal ?? jest.fn(),
-        showContinueWithoutSaving: false,
-        setShowContinueWithoutSaving: setShowContinueWithoutSaving ?? jest.fn(),
-        userWantsToContinueWithoutSaving: false,
-        setUserWantsToContinueWithoutSaving: setUserWantsToContinueWithoutSaving ?? jest.fn(),
       },
     ),
   );

--- a/web/test/helpers/helpers-renderers.tsx
+++ b/web/test/helpers/helpers-renderers.tsx
@@ -43,13 +43,9 @@ export const withNeedsAccountContext = (
     showNeedsAccountSnackbar?: boolean;
     showNeedsAccountModal?: boolean;
     registrationStatus?: RegistrationStatus;
-    showContinueWithoutSaving?: boolean;
-    userWantsToContinueWithoutSaving?: boolean;
     setRegistrationStatus?: (value: RegistrationStatus | undefined) => void;
     setShowNeedsAccountSnackbar?: (value: boolean) => void;
     setShowNeedsAccountModal?: (value: boolean) => void;
-    setShowContinueWithoutSaving?: (value: boolean) => void;
-    setUserWantsToContinueWithoutSaving?: (value: boolean) => void;
   },
 ): ReactElement => {
   return (
@@ -62,11 +58,6 @@ export const withNeedsAccountContext = (
         setRegistrationStatus: context?.setRegistrationStatus || jest.fn(),
         setShowNeedsAccountSnackbar: context?.setShowNeedsAccountSnackbar || jest.fn(),
         setShowNeedsAccountModal: context?.setShowNeedsAccountModal || jest.fn(),
-        showContinueWithoutSaving: context?.showContinueWithoutSaving || false,
-        setShowContinueWithoutSaving: context?.setShowContinueWithoutSaving || jest.fn(),
-        userWantsToContinueWithoutSaving: context?.userWantsToContinueWithoutSaving || false,
-        setUserWantsToContinueWithoutSaving:
-          context?.setUserWantsToContinueWithoutSaving || jest.fn(),
       }}
     >
       {subject}

--- a/web/test/pages/profile/profile-govdelivery.test.tsx
+++ b/web/test/pages/profile/profile-govdelivery.test.tsx
@@ -1,17 +1,17 @@
 import * as api from "@/lib/api-client/apiClient";
+import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import * as useUserModule from "@/lib/data-hooks/useUserData";
 import { UpdateQueue } from "@/lib/UpdateQueue";
+import Profile from "@/pages/profile";
+import { withNeedsAccountContext } from "@/test/helpers/helpers-renderers";
 import { useMockIntersectionObserver } from "@/test/mock/MockIntersectionObserver";
 import { useMockRouter } from "@/test/mock/mockRouter";
 import { useMockDocuments } from "@/test/mock/mockUseDocuments";
 import { useMockRoadmap } from "@/test/mock/mockUseRoadmap";
 import { clickSave, generateBusinessForProfile } from "@/test/pages/profile/profile-helpers";
 import { Business, generateUserDataForBusiness, UserData } from "@businessnjgovnavigator/shared";
-import { getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
 import { generateOwningProfileData } from "@businessnjgovnavigator/shared/";
-import Profile from "@/pages/profile";
-import { withNeedsAccountContext } from "@/test/helpers/helpers-renderers";
-import { IsAuthenticated } from "@/lib/auth/AuthContext";
+import { getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
 import { createTheme, ThemeProvider } from "@mui/material";
 import { render, screen, waitFor } from "@testing-library/react";
 import { act } from "react";
@@ -83,10 +83,6 @@ const renderProfileOnContactTab = (business: Business, mockUpdate: jest.Mock): v
       {
         showNeedsAccountModal: false,
         setShowNeedsAccountModal: jest.fn(),
-        showContinueWithoutSaving: false,
-        setShowContinueWithoutSaving: jest.fn(),
-        userWantsToContinueWithoutSaving: false,
-        setUserWantsToContinueWithoutSaving: jest.fn(),
       },
     ),
   );
@@ -250,10 +246,6 @@ describe("profile - govDelivery error handling", () => {
         {
           showNeedsAccountModal: false,
           setShowNeedsAccountModal: jest.fn(),
-          showContinueWithoutSaving: false,
-          setShowContinueWithoutSaving: jest.fn(),
-          userWantsToContinueWithoutSaving: false,
-          setUserWantsToContinueWithoutSaving: jest.fn(),
         },
       ),
     );

--- a/web/test/pages/profile/profile-helpers.tsx
+++ b/web/test/pages/profile/profile-helpers.tsx
@@ -90,10 +90,6 @@ export const renderPage = ({
       {
         showNeedsAccountModal: false,
         setShowNeedsAccountModal: setShowNeedsAccountModal ?? jest.fn(),
-        showContinueWithoutSaving: false,
-        setShowContinueWithoutSaving: jest.fn(),
-        userWantsToContinueWithoutSaving: false,
-        setUserWantsToContinueWithoutSaving: jest.fn(),
       },
     ),
   );


### PR DESCRIPTION
## Description

This PR adds a "Continue Exploring" button to all login modals, as [designed for in the login modal mission](https://www.figma.com/design/H2mER7gGeHKTM3TgySmSvm/101-105-Business-Experience-Sprint-Designs?node-id=75788-22703&t=0LEbcQoB0WEyRrrm-4) and updates the modal copy to use friendlier language. 

The universal "Continue Exploring" button serves as a replacement for the conditionally-shown "Continue without saving" button, which used to only exist in [the Environmental Requirements task](https://github.com/newjersey/navigator.business.nj.gov/pull/11163). 

Making it universal allows us to simplify the NeedsAccountModal by removing all the code related to the `showContinueWithoutSaving` and `userWantsToContinueWithoutSaving` states.

### Ticket

This pull request resolves [#17867](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17867).

### Approach

- Removed `showContinueWithoutSaving`, `setShowContinueWithoutSaving`, `userWantsToContinueWithoutSaving`, and `setUserWantsToContinueWithoutSaving` from `NeedsAccountContext` and all consumers.
- Added a `guest_modal.click.continue_exploring` analytics event for the new button.
- Updated CMS field config and Decap collection to rename the field from `continueWithoutSaving` to `continueExploringButtonText`.

### Steps to Test

1. Onboard as a new business.
2. Trigger the login modal by interacting with a locked task.
3. Verify the modal shows "Do You Want to Save Your Progress?" with a "Create My Free Account" primary button and a "Continue Exploring" secondary button.
4. Click "Continue Exploring" and the modal should close.

### Notes

The `env_continue_without_auth` analytics event type has been removed; tracking is now covered by combining the `guest_modal.click.continue_exploring` event with a page path filter for the env permit page.


## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews