### PR TITLE
feat: [AB#17975] add descriptive page titles

### DIFF
--- a/packages/static-site/app/[locale]/(learn)/[category]/page.test.tsx
+++ b/packages/static-site/app/[locale]/(learn)/[category]/page.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import CategoryPage, { generateStaticParams } from "./page";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import CategoryPage, { generateMetadata, generateStaticParams } from "./page";
 
 vi.mock("@/domain/categories", () => ({
   CATEGORY_HIERARCHY: {
@@ -18,6 +19,35 @@ vi.mock("@/domain/categories", () => ({
     start: { children: [] },
   },
 }));
+
+describe("generateMetadata", () => {
+  it("brands the title with the category's own title and its subtitle as the description", async () => {
+    const { learn } = getApplicationMessages({ locale: "en-US" });
+    const plan = learn.categories.find((category) => category.key === "plan");
+    if (!plan) {
+      throw new Error("Expected a 'plan' category in real en-US messages");
+    }
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: "en-US", category: "plan" }),
+    });
+
+    expect(metadata.title).toEqual({ absolute: `${plan.title} | Business.NJ.gov` });
+    expect(metadata.description).toBe(plan.subtitle);
+    expect(metadata.openGraph?.title).toEqual(metadata.title);
+    expect(metadata.twitter?.title).toEqual(metadata.title);
+    expect(metadata.alternates?.canonical).toBe("/plan");
+  });
+
+  it("falls back to alternates-only metadata for an unknown category", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: "en-US", category: "does-not-exist" }),
+    });
+
+    expect(metadata.title).toBeUndefined();
+    expect(metadata.alternates?.canonical).toBe("/does-not-exist");
+  });
+});
 
 describe("generateStaticParams", () => {
   it("returns each category from CATEGORY_HIERARCHY", () => {

--- a/packages/static-site/app/[locale]/(learn)/[category]/page.tsx
+++ b/packages/static-site/app/[locale]/(learn)/[category]/page.tsx
@@ -2,8 +2,9 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { CATEGORY_HIERARCHY } from "@/domain/categories";
 import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
-import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
+import { type AppLocale, hasAppLocale, resolveAppLocale } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
+import { buildPageMetadata } from "@/domain/metadata/pageMetadata";
 
 interface PageParams {
   readonly locale: AppLocale;
@@ -22,9 +23,21 @@ interface Props {
  * @returns Metadata containing canonical and alternate-language links.
  */
 export const generateMetadata = async ({ params }: Props): Promise<Metadata> => {
-  const { category } = await params;
+  const { locale, category } = await params;
+  const pathnameWithoutLocale = `/${category}`;
 
-  return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: `/${category}` }) };
+  const messages = getApplicationMessages({ locale: resolveAppLocale({ locale }) });
+  const categoryMessages = messages.learn.categories.find((content) => content.key === category);
+
+  if (!categoryMessages) {
+    return { alternates: buildAlternateLanguages({ pathnameWithoutLocale }) };
+  }
+
+  return buildPageMetadata({
+    pageTitle: categoryMessages.title,
+    description: categoryMessages.subtitle,
+    pathnameWithoutLocale,
+  });
 };
 
 /**

--- a/packages/static-site/app/[locale]/(learn)/learn/page.test.tsx
+++ b/packages/static-site/app/[locale]/(learn)/learn/page.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import LearnPage, { generateMetadata } from "./page";
+
+describe("generateMetadata", () => {
+  it("brands the title with the learn page's own name and its sub-heading as the description", async () => {
+    const { learn } = getApplicationMessages({ locale: "en-US" });
+
+    const metadata = await generateMetadata({ params: Promise.resolve({ locale: "en-US" }) });
+
+    expect(metadata.title).toEqual({ absolute: `${learn.name} | Business.NJ.gov` });
+    expect(metadata.description).toBe(learn.subHeadingText);
+    expect(metadata.openGraph?.title).toEqual(metadata.title);
+    expect(metadata.twitter?.title).toEqual(metadata.title);
+    expect(metadata.alternates?.canonical).toBe("/learn");
+  });
+});
+
+describe("LearnPage", () => {
+  it("renders the learn page's name as an h1", async () => {
+    const { learn } = getApplicationMessages({ locale: "en-US" });
+
+    render(await LearnPage({ params: Promise.resolve({ locale: "en-US" }) }));
+
+    expect(screen.getByRole("heading", { level: 1, name: learn.name })).toBeInTheDocument();
+  });
+});

--- a/packages/static-site/app/[locale]/(learn)/learn/page.tsx
+++ b/packages/static-site/app/[locale]/(learn)/learn/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
-import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
-import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
+import { type AppLocale, hasAppLocale, resolveAppLocale } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
+import { buildPageMetadata } from "@/domain/metadata/pageMetadata";
 
 interface PageParams {
   readonly locale: AppLocale;
@@ -14,12 +14,21 @@ interface Props {
 }
 
 /**
- * Generates metadata advertising hreflang alternates for the learn page.
+ * Generates branded, descriptive metadata for the learn page.
  *
- * @returns Metadata containing canonical and alternate-language links.
+ * @param props Route props provided by Next.js.
+ * @param props.params Async route params including the locale segment.
+ * @returns Metadata with a title matching the page's `<h1>`, its description, and alternate-language links.
  */
-export const generateMetadata = (): Metadata => {
-  return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: "/learn" }) };
+export const generateMetadata = async ({ params }: Props): Promise<Metadata> => {
+  const { locale } = await params;
+  const { learn } = getApplicationMessages({ locale: resolveAppLocale({ locale }) });
+
+  return buildPageMetadata({
+    pageTitle: learn.name,
+    description: learn.subHeadingText,
+    pathnameWithoutLocale: "/learn",
+  });
 };
 
 const LearnPage = async ({ params }: Props) => {

--- a/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.test.tsx
+++ b/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import { describe, expect, it, vi } from "vitest";
 import { getApplicationMessages } from "@/domain/i18n/messages";
-import ContentPage, { generateStaticParams } from "./page";
+import ContentPage, { generateMetadata, generateStaticParams } from "./page";
 
 vi.mock("@/domain/categories", () => ({
   CATEGORY_HIERARCHY: {
@@ -42,6 +42,35 @@ describe("generateStaticParams", () => {
       { slug: "choose-a-business-structure" },
       { slug: "something-else" },
     ]);
+  });
+});
+
+describe("generateMetadata", () => {
+  it("brands the title with the page's own name and its sub-heading as the description", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: "en-US", slug: "create-a-business-plan" }),
+    });
+
+    expect(metadata.title).toEqual({ absolute: "Create a Business Plan | Business.NJ.gov" });
+    expect(metadata.alternates?.canonical).toBe("/pages/create-a-business-plan");
+  });
+
+  it("uses the localized message title for the funding page, not the English-only frontmatter name", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: "en-US", slug: "funding" }),
+    });
+
+    expect(metadata.title).toEqual({ absolute: "Funding | Business.NJ.gov" });
+    expect(metadata.description).toBe("Whether you're looking for startup capital...");
+  });
+
+  it("falls back to alternates-only metadata for an unknown slug", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: "en-US", slug: "does-not-exist" }),
+    });
+
+    expect(metadata.title).toBeUndefined();
+    expect(metadata.alternates?.canonical).toBe("/pages/does-not-exist");
   });
 });
 

--- a/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.tsx
+++ b/packages/static-site/app/[locale]/(learn)/pages/[slug]/page.tsx
@@ -1,10 +1,13 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { PageSwitchComponent } from "@/components/learn/PageSwitchComponent";
+import { resolvePageTitle } from "@/components/learn/resolvePageTitle";
 import { CATEGORY_HIERARCHY } from "@/domain/categories";
 import { loadPages } from "@/domain/content/loadContent";
 import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
-import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
+import { type AppLocale, hasAppLocale, resolveAppLocale } from "@/domain/i18n/locales";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { buildPageMetadata } from "@/domain/metadata/pageMetadata";
 
 interface PageParams {
   readonly locale: AppLocale;
@@ -16,16 +19,28 @@ interface Props {
 }
 
 /**
- * Generates metadata advertising hreflang alternates for a content page.
+ * Generates branded, descriptive metadata for a content page.
  *
  * @param props Route props provided by Next.js.
  * @param props.params Async route params including the slug segment.
- * @returns Metadata containing canonical and alternate-language links.
+ * @returns Metadata with a title matching the page's `<h1>`, its description, and alternate-language links.
  */
 export const generateMetadata = async ({ params }: Props): Promise<Metadata> => {
-  const { slug } = await params;
+  const { locale, slug } = await params;
+  const pathnameWithoutLocale = `/pages/${slug}`;
 
-  return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: `/pages/${slug}` }) };
+  const page = loadPages().find((item) => item.slug === slug);
+  if (!page) {
+    return { alternates: buildAlternateLanguages({ pathnameWithoutLocale }) };
+  }
+
+  const messages = getApplicationMessages({ locale: resolveAppLocale({ locale }) });
+
+  return buildPageMetadata({
+    pageTitle: resolvePageTitle({ page, messages }),
+    description: page["sub-heading-text"],
+    pathnameWithoutLocale,
+  });
 };
 
 export const generateStaticParams = () => {

--- a/packages/static-site/app/[locale]/impact-report/page.test.tsx
+++ b/packages/static-site/app/[locale]/impact-report/page.test.tsx
@@ -6,8 +6,13 @@ import ImpactReportRoute, { generateMetadata } from "./page";
 const { impactReport } = getApplicationMessages({ locale: "en-US" });
 
 describe("generateMetadata", () => {
-  it("builds hreflang alternates for /impact-report", () => {
-    const metadata = generateMetadata();
+  it("brands the title with the page's own title and its meta description", async () => {
+    const metadata = await generateMetadata({ params: Promise.resolve({ locale: "en-US" }) });
+
+    expect(metadata.title).toEqual({ absolute: `${impactReport.title} | Business.NJ.gov` });
+    expect(metadata.description).toBe(impactReport.metaDescription);
+    expect(metadata.openGraph?.title).toEqual(metadata.title);
+    expect(metadata.twitter?.title).toEqual(metadata.title);
     expect(metadata.alternates?.canonical).toBe("/impact-report");
   });
 });

--- a/packages/static-site/app/[locale]/impact-report/page.tsx
+++ b/packages/static-site/app/[locale]/impact-report/page.tsx
@@ -2,8 +2,9 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { ImpactReportPage } from "@/components/impactReport/ImpactReportPage";
-import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
-import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
+import { type AppLocale, hasAppLocale, resolveAppLocale } from "@/domain/i18n/locales";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { buildPageMetadata } from "@/domain/metadata/pageMetadata";
 
 interface PageParams {
   readonly locale: AppLocale;
@@ -14,12 +15,21 @@ interface Props {
 }
 
 /**
- * Generates metadata advertising hreflang alternates for the impact report page.
+ * Generates branded, descriptive metadata for the impact report page.
  *
- * @returns Metadata containing canonical and alternate-language links.
+ * @param props Route props provided by Next.js.
+ * @param props.params Async route params including the locale segment.
+ * @returns Metadata with a title matching the page's `<h1>`, its description, and alternate-language links.
  */
-export const generateMetadata = (): Metadata => {
-  return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: "/impact-report" }) };
+export const generateMetadata = async ({ params }: Props): Promise<Metadata> => {
+  const { locale } = await params;
+  const { impactReport } = getApplicationMessages({ locale: resolveAppLocale({ locale }) });
+
+  return buildPageMetadata({
+    pageTitle: impactReport.title,
+    description: impactReport.metaDescription,
+    pathnameWithoutLocale: "/impact-report",
+  });
 };
 
 const ImpactReportRoute = async ({ params }: Props) => {

--- a/packages/static-site/app/[locale]/layout.tsx
+++ b/packages/static-site/app/[locale]/layout.tsx
@@ -27,12 +27,12 @@ import { SkipNav } from "@/components/landing/SkipNav";
 import { textDirectionForLocale } from "@/domain/i18n/languages";
 import { ENABLED_LOCALES, hasAppLocale } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
-import { SITE_BASE_URL } from "@/domain/siteConfig";
+import { SITE_BASE_URL, SOCIAL_PREVIEW_IMAGE } from "@/domain/siteConfig";
 
 /**
- * Stores the logo path used in metadata icons and social previews.
+ * Stores the logo path used in metadata icons.
  */
-const NJ_LOGO_IMAGE_PATH = "/assets/njwds/dist/img/nj-logo-gray-20.png";
+const NJ_LOGO_IMAGE_PATH = SOCIAL_PREVIEW_IMAGE.url;
 
 /**
  * Public path for the synced NJWDS stylesheet.
@@ -130,20 +130,13 @@ export const generateMetadata = async ({ params }: GenerateMetadataProps): Promi
     openGraph: {
       title: messages.metadata.title,
       description: messages.metadata.description,
-      images: [
-        {
-          url: NJ_LOGO_IMAGE_PATH,
-          width: 144,
-          height: 144,
-          alt: "State of New Jersey logo",
-        },
-      ],
+      images: [SOCIAL_PREVIEW_IMAGE],
     },
     twitter: {
       card: "summary",
       title: messages.metadata.title,
       description: messages.metadata.description,
-      images: [NJ_LOGO_IMAGE_PATH],
+      images: [SOCIAL_PREVIEW_IMAGE.url],
     },
   };
 };

--- a/packages/static-site/app/[locale]/newsletter-signup/page.test.tsx
+++ b/packages/static-site/app/[locale]/newsletter-signup/page.test.tsx
@@ -6,8 +6,13 @@ import NewsletterSignupRoute, { generateMetadata } from "./page";
 const { newsletterSignup } = getApplicationMessages({ locale: "en-US" });
 
 describe("generateMetadata", () => {
-  it("builds hreflang alternates for /newsletter-signup", () => {
-    const metadata = generateMetadata();
+  it("brands the title with the page's own title and its meta description", async () => {
+    const metadata = await generateMetadata({ params: Promise.resolve({ locale: "en-US" }) });
+
+    expect(metadata.title).toEqual({ absolute: `${newsletterSignup.title} | Business.NJ.gov` });
+    expect(metadata.description).toBe(newsletterSignup.metaDescription);
+    expect(metadata.openGraph?.title).toEqual(metadata.title);
+    expect(metadata.twitter?.title).toEqual(metadata.title);
     expect(metadata.alternates?.canonical).toBe("/newsletter-signup");
   });
 });

--- a/packages/static-site/app/[locale]/newsletter-signup/page.tsx
+++ b/packages/static-site/app/[locale]/newsletter-signup/page.tsx
@@ -2,8 +2,9 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { NewsletterSignupPage } from "@/components/newsletterSignup/NewsletterSignupPage";
-import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
-import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
+import { type AppLocale, hasAppLocale, resolveAppLocale } from "@/domain/i18n/locales";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { buildPageMetadata } from "@/domain/metadata/pageMetadata";
 
 interface PageParams {
   readonly locale: AppLocale;
@@ -14,12 +15,21 @@ interface Props {
 }
 
 /**
- * Generates metadata advertising hreflang alternates for the newsletter signup page.
+ * Generates branded, descriptive metadata for the newsletter signup page.
  *
- * @returns Metadata containing canonical and alternate-language links.
+ * @param props Route props provided by Next.js.
+ * @param props.params Async route params including the locale segment.
+ * @returns Metadata with a title matching the page's `<h1>`, its description, and alternate-language links.
  */
-export const generateMetadata = (): Metadata => {
-  return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: "/newsletter-signup" }) };
+export const generateMetadata = async ({ params }: Props): Promise<Metadata> => {
+  const { locale } = await params;
+  const { newsletterSignup } = getApplicationMessages({ locale: resolveAppLocale({ locale }) });
+
+  return buildPageMetadata({
+    pageTitle: newsletterSignup.title,
+    description: newsletterSignup.metaDescription,
+    pathnameWithoutLocale: "/newsletter-signup",
+  });
 };
 
 const NewsletterSignupRoute = async ({ params }: Props) => {

--- a/packages/static-site/app/[locale]/not-found.test.tsx
+++ b/packages/static-site/app/[locale]/not-found.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { getApplicationMessages } from "@/domain/i18n/messages";
-import PageNotFound from "./not-found";
+import { SITE_TITLE_SUFFIX } from "@/domain/siteConfig";
+import PageNotFound, { generateMetadata } from "./not-found";
 
 vi.mock("next-intl/server", () => ({
   getLocale: vi.fn(),
@@ -11,6 +12,28 @@ const { getLocale } = await import("next-intl/server");
 
 const enMessages = await getApplicationMessages({ locale: "en-US" });
 const esMessages = await getApplicationMessages({ locale: "es-US" });
+
+describe("generateMetadata", () => {
+  it("builds a branded title matching the 404 page's own h1", async () => {
+    vi.mocked(getLocale).mockResolvedValue("en-US");
+
+    const metadata = await generateMetadata();
+
+    expect(metadata.title).toEqual({
+      absolute: `${enMessages.pageNotFound.title} | ${SITE_TITLE_SUFFIX}`,
+    });
+  });
+
+  it("builds a branded title for es-US", async () => {
+    vi.mocked(getLocale).mockResolvedValue("es-US");
+
+    const metadata = await generateMetadata();
+
+    expect(metadata.title).toEqual({
+      absolute: `${esMessages.pageNotFound.title} | ${SITE_TITLE_SUFFIX}`,
+    });
+  });
+});
 
 describe("PageNotFound", () => {
   it("renders the localized title and description for the resolved locale", async () => {

--- a/packages/static-site/app/[locale]/not-found.tsx
+++ b/packages/static-site/app/[locale]/not-found.tsx
@@ -1,8 +1,22 @@
+import type { Metadata } from "next";
 import Image from "next/image";
 import { getLocale } from "next-intl/server";
 import { LocalizedLink } from "@/components/landing/LocalizedLink";
 import { resolveAppLocale } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
+import { SITE_TITLE_SUFFIX } from "@/domain/siteConfig";
+
+/**
+ * Generates a branded, localized title for the 404 page.
+ *
+ * @returns Metadata with a title matching the page's own `<h1>` in the visitor's locale.
+ */
+export const generateMetadata = async (): Promise<Metadata> => {
+  const locale = resolveAppLocale({ locale: await getLocale() });
+  const { pageNotFound } = getApplicationMessages({ locale });
+
+  return { title: { absolute: `${pageNotFound.title} | ${SITE_TITLE_SUFFIX}` } };
+};
 
 const PageNotFound = async () => {
   const locale = resolveAppLocale({ locale: await getLocale() });

--- a/packages/static-site/app/[locale]/our-software-and-reuse/page.test.tsx
+++ b/packages/static-site/app/[locale]/our-software-and-reuse/page.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { loadPageBySlug } from "@/domain/content/loadContent";
-import PrivacyPolicyRoute, { generateMetadata } from "./page";
+import SoftwareAndReuseRoute, { generateMetadata } from "./page";
 
-const page = loadPageBySlug("privacy-policy");
+const page = loadPageBySlug("our-software-and-reuse");
 const { name } = page;
 
 describe("generateMetadata", () => {
@@ -14,14 +14,14 @@ describe("generateMetadata", () => {
     expect(metadata.description).toBe(page["sub-heading-text"]);
     expect(metadata.openGraph?.title).toEqual(metadata.title);
     expect(metadata.twitter?.title).toEqual(metadata.title);
-    expect(metadata.alternates?.canonical).toBe("/privacy-policy");
+    expect(metadata.alternates?.canonical).toBe("/our-software-and-reuse");
   });
 });
 
-describe("PrivacyPolicyRoute", () => {
-  it("renders the privacy policy page for a supported locale", async () => {
+describe("SoftwareAndReuseRoute", () => {
+  it("renders the page for a supported locale", async () => {
     render(
-      await PrivacyPolicyRoute({
+      await SoftwareAndReuseRoute({
         params: Promise.resolve({ locale: "en-US" }),
       }),
     );

--- a/packages/static-site/app/[locale]/our-software-and-reuse/page.tsx
+++ b/packages/static-site/app/[locale]/our-software-and-reuse/page.tsx
@@ -13,6 +13,7 @@ import PageContent from "@/components/learn/PageContent";
 import { loadPages } from "@/domain/content/loadContent";
 import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
 import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
+import { buildPageMetadata } from "@/domain/metadata/pageMetadata";
 
 /**
  * Slug of the Markdown file backing this page (`content/src/pages/<slug>.md`).
@@ -28,12 +29,21 @@ interface Props {
 }
 
 /**
- * Generates metadata advertising hreflang alternates for the page.
+ * Generates branded, descriptive metadata for the page.
  *
- * @returns Metadata containing canonical and alternate-language links.
+ * @returns Metadata with a title matching the page's `<h1>`, its description, and alternate-language links.
  */
 export const generateMetadata = (): Metadata => {
-  return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: `/${PAGE_SLUG}` }) };
+  const page = loadPages().find((item) => item.slug === PAGE_SLUG);
+  if (!page) {
+    return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: `/${PAGE_SLUG}` }) };
+  }
+
+  return buildPageMetadata({
+    pageTitle: page.name,
+    description: page["sub-heading-text"],
+    pathnameWithoutLocale: `/${PAGE_SLUG}`,
+  });
 };
 
 const SoftwareAndReuseRoute = async ({ params }: Props) => {

--- a/packages/static-site/app/[locale]/privacy-policy/page.tsx
+++ b/packages/static-site/app/[locale]/privacy-policy/page.tsx
@@ -13,6 +13,7 @@ import PageContent from "@/components/learn/PageContent";
 import { loadPages } from "@/domain/content/loadContent";
 import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
 import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
+import { buildPageMetadata } from "@/domain/metadata/pageMetadata";
 
 /**
  * Slug of the Markdown file backing this page (`content/src/pages/<slug>.md`).
@@ -28,12 +29,21 @@ interface Props {
 }
 
 /**
- * Generates metadata advertising hreflang alternates for the page.
+ * Generates branded, descriptive metadata for the page.
  *
- * @returns Metadata containing canonical and alternate-language links.
+ * @returns Metadata with a title matching the page's `<h1>`, its description, and alternate-language links.
  */
 export const generateMetadata = (): Metadata => {
-  return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: `/${PAGE_SLUG}` }) };
+  const page = loadPages().find((item) => item.slug === PAGE_SLUG);
+  if (!page) {
+    return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: `/${PAGE_SLUG}` }) };
+  }
+
+  return buildPageMetadata({
+    pageTitle: page.name,
+    description: page["sub-heading-text"],
+    pathnameWithoutLocale: `/${PAGE_SLUG}`,
+  });
 };
 
 const PrivacyPolicyRoute = async ({ params }: Props) => {

--- a/packages/static-site/app/[locale]/updates/[slug]/page.test.tsx
+++ b/packages/static-site/app/[locale]/updates/[slug]/page.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { loadRecents } from "@/domain/content/loadContent";
+import { buildUpdateDescription } from "@/domain/metadata/buildUpdateDescription";
+import UpdateDetailRoute, { generateMetadata } from "./page";
+
+const recent = loadRecents().find(
+  (item) => item.slug === "drought-warning-in-effect-voluntary-water-reduction-urged",
+);
+
+if (!recent) {
+  throw new Error("Expected fixture update to exist in content/src/recents");
+}
+
+describe("generateMetadata", () => {
+  it("builds a branded title matching the update's own name", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: "en-US", slug: recent.slug }),
+    });
+
+    expect(metadata.title).toEqual({ absolute: `${recent.name} | Business.NJ.gov` });
+    expect(metadata.openGraph?.title).toEqual(metadata.title);
+    expect(metadata.twitter?.title).toEqual(metadata.title);
+  });
+
+  it("derives a description from the update's body, matching openGraph and twitter", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: "en-US", slug: recent.slug }),
+    });
+
+    const expectedDescription = buildUpdateDescription({ body: recent.body });
+
+    expect(metadata.description).toBe(expectedDescription);
+    expect(metadata.openGraph?.description).toBe(expectedDescription);
+    expect(metadata.twitter?.description).toBe(expectedDescription);
+  });
+
+  it("builds hreflang alternates for /updates/<slug>", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: "en-US", slug: recent.slug }),
+    });
+
+    expect(metadata.alternates?.canonical).toBe(`/updates/${recent.slug}`);
+  });
+
+  it("falls back to alternates-only metadata for an unknown slug", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: "en-US", slug: "does-not-exist" }),
+    });
+
+    expect(metadata.title).toBeUndefined();
+    expect(metadata.alternates?.canonical).toBe("/updates/does-not-exist");
+  });
+});
+
+describe("UpdateDetailRoute", () => {
+  it("renders the update's name as an h1", async () => {
+    render(
+      await UpdateDetailRoute({
+        params: Promise.resolve({ locale: "en-US", slug: recent.slug }),
+      }),
+    );
+
+    expect(screen.getByRole("heading", { level: 1, name: recent.name })).toBeInTheDocument();
+  });
+});

--- a/packages/static-site/app/[locale]/updates/[slug]/page.tsx
+++ b/packages/static-site/app/[locale]/updates/[slug]/page.tsx
@@ -6,6 +6,8 @@ import { loadRecents } from "@/domain/content/loadContent";
 import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
 import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
+import { buildUpdateDescription } from "@/domain/metadata/buildUpdateDescription";
+import { buildPageMetadata } from "@/domain/metadata/pageMetadata";
 
 interface PageParams {
   readonly locale: AppLocale;
@@ -17,16 +19,26 @@ interface Props {
 }
 
 /**
- * Generates metadata advertising hreflang alternates for an update's detail page.
+ * Generates branded, descriptive metadata for an update's detail page.
  *
  * @param props Route props provided by Next.js.
  * @param props.params Async route params including the slug segment.
- * @returns Metadata containing canonical and alternate-language links.
+ * @returns Metadata with a title matching the update's `<h1>` and alternate-language links.
  */
 export const generateMetadata = async ({ params }: Props): Promise<Metadata> => {
   const { slug } = await params;
+  const pathnameWithoutLocale = `/updates/${slug}`;
 
-  return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: `/updates/${slug}` }) };
+  const recent = loadRecents().find((item) => item.slug === slug);
+  if (!recent) {
+    return { alternates: buildAlternateLanguages({ pathnameWithoutLocale }) };
+  }
+
+  return buildPageMetadata({
+    pageTitle: recent.name,
+    description: buildUpdateDescription({ body: recent.body }),
+    pathnameWithoutLocale,
+  });
 };
 
 export const generateStaticParams = () => loadRecents().map((recent) => ({ slug: recent.slug }));

--- a/packages/static-site/app/[locale]/updates/page.test.tsx
+++ b/packages/static-site/app/[locale]/updates/page.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { generateMetadata } from "./page";
+
+describe("generateMetadata", () => {
+  it("brands the title with the updates page's own title and its intro as the description", async () => {
+    const { updates } = getApplicationMessages({ locale: "en-US" });
+
+    const metadata = await generateMetadata({ params: Promise.resolve({ locale: "en-US" }) });
+
+    expect(metadata.title).toEqual({ absolute: `${updates.title} | Business.NJ.gov` });
+    expect(metadata.description).toBe(updates.intro);
+    expect(metadata.openGraph?.title).toEqual(metadata.title);
+    expect(metadata.twitter?.title).toEqual(metadata.title);
+    expect(metadata.alternates?.canonical).toBe("/updates");
+  });
+});

--- a/packages/static-site/app/[locale]/updates/page.tsx
+++ b/packages/static-site/app/[locale]/updates/page.tsx
@@ -2,8 +2,9 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { UpdatesPage } from "@/components/learn/UpdatesPage";
-import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
-import { type AppLocale, hasAppLocale } from "@/domain/i18n/locales";
+import { type AppLocale, hasAppLocale, resolveAppLocale } from "@/domain/i18n/locales";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { buildPageMetadata } from "@/domain/metadata/pageMetadata";
 
 interface PageParams {
   readonly locale: AppLocale;
@@ -14,12 +15,21 @@ interface Props {
 }
 
 /**
- * Generates metadata advertising hreflang alternates for the updates page.
+ * Generates branded, descriptive metadata for the updates page.
  *
- * @returns Metadata containing canonical and alternate-language links.
+ * @param props Route props provided by Next.js.
+ * @param props.params Async route params including the locale segment.
+ * @returns Metadata with a title matching the page's `<h1>`, its description, and alternate-language links.
  */
-export const generateMetadata = (): Metadata => {
-  return { alternates: buildAlternateLanguages({ pathnameWithoutLocale: "/updates" }) };
+export const generateMetadata = async ({ params }: Props): Promise<Metadata> => {
+  const { locale } = await params;
+  const { updates } = getApplicationMessages({ locale: resolveAppLocale({ locale }) });
+
+  return buildPageMetadata({
+    pageTitle: updates.title,
+    description: updates.intro,
+    pathnameWithoutLocale: "/updates",
+  });
 };
 
 const UpdatesRoute = async ({ params }: Props) => {

--- a/packages/static-site/app/globals.css
+++ b/packages/static-site/app/globals.css
@@ -103,6 +103,10 @@ body:has(.page-not-found) .usa-footer__return-to-top {
   display: none;
 }
 
+li {
+  line-height: 1.6rem;
+}
+
 .grid-container p,
 .grid-container .usa-prose > p,
 .grid-container .usa-prose > ul li,
@@ -215,10 +219,6 @@ div.usa-card__container {
     position: sticky;
     top: 20px;
   }
-}
-
-li {
-  line-height: 1.6rem;
 }
 
 :is(h1, h2, h3, h4, h5, h6).dark-blue {

--- a/packages/static-site/app/not-found.tsx
+++ b/packages/static-site/app/not-found.tsx
@@ -1,3 +1,7 @@
+import type { Metadata } from "next";
+
+import { SITE_TITLE_SUFFIX } from "@/domain/siteConfig";
+
 /**
  * Fallback 404 for requests that never reach the `[locale]` segment (paths
  * excluded by the middleware matcher in `proxy.ts`). Every other unmatched
@@ -7,6 +11,11 @@
  * without site chrome, per next-intl's documented pattern for this case:
  * https://next-intl.dev/docs/environments/error-files
  */
+
+export const metadata: Metadata = {
+  title: { absolute: `Page Not Found | ${SITE_TITLE_SUFFIX}` },
+};
+
 const NotFound = () => {
   return (
     <html lang="en">

--- a/packages/static-site/app/routeMetadata.test.ts
+++ b/packages/static-site/app/routeMetadata.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Guards every route against shipping a non-descriptive `<title>`.
+ *
+ * SiteImprove flagged 13 URLs sharing the generic layout title
+ * (`messages.metadata.title`) because their `generateMetadata` returned only
+ * `{ alternates }` and inherited it. This test walks every `page.tsx` under
+ * `app/`, resolves its real params, and asserts its metadata is branded and
+ * consistent across `<title>`, `og:title`, and `twitter:title` — using real
+ * content and messages, not mocks, so the assertion also proves the content
+ * actually yields a title. A route can opt out only via
+ * `ROUTES_WITHOUT_OWN_TITLE`, with a reason that is diff-visible in review.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type { Metadata } from "next";
+import { describe, expect, it } from "vitest";
+
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { SITE_TITLE_SUFFIX } from "@/domain/siteConfig";
+import { ROUTES_WITHOUT_OWN_TITLE } from "./routeMetadataAllowlist";
+
+const APP_DIR = path.join(__dirname);
+
+/**
+ * Derives a route id from a `page.tsx` file path, relative to `app/`, with
+ * route-group segments (e.g. `(learn)`) removed.
+ *
+ * @param pageFilePath Absolute or `app/`-relative path to a `page.tsx` file.
+ * @returns The route id, e.g. `[locale]/updates/[slug]`.
+ */
+const deriveRouteId = (pageFilePath: string): string => {
+  const relative = path.relative(APP_DIR, pageFilePath);
+  const withoutFile = relative.replace(/[/\\]page\.tsx$/, "");
+
+  return withoutFile
+    .split(path.sep)
+    .filter((segment) => !/^\(.*\)$/.test(segment))
+    .join("/");
+};
+
+interface RouteModule {
+  readonly generateMetadata?: (props: {
+    params: Promise<Record<string, string>>;
+  }) => Metadata | Promise<Metadata>;
+  readonly generateStaticParams?: () =>
+    | readonly Record<string, string>[]
+    | Promise<readonly Record<string, string>[]>;
+}
+
+/**
+ * Resolves the list of param sets a route should be checked with.
+ *
+ * `[locale]` always resolves to `"en-US"`. Any other dynamic segment must be
+ * resolvable via the route's own `generateStaticParams`, so a new dynamic
+ * route with neither that nor an allowlist entry fails loudly instead of
+ * being silently skipped.
+ *
+ * @param routeId Route id derived from its file path.
+ * @param routeModule The imported route module.
+ * @returns One params object per case the route should be checked with.
+ */
+const resolveParamCases = async (
+  routeId: string,
+  routeModule: RouteModule,
+): Promise<readonly Record<string, string>[]> => {
+  const dynamicSegments = routeId.match(/\[[^\]]+\]/g) ?? [];
+  const nonLocaleDynamicSegments = dynamicSegments.filter((segment) => segment !== "[locale]");
+
+  if (nonLocaleDynamicSegments.length === 0) {
+    return [{ locale: "en-US" }];
+  }
+
+  if (!routeModule.generateStaticParams) {
+    throw new Error(
+      `Route "${routeId}" has dynamic segments (${nonLocaleDynamicSegments.join(", ")}) but no ` +
+        "generateStaticParams to resolve them for this test.",
+    );
+  }
+
+  const staticParams = await routeModule.generateStaticParams();
+
+  return staticParams.map((params) => ({ locale: "en-US", ...params }));
+};
+
+const resolveTitleText = (title: Metadata["title"]): string | undefined => {
+  if (typeof title === "string") {
+    return title;
+  }
+
+  if (title && typeof title === "object" && "absolute" in title) {
+    return title.absolute;
+  }
+
+  return undefined;
+};
+
+const pageFilePaths = fs.globSync("app/**/page.tsx", { cwd: path.join(APP_DIR, "..") });
+const routeIds = pageFilePaths.map((filePath) => deriveRouteId(path.join(APP_DIR, "..", filePath)));
+
+describe("ROUTES_WITHOUT_OWN_TITLE", () => {
+  it("only lists routes that currently exist", () => {
+    for (const routeId of Object.keys(ROUTES_WITHOUT_OWN_TITLE)) {
+      expect(routeIds).toContain(routeId);
+    }
+  });
+});
+
+describe.each(
+  pageFilePaths.map((filePath) => ({
+    filePath,
+    routeId: deriveRouteId(path.join(APP_DIR, "..", filePath)),
+  })),
+)("route $routeId", ({ filePath, routeId }) => {
+  const exemptionReason = ROUTES_WITHOUT_OWN_TITLE[routeId];
+
+  if (exemptionReason !== undefined) {
+    it.skip(`exempt: ${exemptionReason}`, () => {});
+    return;
+  }
+
+  it("exports generateMetadata and returns a branded, consistent title", async () => {
+    const routeModule: RouteModule = await import(path.join(APP_DIR, "..", filePath));
+
+    expect(
+      routeModule.generateMetadata,
+      `"${routeId}" has no generateMetadata. Call buildPageMetadata from ` +
+        '"@/domain/metadata/pageMetadata", or add a ROUTES_WITHOUT_OWN_TITLE entry with a reason.',
+    ).toBeDefined();
+
+    const paramCases = await resolveParamCases(routeId, routeModule);
+    const genericTitle = getApplicationMessages({ locale: "en-US" }).metadata.title;
+
+    for (const params of paramCases) {
+      // biome-ignore lint/style/noNonNullAssertion: asserted defined above.
+      const metadata = await routeModule.generateMetadata!({ params: Promise.resolve(params) });
+      const titleText = resolveTitleText(metadata.title);
+      const context = `"${routeId}" with params ${JSON.stringify(params)}`;
+
+      expect(titleText, `${context} has no title.`).toBeTruthy();
+      expect(titleText, `${context} inherited the generic layout title.`).not.toBe(genericTitle);
+      expect(
+        titleText?.endsWith(SITE_TITLE_SUFFIX),
+        `${context} is not branded with "${SITE_TITLE_SUFFIX}".`,
+      ).toBe(true);
+
+      expect(metadata.openGraph?.title, `${context} og:title does not match <title>.`).toEqual(
+        metadata.title,
+      );
+      expect(metadata.twitter?.title, `${context} twitter:title does not match <title>.`).toEqual(
+        metadata.title,
+      );
+      expect(
+        metadata.openGraph?.images,
+        `${context} og:image is missing — a bare openGraph.title block drops it.`,
+      ).toBeTruthy();
+      expect(
+        metadata.alternates?.canonical,
+        `${context} is missing alternates.canonical.`,
+      ).toBeTruthy();
+    }
+  });
+});

--- a/packages/static-site/app/routeMetadataAllowlist.ts
+++ b/packages/static-site/app/routeMetadataAllowlist.ts
@@ -1,0 +1,18 @@
+/**
+ * Lists routes exempt from `routeMetadata.test.ts`'s descriptive-title check.
+ *
+ * Every entry here is a route that is not a real, indexable page. Keep this
+ * list shrinking, not growing.
+ */
+
+/**
+ * Maps a route id (its `page.tsx` path relative to `app/`, with route-group
+ * segments stripped) to the reason it does not need its own descriptive
+ * title.
+ */
+export const ROUTES_WITHOUT_OWN_TITLE: Readonly<Record<string, string>> = {
+  "[locale]": "Home page; correctly inherits the brand-led layout title by design.",
+  "[locale]/[...rest]": "Unconditionally calls notFound(); never renders a title.",
+  "[locale]/language-switcher-harness": "Dev/test-only harness, gated out of production builds.",
+  "[locale]/support": 'Placeholder page with a literal "PLACEHOLDER" h1, not linked from the site.',
+};

--- a/packages/static-site/biome.json
+++ b/packages/static-site/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": [
       "**",

--- a/packages/static-site/components/learn/resolvePageTitle.test.ts
+++ b/packages/static-site/components/learn/resolvePageTitle.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { loadPageBySlug } from "@/domain/content/loadContent";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { resolvePageTitle } from "./resolvePageTitle";
+
+describe("resolvePageTitle", () => {
+  it("uses the locale-specific message title for the funding page", () => {
+    const page = loadPageBySlug("funding");
+
+    expect(resolvePageTitle({ page, messages: getApplicationMessages({ locale: "en-US" }) })).toBe(
+      "Funding",
+    );
+    expect(resolvePageTitle({ page, messages: getApplicationMessages({ locale: "es-US" }) })).toBe(
+      "Financiamiento",
+    );
+  });
+
+  it("uses the locale-specific message title for the licensing guide page", () => {
+    const page = loadPageBySlug("licensing-and-certification-guide");
+
+    expect(resolvePageTitle({ page, messages: getApplicationMessages({ locale: "en-US" }) })).toBe(
+      "Licensing and Certification Guide",
+    );
+    expect(resolvePageTitle({ page, messages: getApplicationMessages({ locale: "es-US" }) })).toBe(
+      "Guía de Licencias y Certificaciones",
+    );
+  });
+
+  it("falls back to the page's own name for every other slug", () => {
+    const page = loadPageBySlug("government-contracting");
+
+    expect(resolvePageTitle({ page, messages: getApplicationMessages({ locale: "en-US" }) })).toBe(
+      page.name,
+    );
+  });
+
+  it("falls back to the page's own name for the starter-kits page, which PageSwitchComponent also special-cases", () => {
+    const page = loadPageBySlug("starter-kits");
+
+    expect(resolvePageTitle({ page, messages: getApplicationMessages({ locale: "en-US" }) })).toBe(
+      page.name,
+    );
+  });
+});

--- a/packages/static-site/components/learn/resolvePageTitle.ts
+++ b/packages/static-site/components/learn/resolvePageTitle.ts
@@ -1,0 +1,48 @@
+/**
+ * Resolves the correct locale-aware title for a content page.
+ *
+ * `PageSwitchComponent` renders a message-driven `<h1>` for `funding` and
+ * `licensing-and-certification-guide` instead of the page's own `name`
+ * frontmatter (which is English-only). This resolver mirrors that same slug
+ * switch so a page's metadata title always matches what actually renders as
+ * its `<h1>`, in every locale.
+ */
+
+import type { ApplicationMessages } from "@/domain/content/messageTypes";
+import type { PageItem } from "@/domain/content/types";
+
+/**
+ * Describes input for resolving a content page's title.
+ *
+ * This type defines a stable shape for related data.
+ */
+export interface ResolvePageTitleParams {
+  /** The content page to resolve a title for. */
+  readonly page: PageItem;
+  /** Localized messages for the page's locale. */
+  readonly messages: ApplicationMessages;
+}
+
+/**
+ * Resolves the title that matches the page's rendered `<h1>`.
+ *
+ * @param params Resolve input.
+ * @param params.page The content page to resolve a title for.
+ * @param params.messages Localized messages for the page's locale.
+ * @returns The locale-correct page title.
+ * @example
+ * ```ts
+ * resolvePageTitle({ page: fundingPage, messages: esMessages });
+ * // the es-US funding title, not the page's English-only frontmatter name
+ * ```
+ */
+export const resolvePageTitle = ({ page, messages }: ResolvePageTitleParams): string => {
+  switch (page.slug) {
+    case "funding":
+      return messages.funding.title;
+    case "licensing-and-certification-guide":
+      return messages.licensingGuide.title;
+    default:
+      return page.name;
+  }
+};

--- a/packages/static-site/domain/content/messageTypes.ts
+++ b/packages/static-site/domain/content/messageTypes.ts
@@ -892,6 +892,8 @@ export interface ImpactReportMessages {
   readonly customerServiceExperience: CustomerServiceExperienceContent;
   /** "Driving Equity and Accessibility" section content. */
   readonly drivingEquity: DrivingEquityContent;
+  /** Page `<meta name="description">` content. */
+  readonly metaDescription: string;
 }
 
 /**
@@ -900,6 +902,8 @@ export interface ImpactReportMessages {
 export interface NewsletterSignupMessages {
   /** Page H1 title. */
   readonly title: string;
+  /** Page `<meta name="description">` content. */
+  readonly metaDescription: string;
 }
 
 /**

--- a/packages/static-site/domain/metadata/buildUpdateDescription.test.ts
+++ b/packages/static-site/domain/metadata/buildUpdateDescription.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { buildUpdateDescription } from "./buildUpdateDescription";
+
+describe("buildUpdateDescription", () => {
+  it("uses only the first paragraph of the body", () => {
+    const body = [
+      "Eligible companies can receive grants worth up to $500,000 per business to relocate",
+      "out-of-State, NJ-resident employees back to New Jersey.",
+      "",
+      "### Eligibility",
+      "",
+      "Applicants must have an active Certificate of Approval.",
+    ].join("\n");
+
+    expect(buildUpdateDescription({ body })).toBe(
+      "Eligible companies can receive grants worth up to $500,000 per business to relocate out-of-State, NJ-resident employees back to New Jersey.",
+    );
+  });
+
+  it("strips markdown emphasis, keeping the inner text", () => {
+    const body =
+      "Calling all startups who want to access capital from the **New Jersey Innovation Evergreen Fund (NJIEF). **The NJIEF is catalyzing up to $600 million in support.";
+
+    expect(buildUpdateDescription({ body })).toBe(
+      "Calling all startups who want to access capital from the New Jersey Innovation Evergreen Fund (NJIEF). The NJIEF is catalyzing up to $600 million in support.",
+    );
+  });
+
+  it("strips markdown links down to their label", () => {
+    const body =
+      "The [2022 Summer Youth Camp Grant](https://www.childcarenj.gov/grants.pdf) application is now available.";
+
+    expect(buildUpdateDescription({ body })).toBe(
+      "The 2022 Summer Youth Camp Grant application is now available.",
+    );
+  });
+
+  it("strips content directives and contextual-info spans", () => {
+    const body = [
+      ':::infoAlert{ headerText="Keep in mind:" }',
+      "Contact your `Local Enforcing Agency (LEA)|lea` before applying.",
+      ":::",
+    ].join("\n");
+
+    expect(buildUpdateDescription({ body })).toBe(
+      "Contact your Local Enforcing Agency (LEA) before applying.",
+    );
+  });
+
+  it("drops trailing zero-width joiners and collapses whitespace", () => {
+    const body = "Grants are now open for eligible businesses.\n\n‍\n";
+
+    expect(buildUpdateDescription({ body })).toBe("Grants are now open for eligible businesses.");
+  });
+
+  it("truncates on a word boundary near 160 characters and appends an ellipsis", () => {
+    const body =
+      "Eligible companies can receive grants worth up to five hundred thousand dollars per business to relocate out-of-State, New Jersey-resident employees back to the great state of New Jersey.";
+
+    const description = buildUpdateDescription({ body });
+
+    expect(description.length).toBeLessThanOrEqual(160);
+    expect(description.endsWith("…")).toBe(true);
+    expect(body.startsWith(description.slice(0, -1))).toBe(true);
+  });
+
+  it("returns an empty string for a blank body", () => {
+    expect(buildUpdateDescription({ body: "   " })).toBe("");
+  });
+});

--- a/packages/static-site/domain/metadata/buildUpdateDescription.ts
+++ b/packages/static-site/domain/metadata/buildUpdateDescription.ts
@@ -1,0 +1,81 @@
+/**
+ * Derives a page description for an update's detail page from its body.
+ *
+ * Updates have no dedicated description field — `RecentItem.summary` is
+ * declared in the type but unused in every published item, so the first
+ * paragraph of `body` is the only real description-shaped text available.
+ * This strips the CMS markdown formatting the static site can't otherwise
+ * render as plain text, then truncates on a word boundary for a meta
+ * description-appropriate length.
+ */
+
+import { stripContentDirectives } from "@/components/learn/stripContentDirectives";
+
+/** Target maximum length for a derived description, in characters. */
+const MAX_DESCRIPTION_LENGTH = 160;
+
+const zeroWidthJoiner = /‍/g;
+const markdownLink = /\[([^\]]*)\]\([^)]*\)/g;
+const markdownEmphasis = /(\*\*|__|\*|_)(.+?)\1/g;
+const whitespaceRun = /\s+/g;
+
+/**
+ * Strips residual markdown emphasis and link syntax down to their plain text.
+ *
+ * @param text Markdown text to plain-text.
+ * @returns The text with `**bold**`, `_italic_`, and `[label](href)` markup removed.
+ */
+const stripMarkdownFormatting = (text: string): string =>
+  text.replace(markdownLink, "$1").replace(markdownEmphasis, "$2");
+
+/**
+ * Truncates text to at most `maxLength` characters, breaking on a word
+ * boundary rather than mid-word, and appending an ellipsis when truncated.
+ *
+ * @param text Text to truncate.
+ * @param maxLength Maximum length of the returned text, ellipsis included.
+ * @returns The original text if already short enough, otherwise a truncated copy.
+ */
+const truncateOnWordBoundary = (text: string, maxLength: number): string => {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  const truncated = text.slice(0, maxLength);
+  const lastSpaceIndex = truncated.lastIndexOf(" ");
+  const boundary = lastSpaceIndex > 0 ? truncated.slice(0, lastSpaceIndex) : truncated;
+
+  return `${boundary.trimEnd()}…`;
+};
+
+/**
+ * Describes input for deriving an update's description.
+ *
+ * This type defines a stable shape for related data.
+ */
+export interface BuildUpdateDescriptionParams {
+  /** Markdown body of the update, as loaded from its CMS source. */
+  readonly body: string;
+}
+
+/**
+ * Derives a plain-text, meta description-length summary from an update's body.
+ *
+ * @param params Build input.
+ * @param params.body Markdown body of the update.
+ * @returns A single-paragraph plain-text description, or an empty string when `body` is blank.
+ * @example
+ * ```ts
+ * buildUpdateDescription({ body: recent.body });
+ * ```
+ */
+export const buildUpdateDescription = ({ body }: BuildUpdateDescriptionParams): string => {
+  const [firstParagraph = ""] = body.trim().split(/\n\s*\n/);
+
+  const plainText = stripMarkdownFormatting(stripContentDirectives(firstParagraph))
+    .replace(zeroWidthJoiner, "")
+    .replace(whitespaceRun, " ")
+    .trim();
+
+  return truncateOnWordBoundary(plainText, MAX_DESCRIPTION_LENGTH);
+};

--- a/packages/static-site/domain/metadata/pageMetadata.test.ts
+++ b/packages/static-site/domain/metadata/pageMetadata.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPageMetadata } from "./pageMetadata";
+
+describe("pageMetadata", () => {
+  describe("buildPageMetadata", () => {
+    it("brands the title and matches it across title, openGraph, and twitter", () => {
+      const metadata = buildPageMetadata({
+        pageTitle: "Government Contracting",
+        pathnameWithoutLocale: "/pages/government-contracting",
+      });
+
+      expect(metadata.title).toEqual({ absolute: "Government Contracting | Business.NJ.gov" });
+      expect(metadata.openGraph?.title).toEqual(metadata.title);
+      expect(metadata.twitter?.title).toEqual(metadata.title);
+    });
+
+    it("carries the social preview image into both openGraph and twitter", () => {
+      const metadata = buildPageMetadata({
+        pageTitle: "Government Contracting",
+        pathnameWithoutLocale: "/pages/government-contracting",
+      });
+
+      expect(metadata.openGraph?.images).toEqual([
+        expect.objectContaining({ url: "/assets/njwds/dist/img/nj-logo-gray-20.png" }),
+      ]);
+      expect(metadata.twitter?.images).toEqual(["/assets/njwds/dist/img/nj-logo-gray-20.png"]);
+    });
+
+    it("delegates alternates to buildAlternateLanguages", () => {
+      const metadata = buildPageMetadata({
+        pageTitle: "Government Contracting",
+        pathnameWithoutLocale: "/pages/government-contracting",
+      });
+
+      expect(metadata.alternates?.canonical).toBe("/pages/government-contracting");
+      expect(metadata.alternates?.languages).toEqual(
+        expect.objectContaining({ "en-US": "/pages/government-contracting" }),
+      );
+    });
+
+    it("includes a trimmed description on the root, openGraph, and twitter fields", () => {
+      const metadata = buildPageMetadata({
+        pageTitle: "Government Contracting",
+        pathnameWithoutLocale: "/pages/government-contracting",
+        description: "  Learn how to bid on state contracts.  ",
+      });
+
+      expect(metadata.description).toBe("Learn how to bid on state contracts.");
+      expect(metadata.openGraph?.description).toBe("Learn how to bid on state contracts.");
+      expect(metadata.twitter?.description).toBe("Learn how to bid on state contracts.");
+    });
+
+    it("omits the description key entirely when no description is given", () => {
+      const metadata = buildPageMetadata({
+        pageTitle: "Government Contracting",
+        pathnameWithoutLocale: "/pages/government-contracting",
+      });
+
+      expect("description" in metadata).toBe(false);
+      expect(metadata.openGraph && "description" in metadata.openGraph).toBe(false);
+      expect(metadata.twitter && "description" in metadata.twitter).toBe(false);
+    });
+
+    it("omits the description key when given a blank string", () => {
+      const metadata = buildPageMetadata({
+        pageTitle: "Government Contracting",
+        pathnameWithoutLocale: "/pages/government-contracting",
+        description: "   ",
+      });
+
+      expect("description" in metadata).toBe(false);
+    });
+  });
+});

--- a/packages/static-site/domain/metadata/pageMetadata.ts
+++ b/packages/static-site/domain/metadata/pageMetadata.ts
@@ -1,0 +1,75 @@
+/**
+ * Builds complete, per-page metadata for App Router routes.
+ *
+ * Next.js's `title.template` mechanism only rewrites the plain `title` field —
+ * `openGraph.title` and `twitter.title` are resolved from their own,
+ * independent template slots (see `resolve-metadata.js`), so a layout-level
+ * template silently leaves `og:title`/`twitter:title` on the generic parent
+ * value unless every child route restates it. This helper sidesteps that by
+ * returning a fully composed, `absolute` title for all three surfaces in one
+ * call, so a route can never brand its `<title>` without also branding its
+ * social preview.
+ */
+
+import type { Metadata } from "next";
+
+import { buildAlternateLanguages } from "@/domain/i18n/alternateLanguages";
+import { SITE_TITLE_SUFFIX, SOCIAL_PREVIEW_IMAGE } from "@/domain/siteConfig";
+
+/**
+ * Describes input for building a page's metadata.
+ *
+ * This type defines a stable shape for related data.
+ */
+export interface BuildPageMetadataParams {
+  /** Bare, unbranded page title — normally the page's own `<h1>` text. */
+  readonly pageTitle: string;
+  /** Page pathname without any locale prefix, starting with `/`. */
+  readonly pathnameWithoutLocale: string;
+  /** Page description. Omit to inherit the site-wide description from the locale layout. */
+  readonly description?: string;
+}
+
+/**
+ * Builds branded title, description, social preview, and hreflang metadata for a page.
+ *
+ * The returned title is an `absolute` string, so it cannot be re-templated by
+ * an ancestor layout — the brand suffix is applied exactly once, here.
+ *
+ * @param params Build input.
+ * @param params.pageTitle Bare, unbranded page title.
+ * @param params.pathnameWithoutLocale Unprefixed page pathname.
+ * @param params.description Page description; omitted keys inherit the layout default.
+ * @returns Metadata with a branded title, matching Open Graph and Twitter titles, and alternates.
+ * @example
+ * ```ts
+ * buildPageMetadata({ pageTitle: "Government Contracting", pathnameWithoutLocale: "/pages/government-contracting" });
+ * // { title: { absolute: "Government Contracting | Business.NJ.gov" }, ... }
+ * ```
+ */
+export const buildPageMetadata = ({
+  pageTitle,
+  pathnameWithoutLocale,
+  description,
+}: BuildPageMetadataParams): Metadata => {
+  const brandedTitle = `${pageTitle} | ${SITE_TITLE_SUFFIX}`;
+  const trimmedDescription = description?.trim();
+  const descriptionFields = trimmedDescription ? { description: trimmedDescription } : {};
+
+  return {
+    title: { absolute: brandedTitle },
+    ...descriptionFields,
+    alternates: buildAlternateLanguages({ pathnameWithoutLocale }),
+    openGraph: {
+      title: { absolute: brandedTitle },
+      ...descriptionFields,
+      images: [SOCIAL_PREVIEW_IMAGE],
+    },
+    twitter: {
+      card: "summary",
+      title: { absolute: brandedTitle },
+      ...descriptionFields,
+      images: [SOCIAL_PREVIEW_IMAGE.url],
+    },
+  };
+};

--- a/packages/static-site/domain/siteConfig.ts
+++ b/packages/static-site/domain/siteConfig.ts
@@ -15,6 +15,25 @@
 export const SITE_BASE_URL = "https://business.nj.gov";
 
 /**
+ * Brand suffix appended to every page's browser title.
+ *
+ * Mirrors `titlePostfix` in `content/src/page-metadata/page-metadata.json`,
+ * which the `web` app's `getNextSeoTitle` already uses, so both apps brand
+ * page titles identically.
+ */
+export const SITE_TITLE_SUFFIX = "Business.NJ.gov";
+
+/**
+ * Social preview image shared by Open Graph and Twitter card metadata.
+ */
+export const SOCIAL_PREVIEW_IMAGE = {
+  url: "/assets/njwds/dist/img/nj-logo-gray-20.png",
+  width: 144,
+  height: 144,
+  alt: "State of New Jersey logo",
+};
+
+/**
  * Cookie name recording that a visitor dismissed the language prompt.
  *
  * Once set, the preferred-language modal stays hidden so a returning visitor is

--- a/packages/static-site/messages/en-US.json
+++ b/packages/static-site/messages/en-US.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "title": "Business.NJ.gov | Plan, Start, and Grow",
-    "description": "Landing page prototype for a Next.js and NJWDS-powered business guidance experience."
+    "description": "Business.NJ.gov is your first stop to plan, start, operate, and grow a business in New Jersey."
   },
   "layout": {
     "skipNavigationLabel": "Skip to main content",
@@ -894,9 +894,11 @@
           "text": "**40,748** - Number of visits to Spanish language content from June 1, 2023, to April 1, 2025"
         }
       ]
-    }
+    },
+    "metaDescription": "See how Business.NJ.gov streamlined licensing, funding, and support for New Jersey businesses from 2020 to 2025."
   },
   "newsletterSignup": {
-    "title": "Subscribe to Business.NJ.gov Updates"
+    "title": "Subscribe to Business.NJ.gov Updates",
+    "metaDescription": "Subscribe to get New Jersey business news, funding opportunities, and program updates from Business.NJ.gov delivered to your inbox."
   }
 }

--- a/packages/static-site/messages/es-US.json
+++ b/packages/static-site/messages/es-US.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "title": "Business.NJ.gov | Planifique, Comience y Haga Crecer",
-    "description": "Prototipo de página principal para una experiencia de orientación empresarial impulsada por Next.js y NJWDS."
+    "description": "Business.NJ.gov es su primera parada para planificar, iniciar, operar y hacer crecer un negocio en Nueva Jersey."
   },
   "layout": {
     "skipNavigationLabel": "Saltar al contenido principal",
@@ -894,9 +894,11 @@
           "text": "**40,748** - Cantidad de visitas a contenido en español del 1 de junio de 2023 al 1 de abril de 2025"
         }
       ]
-    }
+    },
+    "metaDescription": "Descubra cómo Business.NJ.gov simplificó las licencias, el financiamiento y el apoyo para las empresas de Nueva Jersey de 2020 a 2025."
   },
   "newsletterSignup": {
-    "title": "Subscribe to Business.NJ.gov Updates"
+    "title": "Subscribe to Business.NJ.gov Updates",
+    "metaDescription": "Suscríbase para recibir noticias empresariales de Nueva Jersey, oportunidades de financiamiento y actualizaciones de programas de Business.NJ.gov directamente en su correo electrónico."
   }
 }

--- a/packages/static-site/package.json
+++ b/packages/static-site/package.json
@@ -46,7 +46,7 @@
     "url": "https://github.com/newjersey"
   },
   "license": "MIT",
-  "packageManager": "pnpm@11.13.0",
+  "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee",
   "devDependencies": {
     "@axe-core/playwright": "4.12.1",
     "@biomejs/biome": "2.5.5",

--- a/packages/static-site/tests/accessibility/homepage.a11y.spec.ts
+++ b/packages/static-site/tests/accessibility/homepage.a11y.spec.ts
@@ -43,6 +43,7 @@ const createLocaleAccessibilityTest = ({ locale }: CreateLocaleAccessibilityTest
 
     await page.goto(`/${locale}`);
     await page.getByRole("heading", { level: 1, name: messages.landing.hero.title }).waitFor();
+    await expect(page).toHaveTitle(messages.metadata.title);
 
     const results = await new AxeBuilder({ page }).analyze();
 

--- a/packages/static-site/tests/accessibility/impact-report.a11y.spec.ts
+++ b/packages/static-site/tests/accessibility/impact-report.a11y.spec.ts
@@ -4,7 +4,7 @@ import type { BrowserContext, Page } from "playwright";
 import type { AppLocale } from "@/domain/i18n/locales";
 import { ENABLED_LOCALES } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
-import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE, SITE_TITLE_SUFFIX } from "@/domain/siteConfig";
 
 /**
  * Defines the test context provided by Playwright.
@@ -43,6 +43,7 @@ const createLocaleAccessibilityTest = ({ locale }: CreateLocaleAccessibilityTest
 
     await page.goto(`/${locale}/impact-report`);
     await page.getByRole("heading", { level: 1, name: impactReport.title }).waitFor();
+    await expect(page).toHaveTitle(`${impactReport.title} | ${SITE_TITLE_SUFFIX}`);
 
     const results = await new AxeBuilder({ page }).analyze();
 

--- a/packages/static-site/tests/accessibility/licensing-guide.a11y.spec.ts
+++ b/packages/static-site/tests/accessibility/licensing-guide.a11y.spec.ts
@@ -4,7 +4,7 @@ import type { BrowserContext, Page } from "playwright";
 import type { AppLocale } from "@/domain/i18n/locales";
 import { ENABLED_LOCALES } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
-import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE, SITE_TITLE_SUFFIX } from "@/domain/siteConfig";
 
 /**
  * Defines the test context provided by Playwright.
@@ -43,6 +43,7 @@ const createLocaleAccessibilityTest = ({ locale }: CreateLocaleAccessibilityTest
 
     await page.goto(`/${locale}/pages/licensing-and-certification-guide`);
     await page.getByRole("heading", { level: 1, name: messages.licensingGuide.title }).waitFor();
+    await expect(page).toHaveTitle(`${messages.licensingGuide.title} | ${SITE_TITLE_SUFFIX}`);
 
     // `color-contrast` is a pre-existing NJWDS banner/chrome issue present on
     // every page (it also fails the homepage audit) and is outside this page's

--- a/packages/static-site/tests/accessibility/newsletter-signup.a11y.spec.ts
+++ b/packages/static-site/tests/accessibility/newsletter-signup.a11y.spec.ts
@@ -4,7 +4,7 @@ import type { BrowserContext, Page } from "playwright";
 import type { AppLocale } from "@/domain/i18n/locales";
 import { ENABLED_LOCALES } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
-import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE, SITE_TITLE_SUFFIX } from "@/domain/siteConfig";
 
 /**
  * Defines the test context provided by Playwright.
@@ -46,6 +46,7 @@ const createLocaleAccessibilityTest = ({ locale }: CreateLocaleAccessibilityTest
 
     await page.goto(`/${locale}/newsletter-signup`);
     await page.getByRole("heading", { level: 1, name: newsletterSignup.title }).waitFor();
+    await expect(page).toHaveTitle(`${newsletterSignup.title} | ${SITE_TITLE_SUFFIX}`);
 
     const results = await new AxeBuilder({ page }).analyze();
 

--- a/packages/static-site/tests/accessibility/not-found.a11y.spec.ts
+++ b/packages/static-site/tests/accessibility/not-found.a11y.spec.ts
@@ -4,7 +4,7 @@ import type { BrowserContext, Page } from "playwright";
 import type { AppLocale } from "@/domain/i18n/locales";
 import { ENABLED_LOCALES } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
-import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE, SITE_TITLE_SUFFIX } from "@/domain/siteConfig";
 
 /**
  * Defines the test context provided by Playwright.
@@ -43,6 +43,7 @@ const createLocaleAccessibilityTest = ({ locale }: CreateLocaleAccessibilityTest
 
     await page.goto(`/${locale}/this-page-does-not-exist`);
     await page.getByRole("heading", { level: 1, name: messages.pageNotFound.title }).waitFor();
+    await expect(page).toHaveTitle(`${messages.pageNotFound.title} | ${SITE_TITLE_SUFFIX}`);
 
     const results = await new AxeBuilder({ page }).analyze();
 

--- a/packages/static-site/tests/accessibility/our-software-and-reuse.a11y.spec.ts
+++ b/packages/static-site/tests/accessibility/our-software-and-reuse.a11y.spec.ts
@@ -4,7 +4,7 @@ import type { BrowserContext, Page } from "playwright";
 import { loadPageBySlug } from "@/domain/content/loadContent";
 import type { AppLocale } from "@/domain/i18n/locales";
 import { ENABLED_LOCALES } from "@/domain/i18n/locales";
-import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE, SITE_TITLE_SUFFIX } from "@/domain/siteConfig";
 
 /**
  * Defines the test context provided by Playwright.
@@ -47,6 +47,7 @@ const createLocaleAccessibilityTest = ({ locale }: CreateLocaleAccessibilityTest
 
     await page.goto(`/${locale}/our-software-and-reuse`);
     await page.getByRole("heading", { level: 1, name: pageName }).waitFor();
+    await expect(page).toHaveTitle(`${pageName} | ${SITE_TITLE_SUFFIX}`);
 
     // `color-contrast` is a pre-existing NJWDS banner/chrome issue present on
     // every page (it also fails the homepage audit) and is outside this page's

--- a/packages/static-site/tests/accessibility/privacy-policy.a11y.spec.ts
+++ b/packages/static-site/tests/accessibility/privacy-policy.a11y.spec.ts
@@ -4,7 +4,7 @@ import type { BrowserContext, Page } from "playwright";
 import { loadPageBySlug } from "@/domain/content/loadContent";
 import type { AppLocale } from "@/domain/i18n/locales";
 import { ENABLED_LOCALES } from "@/domain/i18n/locales";
-import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE, SITE_TITLE_SUFFIX } from "@/domain/siteConfig";
 
 /**
  * Defines the test context provided by Playwright.
@@ -48,6 +48,7 @@ const createLocaleAccessibilityTest = ({ locale }: CreateLocaleAccessibilityTest
 
     await page.goto(`/${locale}/privacy-policy`);
     await page.getByRole("heading", { level: 1, name: pageName }).waitFor();
+    await expect(page).toHaveTitle(`${pageName} | ${SITE_TITLE_SUFFIX}`);
 
     // `color-contrast` is a pre-existing NJWDS banner/chrome issue present on
     // every page (it also fails the homepage audit) and is outside this page's

--- a/packages/static-site/tests/accessibility/updates.a11y.spec.ts
+++ b/packages/static-site/tests/accessibility/updates.a11y.spec.ts
@@ -4,7 +4,7 @@ import type { BrowserContext, Page } from "playwright";
 import type { AppLocale } from "@/domain/i18n/locales";
 import { ENABLED_LOCALES } from "@/domain/i18n/locales";
 import { getApplicationMessages } from "@/domain/i18n/messages";
-import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE, SITE_TITLE_SUFFIX } from "@/domain/siteConfig";
 
 /**
  * Defines the test context provided by Playwright.
@@ -44,6 +44,7 @@ const createLocaleAccessibilityTest = ({ locale }: CreateLocaleAccessibilityTest
 
     await page.goto(`/${locale}/updates`);
     await page.getByRole("heading", { level: 1, name: messages.updates.title }).waitFor();
+    await expect(page).toHaveTitle(`${messages.updates.title} | ${SITE_TITLE_SUFFIX}`);
 
     // `color-contrast` is a pre-existing NJWDS banner/chrome issue present on
     // every page (it also fails the homepage audit) and is outside this page's


### PR DESCRIPTION
## Description

SiteImprove flagged "Page title is not descriptive" across 13 static-site URLs (the `/pages/*` and `/updates/*` routes), all emitting the same generic layout title. This adds a real, branded title and description to every static-site route, and a regression test so a future route cannot ship without one.

### Ticket

This pull request resolves [#17975](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17975).

### Approach

- Added `buildPageMetadata` (`domain/metadata/pageMetadata.ts`), a shared helper that returns a branded `title`, matching `openGraph.title`/`twitter.title`, restated preview image, and hreflang alternates in one call, using `title: { absolute }` so the brand suffix is never re-applied by an ancestor layout.

- Converted every static-site route's `generateMetadata` to use it, sourcing titles from each page's own `name`/message frontmatter (the same text already rendered as the page's `<h1>`), rather than adding a new CMS field.

- Added `resolvePageTitle` to fix an existing es-US mismatch on `funding` and `licensing-and-certification-guide`, where the rendered `<h1>` is message-driven but `page.name` is English-only.

- Added descriptions from existing page/message fields where available, added new `impactReport.metaDescription` and `newsletterSignup.metaDescription` message keys where there was no existing field, and added `buildUpdateDescription` to derive update-page descriptions from the first paragraph of `recent.body` (stripping CMS markdown/directive syntax), since `RecentItem.summary` is unused in every published item.

- Replaced the placeholder site-wide description in `messages/en-US.json`/`es-US.json`.

- Added `app/routeMetadata.test.ts`, a filesystem-walk Vitest test over every `app/**/page.tsx`, asserting a descriptive, branded title with matching `openGraph`/`twitter` fields and a preserved preview image, with a small `ROUTES_WITHOUT_OWN_TITLE` allowlist for the few routes that legitimately have no title of their own (home page, catch-all 404, dev harness, placeholder page).

- Added `toHaveTitle` assertions to the existing Playwright a11y specs, and titles to both `not-found.tsx` files, since axe only flags a missing title, never a non-descriptive one.

### Before / After

One representative page per kind of route affected. Every row's "Before" title/description was identical across all affected pages of that kind (the shared generic layout value); "After" is now unique per page.

| Page | Before title | After title | Before description | After description |
| --- | --- | --- | --- | --- |
| `/pages/government-contracting` (content page) | Business.NJ.gov \| Plan, Start, and Grow | Government Contracting \| Business.NJ.gov | Landing page prototype for a Next.js and NJWDS-powered business guidance experience. | The State buys goods, services, and construction projects from New Jersey businesses to provide services to residents. Businesses must get certified and registered to qualify for government contracts. |
| `/plan` (learn category) | Business.NJ.gov \| Plan, Start, and Grow | Plan \| Business.NJ.gov | Landing page prototype for a Next.js and NJWDS-powered business guidance experience. | Expand on your great idea to lay the foundation for a successful business. |
| `/learn` (learn index) | Business.NJ.gov \| Plan, Start, and Grow | Learn \| Business.NJ.gov | Landing page prototype for a Next.js and NJWDS-powered business guidance experience. | Find guides and resources for every stage, from your first idea to long-term growth. |
| `/updates` (updates index) | Business.NJ.gov \| Plan, Start, and Grow | All Updates \| Business.NJ.gov | Landing page prototype for a Next.js and NJWDS-powered business guidance experience. | Learn about new rules, resources, and upcoming changes that may affect your business, including critical information and programs for state emergencies. |
| `/updates/drought-warning-in-effect-voluntary-water-reduction-urged` (update detail) | Business.NJ.gov \| Plan, Start, and Grow | Drought Warning In Effect; Voluntary Water Reduction Urged \| Business.NJ.gov | Landing page prototype for a Next.js and NJWDS-powered business guidance experience. | Derived from the update's own body text (new; there was no per-update description field before). |
| `/impact-report` | Business.NJ.gov \| Plan, Start, and Grow | Impact Report \| Business.NJ.gov | Landing page prototype for a Next.js and NJWDS-powered business guidance experience. | New `impactReport.metaDescription` message key (there was no description field before). |
| `/newsletter-signup` | Business.NJ.gov \| Plan, Start, and Grow | Subscribe to Business.NJ.gov Updates \| Business.NJ.gov | Landing page prototype for a Next.js and NJWDS-powered business guidance experience. | New `newsletterSignup.metaDescription` message key (there was no description field before). |
| Site-wide default (home page, and the fallback for any unmatched route) | Business.NJ.gov \| Plan, Start, and Grow | Business.NJ.gov \| Plan, Start, and Grow (unchanged; correct by design) | Landing page prototype for a Next.js and NJWDS-powered business guidance experience. | Business.NJ.gov is your first stop to plan, start, operate, and grow a business in New Jersey. |

### Steps to Test

1. From `packages/static-site`, run `pnpm dev` and visit a previously-flagged page, e.g. `/pages/government-contracting`, `/es-US/pages/funding`, or any `/updates/<slug>`.

2. Confirm the browser tab title matches the page's own heading, suffixed with "Business.NJ.gov" (not the generic "Business.NJ.gov | Plan, Start, and Grow").

3. View source and confirm `og:title`, `twitter:title`, and `og:image` are all present and match.

4. From `packages/static-site`, run `pnpm test` to confirm `routeMetadata.test.ts` passes for all routes.

### Notes

Deferred, out of scope for this PR: a Decap CMS `meta-title` field, adding the Playwright a11y suite to CI, `app/sitemap.ts`'s existing route-coverage gaps, `/support`'s fate, and the pre-existing untranslated `learn.name` in `es-US.json`.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
