### PR TITLE
feat: [AB#17963] remove step numbers from onboarding pages

### DIFF
--- a/content/src/fieldConfig/onboarding-defaults.json
+++ b/content/src/fieldConfig/onboarding-defaults.json
@@ -3,7 +3,6 @@
     "additionalBusinessFinalNextButtonText": "Save Additional Business",
     "returnToPreviousBusiness": "Return to ${previousBusiness}",
     "errorTextMinimumNumericField": "Must be ${length} digits long.",
-    "stepXTemplate": "(Step ${currentPage})",
     "backButtonText": "Back",
     "finalNextButtonText": "Show My Guide",
     "pageTitle": "Tell Us About Your ${Additional} Business",

--- a/web/decap-config/collections/12-misc.yml
+++ b/web/decap-config/collections/12-misc.yml
@@ -555,7 +555,6 @@ collections:
                   widget: string,
                 }
               - { label: Back Button Test, name: backButtonText, widget: string }
-              - { label: Step X Template, name: stepXTemplate, widget: string }
               - {
                   label: Error Text - Minimum Numeric Field,
                   name: errorTextMinimumNumericField,

--- a/web/src/lib/utils/analytics.ts
+++ b/web/src/lib/utils/analytics.ts
@@ -1548,7 +1548,7 @@ export default {
         },
       },
     },
-    onboarding_last_step: {
+    onboarding_last_page: {
       submit: {
         finish_onboarding: () => {
           eventRunner.track({
@@ -1561,7 +1561,7 @@ export default {
         },
       },
     },
-    onboarding_last_step_save_additional_business_button: {
+    onboarding_last_page_save_additional_business_button: {
       click: {
         finish_additional_business_onboarding: () => {
           eventRunner.track({

--- a/web/src/lib/utils/onboardingPageHelpers.ts
+++ b/web/src/lib/utils/onboardingPageHelpers.ts
@@ -1,9 +1,8 @@
 import { OnboardingFlow } from "@/components/onboarding/OnboardingFlows";
 import { Business, LookupIndustryById, LookupSectorTypeById } from "@businessnjgovnavigator/shared";
-import { getMergedConfig } from "@businessnjgovnavigator/shared/contexts";
 import { FlowType, Page } from "@businessnjgovnavigator/shared/types";
 import { QUERY_PARAMS_VALUES } from "../domain-logic/routes";
-import { getFlow, templateEval } from "./helpers";
+import { getFlow } from "./helpers";
 
 export const mapFlowQueryToPersona: Record<QUERY_PARAMS_VALUES["flow"], FlowType> = {
   starting: "STARTING",
@@ -33,13 +32,6 @@ export const pageQueryParamIsValid = (
   const requestedPageIsInRange = page <= onboardingFlows[flow].pages.length && page > 0;
 
   return hasAnsweredBusinessPersona && requestedPageIsInRange;
-};
-
-export const evalHeaderStepsTemplate = (page: Page): string => {
-  const Config = getMergedConfig();
-  return templateEval(Config.onboardingDefaults.stepXTemplate, {
-    currentPage: page.current.toString(),
-  });
 };
 
 export const getAnimation = (page: Page): string => {

--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -39,7 +39,6 @@ import {
 } from "@/lib/utils/analytics-helpers";
 import { getFlow, scrollToTop } from "@/lib/utils/helpers";
 import {
-  evalHeaderStepsTemplate,
   flowQueryParamIsValid,
   getAnimation,
   getTimeout,
@@ -318,9 +317,9 @@ const OnboardingPage = (props: Props): ReactElement => {
     setProfileData(newProfileData);
     setCurrentFlow(flowType);
 
-    /* The logic below used to skip the first step of onboarding for STARTING businesses,
+    /* The logic below used to skip the first page of onboarding for STARTING businesses,
     it has been temporarily commented out because it is incompatible with our current AB
-    test to skip the second onboarding step.
+    test to skip the second onboarding page.
 
     if (flowType === "OWNING") {
       setPage({ current: 1, previous: 1 });
@@ -341,8 +340,8 @@ const OnboardingPage = (props: Props): ReactElement => {
     setRegistrationDimension("Onboarded Guest");
 
     isAdditionalBusiness
-      ? analytics.event.onboarding_last_step_save_additional_business_button.click.finish_additional_business_onboarding()
-      : analytics.event.onboarding_last_step.submit.finish_onboarding();
+      ? analytics.event.onboarding_last_page_save_additional_business_button.click.finish_additional_business_onboarding()
+      : analytics.event.onboarding_last_page.submit.finish_onboarding();
 
     updateQueue.queueBusiness({
       ...updateQueue.currentBusiness(),
@@ -502,9 +501,9 @@ const OnboardingPage = (props: Props): ReactElement => {
     return (
       <div
         className="margin-y-2 desktop:margin-y-0 desktop:padding-bottom-1"
-        data-testid={`step-${page.current.toString()}`}
+        data-testid={`page-${page.current.toString()}-header`}
       >
-        <h1 ref={headerRef}>{`${[pageTitle, evalHeaderStepsTemplate(page)].join(" ")}`}</h1>
+        <h1 ref={headerRef}>{`${pageTitle}`}</h1>
       </div>
     );
   };
@@ -522,7 +521,7 @@ const OnboardingPage = (props: Props): ReactElement => {
             onBack,
           }}
         >
-          <NextSeo title={getNextSeoTitle(`${pageTitle} ${evalHeaderStepsTemplate(page)}`)} />
+          <NextSeo title={getNextSeoTitle(`${pageTitle}`)} />
           <PageSkeleton
             showNavBar
             previousBusinessId={previousBusiness?.id}

--- a/web/test/pages/onboarding/helpers-onboarding.tsx
+++ b/web/test/pages/onboarding/helpers-onboarding.tsx
@@ -84,7 +84,7 @@ export type PageHelpers = {
   getFullNameValue: () => string;
   getEmailValue: () => string;
   getConfirmEmailValue: () => string;
-  visitStep: (step: number) => Promise<void>;
+  visitOnboardingPage: (pageNumber: number) => Promise<void>;
   chooseEssentialQuestionRadio: (industryId: string, indexOfDataChoice: number) => void;
 };
 
@@ -166,13 +166,13 @@ export const createPageHelpers = (): PageHelpers => {
     )?.value;
   };
 
-  const visitStep = async (step: number): Promise<void> => {
+  const visitOnboardingPage = async (pageNumber: number): Promise<void> => {
     clickNext();
-    const currentStep = step - 1;
+    const currentPage = pageNumber - 1;
     await waitForElementToBeRemoved(() => {
-      return screen.getByTestId(`step-${currentStep}`);
+      return screen.getByTestId(`page-${currentPage}-header`);
     });
-    expect(screen.getByTestId(`step-${step}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`page-${pageNumber}-header`)).toBeInTheDocument();
   };
 
   const checkByLabelText = (label: string): void => {
@@ -217,7 +217,7 @@ export const createPageHelpers = (): PageHelpers => {
     getFullNameValue,
     getEmailValue,
     getConfirmEmailValue,
-    visitStep,
+    visitOnboardingPage,
     checkByLabelText,
     chooseEssentialQuestionRadio,
   };
@@ -283,7 +283,7 @@ export const industryIdsWithRequiredEssentialQuestion: string[] = getIndustries(
   .filter((industry) => industryHasRequiredUndefinedEssentialQuestion(industry.id))
   .map((industry) => industry.id);
 
-export const composeOnBoardingTitle = (step: string, pageTitle?: string): string => {
+export const composeOnBoardingTitle = (pageTitle?: string): string => {
   const Config = getMergedConfig();
   if (pageTitle === undefined) {
     const pageTitleDefault = modifyContent({
@@ -294,9 +294,7 @@ export const composeOnBoardingTitle = (step: string, pageTitle?: string): string
         additional: "additional",
       },
     });
-    // return `${pageTitleDefault} ${step}`;
-    return `${[pageTitleDefault, step].join(" ")}`;
+    return `${pageTitleDefault}`;
   }
-  // return `${pageTitle} ${step}`;
-  return `${[pageTitle, step].join(" ")}`;
+  return `${pageTitle}`;
 };

--- a/web/test/pages/onboarding/onboarding-additional-business.test.tsx
+++ b/web/test/pages/onboarding/onboarding-additional-business.test.tsx
@@ -3,7 +3,6 @@ import { IsAuthenticated } from "@/lib/auth/AuthContext";
 import { getNavBarBusinessTitle } from "@/lib/domain-logic/getNavBarBusinessTitle";
 import { QUERIES, ROUTES } from "@/lib/domain-logic/routes";
 import { templateEval } from "@/lib/utils/helpers";
-import { evalHeaderStepsTemplate } from "@/lib/utils/onboardingPageHelpers";
 import { mockPush, useMockRouter } from "@/test/mock/mockRouter";
 import {
   currentBusiness,
@@ -61,9 +60,8 @@ describe("onboarding - additional business", () => {
     const expectedTitle = templateEval(Config.onboardingDefaults.pageTitle, {
       Additional: "Additional",
     });
-    const step = evalHeaderStepsTemplate({ current: 1, previous: 1 });
 
-    expect(screen.getByText(composeOnBoardingTitle(step, expectedTitle))).toBeInTheDocument();
+    expect(screen.getByText(composeOnBoardingTitle(expectedTitle))).toBeInTheDocument();
   });
 
   it("returns user to previous business without saving", async () => {
@@ -115,7 +113,7 @@ describe("onboarding - additional business", () => {
     });
 
     page.chooseRadio("business-persona-starting");
-    await page.visitStep(2);
+    await page.visitOnboardingPage(2);
 
     const newBusinessId = currentBusiness().id;
     expect(currentBusiness().profileData.businessPersona).toEqual("STARTING");
@@ -179,7 +177,7 @@ describe("onboarding - additional business", () => {
     });
 
     page.chooseRadio("business-persona-foreign");
-    await page.visitStep(2);
+    await page.visitOnboardingPage(2);
 
     page.checkByLabelText(nexusNoneOfTheAboveCheckboxLabel);
     act(() => {

--- a/web/test/pages/onboarding/onboarding-foreign.test.tsx
+++ b/web/test/pages/onboarding/onboarding-foreign.test.tsx
@@ -1,5 +1,4 @@
 import { ROUTES } from "@/lib/domain-logic/routes";
-import { templateEval } from "@/lib/utils/helpers";
 import { randomHomeBasedIndustry } from "@/test/factories";
 import { mockPush, useMockRouter } from "@/test/mock/mockRouter";
 import {
@@ -8,7 +7,6 @@ import {
   userDataWasNotUpdated,
 } from "@/test/mock/withStatefulUserData";
 import {
-  composeOnBoardingTitle,
   industryIdsWithRequiredEssentialQuestion,
   industryIdsWithSingleRequiredEssentialQuestion,
   mockEmptyApiSignups,
@@ -56,22 +54,6 @@ describe("onboarding - foreign business", () => {
     jest.useFakeTimers();
   });
 
-  describe("page headers", () => {
-    it("uses special template eval for step 1 label", () => {
-      renderPage({});
-      const step = templateEval(Config.onboardingDefaults.stepXTemplate, { currentPage: "1" });
-      expect(screen.getByText(composeOnBoardingTitle(step))).toBeInTheDocument();
-    });
-
-    it("uses special template eval for step 2 label", () => {
-      const userData = generateTestUserData({ businessPersona: "FOREIGN" });
-      useMockRouter({ isReady: true, query: { page: "2" } });
-      renderPage({ userData });
-      const step = templateEval(Config.onboardingDefaults.stepXTemplate, { currentPage: "2" });
-      expect(screen.getByText(composeOnBoardingTitle(step))).toBeInTheDocument();
-    });
-  });
-
   describe("page 2", () => {
     let userData: UserData;
 
@@ -97,7 +79,7 @@ describe("onboarding - foreign business", () => {
         screen.getByText(Config.profileDefaults.fields.foreignBusinessTypeIds.default.NEXUS),
       ).toBeInTheDocument();
 
-      await page.visitStep(3);
+      await page.visitOnboardingPage(3);
       expect(currentBusiness().profileData.foreignBusinessTypeIds).toEqual([
         "employeeOrContractorInNJ",
       ]);
@@ -165,13 +147,13 @@ describe("onboarding - foreign business", () => {
       expect(currentBusiness().profileData.foreignBusinessTypeIds).toEqual(["transactionsInNJ"]);
     });
 
-    it("prevents user from moving past Step 2 if no foreign business type checked", async () => {
+    it("prevents user from moving past the second onboarding page if no foreign business type checked", async () => {
       useMockRouter({ isReady: true, query: { page: "2" } });
       const { page } = renderPage({ userData });
 
       page.clickNext();
       await waitFor(() => {
-        expect(screen.getByTestId("step-2")).toBeInTheDocument();
+        expect(screen.getByTestId("page-2-header")).toBeInTheDocument();
       });
       expect(
         screen.getByText(
@@ -180,14 +162,14 @@ describe("onboarding - foreign business", () => {
       ).toBeInTheDocument();
     });
 
-    it("prevents user from moving past Step 2 if you check a foreign business type and uncheck it leaving no foreign business type checked", async () => {
+    it("prevents user from moving past the second onboarding page if you check a foreign business type and uncheck it leaving no foreign business type checked", async () => {
       useMockRouter({ isReady: true, query: { page: "2" } });
       const { page } = renderPage({ userData });
       page.checkByLabelText(transactionsInNJ);
       page.checkByLabelText(transactionsInNJ);
       page.clickNext();
       await waitFor(() => {
-        expect(screen.getByTestId("step-2")).toBeInTheDocument();
+        expect(screen.getByTestId("page-2-header")).toBeInTheDocument();
       });
       expect(
         screen.getByText(
@@ -196,7 +178,7 @@ describe("onboarding - foreign business", () => {
       ).toBeInTheDocument();
     });
 
-    it("allows user to move past Step 2 if you have made a selection", async () => {
+    it("allows user to move past the second onboarding page if you have made a selection", async () => {
       useMockRouter({ isReady: true, query: { page: "2" } });
       const { page } = renderPage({ userData });
       page.checkByLabelText(transactionsInNJ);
@@ -266,7 +248,7 @@ describe("onboarding - foreign business", () => {
       await waitFor(() => {
         expect(mockPush).toHaveBeenCalled();
       });
-      expect(screen.queryByTestId("step-3")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("page-3-header")).not.toBeInTheDocument();
     });
 
     it("sets operating phase to GUEST_MODE_WITH_BUSINESS_STRUCTURE to prevent prompt", async () => {
@@ -301,7 +283,7 @@ describe("onboarding - foreign business", () => {
       await waitFor(() => {
         expect(mockPush).toHaveBeenCalled();
       });
-      expect(screen.queryByTestId("step-3")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("page-3-header")).not.toBeInTheDocument();
     });
 
     it("sets operating phase to GUEST_MODE_WITH_BUSINESS_STRUCTURE to prevent prompt", async () => {
@@ -323,7 +305,7 @@ describe("onboarding - foreign business", () => {
     });
   });
 
-  describe("Nexus - step 3", () => {
+  describe("Nexus - third onboarding page", () => {
     let userData: UserData;
 
     beforeEach(() => {
@@ -333,12 +315,6 @@ describe("onboarding - foreign business", () => {
         foreignBusinessTypeIds: ["employeeOrContractorInNJ"],
       });
       useMockRouter({ isReady: true, query: { page: "3" } });
-    });
-
-    it("displays step 3", () => {
-      renderPage({ userData });
-      const step = templateEval(Config.onboardingDefaults.stepXTemplate, { currentPage: "3" });
-      expect(screen.getByText(composeOnBoardingTitle(step))).toBeInTheDocument();
     });
 
     it("displays industry question", async () => {
@@ -374,18 +350,18 @@ describe("onboarding - foreign business", () => {
       });
     });
 
-    it("prevents user from moving past Step 3 if you have not selected an industry", async () => {
+    it("prevents user from moving past the third onboarding page if you have not selected an industry", async () => {
       useMockRouter({ isReady: true, query: { page: "3" } });
       const { page } = renderPage({ userData });
       page.clickNext();
 
-      expect(screen.getByTestId("step-3")).toBeInTheDocument();
-      expect(screen.queryByTestId("step-4")).not.toBeInTheDocument();
+      expect(screen.getByTestId("page-3-header")).toBeInTheDocument();
+      expect(screen.queryByTestId("page-4-header")).not.toBeInTheDocument();
       expect(screen.getByTestId("banner-alert-REQUIRED_REVIEW_INFO_BELOW")).toBeInTheDocument();
     });
 
     it.each(industryIdsWithSingleRequiredEssentialQuestion)(
-      "prevents user from moving to Step 4 when %s is selected as industry, but essential question is not answered",
+      "prevents user from moving to the fourth onboarding page when %s is selected as industry, but essential question is not answered",
       async (industryId) => {
         const userData = generateTestUserData({
           businessPersona: "FOREIGN",
@@ -396,8 +372,8 @@ describe("onboarding - foreign business", () => {
         useMockRouter({ isReady: true, query: { page: "3" } });
         const { page } = renderPage({ userData });
         page.clickNext();
-        expect(screen.getByTestId("step-3")).toBeInTheDocument();
-        expect(screen.queryByTestId("step-4")).not.toBeInTheDocument();
+        expect(screen.getByTestId("page-3-header")).toBeInTheDocument();
+        expect(screen.queryByTestId("page-4-header")).not.toBeInTheDocument();
         expect(screen.getByTestId("banner-alert-REQUIRED_ESSENTIAL_QUESTION")).toBeInTheDocument();
         expect(
           screen.getAllByText(Config.siteWideErrorMessages.errorRadioButton)[0],
@@ -406,7 +382,7 @@ describe("onboarding - foreign business", () => {
     );
 
     it.each([industryIdsWithSingleRequiredEssentialQuestion])(
-      "allows user to move past Step 3 when you have selected an industry %s and answered the essential question",
+      "allows user to move past the third onboarding page when you have selected an industry %s and answered the essential question",
       async (industryId) => {
         const userData = generateTestUserData({
           businessPersona: "FOREIGN",
@@ -438,7 +414,7 @@ describe("onboarding - foreign business", () => {
         useMockRouter({ isReady: true, query: { page: "3" } });
         const { page } = renderPage({ userData });
         page.clickNext();
-        expect(screen.getByTestId("step-3")).toBeInTheDocument();
+        expect(screen.getByTestId("page-3-header")).toBeInTheDocument();
         expect(
           screen.getAllByText(Config.siteWideErrorMessages.errorRadioButton)[0],
         ).toBeInTheDocument();
@@ -451,7 +427,7 @@ describe("onboarding - foreign business", () => {
 
     const employmentAgencyIndustryId = "employment-agency";
 
-    it("prevents user from moving to Step 4 when employment agency is selected as industry, but essential question is not answered", async () => {
+    it("prevents user from moving to the fourth onboarding page when employment agency is selected as industry, but essential question is not answered", async () => {
       const userData = generateTestUserData({
         businessPersona: "FOREIGN",
         foreignBusinessTypeIds: ["employeeOrContractorInNJ"],
@@ -461,15 +437,15 @@ describe("onboarding - foreign business", () => {
       useMockRouter({ isReady: true, query: { page: "3" } });
       const { page } = renderPage({ userData });
       page.clickNext();
-      expect(screen.getByTestId("step-3")).toBeInTheDocument();
-      expect(screen.queryByTestId("step-4")).not.toBeInTheDocument();
+      expect(screen.getByTestId("page-3-header")).toBeInTheDocument();
+      expect(screen.queryByTestId("page-4-header")).not.toBeInTheDocument();
       expect(screen.getByTestId("banner-alert-REQUIRED_ESSENTIAL_QUESTION")).toBeInTheDocument();
       expect(
         screen.getAllByText(Config.siteWideErrorMessages.errorRadioButton)[0],
       ).toBeInTheDocument();
     });
 
-    it("allows user to move past Step 3 when you have selected an industry employment agency and answered the essential question", async () => {
+    it("allows user to move past the third onboarding page when you have selected an industry employment agency and answered the essential question", async () => {
       const userData = generateTestUserData({
         businessPersona: "FOREIGN",
         foreignBusinessTypeIds: ["employeeOrContractorInNJ"],
@@ -497,7 +473,7 @@ describe("onboarding - foreign business", () => {
       useMockRouter({ isReady: true, query: { page: "3" } });
       const { page } = renderPage({ userData });
       page.clickNext();
-      expect(screen.getByTestId("step-3")).toBeInTheDocument();
+      expect(screen.getByTestId("page-3-header")).toBeInTheDocument();
       expect(
         screen.getAllByText(Config.siteWideErrorMessages.errorRadioButton)[0],
       ).toBeInTheDocument();
@@ -508,7 +484,7 @@ describe("onboarding - foreign business", () => {
     });
   });
 
-  describe("Nexus - final step", () => {
+  describe("Nexus - final page", () => {
     it("keeps operating phase set to GUEST_MODE", async () => {
       const userData = generateTestUserData({
         operatingPhase: OperatingPhaseId.GUEST_MODE,

--- a/web/test/pages/onboarding/onboarding-owning.test.tsx
+++ b/web/test/pages/onboarding/onboarding-owning.test.tsx
@@ -1,12 +1,7 @@
 import * as api from "@/lib/api-client/apiClient";
-import { templateEval } from "@/lib/utils/helpers";
 import { mockPush, useMockRouter } from "@/test/mock/mockRouter";
 import { currentBusiness, setupStatefulUserDataContext } from "@/test/mock/withStatefulUserData";
-import {
-  composeOnBoardingTitle,
-  mockEmptyApiSignups,
-  renderPage,
-} from "@/test/pages/onboarding/helpers-onboarding";
+import { mockEmptyApiSignups, renderPage } from "@/test/pages/onboarding/helpers-onboarding";
 import {
   createEmptyUserData,
   generateMunicipality,
@@ -59,13 +54,6 @@ describe("onboarding - owning a business", () => {
   });
 
   describe("page 1", () => {
-    it("uses standard template eval for step label", () => {
-      renderPage({});
-      const step = templateEval(Config.onboardingDefaults.stepXTemplate, { currentPage: "1" });
-
-      expect(screen.getByText(composeOnBoardingTitle(step))).toBeInTheDocument();
-    });
-
     it("displays the sector dropdown after radio selected", () => {
       const { page } = renderPage({});
       expect(screen.queryByLabelText("Sector")).not.toBeInTheDocument();
@@ -73,7 +61,7 @@ describe("onboarding - owning a business", () => {
       expect(screen.getByLabelText("Sector")).toBeInTheDocument();
     });
 
-    it("does not allow OWNING user persona to move past Step 1 if user has not entered a sector", async () => {
+    it("does not allow OWNING user persona to move past the first onboarding page if user has not entered a sector", async () => {
       const { page } = renderPage({ userData: undefined });
       page.chooseRadio("business-persona-owning");
       fireEvent.click(screen.getByTestId("next"));
@@ -83,7 +71,7 @@ describe("onboarding - owning a business", () => {
         ).toBeInTheDocument();
       });
       expect(screen.getByTestId("banner-alert-REQUIRED_REVIEW_INFO_BELOW")).toBeInTheDocument();
-      expect(screen.getByTestId("step-1")).toBeInTheDocument();
+      expect(screen.getByTestId("page-1-header")).toBeInTheDocument();
     });
 
     it("updates operating phase when user changes their business persona", async () => {
@@ -103,7 +91,7 @@ describe("onboarding - owning a business", () => {
       });
     });
 
-    it("allows user to move past Step 1 if you have entered a sector", async () => {
+    it("allows user to move past the first onboarding page if you have entered a sector", async () => {
       const userData = generateTestUserData({ sectorId: undefined });
       useMockRouter({ isReady: true, query: { page: "1" } });
       const { page } = renderPage({ userData });

--- a/web/test/pages/onboarding/onboarding-shared.test.tsx
+++ b/web/test/pages/onboarding/onboarding-shared.test.tsx
@@ -1,6 +1,5 @@
 import { onboardingFlows } from "@/components/onboarding/OnboardingFlows";
 import { QUERIES, ROUTES } from "@/lib/domain-logic/routes";
-import { templateEval } from "@/lib/utils/helpers";
 import { randomElementFromArray } from "@/test/helpers/helpers-utilities";
 import * as mockRouter from "@/test/mock/mockRouter";
 import { mockPush, useMockRouter } from "@/test/mock/mockRouter";
@@ -65,18 +64,18 @@ describe("onboarding - shared", () => {
   it("routes to the first onboarding question when they have not answered the first question", async () => {
     useMockRouter({ isReady: true, query: { page: "3" } });
     renderPage({});
-    expect(screen.getByTestId("step-1")).toBeInTheDocument();
+    expect(screen.getByTestId("page-1-header")).toBeInTheDocument();
   });
 
   it.each(["business-persona-starting", "business-persona-foreign"])(
-    "allows %s to move past Step 1",
+    "allows %s to move past the first onboarding page",
     async (radioOption: string) => {
       const { page } = renderPage({ userData: generateExperienceAUserData() });
 
       page.chooseRadio(radioOption);
       fireEvent.click(screen.getByTestId("next"));
       await waitFor(() => {
-        expect(screen.getByTestId("step-2")).toBeInTheDocument();
+        expect(screen.getByTestId("page-2-header")).toBeInTheDocument();
       });
     },
   );
@@ -96,25 +95,25 @@ describe("onboarding - shared", () => {
         user: generateUser({ id: business.userId, abExperience: "ExperienceA" }),
       }),
     });
-    expect(screen.getByTestId("step-2")).toBeInTheDocument();
+    expect(screen.getByTestId("page-2-header")).toBeInTheDocument();
   });
 
   it("displays page one when a user goes to /onboarding", async () => {
     mockRouter.mockQuery.mockReturnValue({});
     renderPage({});
-    expect(screen.getByTestId("step-1")).toBeInTheDocument();
+    expect(screen.getByTestId("page-1-header")).toBeInTheDocument();
   });
 
   it("pushes to page one when a user visits a page number above the valid page range", async () => {
     useMockRouter({ isReady: true, query: { page: "6" } });
     renderPage({});
-    expect(screen.getByTestId("step-1")).toBeInTheDocument();
+    expect(screen.getByTestId("page-1-header")).toBeInTheDocument();
   });
 
   it("pushes to page one when a user visits a page number below the valid page range", async () => {
     useMockRouter({ isReady: true, query: { page: "0" } });
     renderPage({});
-    expect(screen.getByTestId("step-1")).toBeInTheDocument();
+    expect(screen.getByTestId("page-1-header")).toBeInTheDocument();
   });
 
   it("autocompletes onboarding and routes to dashboard page when industry WITHOUT essential question is set by using industry query string", async () => {
@@ -155,7 +154,7 @@ describe("onboarding - shared", () => {
     const industry = randomElementFromArray(industriesWithSingleEssentialQuestion).id;
     useMockRouter({ isReady: true, query: { industry } });
     const { page } = renderPage({ userData: generateExperienceAUserData() });
-    expect(screen.getByTestId("step-2")).toBeInTheDocument();
+    expect(screen.getByTestId("page-2-header")).toBeInTheDocument();
     page.chooseEssentialQuestionRadio(industry, 0);
     page.clickNext();
     await waitFor(() => {
@@ -167,10 +166,10 @@ describe("onboarding - shared", () => {
   it("routes to the first page when using industry query string is invalid", async () => {
     useMockRouter({ isReady: true, query: { industry: "something-nonexistent" } });
     renderPage({});
-    expect(screen.getByTestId("step-1")).toBeInTheDocument();
+    expect(screen.getByTestId("page-1-header")).toBeInTheDocument();
   });
 
-  it("updates locally for each step", async () => {
+  it("updates locally for each page", async () => {
     const business = generateBusiness({
       profileData: generateProfileData({ businessPersona: "STARTING" }),
     });
@@ -182,32 +181,32 @@ describe("onboarding - shared", () => {
     const numberOfPages = onboardingFlows.STARTING.pages.length;
 
     for (let pageNumber = 2; pageNumber < numberOfPages; pageNumber += 1) {
-      await page.visitStep(pageNumber);
+      await page.visitOnboardingPage(pageNumber);
       expect(getLastCalledWithConfig().local).toEqual(true);
     }
   });
 
-  it("prevents user from moving after Step 1 if you have not selected whether you own a business", async () => {
+  it("prevents user from moving past the first onboarding page if you have not selected whether you own a business", async () => {
     const { page } = renderPage({});
     page.clickNext();
-    expect(screen.getByTestId("step-1")).toBeInTheDocument();
+    expect(screen.getByTestId("page-1-header")).toBeInTheDocument();
     expect(screen.getByTestId("banner-alert-REQUIRED_EXISTING_BUSINESS")).toBeInTheDocument();
   });
 
-  it("allows user to move past Step 1 if you have selected whether you own a business", async () => {
+  it("allows user to move past the first onboarding page if you have selected whether you own a business", async () => {
     const { page } = renderPage({ userData: generateExperienceAUserData() });
     page.chooseRadio("business-persona-starting");
-    await page.visitStep(2);
-    expect(screen.getByTestId("step-2")).toBeInTheDocument();
+    await page.visitOnboardingPage(2);
+    expect(screen.getByTestId("page-2-header")).toBeInTheDocument();
   });
 
   it("is able to go back", async () => {
     const { page } = renderPage({ userData: generateExperienceAUserData() });
     page.chooseRadio("business-persona-starting");
-    await page.visitStep(2);
-    expect(screen.getByTestId("step-2")).toBeInTheDocument();
+    await page.visitOnboardingPage(2);
+    expect(screen.getByTestId("page-2-header")).toBeInTheDocument();
     page.clickBack();
-    expect(screen.getByTestId("step-1")).toBeInTheDocument();
+    expect(screen.getByTestId("page-1-header")).toBeInTheDocument();
   });
 
   it("resets non-shared information when switching from starting flow to owning flow", async () => {
@@ -222,15 +221,13 @@ describe("onboarding - shared", () => {
     });
 
     page.chooseRadio("business-persona-starting");
-    await page.visitStep(2);
+    await page.visitOnboardingPage(2);
     page.selectByValue("Industry", "e-commerce");
     page.clickBack();
 
-    const step = templateEval(Config.onboardingDefaults.stepXTemplate, { currentPage: "1" });
-
-    expect(screen.getByTestId("step-1")).toBeInTheDocument();
+    expect(screen.getByTestId("page-1-header")).toBeInTheDocument();
     expect(screen.getByTestId("business-persona-owning")).toBeInTheDocument();
-    expect(screen.getByText(composeOnBoardingTitle(step))).toBeInTheDocument();
+    expect(screen.getByText(composeOnBoardingTitle())).toBeInTheDocument();
     page.chooseRadio("business-persona-owning");
     page.clickNext();
     await waitFor(() => {
@@ -265,21 +262,21 @@ describe("onboarding - shared", () => {
     });
 
     page.chooseRadio("business-persona-starting");
-    await page.visitStep(2);
+    await page.visitOnboardingPage(2);
     page.selectByValue("Industry", "e-commerce");
     page.clickBack();
 
-    await page.visitStep(2);
+    await page.visitOnboardingPage(2);
     expect(currentBusiness().profileData.industryId).toEqual("e-commerce");
   });
 
-  // This suite is skipped because routing between steps has been disabled for the duration of the AB test
+  // This suite is skipped because routing between pages has been disabled for the duration of the AB test
   describe.skip("when query parameter sets onboarding flow", () => {
-    it("routes user to step 2 when query parameter exists and value is starting", async () => {
+    it("routes user to the second onboarding page when query parameter exists and value is starting", async () => {
       useMockRouter({ isReady: true, query: { flow: "starting" } });
       const { page } = renderPage({ userData: generateExperienceAUserData() });
 
-      expect(screen.getByTestId("step-2")).toBeInTheDocument();
+      expect(screen.getByTestId("page-2-header")).toBeInTheDocument();
       page.selectByText("Industry", "All Other Businesses");
       page.clickNext();
       await waitFor(() => {
@@ -289,24 +286,24 @@ describe("onboarding - shared", () => {
       expect(currentBusiness().profileData.businessPersona).toEqual("STARTING");
     });
 
-    it("routes user to step 2 when query parameter exists and value is out-of-state", async () => {
+    it("routes user to the second onboarding page when query parameter exists and value is out-of-state", async () => {
       useMockRouter({ isReady: true, query: { flow: "out-of-state" } });
       const { page } = renderPage({ userData: generateExperienceAUserData() });
 
-      expect(screen.getByTestId("step-2")).toBeInTheDocument();
+      expect(screen.getByTestId("page-2-header")).toBeInTheDocument();
       const { employeeOrContractorInNJ } =
         Config.profileDefaults.fields.foreignBusinessTypeIds.default.optionContent;
 
       page.checkByLabelText(employeeOrContractorInNJ);
-      await page.visitStep(3);
+      await page.visitOnboardingPage(3);
       expect(currentBusiness().profileData.businessPersona).toEqual("FOREIGN");
     });
 
-    it("routes user to step 1 with up-and-running business selected when up-and-running query parameter exists", async () => {
+    it("routes user to the first onboarding page with up-and-running business selected when up-and-running query parameter exists", async () => {
       useMockRouter({ isReady: true, query: { flow: "up-and-running" } });
       const { page } = renderPage({});
 
-      expect(screen.getByTestId("step-1")).toBeInTheDocument();
+      expect(screen.getByTestId("page-1-header")).toBeInTheDocument();
       page.selectByValue("Sector", "clean-energy");
       page.clickNext();
       await waitFor(() => {

--- a/web/test/pages/onboarding/onboarding-starting.test.tsx
+++ b/web/test/pages/onboarding/onboarding-starting.test.tsx
@@ -77,7 +77,7 @@ describe("onboarding - starting a business", () => {
       useMockRouter({ isReady: true, query: { page: "1" } });
       const { page } = renderPage({ userData });
 
-      expect(screen.getByTestId("step-1")).toBeInTheDocument();
+      expect(screen.getByTestId("page-1-header")).toBeInTheDocument();
 
       page.chooseRadio("business-persona-starting");
       page.clickNext();
@@ -90,7 +90,7 @@ describe("onboarding - starting a business", () => {
       });
     });
 
-    it("shows 'Show My Guide' button on Step 1 instead of 'Next' for ExperienceB", async () => {
+    it("shows 'Show My Guide' button on the first onboarding page instead of 'Next' for ExperienceB", async () => {
       const business = generateBusiness({
         profileData: generateProfileData({
           businessPersona: "STARTING",
@@ -109,16 +109,16 @@ describe("onboarding - starting a business", () => {
       expect(page1.queryByText(Config.onboardingDefaults.nextButtonText)).not.toBeInTheDocument();
     });
 
-    it("prevents user from moving after Step 2 if you have not selected an industry", async () => {
+    it("prevents user from moving after the second onboarding page if you have not selected an industry", async () => {
       const userData = generateTestUserData({ industryId: undefined });
       useMockRouter({ isReady: true, query: { page: "2" } });
       const { page } = renderPage({ userData });
       page.clickNext();
-      expect(screen.getByTestId("step-2")).toBeInTheDocument();
+      expect(screen.getByTestId("page-2-header")).toBeInTheDocument();
       expect(screen.getByTestId("banner-alert-REQUIRED_REVIEW_INFO_BELOW")).toBeInTheDocument();
     });
 
-    it("allows user to move past Step 2 if you have selected an industry", async () => {
+    it("allows user to move past the second onboarding page if you have selected an industry", async () => {
       const userData = generateTestUserData({ industryId: undefined });
       useMockRouter({ isReady: true, query: { page: "2" } });
       const { page } = renderPage({ userData });
@@ -133,7 +133,7 @@ describe("onboarding - starting a business", () => {
     });
 
     it.each(industryIdsWithSingleRequiredEssentialQuestion)(
-      "prevents user from moving to Step 3 when %s is selected as industry, but essential question is not answered",
+      "prevents user from moving to the third onboarding page when %s is selected as industry, but essential question is not answered",
       async (industryId) => {
         const userData = generateTestUserData({
           industryId: industryId,
@@ -143,7 +143,7 @@ describe("onboarding - starting a business", () => {
         const { page } = renderPage({ userData });
 
         page.clickNext();
-        expect(screen.getByTestId("step-2")).toBeInTheDocument();
+        expect(screen.getByTestId("page-2-header")).toBeInTheDocument();
         expect(screen.getByTestId("banner-alert-REQUIRED_ESSENTIAL_QUESTION")).toBeInTheDocument();
         expect(
           screen.getAllByText(Config.siteWideErrorMessages.errorRadioButton)[0],
@@ -152,7 +152,7 @@ describe("onboarding - starting a business", () => {
     );
 
     it.each(industryIdsWithSingleRequiredEssentialQuestion)(
-      "allows user to move past Step 2 when you have selected an industry %s and answered the essential question",
+      "allows user to move past the second onboarding page when you have selected an industry %s and answered the essential question",
       async (industryId) => {
         const userData = generateTestUserData({
           industryId: industryId,
@@ -183,7 +183,7 @@ describe("onboarding - starting a business", () => {
         const { page } = renderPage({ userData });
 
         page.clickNext();
-        expect(screen.getByTestId("step-2")).toBeInTheDocument();
+        expect(screen.getByTestId("page-2-header")).toBeInTheDocument();
         expect(
           screen.getAllByText(Config.siteWideErrorMessages.errorRadioButton)[0],
         ).toBeInTheDocument();
@@ -196,7 +196,7 @@ describe("onboarding - starting a business", () => {
 
     const employmentAgencyIndustryId = "employment-agency";
 
-    it("prevents user from moving to Step 3 when employment agency is selected as industry, but essential question is not answered", async () => {
+    it("prevents user from moving to the third onboarding page when employment agency is selected as industry, but essential question is not answered", async () => {
       const userData = generateTestUserData({
         industryId: employmentAgencyIndustryId,
         ...emptyIndustrySpecificData,
@@ -205,14 +205,14 @@ describe("onboarding - starting a business", () => {
       const { page } = renderPage({ userData });
 
       page.clickNext();
-      expect(screen.getByTestId("step-2")).toBeInTheDocument();
+      expect(screen.getByTestId("page-2-header")).toBeInTheDocument();
       expect(screen.getByTestId("banner-alert-REQUIRED_ESSENTIAL_QUESTION")).toBeInTheDocument();
       expect(
         screen.getAllByText(Config.siteWideErrorMessages.errorRadioButton)[0],
       ).toBeInTheDocument();
     });
 
-    it("allows user to move past Step 2 when you have selected an industry employment agency and answered the essential question", async () => {
+    it("allows user to move past the second onboarding page when you have selected an industry employment agency and answered the essential question", async () => {
       const userData = generateTestUserData({
         industryId: employmentAgencyIndustryId,
         ...emptyIndustrySpecificData,
@@ -239,7 +239,7 @@ describe("onboarding - starting a business", () => {
       const { page } = renderPage({ userData });
 
       page.clickNext();
-      expect(screen.getByTestId("step-2")).toBeInTheDocument();
+      expect(screen.getByTestId("page-2-header")).toBeInTheDocument();
       expect(
         screen.getAllByText(Config.siteWideErrorMessages.errorRadioButton)[0],
       ).toBeInTheDocument();
@@ -253,16 +253,16 @@ describe("onboarding - starting a business", () => {
   it("changes url pathname every time a user goes to a different page", async () => {
     const userData = generateTestUserData({});
     const { page } = renderPage({ userData });
-    expect(screen.getByTestId("step-1")).toBeInTheDocument();
+    expect(screen.getByTestId("page-1-header")).toBeInTheDocument();
     page.chooseRadio("business-persona-starting");
 
-    await page.visitStep(2);
+    await page.visitOnboardingPage(2);
     expect(mockRouter.mockPush).toHaveBeenCalledWith(
       expect.objectContaining({ query: expect.objectContaining({ page: 2 }) }),
       undefined,
       { shallow: true },
     );
-    expect(screen.getByTestId("step-2")).toBeInTheDocument();
+    expect(screen.getByTestId("page-2-header")).toBeInTheDocument();
   });
 
   it("shows correct next-button text on each page", async () => {
@@ -276,7 +276,7 @@ describe("onboarding - starting a business", () => {
       page1.queryByText(Config.onboardingDefaults.finalNextButtonText),
     ).not.toBeInTheDocument();
 
-    await page.visitStep(2);
+    await page.visitOnboardingPage(2);
     const page2 = within(screen.getByTestId("page-2-form"));
     expect(page2.queryByText(Config.onboardingDefaults.nextButtonText)).not.toBeInTheDocument();
     expect(page2.getByText(Config.onboardingDefaults.finalNextButtonText)).toBeInTheDocument();
@@ -306,7 +306,7 @@ describe("onboarding - starting a business", () => {
       ),
     ).toBeChecked();
 
-    await page.visitStep(2);
+    await page.visitOnboardingPage(2);
     expect(page.getIndustryValue()).toEqual(LookupIndustryById("cosmetology").name);
   });
 
@@ -316,7 +316,7 @@ describe("onboarding - starting a business", () => {
     const { page } = renderPage({ userData: initialUserData });
 
     page.chooseRadio("business-persona-starting");
-    await page.visitStep(2);
+    await page.visitOnboardingPage(2);
     expect(currentBusiness().profileData.businessPersona).toEqual("STARTING");
 
     page.selectByValue("Industry", "e-commerce");
@@ -358,11 +358,11 @@ describe("onboarding - starting a business", () => {
   it("removes required fields error when user goes back", async () => {
     const { page } = renderPage({});
     page.chooseRadio("business-persona-foreign");
-    await page.visitStep(2);
+    await page.visitOnboardingPage(2);
     act(() => {
       return page.clickNext();
     });
-    expect(screen.getByTestId("step-2")).toBeInTheDocument();
+    expect(screen.getByTestId("page-2-header")).toBeInTheDocument();
     expect(screen.getByTestId("banner-alert-REQUIRED_FOREIGN_BUSINESS_TYPE")).toBeInTheDocument();
     page.clickBack();
     expect(


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
In advance of further changes to the onboarding flow, we're removing the step numbers on each page of onboarding. This PR removes that logic and the tests related to it. It also renames some variables and test titles for clarity, now that we no longer show the user the "(Step X)" copy.

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to the URL for the board that owns it.
     Board routing is not a clean cutover; run `python3 scripts/fetch_ado_ticket.py <id>`
     or check scripts/ado-boards.json for the current cutover and exceptions list. -->

This pull request resolves [#17963](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17963).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
