### PR TITLE
feat: [AB#17961] add callout to create an account on locked task pages

### DIFF
--- a/content/src/fieldConfig/task-defaults.json
+++ b/content/src/fieldConfig/task-defaults.json
@@ -18,6 +18,7 @@
     "previousTaskButtonText": "Previous Task",
     "formNameText": "Form",
     "defaultCallToActionText": "Start Application",
-    "unlockedByPlural": "Before starting this task, we recommend you take a look at:"
+    "unlockedByPlural": "Before starting this task, we recommend you take a look at:",
+    "needsAccountCallout": "To complete this task, you will need to [create an account](/account-setup)."
   }
 }

--- a/web/decap-config/collections/12-misc.yml
+++ b/web/decap-config/collections/12-misc.yml
@@ -809,6 +809,8 @@ collections:
               - { label: Back, name: backButtonText, widget: string }
               - { label: Continue Text, name: continueButtonText, widget: string }
               - { label: Mark As Complete, name: "markAsCompleteButtonText", widget: string }
+              - { label: Needs Account Callout, name: "needsAccountCallout", widget: markdown }
+
   - label: Task - Business Name Search
     name: searchBusinessNameTask
     delete: false

--- a/web/src/components/NeedsAccountMiniCallout.tsx
+++ b/web/src/components/NeedsAccountMiniCallout.tsx
@@ -1,0 +1,19 @@
+import { Content } from "@/components/Content";
+import { MiniCallout } from "@/components/njwds-extended/callout/MiniCallout";
+import { NeedsAccountContext } from "@/contexts/needsAccountContext";
+import { IsAuthenticated } from "@/lib/auth/AuthContext";
+import { useConfig } from "@/lib/data-hooks/useConfig";
+import { ReactElement, useContext } from "react";
+
+export const NeedsAccountMiniCallout = (): ReactElement => {
+  const { isAuthenticated } = useContext(NeedsAccountContext);
+  const { Config } = useConfig();
+
+  return isAuthenticated === IsAuthenticated.FALSE ? (
+    <MiniCallout calloutType="warning">
+      <Content>{Config.taskDefaults.needsAccountCallout}</Content>
+    </MiniCallout>
+  ) : (
+    <></>
+  );
+};

--- a/web/src/components/tasks/EinTask.tsx
+++ b/web/src/components/tasks/EinTask.tsx
@@ -1,5 +1,6 @@
 import { Content } from "@/components/Content";
 import { HorizontalLine } from "@/components/HorizontalLine";
+import { NeedsAccountMiniCallout } from "@/components/NeedsAccountMiniCallout";
 import { TaskHeader } from "@/components/TaskHeader";
 import { EinDisplay } from "@/components/tasks/EinDisplay";
 import { EinInput } from "@/components/tasks/EinInput";
@@ -63,10 +64,13 @@ export const EinTask = (props: Props): ReactElement => {
   return (
     <div className="min-height-38rem">
       <TaskHeader task={props.task} />
-      <UnlockedBy task={props.task} />
+      <NeedsAccountMiniCallout />
+      {isAuthenticated === IsAuthenticated.TRUE && <UnlockedBy task={props.task} />}
       <Content>{props.task.summaryDescriptionMd}</Content>
+
       <HorizontalLine />
       <Content>{preInputContent}</Content>
+
       <div className="margin-left-3ch margin-top-1">
         <Content>{Config.ein.descriptionText}</Content>
         {showInput && (

--- a/web/src/components/tasks/NaicsCodeTask.tsx
+++ b/web/src/components/tasks/NaicsCodeTask.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { NeedsAccountMiniCallout } from "@/components/NeedsAccountMiniCallout";
 import { SnackbarAlert } from "@/components/njwds-extended/SnackbarAlert";
 import { TaskHeader } from "@/components/TaskHeader";
 import { NaicsCodeDisplay } from "@/components/tasks/NaicsCodeDisplay";
@@ -74,6 +75,7 @@ export const NaicsCodeTask = (props: Props): ReactElement => {
     <div className="min-height-38rem">
       <TaskHeader task={props.task} />
       <UnlockedBy task={props.task} />
+      <NeedsAccountMiniCallout />
       <Content>{preLookupContent}</Content>
       <div className="margin-y-4 bg-base-extra-light padding-3 radius-lg">
         {showInput ? (

--- a/web/src/components/tasks/TaxTask.tsx
+++ b/web/src/components/tasks/TaxTask.tsx
@@ -1,13 +1,16 @@
 import { Content } from "@/components/Content";
+import { NeedsAccountMiniCallout } from "@/components/NeedsAccountMiniCallout";
 import { SingleCtaLink } from "@/components/njwds-extended/cta/SingleCtaLink";
 import { TaskHeader } from "@/components/TaskHeader";
 import { TaxInput } from "@/components/tasks/TaxInput";
 import { UnlockedBy } from "@/components/tasks/UnlockedBy";
 import { TaxDisclaimer } from "@/components/TaxDisclaimer";
+import { NeedsAccountContext } from "@/contexts/needsAccountContext";
+import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { Task } from "@businessnjgovnavigator/shared/types";
-import { ReactElement } from "react";
+import { ReactElement, useContext } from "react";
 
 interface Props {
   task: Task;
@@ -16,14 +19,15 @@ interface Props {
 export const TaxTask = (props: Props): ReactElement => {
   const { Config } = useConfig();
   const { business } = useUserData();
-
+  const { isAuthenticated } = useContext(NeedsAccountContext);
   const preInputContent = props.task.contentMd.split("${taxInputComponent}")[0];
   const postInputContent = props.task.contentMd.split("${taxInputComponent}")[1];
 
   return (
     <div className="min-height-38rem">
       <TaskHeader task={props.task} />
-      <UnlockedBy task={props.task} />
+      <NeedsAccountMiniCallout />
+      {isAuthenticated === IsAuthenticated.TRUE && <UnlockedBy task={props.task} />}
       <Content>{preInputContent}</Content>
       <div className="margin-left-3ch margin-top-1">
         <Content>{Config.taxId.descriptionText}</Content>

--- a/web/src/components/tasks/business-formation/BusinessFormation.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormation.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@/components/Content";
+import { NeedsAccountMiniCallout } from "@/components/NeedsAccountMiniCallout";
 import { SingleCtaLink } from "@/components/njwds-extended/cta/SingleCtaLink";
 import { PageCircularIndicator } from "@/components/PageCircularIndicator";
 import { TaskHeader } from "@/components/TaskHeader";
@@ -10,7 +11,9 @@ import { NexusFormationFlow } from "@/components/tasks/business-formation/NexusF
 import { FormationSuccessPage } from "@/components/tasks/business-formation/success/FormationSuccessPage";
 import { UnlockedBy } from "@/components/tasks/UnlockedBy";
 import { BusinessFormationContext } from "@/contexts/businessFormationContext";
+import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import * as api from "@/lib/api-client/apiClient";
+import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useRoadmap } from "@/lib/data-hooks/useRoadmap";
 import { useUserData } from "@/lib/data-hooks/useUserData";
@@ -36,7 +39,7 @@ import {
 import { getCurrentBusiness } from "@businessnjgovnavigator/shared/domain-logic/getCurrentBusiness";
 import { FormationDbaDisplayContent, Task } from "@businessnjgovnavigator/shared/types";
 import { useRouter } from "next/compat/router";
-import { ReactElement, useEffect, useMemo, useRef, useState } from "react";
+import { ReactElement, useContext, useEffect, useMemo, useRef, useState } from "react";
 
 interface Props {
   task: Task | undefined;
@@ -48,6 +51,7 @@ export const BusinessFormation = (props: Props): ReactElement => {
   const { updateQueue, business, userData } = useUserData();
   const router = useRouter();
   const { Config } = useConfig();
+  const { isAuthenticated } = useContext(NeedsAccountContext);
 
   const [formationFormData, setFormationFormData] = useState<FormationFormData>(
     createEmptyFormationFormData(),
@@ -215,7 +219,7 @@ export const BusinessFormation = (props: Props): ReactElement => {
       <div className="flex flex-column space-between min-height-38rem">
         <div>
           <TaskHeader task={props.task} />
-          <UnlockedBy task={props.task} />
+          {isAuthenticated === IsAuthenticated.TRUE && <UnlockedBy task={props.task} />}
           <Content>{props.task.contentMd}</Content>
         </div>
         {getModifiedTaskContent(roadmap, props.task, "callToActionLink") &&
@@ -306,20 +310,19 @@ export const BusinessFormation = (props: Props): ReactElement => {
       }}
     >
       <div className="flex flex-column min-height-38rem" data-testid="formation-form">
-        <>
-          <div>
-            <TaskHeader task={props.task} />
-            {stepIndex === 0 && (
-              <>
-                <UnlockedBy task={props.task} dataTestid="dependency-alert" />
-                <div className="margin-bottom-2">
-                  <Content>{getIntro()}</Content>
-                </div>
-              </>
-            )}
-          </div>
-          {isForeign ? <NexusFormationFlow /> : <BusinessFormationPaginator />}
-        </>
+        <div>
+          <TaskHeader task={props.task} />
+          {stepIndex === 0 && (
+            <>
+              <UnlockedBy task={props.task} dataTestid="dependency-alert" />
+              <div className="margin-bottom-2">
+                <Content>{getIntro()}</Content>
+              </div>
+              <NeedsAccountMiniCallout />
+            </>
+          )}
+        </div>
+        {isForeign ? <NexusFormationFlow /> : <BusinessFormationPaginator />}
       </div>
     </BusinessFormationContext.Provider>
   );

--- a/web/src/components/tasks/business-formation/BusinessFormationPaginator.tsx
+++ b/web/src/components/tasks/business-formation/BusinessFormationPaginator.tsx
@@ -546,7 +546,7 @@ export const BusinessFormationPaginator = (): ReactElement => {
       <div ref={errorAlertRef} tabIndex={-1} data-testid={`error-alert-focus-container`}>
         {getErrorComponent()}
       </div>
-      <div className="margin-top-3" ref={stepperRef}>
+      <div ref={stepperRef}>
         <HorizontalStepper
           steps={stepStates}
           currentStep={state.stepIndex}

--- a/web/src/components/tasks/cannabis/CannabisPriorityStatusTask.tsx
+++ b/web/src/components/tasks/cannabis/CannabisPriorityStatusTask.tsx
@@ -1,13 +1,16 @@
+import { NeedsAccountMiniCallout } from "@/components/NeedsAccountMiniCallout";
 import { TaskHeader } from "@/components/TaskHeader";
 import { CannabisPriorityRequirements } from "@/components/tasks/cannabis/CannabisPriorityRequirements";
 import { CannabisPriorityTypes } from "@/components/tasks/cannabis/CannabisPriorityTypes";
 import { UnlockedBy } from "@/components/tasks/UnlockedBy";
 import { TaskStatusChangeSnackbar } from "@/components/TaskStatusChangeSnackbar";
+import { NeedsAccountContext } from "@/contexts/needsAccountContext";
+import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useUpdateTaskProgress } from "@/lib/data-hooks/useUpdateTaskProgress";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { scrollToTop, useMountEffect } from "@/lib/utils/helpers";
 import { Task } from "@businessnjgovnavigator/shared/types";
-import { ReactElement, useState } from "react";
+import { ReactElement, useContext, useState } from "react";
 
 interface Props {
   task: Task;
@@ -19,6 +22,7 @@ export const CannabisPriorityStatusTask = (props: Props): ReactElement => {
   const [successSnackbarIsOpen, setSuccessSnackbarIsOpen] = useState(false);
   const [displayFirstTab, setDisplayFirstTab] = useState(true);
   const { queueUpdateTaskProgress } = useUpdateTaskProgress();
+  const { isAuthenticated } = useContext(NeedsAccountContext);
 
   useMountEffect(() => {
     if (props.CMS_ONLY_tab === "1") {
@@ -63,7 +67,8 @@ export const CannabisPriorityStatusTask = (props: Props): ReactElement => {
         status={business?.taskProgress[props.task.id] ?? "TO_DO"}
       />
       <TaskHeader task={props.task} />
-      <UnlockedBy task={props.task} />
+      <NeedsAccountMiniCallout />
+      {isAuthenticated === IsAuthenticated.TRUE && <UnlockedBy task={props.task} />}
       {displayFirstTab ? (
         <CannabisPriorityTypes
           task={props.task}


### PR DESCRIPTION
## Description

As part of the login modal mission, we want to alert guest users that the task they're looking at requires an account.

This PR adds this yellow callout to the following tasks: 
- NAICS code
- Check Available Names and Form Your Business
- Get Your EIN
- Register for Taxes
- Cannabis Priority Status. 

<img width="916" height="719" alt="Screenshot 2026-08-05 at 10 44 05 AM" src="https://github.com/user-attachments/assets/83071823-e6c3-4e56-89c6-cf6007568737" />

### Ticket


This pull request resolves [#17961](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17961).

### Approach
I made a component that wraps the MiniCallout NJWDS component and does not appear if a user is already authenticated.

Some tasks have another alert (`UnlockedBy` component) that warns users of task prerequisites that haven't been completed. Because multiple alerts on the page look crowded and in most cases, lack of an account blocks users from completing prereqs anyway, I hide the prereq alert when the user doesn't have an account.

I added it only to the `needsAccount: true` tasks that show up in the required-only roadmap, which doesn't include non-required tasks that no longer show up in the roadmap (EIN for domestic employers) and License status tasks, which show the login modal immediately upon opening. Given the forthcoming roadmap redesign, these tasks may never be shown to users, so accounting for them is not worth the effort at this moment.


### Steps to Test

1. Onboard as a new business (while logged out)
2. Click into any task with a lock icon
3. The task page should show a callout that you need to create an account.

When logged in, follow the same steps, and the task page should not show this callout.

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
