### PR TITLE
chore: change quarantine logging strategy

### DIFF
--- a/api/src/db/DynamoDataClient.test.ts
+++ b/api/src/db/DynamoDataClient.test.ts
@@ -352,6 +352,27 @@ describe("User and Business Migration with DynamoDataClient", () => {
     );
   });
 
+  it.each(["Ciphertext wrapping key is not accepted", "Ciphertext header is malformed"])(
+    "returns the stored record without a generic error for quarantined ciphertext: %s",
+    async (quarantineReason) => {
+      const outdatedUser = { ...generateUserData(), version: CURRENT_VERSION - 1 };
+      jest.spyOn(dynamoUsersDataClient, "get").mockResolvedValueOnce(outdatedUser);
+      migrationDataClient.migrateAndPut.mockRejectedValueOnce(
+        new Error("Migration v193 failed", {
+          cause: new QuarantinedCiphertextError(quarantineReason),
+        }),
+      );
+
+      await expect(dynamoDataClient.get(outdatedUser.user.id)).resolves.toEqual(outdatedUser);
+      expect(logger.LogInfo).toHaveBeenCalledWith(
+        expect.stringContaining("Quarantined request-time migration"),
+      );
+      expect(logger.LogError).not.toHaveBeenCalledWith(
+        expect.stringContaining("Request-time migration failed"),
+      );
+    },
+  );
+
   it("uses submitted-user migration for an outdated write", async () => {
     const outdatedUser = { ...generateUserData(), version: CURRENT_VERSION - 1 };
     const migratedUser = { ...outdatedUser, version: CURRENT_VERSION };
@@ -427,27 +448,33 @@ describe("User and Business Migration with DynamoDataClient", () => {
     );
   });
 
-  it("quarantines a record-level ciphertext failure and continues the batch", async () => {
-    const first = generateUserData();
-    const second = generateUserData();
-    jest.spyOn(dynamoUsersDataClient, "getUsersWithOutdatedVersion").mockResolvedValueOnce({
-      usersToMigrate: [first, second],
-      nextToken: undefined,
-    });
-    migrationDataClient.migrateAndPut.mockRejectedValueOnce(
-      new Error("Migration v193 failed", {
-        cause: new QuarantinedCiphertextError("Ciphertext wrapping key is not accepted"),
-      }),
-    );
+  it.each(["Ciphertext wrapping key is not accepted", "Ciphertext header is malformed"])(
+    "quarantines a record-level ciphertext failure without a generic error: %s",
+    async (quarantineReason) => {
+      const first = generateUserData();
+      const second = generateUserData();
+      jest.spyOn(dynamoUsersDataClient, "getUsersWithOutdatedVersion").mockResolvedValueOnce({
+        usersToMigrate: [first, second],
+        nextToken: undefined,
+      });
+      migrationDataClient.migrateAndPut.mockRejectedValueOnce(
+        new Error("Migration v193 failed", {
+          cause: new QuarantinedCiphertextError(quarantineReason),
+        }),
+      );
 
-    const result = await dynamoDataClient.migrateOutdatedVersionUsers();
+      const result = await dynamoDataClient.migrateOutdatedVersionUsers();
 
-    expect(result).toEqual({ success: true, migratedCount: 1, quarantinedCount: 1 });
-    expect(migrationDataClient.migrateAndPut).toHaveBeenCalledTimes(2);
-    expect(logger.LogError).toHaveBeenCalledWith(
-      expect.stringContaining(`Quarantined scheduled migration for user ${first.user.id}`),
-    );
-  });
+      expect(result).toEqual({ success: true, migratedCount: 1, quarantinedCount: 1 });
+      expect(migrationDataClient.migrateAndPut).toHaveBeenCalledTimes(2);
+      expect(logger.LogInfo).toHaveBeenCalledWith(
+        expect.stringContaining(`Quarantined scheduled migration for user ${first.user.id}`),
+      );
+      expect(logger.LogError).not.toHaveBeenCalledWith(
+        expect.stringContaining("Quarantined scheduled migration"),
+      );
+    },
+  );
 
   it("stops successfully between users when the Lambda time budget is exhausted", async () => {
     const first = generateUserData();

--- a/api/src/db/DynamoDataClient.ts
+++ b/api/src/db/DynamoDataClient.ts
@@ -129,7 +129,7 @@ export const DynamoDataClient = (
         const errorMessage = error instanceof Error ? error.message : String(error);
         if (isQuarantinedCiphertextError(error)) {
           quarantinedCount += 1;
-          logger.LogError(
+          logger.LogInfo(
             `Quarantined scheduled migration for user ${user.user.id} from version ${user.version}: ${errorMessage}`,
           );
           continue;
@@ -177,6 +177,13 @@ export const DynamoDataClient = (
       }
 
       const errorMessage = error instanceof Error ? error.message : String(error);
+      if (isQuarantinedCiphertextError(error)) {
+        logger.LogInfo(
+          `Quarantined request-time migration from version ${sourceUserData.version} to ${CURRENT_VERSION}; returning the stored record: ${errorMessage}`,
+        );
+        return sourceUserData;
+      }
+
       logger.LogError(
         `Request-time migration failed from version ${sourceUserData.version} to ${CURRENT_VERSION}: ${errorMessage}`,
       );


### PR DESCRIPTION
## Description

Quarantined ciphertext migrations (both scheduled batch migrations and request-time migrations) were being logged with `logger.LogError`, which surfaces as a production alarm even though quarantining is expected, handled behavior rather than a failure. This PR downgrades those log calls to `logger.LogInfo` so quarantine events stop tripping prod API alarms.

### Approach

- In `DynamoDataClient.ts`, changed the scheduled-migration quarantine log from `logger.LogError` to `logger.LogInfo`.

- Added a matching `logger.LogInfo` path for request-time migrations: when `get()` hits a quarantined ciphertext error during migration, it now logs at info level and returns the stored (unmigrated) record instead of falling through to the generic `logger.LogError` "Request-time migration failed" path.

- Updated `DynamoDataClient.test.ts` to assert `logger.LogInfo` is called (and `logger.LogError` is not) for both quarantine reasons (`Ciphertext wrapping key is not accepted` and `Ciphertext header is malformed`), for both the scheduled-migration and request-time-migration paths.

### Steps to Test

- `yarn workspace @businessnjgovnavigator/api test` covers the new behavior:
  - `DynamoDataClient.test.ts`: quarantined scheduled migrations and quarantined request-time migrations both log via `logger.LogInfo` and never via `logger.LogError`.
- No user-facing UI changes; this only affects backend log severity.

### Notes

This is a follow-up to the migration-conflict reconciliation work in this branch, targeting the remaining source of prod API alarm noise: quarantine events being logged as errors when they are expected, handled outcomes.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews