### PR TITLE
feat: [AB#17980] open account modal on locked field interaction

### DIFF
--- a/web/src/components/GenericTextField.tsx
+++ b/web/src/components/GenericTextField.tsx
@@ -33,6 +33,7 @@ export interface GenericTextFieldProps<T = FieldErrorType> extends FormContextFi
   handleChange?: (value: string) => void | ((value: ChangeEvent<HTMLInputElement>) => void);
   onChange?: (value: string) => void | ((value: ChangeEvent<HTMLInputElement>) => void);
   onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  onClick?: () => void;
   onFocus?: () => void;
   error?: boolean;
   validationText?: string;
@@ -188,6 +189,7 @@ export const GenericTextField = forwardRef(
           sx={{ width: 1, ...fieldOptions?.sx }}
           required={props.required}
           type={props.type}
+          onClick={props.onClick}
           onFocus={props.onFocus}
           onKeyDown={props.onKeyDown}
           slotProps={{

--- a/web/src/components/tasks/EinInput.tsx
+++ b/web/src/components/tasks/EinInput.tsx
@@ -3,6 +3,7 @@ import { SecondaryButton } from "@/components/njwds-extended/SecondaryButton";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
+import { useNeedsAccountLockedField } from "@/lib/data-hooks/useNeedsAccountLockedField";
 import { useUpdateTaskProgress } from "@/lib/data-hooks/useUpdateTaskProgress";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { displayAsEin } from "@/lib/utils/displayAsEin";
@@ -23,6 +24,7 @@ export const EinInput = (props: Props): ReactElement => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [employerId, setEmployerId] = useState<string>("");
   const { isAuthenticated, setShowNeedsAccountModal } = useContext(NeedsAccountContext);
+  const needsAccountLockedFieldProps = useNeedsAccountLockedField();
   const { business, updateQueue } = useUserData();
   const { queueUpdateTaskProgress } = useUpdateTaskProgress();
 
@@ -32,10 +34,6 @@ export const EinInput = (props: Props): ReactElement => {
   }, business);
 
   const handleChange = (value: string): void => {
-    if (isAuthenticated === IsAuthenticated.FALSE) {
-      setShowNeedsAccountModal(true);
-      return;
-    }
     setEmployerId(value);
   };
 
@@ -82,6 +80,7 @@ export const EinInput = (props: Props): ReactElement => {
         value={employerId}
         inputWidth="full"
         ariaLabel="Save your EIN"
+        {...needsAccountLockedFieldProps}
       />
       <div className="mobile-lg:margin-left-1 mobile-lg:margin-top-05">
         <SecondaryButton

--- a/web/src/components/tasks/EinTask.test.tsx
+++ b/web/src/components/tasks/EinTask.test.tsx
@@ -202,14 +202,19 @@ describe("<EinTask />", () => {
       });
     });
 
-    it("opens Needs Account modal when the field is edited", async () => {
+    it("locks the EIN field for guest users", () => {
       renderPage();
-      fireEvent.change(screen.getByLabelText("Save your EIN"), {
-        target: { value: "123456789" },
-      });
-      await waitFor(() => {
-        return expect(setShowNeedsAccountModal).toHaveBeenCalledWith(true);
-      });
+      expect(screen.getByLabelText("Save your EIN")).toHaveAttribute("readonly");
+      expect(screen.getByLabelText("Save your EIN")).toHaveAttribute("aria-readonly", "true");
+    });
+
+    it("opens Needs Account modal when the EIN field is clicked, but not on focus alone", () => {
+      renderPage();
+      fireEvent.focus(screen.getByLabelText("Save your EIN"));
+      expect(setShowNeedsAccountModal).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByLabelText("Save your EIN"));
+      expect(setShowNeedsAccountModal).toHaveBeenCalledWith(true);
     });
 
     it("opens Needs Account modal when the save button is clicked", async () => {

--- a/web/src/components/tasks/NaicsCodeInput.tsx
+++ b/web/src/components/tasks/NaicsCodeInput.tsx
@@ -7,6 +7,7 @@ import { WithErrorBar } from "@/components/WithErrorBar";
 import { NeedsAccountContext } from "@/contexts/needsAccountContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
+import { useNeedsAccountLockedField } from "@/lib/data-hooks/useNeedsAccountLockedField";
 import { useUpdateTaskProgress } from "@/lib/data-hooks/useUpdateTaskProgress";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import NaicsCodes from "@/lib/static/records/naics2022.json";
@@ -49,6 +50,7 @@ export const NaicsCodeInput = (props: Props): ReactElement => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [displayInputState, setDisplayInput] = useState<boolean>(false);
   const { isAuthenticated, setShowNeedsAccountModal } = useContext(NeedsAccountContext);
+  const needsAccountLockedFieldProps = useNeedsAccountLockedField();
   const displayInput = props.CMS_ONLY_displayInput ?? displayInputState;
   const saveButtonText =
     props.isAuthenticated === IsAuthenticated.FALSE
@@ -71,10 +73,6 @@ export const NaicsCodeInput = (props: Props): ReactElement => {
         return value.length > 0;
       }) ?? [];
   const handleTextInputChange = (value: string): void => {
-    if (isAuthenticated !== IsAuthenticated.TRUE) {
-      setShowNeedsAccountModal(true);
-      return;
-    }
     setNaicsCode(value);
     if (value.length === REQUIRED_LENGTH) {
       if (getNaicsCode(value)) {
@@ -258,6 +256,7 @@ export const NaicsCodeInput = (props: Props): ReactElement => {
                 error={isInvalid !== undefined}
                 handleChange={handleTextInputChange}
                 validationText={errorMessages[isInvalid ?? "length"]}
+                {...needsAccountLockedFieldProps}
               />
             </WithErrorBar>
           </div>

--- a/web/src/components/tasks/NaicsCodeTask.test.tsx
+++ b/web/src/components/tasks/NaicsCodeTask.test.tsx
@@ -560,16 +560,26 @@ describe("<NaicsCodeTask />", () => {
     });
 
     describe("guest mode - generic industry", () => {
-      it("opens modal when a user types in NAICS code input field", () => {
+      const renderGenericIndustryPage = (): void => {
         initialBusiness = generateBusiness({
           profileData: generateProfileData({ naicsCode: "", industryId: "generic" }),
         });
         renderPage();
+      };
 
-        fireEvent.change(screen.getByLabelText("Save NAICS Code"), { target: { value: "123456" } });
+      it("locks the NAICS code input field for guest users", () => {
+        renderGenericIndustryPage();
+        expect(screen.getByLabelText("Save NAICS Code")).toHaveAttribute("readonly");
+        expect(screen.getByLabelText("Save NAICS Code")).toHaveAttribute("aria-readonly", "true");
+      });
 
+      it("opens modal when the NAICS code input is clicked, but not on focus alone", () => {
+        renderGenericIndustryPage();
+        fireEvent.focus(screen.getByLabelText("Save NAICS Code"));
+        expect(setShowNeedsAccountModal).not.toHaveBeenCalled();
+
+        fireEvent.click(screen.getByLabelText("Save NAICS Code"));
         expect(setShowNeedsAccountModal).toHaveBeenCalledWith(true);
-        expect(screen.getByLabelText("Save NAICS Code")).toHaveValue("");
       });
     });
   });

--- a/web/src/components/tasks/TaxInput.tsx
+++ b/web/src/components/tasks/TaxInput.tsx
@@ -13,6 +13,7 @@ import { ProfileDataContext } from "@/contexts/profileDataContext";
 import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { useConfig } from "@/lib/data-hooks/useConfig";
 import { useFormContextHelper } from "@/lib/data-hooks/useFormContextHelper";
+import { useNeedsAccountLockedField } from "@/lib/data-hooks/useNeedsAccountLockedField";
 import { useUserData } from "@/lib/data-hooks/useUserData";
 import { MediaQueries } from "@/lib/PageSizes";
 import { useMountEffectWhenDefined } from "@/lib/utils/helpers";
@@ -28,6 +29,7 @@ interface Props {
 export const TaxInput = (props: Props): ReactElement => {
   const { business, updateQueue } = useUserData();
   const { isAuthenticated, setShowNeedsAccountModal } = useContext(NeedsAccountContext);
+  const needsAccountLockedFieldProps = useNeedsAccountLockedField();
   const { Config } = useConfig();
   const [profileData, setProfileData] = useState<ProfileData>(
     business?.profileData ?? createEmptyProfileData(),
@@ -114,15 +116,6 @@ export const TaxInput = (props: Props): ReactElement => {
     </div>
   );
 
-  const getNeedsAccountModalFunction = (): (() => void) | undefined => {
-    if (isAuthenticated === IsAuthenticated.FALSE) {
-      return () => {
-        return setShowNeedsAccountModal(true);
-      };
-    }
-    return undefined;
-  };
-
   const onSave = (): void => {
     if (isAuthenticated === IsAuthenticated.FALSE) {
       setShowNeedsAccountModal(true);
@@ -154,7 +147,7 @@ export const TaxInput = (props: Props): ReactElement => {
                 key={business?.profileData.taxId}
                 dbBusinessTaxId={business?.profileData.taxId}
                 required={isAuthenticated === IsAuthenticated.TRUE}
-                handleChangeOverride={getNeedsAccountModalFunction()}
+                {...needsAccountLockedFieldProps}
               />
               <div className="tablet:margin-top-05 tablet:margin-left-2">
                 <SecondaryButton

--- a/web/src/components/tasks/TaxTask.test.tsx
+++ b/web/src/components/tasks/TaxTask.test.tsx
@@ -263,10 +263,24 @@ describe("<TaxTask />", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("opens Needs Account modal when trying to enter tax input data, and does not show inline errors or update userData", async () => {
+    it("locks the tax input for guest users", () => {
       renderPage();
-      fireEvent.change(screen.getByLabelText("Tax id"), { target: { value: "1" } });
-      fireEvent.blur(screen.getByLabelText("Tax id"));
+      expect(screen.getByLabelText("Tax id")).toHaveAttribute("readonly");
+      expect(screen.getByLabelText("Tax id")).toHaveAttribute("aria-readonly", "true");
+    });
+
+    it("opens Needs Account modal when the tax input is clicked, but not on focus alone", () => {
+      renderPage();
+      fireEvent.focus(screen.getByLabelText("Tax id"));
+      expect(setShowNeedsAccountModal).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByLabelText("Tax id"));
+      expect(setShowNeedsAccountModal).toHaveBeenCalledWith(true);
+    });
+
+    it("does not show inline errors or update userData when the locked tax input is used", async () => {
+      renderPage();
+      fireEvent.click(screen.getByLabelText("Tax id"));
       await waitFor(() => {
         return expect(setShowNeedsAccountModal).toHaveBeenCalledWith(true);
       });

--- a/web/src/lib/data-hooks/useNeedsAccountLockedField.test.tsx
+++ b/web/src/lib/data-hooks/useNeedsAccountLockedField.test.tsx
@@ -1,0 +1,110 @@
+import { GenericTextField } from "@/components/GenericTextField";
+import { IsAuthenticated } from "@/lib/auth/AuthContext";
+import { useNeedsAccountLockedField } from "@/lib/data-hooks/useNeedsAccountLockedField";
+import { withNeedsAccountContext } from "@/test/helpers/helpers-renderers";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ReactElement, useState } from "react";
+
+const LockedField = (): ReactElement => {
+  const lockedFieldProps = useNeedsAccountLockedField();
+  const [value, setValue] = useState("");
+  return (
+    <GenericTextField
+      fieldName="taxId"
+      ariaLabel="locked field"
+      value={value}
+      handleChange={setValue}
+      {...lockedFieldProps}
+    />
+  );
+};
+
+describe("useNeedsAccountLockedField", () => {
+  const setShowNeedsAccountModal = jest.fn();
+
+  const renderLockedField = (isAuthenticated: IsAuthenticated): void => {
+    render(
+      withNeedsAccountContext(<LockedField />, isAuthenticated, {
+        setShowNeedsAccountModal,
+      }),
+    );
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("when the user is a guest", () => {
+    it("marks the field as read only", () => {
+      renderLockedField(IsAuthenticated.FALSE);
+      expect(screen.getByLabelText("locked field")).toHaveAttribute("readonly");
+      expect(screen.getByLabelText("locked field")).toHaveAttribute("aria-readonly", "true");
+    });
+
+    it("opens the modal when the field is clicked", () => {
+      renderLockedField(IsAuthenticated.FALSE);
+      fireEvent.click(screen.getByLabelText("locked field"));
+      expect(setShowNeedsAccountModal).toHaveBeenCalledWith(true);
+    });
+
+    it("does not open the modal when the field only receives focus", () => {
+      renderLockedField(IsAuthenticated.FALSE);
+      fireEvent.focus(screen.getByLabelText("locked field"));
+      expect(setShowNeedsAccountModal).not.toHaveBeenCalled();
+    });
+
+    it.each(["Enter", " ", "a", "5"])(
+      "opens the modal when the user tries to enter a value with %s",
+      (key) => {
+        renderLockedField(IsAuthenticated.FALSE);
+        fireEvent.keyDown(screen.getByLabelText("locked field"), { key });
+        expect(setShowNeedsAccountModal).toHaveBeenCalledWith(true);
+      },
+    );
+
+    it.each(["Tab", "Escape", "ArrowLeft", "ArrowRight", "Shift"])(
+      "does not open the modal when the user presses the navigation key %s",
+      (key) => {
+        renderLockedField(IsAuthenticated.FALSE);
+        fireEvent.keyDown(screen.getByLabelText("locked field"), { key });
+        expect(setShowNeedsAccountModal).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each([
+      ["ctrlKey", { ctrlKey: true }],
+      ["metaKey", { metaKey: true }],
+      ["altKey", { altKey: true }],
+    ])("does not open the modal for a %s shortcut", (_label, modifier) => {
+      renderLockedField(IsAuthenticated.FALSE);
+      fireEvent.keyDown(screen.getByLabelText("locked field"), { key: "r", ...modifier });
+      expect(setShowNeedsAccountModal).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the user is authenticated", () => {
+    it("leaves the field editable", () => {
+      renderLockedField(IsAuthenticated.TRUE);
+      expect(screen.getByLabelText("locked field")).not.toHaveAttribute("readonly");
+    });
+
+    it("does not open the modal when the field is clicked", () => {
+      renderLockedField(IsAuthenticated.TRUE);
+      fireEvent.click(screen.getByLabelText("locked field"));
+      expect(setShowNeedsAccountModal).not.toHaveBeenCalled();
+    });
+
+    it("does not open the modal when the user types", () => {
+      renderLockedField(IsAuthenticated.TRUE);
+      fireEvent.keyDown(screen.getByLabelText("locked field"), { key: "a" });
+      expect(setShowNeedsAccountModal).not.toHaveBeenCalled();
+    });
+
+    it("lets the user type into the field", async () => {
+      renderLockedField(IsAuthenticated.TRUE);
+      await userEvent.type(screen.getByLabelText("locked field"), "5");
+      expect(screen.getByLabelText("locked field")).toHaveValue("5");
+    });
+  });
+});

--- a/web/src/lib/data-hooks/useNeedsAccountLockedField.ts
+++ b/web/src/lib/data-hooks/useNeedsAccountLockedField.ts
@@ -1,0 +1,42 @@
+import { NeedsAccountContext } from "@/contexts/needsAccountContext";
+import { IsAuthenticated } from "@/lib/auth/AuthContext";
+import { KeyboardEvent, useContext } from "react";
+
+/**
+ * Locks a text field for guest users so interacting with it opens the Needs Account modal.
+ *
+ * The modal must not open on focus alone: that is a change of context on focus (WCAG 3.2.1), and
+ * MUI's Dialog restores focus to the field it was opened from, which would immediately reopen the
+ * modal and trap the user. The field is readOnly rather than disabled so it stays focusable and
+ * announces its locked state via aria-readonly.
+ */
+export const useNeedsAccountLockedField = (): {
+  readOnly: boolean;
+  onClick: () => void;
+  onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
+} => {
+  const { isAuthenticated, setShowNeedsAccountModal } = useContext(NeedsAccountContext);
+  const isLocked = isAuthenticated !== IsAuthenticated.TRUE;
+
+  const openModalWhenLocked = (): void => {
+    if (isLocked) {
+      setShowNeedsAccountModal(true);
+    }
+  };
+
+  // We want to handle the case where users who navigate via keyboard never click the field,
+  // and open the modal when they try to type into the field.
+  const openModalWhenEnteringValue = (event: KeyboardEvent<HTMLInputElement>): void => {
+    const isShortcut = event.ctrlKey || event.metaKey || event.altKey;
+    const isValueKey = event.key === "Enter" || event.key.length === 1;
+    if (isValueKey && !isShortcut) {
+      openModalWhenLocked();
+    }
+  };
+
+  return {
+    readOnly: isLocked,
+    onClick: openModalWhenLocked,
+    onKeyDown: openModalWhenEnteringValue,
+  };
+};


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

Guest users can see the NAICS code, EIN, and tax ID task fields, but cannot fill them in until they create an account. Previously the Needs Account modal was triggered on keyboard input, which the team felt like was a bait and switch.  It was also triggered inconsistently across these three fields: NAICS and EIN opened it from inside their change handlers, the tax ID field used a `handleChangeOverride`.

These fields are now locked as `readOnly` for guest users, and the modal opens on an explicit interaction: a click, or a keypress that would have entered a value.

### Ticket

This pull request resolves [#17980](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17980).

### Approach

Added `useNeedsAccountLockedField`, a hook returning the `readOnly`, `onClick`, and `onKeyDown` props a locked field needs, and wired it into `NaicsCodeInput`, `EinInput`, and `TaxInput`. This replaces the three divergent per-field triggers with one shared behavior.

### Steps to Test

As a guest user (not signed in):

1. Go to the Determine Your NAICS Code task
2. Click the NAICS code text field. The Needs Account modal should open.
3. Close the modal and confirm focus returns to the field without reopening it.
4. Tab to the text field instead of clicking. The modal should not open on focus. 
5. Then type any character. The modal should open.
6. With the field focused, press Tab, Escape, or an arrow key. The modal should not open.
7. Confirm the field never accepts a typed value and no inline validation errors appear.
8. Repeat steps 1 through 5 on the EIN task and the Tax ID task.

As a signed-in user, confirm all three fields are still editable and the modal never appears.

### Notes

We wait for the user to type if they've navigated to the field by keyboard instead of triggering it on focus to avoid violating [WCAG 3.2.1](https://www.w3.org/WAI/WCAG21/Understanding/on-focus.html).

### Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [ ] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews