### PR TITLE
fix: reconcile stale migration writes

### DIFF
--- a/api/src/api/userRouter.test.ts
+++ b/api/src/api/userRouter.test.ts
@@ -1,5 +1,10 @@
 import { userRouterFactory } from "@api/userRouter";
-import { CryptoClient, DatabaseClient, TimeStampBusinessSearch } from "@domain/types";
+import {
+  CryptoClient,
+  DatabaseClient,
+  MigrationConflictError,
+  TimeStampBusinessSearch,
+} from "@domain/types";
 import { setupExpress } from "@libs/express";
 import { DummyLogWriter } from "@libs/logWriter";
 import { getCurrentDate, parseDate } from "@shared/dateHelpers";
@@ -1251,6 +1256,21 @@ describe("userRouter", () => {
 
       expect(response.status).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
       expect(response.body).toEqual({ error: "error" });
+    });
+
+    it("returns CONFLICT when stale user data loses a migration race", async () => {
+      mockJwt.decode.mockReturnValue(cognitoPayload({ id: "123" }));
+      const userData = generateUserData({ user: generateUser({ id: "123" }) });
+
+      stubUnifiedDataClient.get.mockResolvedValue(userData);
+      stubUnifiedDataClient.put.mockRejectedValue(new MigrationConflictError());
+      const response = await request(app)
+        .post(`/users`)
+        .send(userData)
+        .set("Authorization", "Bearer user-123-token");
+
+      expect(response.status).toEqual(StatusCodes.CONFLICT);
+      expect(response.body).toEqual({ error: "STALE_USER_DATA" });
     });
 
     describe("govDeliveryCommCloudClient", () => {

--- a/api/src/api/userRouter.ts
+++ b/api/src/api/userRouter.ts
@@ -6,6 +6,7 @@ import {
 import {
   CryptoClient,
   DatabaseClient,
+  MigrationConflictError,
   TimeStampBusinessSearch,
   UpdateLicenseStatus,
   UpdateOperatingPhase,
@@ -328,6 +329,17 @@ export const userRouterFactory = (
         );
       })
       .catch((error: Error) => {
+        if (error instanceof MigrationConflictError) {
+          const status = StatusCodes.CONFLICT;
+          logger.LogInfo(
+            `[END] ${method} ${endpoint} - status: ${status}, reason: stale user data, userId: ${postedUserBodyId}, duration: ${
+              Date.now() - requestStart
+            }ms`,
+          );
+          res.status(status).json({ error: "STALE_USER_DATA" });
+          return;
+        }
+
         const status = StatusCodes.INTERNAL_SERVER_ERROR;
         logger.LogError(
           `${method} ${endpoint} - Unknown error: ${

--- a/api/src/db/DynamoDataClient.test.ts
+++ b/api/src/db/DynamoDataClient.test.ts
@@ -109,6 +109,10 @@ describe("User and Business Migration with DynamoDataClient", () => {
         ...input,
         version: CURRENT_VERSION,
       })),
+      migrateAndPutSubmittedUser: jest.fn(async (input) => ({
+        ...input,
+        version: CURRENT_VERSION,
+      })),
     };
 
     dynamoDataClient = DynamoDataClient(
@@ -326,6 +330,46 @@ describe("User and Business Migration with DynamoDataClient", () => {
       `Request-time migration failed from version ${
         CURRENT_VERSION - 1
       } to ${CURRENT_VERSION}: KMS unavailable`,
+    );
+  });
+
+  it("returns the latest stored record when request-time migration conflicts", async () => {
+    const outdatedUser = { ...generateUserData(), version: CURRENT_VERSION - 1 };
+    const migratedUser = { ...outdatedUser, version: CURRENT_VERSION };
+    jest
+      .spyOn(dynamoUsersDataClient, "get")
+      .mockResolvedValueOnce(outdatedUser)
+      .mockResolvedValueOnce(migratedUser);
+    migrationDataClient.migrateAndPut.mockRejectedValueOnce(new MigrationConflictError());
+
+    await expect(dynamoDataClient.get(outdatedUser.user.id)).resolves.toEqual(migratedUser);
+    expect(dynamoUsersDataClient.get).toHaveBeenCalledTimes(2);
+    expect(logger.LogInfo).toHaveBeenCalledWith(
+      "Request-time migration conflicted; returning the latest stored user record",
+    );
+    expect(logger.LogError).not.toHaveBeenCalledWith(
+      expect.stringContaining("User data changed during migration"),
+    );
+  });
+
+  it("uses submitted-user migration for an outdated write", async () => {
+    const outdatedUser = { ...generateUserData(), version: CURRENT_VERSION - 1 };
+    const migratedUser = { ...outdatedUser, version: CURRENT_VERSION };
+    migrationDataClient.migrateAndPutSubmittedUser.mockResolvedValueOnce(migratedUser);
+
+    await expect(dynamoDataClient.put(outdatedUser)).resolves.toEqual(migratedUser);
+    expect(migrationDataClient.migrateAndPutSubmittedUser).toHaveBeenCalledWith(outdatedUser);
+    expect(migrationDataClient.migrateAndPut).not.toHaveBeenCalled();
+  });
+
+  it("propagates submitted-user migration conflicts without logging them as errors", async () => {
+    const outdatedUser = { ...generateUserData(), version: CURRENT_VERSION - 1 };
+    const conflict = new MigrationConflictError();
+    migrationDataClient.migrateAndPutSubmittedUser.mockRejectedValueOnce(conflict);
+
+    await expect(dynamoDataClient.put(outdatedUser)).rejects.toBe(conflict);
+    expect(logger.LogError).not.toHaveBeenCalledWith(
+      expect.stringContaining("User data changed during migration"),
     );
   });
 

--- a/api/src/db/DynamoDataClient.ts
+++ b/api/src/db/DynamoDataClient.ts
@@ -162,6 +162,20 @@ export const DynamoDataClient = (
     try {
       return await migrationDataClient.migrateAndPut(sourceUserData);
     } catch (error) {
+      if (error instanceof MigrationConflictError) {
+        logger.LogInfo(
+          "Request-time migration conflicted; returning the latest stored user record",
+        );
+        try {
+          return await userDataClient.get(sourceUserData.user.id);
+        } catch (refetchError) {
+          const refetchErrorMessage =
+            refetchError instanceof Error ? refetchError.message : String(refetchError);
+          logger.LogError(`Request-time migration conflict refetch failed: ${refetchErrorMessage}`);
+          return sourceUserData;
+        }
+      }
+
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.LogError(
         `Request-time migration failed from version ${sourceUserData.version} to ${CURRENT_VERSION}: ${errorMessage}`,
@@ -214,11 +228,15 @@ export const DynamoDataClient = (
         if (!migrationDataClient) {
           throw new Error("Migration data client is required for coordinated migrations");
         }
-        return await migrationDataClient.migrateAndPut(userData);
+        return await migrationDataClient.migrateAndPutSubmittedUser(userData);
       }
       await updateUserAndBusinesses(userData);
       return userData;
     } catch (error) {
+      if (error instanceof MigrationConflictError) {
+        throw error;
+      }
+
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
       logger.LogError(`Failed to update user ${userData.user.id}: ${errorMessage}`);
       throw new Error(errorMessage);

--- a/api/src/db/DynamoMigrationDataClient.test.ts
+++ b/api/src/db/DynamoMigrationDataClient.test.ts
@@ -52,6 +52,11 @@ const migrateUser = (source: UserData): UserData => ({
   ),
 });
 
+const migrationConflict = {
+  name: "TransactionCanceledException",
+  CancellationReasons: [{ Code: "ConditionalCheckFailed" }],
+};
+
 describe("DynamoMigrationDataClient", () => {
   let send: jest.Mock;
   let userDataClient: jest.Mocked<UserDataClient>;
@@ -112,11 +117,77 @@ describe("DynamoMigrationDataClient", () => {
     expect(source).toEqual(original);
   });
 
-  it("classifies a conditional transaction cancellation as concurrent migration", async () => {
-    send.mockRejectedValueOnce({
-      name: "TransactionCanceledException",
-      CancellationReasons: [{ Code: "ConditionalCheckFailed" }],
+  it("retries submitted stale data against an already-migrated record", async () => {
+    const submittedUserData = generateOutdatedUser();
+    const latestUserData = {
+      ...migrateUser(submittedUserData),
+      lastUpdatedISO: "2026-08-11T18:04:00.000Z",
+    };
+    userDataClient.get.mockResolvedValueOnce(latestUserData);
+    send.mockRejectedValueOnce(migrationConflict).mockResolvedValueOnce({});
+
+    const result = await makeClient().migrateAndPutSubmittedUser(submittedUserData);
+
+    expect(result).toEqual(migrateUser(submittedUserData));
+    expect(userDataClient.get).toHaveBeenCalledWith(submittedUserData.user.id);
+    expect(send).toHaveBeenCalledTimes(2);
+    const retryCommand = send.mock.calls[1][0] as TransactWriteCommand;
+    expect(retryCommand.input.TransactItems?.[0].Put).toMatchObject({
+      ConditionExpression: "#data = :sourceData",
+      ExpressionAttributeValues: { ":sourceData": latestUserData },
+      Item: {
+        data: migrateUser(submittedUserData),
+        userId: submittedUserData.user.id,
+        version: CURRENT_VERSION,
+      },
     });
+  });
+
+  it("does not overwrite an outdated record that changed during a submitted migration", async () => {
+    const submittedUserData = generateOutdatedUser();
+    const latestUserData = {
+      ...submittedUserData,
+      lastUpdatedISO: "2026-08-11T18:04:00.000Z",
+    };
+    userDataClient.get.mockResolvedValueOnce(latestUserData);
+    send.mockRejectedValueOnce(migrationConflict);
+
+    await expect(makeClient().migrateAndPutSubmittedUser(submittedUserData)).rejects.toBeInstanceOf(
+      MigrationConflictError,
+    );
+
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not overwrite a record newer than the submitted migration output", async () => {
+    const submittedUserData = generateOutdatedUser();
+    userDataClient.get.mockResolvedValueOnce({
+      ...migrateUser(submittedUserData),
+      version: CURRENT_VERSION + 1,
+    });
+    send.mockRejectedValueOnce(migrationConflict);
+
+    await expect(makeClient().migrateAndPutSubmittedUser(submittedUserData)).rejects.toBeInstanceOf(
+      MigrationConflictError,
+    );
+
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a conflict when the submitted migration retry loses another race", async () => {
+    const submittedUserData = generateOutdatedUser();
+    userDataClient.get.mockResolvedValueOnce(migrateUser(submittedUserData));
+    send.mockRejectedValueOnce(migrationConflict).mockRejectedValueOnce(migrationConflict);
+
+    await expect(makeClient().migrateAndPutSubmittedUser(submittedUserData)).rejects.toBeInstanceOf(
+      MigrationConflictError,
+    );
+
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("classifies a conditional transaction cancellation as concurrent migration", async () => {
+    send.mockRejectedValueOnce(migrationConflict);
 
     await expect(makeClient().migrateAndPut(generateOutdatedUser())).rejects.toBeInstanceOf(
       MigrationConflictError,

--- a/api/src/db/DynamoMigrationDataClient.ts
+++ b/api/src/db/DynamoMigrationDataClient.ts
@@ -48,13 +48,19 @@ const businessPut = (
   },
 });
 
+interface PutMigratedUserProps {
+  readonly conditionExpression: string;
+  readonly expectedUserData: UserData;
+  readonly migratedUserData: UserData;
+}
+
 export const DynamoMigrationDataClient = ({
   db,
   userDataClient,
   usersTableName,
   businessesTableName,
 }: DynamoMigrationDataClientProps): MigrationDataClient => {
-  const migrateAndPut = async (sourceUserData: UserData): Promise<UserData> => {
+  const migrate = async (sourceUserData: UserData): Promise<UserData> => {
     const sourceBusinessCount = Object.keys(sourceUserData.businesses ?? {}).length;
     if (sourceBusinessCount > MAX_TRANSACTION_BUSINESSES) {
       throw new Error(
@@ -70,17 +76,26 @@ export const DynamoMigrationDataClient = ({
       );
     }
 
+    return migratedUserData;
+  };
+
+  const putMigratedUser = async ({
+    conditionExpression,
+    expectedUserData,
+    migratedUserData,
+  }: PutMigratedUserProps): Promise<void> => {
+    const migratedBusinesses = Object.values(migratedUserData.businesses);
     const transactItems: NonNullable<TransactWriteCommandInput["TransactItems"]> = [
       {
         Put: {
           TableName: usersTableName,
           Item: createUserDataItem(migratedUserData),
-          ConditionExpression: "attribute_not_exists(#data) OR #data = :sourceData",
+          ConditionExpression: conditionExpression,
           ExpressionAttributeNames: {
             "#data": "data",
           },
           ExpressionAttributeValues: {
-            ":sourceData": sourceUserData,
+            ":sourceData": expectedUserData,
           },
         },
       },
@@ -96,9 +111,46 @@ export const DynamoMigrationDataClient = ({
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Atomic migration transaction failed: ${message}`, { cause: error });
     }
+  };
 
+  const migrateAndPut = async (sourceUserData: UserData): Promise<UserData> => {
+    const migratedUserData = await migrate(sourceUserData);
+    await putMigratedUser({
+      conditionExpression: "attribute_not_exists(#data) OR #data = :sourceData",
+      expectedUserData: sourceUserData,
+      migratedUserData,
+    });
     return migratedUserData;
   };
 
-  return { migrateAndPut };
+  const migrateAndPutSubmittedUser = async (submittedUserData: UserData): Promise<UserData> => {
+    const migratedUserData = await migrate(submittedUserData);
+
+    try {
+      await putMigratedUser({
+        conditionExpression: "attribute_not_exists(#data) OR #data = :sourceData",
+        expectedUserData: submittedUserData,
+        migratedUserData,
+      });
+      return migratedUserData;
+    } catch (error) {
+      if (!(error instanceof MigrationConflictError)) {
+        throw error;
+      }
+    }
+
+    const latestUserData = await userDataClient.get(submittedUserData.user.id);
+    if (latestUserData.version !== migratedUserData.version) {
+      throw new MigrationConflictError();
+    }
+
+    await putMigratedUser({
+      conditionExpression: "#data = :sourceData",
+      expectedUserData: latestUserData,
+      migratedUserData,
+    });
+    return migratedUserData;
+  };
+
+  return { migrateAndPut, migrateAndPutSubmittedUser };
 };

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -104,6 +104,7 @@ export interface UserDataClient {
 
 export interface MigrationDataClient {
   migrateAndPut: (userData: UserData) => Promise<UserData>;
+  migrateAndPutSubmittedUser: (userData: UserData) => Promise<UserData>;
 }
 
 export class MigrationConflictError extends Error {


### PR DESCRIPTION
## Description

When a client submits user data for a save while another request concurrently migrates that same user record, the submitted write can lose the DynamoDB conditional check race and previously surfaced as an unhandled error. This PR reconciles that race instead of failing it outright.

### Approach

- Added a `MigrationConflictError`-aware path in `DynamoMigrationDataClient`: a new `migrateAndPutSubmittedUser` method retries the write once against the record that actually won the race, only if that record is already at `CURRENT_VERSION` and matches the version the client attempted to migrate to. If the record moved further (or another client's data differs), the conflict is re-thrown.

- Refactored `migrateAndPut` to share a `migrate` + `putMigratedUser` helper pair with the new `migrateAndPutSubmittedUser`, rather than duplicating the transaction logic.

- In `DynamoDataClient.get`, a request-time migration conflict now falls back to re-fetching the latest stored record instead of surfacing an error, since another request already completed the migration.

- In `userRouter`, a `MigrationConflictError` bubbling out of a user PUT now returns `409 Conflict` with `{ error: "STALE_USER_DATA" }` instead of a `500`, so the client can react to a real conflict distinctly from an unknown server error.

### Steps to Test

- `yarn workspace @businessnjgovnavigator/api test` covers the new behavior:
  - `DynamoMigrationDataClient.test.ts`: retries a submitted stale write against an already-migrated record, and correctly still conflicts when the winning record differs from what the submission expected or is further ahead than the migration target.
  - `DynamoDataClient.test.ts`: falls back to reading the latest stored record when a request-time migration races and loses.
  - `userRouter.test.ts`: a `MigrationConflictError` on `POST /users` returns `409` with `STALE_USER_DATA`.
- No user-facing UI changes; this is a backend reconciliation of a race condition.

### Notes

This targets a class of production API alarms caused by concurrent migration writes clobbering each other; the previous behavior was to fail the request outright on any conditional-check failure during a migration write.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews