### PR TITLE
fix: handle DynamoDB throttling and add alarm

### DIFF
--- a/api/cdk/lib/monitoringStack.ts
+++ b/api/cdk/lib/monitoringStack.ts
@@ -349,6 +349,51 @@ export class MonitoringStack extends Stack {
       apiErrorAlarm.addAlarmAction(new cloudwatch_actions.SnsAction(navigatorApiErrorTopic));
       apiErrorAlarm.applyRemovalPolicy(RemovalPolicy.RETAIN);
 
+      const dynamoDbWriteThrottleMetric = new cloudwatch.MathExpression({
+        expression: "users + businesses",
+        usingMetrics: {
+          users: new cloudwatch.Metric({
+            namespace: "AWS/DynamoDB",
+            metricName: "WriteThrottleEvents",
+            statistic: "Sum",
+            period: Duration.minutes(5),
+            dimensionsMap: {
+              TableName: `${USERS_TABLE}-${props.stage}`,
+            },
+          }),
+          businesses: new cloudwatch.Metric({
+            namespace: "AWS/DynamoDB",
+            metricName: "WriteThrottleEvents",
+            statistic: "Sum",
+            period: Duration.minutes(5),
+            dimensionsMap: {
+              TableName: `${BUSINESSES_TABLE}-${props.stage}`,
+            },
+          }),
+        },
+        period: Duration.minutes(5),
+        label: "DynamoDB write throttle events",
+      });
+
+      const dynamoDbWriteThrottleAlarm = new cloudwatch.Alarm(this, "DynamoDbWriteThrottleAlarm", {
+        alarmName: `${props.stage}-bfs-navigator-dynamodb-write-throttles`,
+        metric: dynamoDbWriteThrottleMetric,
+        threshold: 5,
+        evaluationPeriods: 1,
+        datapointsToAlarm: 1,
+        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+        alarmDescription:
+          "Triggered when sustained write throttling affects Navigator DynamoDB tables.",
+      });
+      dynamoDbWriteThrottleAlarm.addAlarmAction(
+        new cloudwatch_actions.SnsAction(navigatorApiErrorTopic),
+      );
+      dynamoDbWriteThrottleAlarm.addOkAction(
+        new cloudwatch_actions.SnsAction(navigatorApiErrorTopic),
+      );
+      dynamoDbWriteThrottleAlarm.applyRemovalPolicy(RemovalPolicy.RETAIN);
+
       const dynamoDbUsersLatencyMetric = new cloudwatch.Metric({
         namespace: "AWS/DynamoDB",
         metricName: "SuccessfulRequestLatency",

--- a/api/cdk/test/monitoringStack.test.ts
+++ b/api/cdk/test/monitoringStack.test.ts
@@ -85,4 +85,61 @@ describe("MonitoringStack migration alarm", () => {
       },
     ]);
   });
+
+  it("alerts on sustained write throttling across Navigator tables", () => {
+    const app = new App();
+    const stack = new MonitoringStack(app, "TestMonitoringStack", { stage: "local" });
+    const alarms = Template.fromStack(stack).findResources("AWS::CloudWatch::Alarm", {
+      Properties: {
+        AlarmName: "local-bfs-navigator-dynamodb-write-throttles",
+      },
+    });
+    const alarm = Object.values(alarms)[0].Properties;
+
+    expect(alarm).toMatchObject({
+      Threshold: 5,
+      EvaluationPeriods: 1,
+      DatapointsToAlarm: 1,
+      ComparisonOperator: "GreaterThanOrEqualToThreshold",
+      TreatMissingData: "notBreaching",
+      Metrics: expect.arrayContaining([
+        expect.objectContaining({
+          Expression: "users + businesses",
+          Label: "DynamoDB write throttle events",
+          ReturnData: true,
+        }),
+        expect.objectContaining({
+          Id: "users",
+          MetricStat: {
+            Metric: {
+              Namespace: "AWS/DynamoDB",
+              MetricName: "WriteThrottleEvents",
+              Dimensions: [{ Name: "TableName", Value: "users-table-local" }],
+            },
+            Period: 300,
+            Stat: "Sum",
+          },
+          ReturnData: false,
+        }),
+        expect.objectContaining({
+          Id: "businesses",
+          MetricStat: {
+            Metric: {
+              Namespace: "AWS/DynamoDB",
+              MetricName: "WriteThrottleEvents",
+              Dimensions: [{ Name: "TableName", Value: "businesses-table-local" }],
+            },
+            Period: 300,
+            Stat: "Sum",
+          },
+          ReturnData: false,
+        }),
+      ]),
+    });
+    expect(alarm.AlarmActions).toEqual([
+      {
+        Ref: expect.stringContaining("NavigatorApiErrorTopic"),
+      },
+    ]);
+  });
 });

--- a/api/src/api/userRouter.test.ts
+++ b/api/src/api/userRouter.test.ts
@@ -2,6 +2,7 @@ import { userRouterFactory } from "@api/userRouter";
 import {
   CryptoClient,
   DatabaseClient,
+  DatabaseThrottlingError,
   MigrationConflictError,
   TimeStampBusinessSearch,
 } from "@domain/types";
@@ -1271,6 +1272,27 @@ describe("userRouter", () => {
 
       expect(response.status).toEqual(StatusCodes.CONFLICT);
       expect(response.body).toEqual({ error: "STALE_USER_DATA" });
+    });
+
+    it("returns SERVICE UNAVAILABLE with retry guidance when the database write is throttled", async () => {
+      mockJwt.decode.mockReturnValue(cognitoPayload({ id: "123" }));
+      const userData = generateUserData({ user: generateUser({ id: "123" }) });
+
+      stubUnifiedDataClient.get.mockResolvedValue(userData);
+      stubUnifiedDataClient.put.mockRejectedValue(
+        new DatabaseThrottlingError({
+          operation: "put-user",
+          itemSizeBucket: "300-399-kb",
+        }),
+      );
+      const response = await request(app)
+        .post(`/users`)
+        .send(userData)
+        .set("Authorization", "Bearer user-123-token");
+
+      expect(response.status).toEqual(StatusCodes.SERVICE_UNAVAILABLE);
+      expect(response.headers["retry-after"]).toBe("30");
+      expect(response.body).toEqual({ error: "DATABASE_THROTTLED" });
     });
 
     describe("govDeliveryCommCloudClient", () => {

--- a/api/src/api/userRouter.ts
+++ b/api/src/api/userRouter.ts
@@ -6,6 +6,7 @@ import {
 import {
   CryptoClient,
   DatabaseClient,
+  DatabaseThrottlingError,
   MigrationConflictError,
   TimeStampBusinessSearch,
   UpdateLicenseStatus,
@@ -337,6 +338,18 @@ export const userRouterFactory = (
             }ms`,
           );
           res.status(status).json({ error: "STALE_USER_DATA" });
+          return;
+        }
+
+        if (error instanceof DatabaseThrottlingError) {
+          const status = StatusCodes.SERVICE_UNAVAILABLE;
+          res.setHeader("Retry-After", "30");
+          logger.LogInfo(
+            `[END] ${method} ${endpoint} - status: ${status}, reason: database throttled, operation: ${error.context.operation}, itemSizeBucket: ${error.context.itemSizeBucket}, transactionItemCount: ${error.context.transactionItemCount ?? "unknown"}, userId: ${postedUserBodyId}, duration: ${
+              Date.now() - requestStart
+            }ms`,
+          );
+          res.status(status).json({ error: "DATABASE_THROTTLED" });
           return;
         }
 

--- a/api/src/db/DynamoDataClient.test.ts
+++ b/api/src/db/DynamoDataClient.test.ts
@@ -5,6 +5,7 @@ import { DynamoBusinessDataClient } from "@db/DynamoBusinessDataClient";
 import { DynamoUserDataClient } from "@db/DynamoUserDataClient";
 import {
   type BusinessesDataClient,
+  DatabaseThrottlingError,
   type DatabaseClient,
   MigrationConflictError,
   type MigrationDataClient,
@@ -333,6 +334,26 @@ describe("User and Business Migration with DynamoDataClient", () => {
     );
   });
 
+  it("returns the stored record without a generic error when request-time migration is throttled", async () => {
+    const outdatedUser = { ...generateUserData(), version: CURRENT_VERSION - 1 };
+    jest.spyOn(dynamoUsersDataClient, "get").mockResolvedValueOnce(outdatedUser);
+    migrationDataClient.migrateAndPut.mockRejectedValueOnce(
+      new DatabaseThrottlingError({
+        operation: "migration-transaction",
+        itemSizeBucket: "300-399-kb",
+        transactionItemCount: 2,
+      }),
+    );
+
+    await expect(dynamoDataClient.get(outdatedUser.user.id)).resolves.toEqual(outdatedUser);
+    expect(logger.LogInfo).toHaveBeenCalledWith(
+      expect.stringContaining("Request-time migration paused after DynamoDB throttling"),
+    );
+    expect(logger.LogError).not.toHaveBeenCalledWith(
+      expect.stringContaining("Request-time migration failed"),
+    );
+  });
+
   it("returns the latest stored record when request-time migration conflicts", async () => {
     const outdatedUser = { ...generateUserData(), version: CURRENT_VERSION - 1 };
     const migratedUser = { ...outdatedUser, version: CURRENT_VERSION };
@@ -427,6 +448,31 @@ describe("User and Business Migration with DynamoDataClient", () => {
     );
   });
 
+  it("pauses the scheduled migration after the first post-retry throttle", async () => {
+    const first = generateUserData();
+    const second = generateUserData();
+    jest.spyOn(dynamoUsersDataClient, "getUsersWithOutdatedVersion").mockResolvedValueOnce({
+      usersToMigrate: [first, second],
+      nextToken: undefined,
+    });
+    migrationDataClient.migrateAndPut.mockRejectedValueOnce(
+      new DatabaseThrottlingError({
+        operation: "migration-transaction",
+        itemSizeBucket: "300-399-kb",
+        transactionItemCount: 2,
+      }),
+    );
+
+    const result = await dynamoDataClient.migrateOutdatedVersionUsers();
+
+    expect(result).toEqual({ success: true, migratedCount: 0 });
+    expect(migrationDataClient.migrateAndPut).toHaveBeenCalledTimes(1);
+    expect(logger.LogInfo).toHaveBeenCalledWith(
+      expect.stringContaining("Migration paused after DynamoDB throttling"),
+    );
+    expect(logger.LogError).not.toHaveBeenCalled();
+  });
+
   it("continues scheduled migration after a retryable transaction conflict", async () => {
     const first = generateUserData();
     const second = generateUserData();
@@ -493,6 +539,23 @@ describe("User and Business Migration with DynamoDataClient", () => {
     expect(logger.LogInfo).toHaveBeenCalledWith(
       "Migration paused before Lambda timeout; remaining users will retry",
     );
+  });
+
+  it("propagates a direct user write throttle without duplicate error logging", async () => {
+    const currentUser = { ...generateUserData(), version: CURRENT_VERSION };
+    jest.spyOn(dynamoUsersDataClient, "put").mockRejectedValueOnce({
+      name: "ProvisionedThroughputExceededException",
+    });
+
+    await expect(dynamoDataClient.put(currentUser)).rejects.toMatchObject({
+      name: "DatabaseThrottlingError",
+      context: {
+        operation: "put-user",
+        itemSizeBucket: "under-100-kb",
+      },
+    });
+    expect(logger.LogError).not.toHaveBeenCalled();
+    expect(dynamoBusinessesDataClient.put).not.toHaveBeenCalled();
   });
 
   it("should call parseUserData when zod_parsing_on feature flag is true", async () => {

--- a/api/src/db/DynamoDataClient.ts
+++ b/api/src/db/DynamoDataClient.ts
@@ -1,5 +1,6 @@
 import {
   type BusinessesDataClient,
+  DatabaseThrottlingError,
   type DatabaseClient,
   MigrationConflictError,
   type MigrationDataClient,
@@ -7,6 +8,11 @@ import {
   type UserDataClient,
   isQuarantinedCiphertextError,
 } from "@domain/types";
+import {
+  getDynamoDbItemSizeBucket,
+  isDynamoDbThrottlingError,
+  toDatabaseThrottlingError,
+} from "@db/DynamoDbErrors";
 import { type LogWriterType } from "@libs/logWriter";
 import { type Business, CURRENT_VERSION, type UserData } from "@shared/userData";
 import { chunk } from "lodash";
@@ -80,7 +86,7 @@ export const DynamoDataClient = (
           logger.LogInfo(
             `Completed ${batchResult.migratedCount} migrations and quarantined ${batchResult.quarantinedCount} users in this batch. Total migrated so far: ${migratedCount}; total quarantined: ${quarantinedCount}`,
           );
-          if (batchResult.stoppedForTime) {
+          if (batchResult.stoppedForTime || batchResult.stoppedForThrottling) {
             return migrationSuccess(migratedCount, quarantinedCount);
           }
         }
@@ -101,7 +107,12 @@ export const DynamoDataClient = (
     usersToMigrate: UserData[],
     isZodParsingOn: string,
     canStartNextUser: () => boolean,
-  ): Promise<{ migratedCount: number; quarantinedCount: number; stoppedForTime: boolean }> => {
+  ): Promise<{
+    migratedCount: number;
+    quarantinedCount: number;
+    stoppedForTime: boolean;
+    stoppedForThrottling?: boolean;
+  }> => {
     if (!migrationDataClient) {
       throw new Error("Migration data client is required for coordinated migrations");
     }
@@ -125,6 +136,17 @@ export const DynamoDataClient = (
         if (error instanceof MigrationConflictError) {
           logger.LogInfo("Skipped migration because the user record changed concurrently");
           continue;
+        }
+        if (error instanceof DatabaseThrottlingError) {
+          logger.LogInfo(
+            `Migration paused after DynamoDB throttling; operation=${error.context.operation}, itemSizeBucket=${error.context.itemSizeBucket}, transactionItemCount=${error.context.transactionItemCount ?? "unknown"}; remaining users will retry`,
+          );
+          return {
+            migratedCount,
+            quarantinedCount,
+            stoppedForTime: false,
+            stoppedForThrottling: true,
+          };
         }
         const errorMessage = error instanceof Error ? error.message : String(error);
         if (isQuarantinedCiphertextError(error)) {
@@ -177,6 +199,12 @@ export const DynamoDataClient = (
       }
 
       const errorMessage = error instanceof Error ? error.message : String(error);
+      if (error instanceof DatabaseThrottlingError) {
+        logger.LogInfo(
+          `Request-time migration paused after DynamoDB throttling; operation=${error.context.operation}, itemSizeBucket=${error.context.itemSizeBucket}, transactionItemCount=${error.context.transactionItemCount ?? "unknown"}; returning the stored record`,
+        );
+        return sourceUserData;
+      }
       if (isQuarantinedCiphertextError(error)) {
         logger.LogInfo(
           `Quarantined request-time migration from version ${sourceUserData.version} to ${CURRENT_VERSION}; returning the stored record: ${errorMessage}`,
@@ -214,6 +242,12 @@ export const DynamoDataClient = (
               `Processed business with ID ${businessId} for user ${updatedUserData.user.id}`,
             );
           } catch (error) {
+            if (isDynamoDbThrottlingError(error)) {
+              throw toDatabaseThrottlingError(error, {
+                operation: "put-business",
+                itemSizeBucket: getDynamoDbItemSizeBucket(businessData),
+              });
+            }
             logger.LogError(
               `Error processing business with ID ${businessId} for user ${updatedUserData.user.id}: ${error}`,
             );
@@ -223,6 +257,15 @@ export const DynamoDataClient = (
         logger.LogInfo(`No businesses found for user ${updatedUserData.user.id}`);
       }
     } catch (error) {
+      if (error instanceof DatabaseThrottlingError) {
+        throw error;
+      }
+      if (isDynamoDbThrottlingError(error)) {
+        throw toDatabaseThrottlingError(error, {
+          operation: "put-user",
+          itemSizeBucket: getDynamoDbItemSizeBucket(userData),
+        });
+      }
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
       logger.LogError(`Failed to process user ${userData.user.id}: ${errorMessage}`);
       throw new Error(errorMessage);
@@ -240,7 +283,7 @@ export const DynamoDataClient = (
       await updateUserAndBusinesses(userData);
       return userData;
     } catch (error) {
-      if (error instanceof MigrationConflictError) {
+      if (error instanceof MigrationConflictError || error instanceof DatabaseThrottlingError) {
         throw error;
       }
 

--- a/api/src/db/DynamoDbErrors.test.ts
+++ b/api/src/db/DynamoDbErrors.test.ts
@@ -1,0 +1,75 @@
+import {
+  getDynamoDbItemSizeBucket,
+  isDynamoDbThrottlingError,
+  toDatabaseThrottlingError,
+} from "@db/DynamoDbErrors";
+import { DatabaseThrottlingError } from "@domain/types";
+
+describe("DynamoDbErrors", () => {
+  it.each([
+    { name: "ProvisionedThroughputExceededException" },
+    { name: "RequestLimitExceeded" },
+    { name: "ThrottlingException" },
+    { $retryable: { throttling: true } },
+    { $metadata: { httpStatusCode: 429 } },
+    {
+      name: "TransactionCanceledException",
+      CancellationReasons: [{ Code: "None" }, { Code: "ThrottlingError" }],
+    },
+    {
+      name: "TransactionCanceledException",
+      CancellationReasons: [{ Code: "ProvisionedThroughputExceeded" }],
+    },
+  ])("recognizes a DynamoDB throttling response: %#", (error) => {
+    expect(isDynamoDbThrottlingError(error)).toBe(true);
+  });
+
+  it("recognizes a throttling response nested in an error cause", () => {
+    const error = new Error("Database operation failed", {
+      cause: { name: "ThrottlingException" },
+    });
+
+    expect(isDynamoDbThrottlingError(error)).toBe(true);
+  });
+
+  it.each([
+    { name: "AccessDeniedException" },
+    {
+      name: "TransactionCanceledException",
+      CancellationReasons: [{ Code: "ConditionalCheckFailed" }],
+    },
+    {
+      name: "TransactionCanceledException",
+      CancellationReasons: [{ Code: "TransactionConflict" }],
+    },
+  ])("does not classify a non-throttling response as throttling: %#", (error) => {
+    expect(isDynamoDbThrottlingError(error)).toBe(false);
+  });
+
+  it("preserves safe write context without exposing the source error message", () => {
+    const sourceError = new Error("sensitive SDK details");
+
+    const result = toDatabaseThrottlingError(sourceError, {
+      operation: "put-user",
+      itemSizeBucket: "300-399-kb",
+    });
+
+    expect(result).toBeInstanceOf(DatabaseThrottlingError);
+    expect(result.message).toBe("Database write capacity is temporarily unavailable");
+    expect(result.context).toEqual({
+      operation: "put-user",
+      itemSizeBucket: "300-399-kb",
+    });
+    expect(result.cause).toBe(sourceError);
+  });
+
+  it.each([
+    [99, "under-100-kb"],
+    [150, "100-199-kb"],
+    [250, "200-299-kb"],
+    [350, "300-399-kb"],
+    [450, "400-kb-or-more"],
+  ])("buckets an approximately %i KB item as %s", (kilobytes, expectedBucket) => {
+    expect(getDynamoDbItemSizeBucket({ value: "x".repeat(kilobytes * 1024) })).toBe(expectedBucket);
+  });
+});

--- a/api/src/db/DynamoDbErrors.ts
+++ b/api/src/db/DynamoDbErrors.ts
@@ -1,0 +1,97 @@
+import {
+  type DatabaseItemSizeBucket,
+  DatabaseThrottlingError,
+  type DatabaseThrottlingContext,
+} from "@domain/types";
+
+const throttlingErrorNames = new Set([
+  "ProvisionedThroughputExceededException",
+  "RequestLimitExceeded",
+  "ThrottlingException",
+]);
+
+const throttlingCancellationCodes = new Set(["ProvisionedThroughputExceeded", "ThrottlingError"]);
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === "object" && value !== null;
+
+const hasThrottlingCancellationReason = (error: Readonly<Record<string, unknown>>): boolean => {
+  if (error.name !== "TransactionCanceledException" || !Array.isArray(error.CancellationReasons)) {
+    return false;
+  }
+
+  return error.CancellationReasons.some(
+    (reason) =>
+      isRecord(reason) &&
+      typeof reason.Code === "string" &&
+      throttlingCancellationCodes.has(reason.Code),
+  );
+};
+
+const isSingleDynamoDbThrottlingError = (error: unknown): boolean => {
+  if (!isRecord(error)) {
+    return false;
+  }
+
+  if (typeof error.name === "string" && throttlingErrorNames.has(error.name)) {
+    return true;
+  }
+
+  if (hasThrottlingCancellationReason(error)) {
+    return true;
+  }
+
+  const retryable = error.$retryable;
+  if (isRecord(retryable) && retryable.throttling === true) {
+    return true;
+  }
+
+  const metadata = error.$metadata;
+  return isRecord(metadata) && metadata.httpStatusCode === 429;
+};
+
+export const isDynamoDbThrottlingError = (error: unknown): boolean => {
+  const visited = new Set<unknown>();
+  let current: unknown = error;
+
+  while (current && !visited.has(current)) {
+    if (current instanceof DatabaseThrottlingError || isSingleDynamoDbThrottlingError(current)) {
+      return true;
+    }
+
+    visited.add(current);
+    current = isRecord(current) ? current.cause : undefined;
+  }
+
+  return false;
+};
+
+export const getDynamoDbItemSizeBucket = (item: unknown): DatabaseItemSizeBucket => {
+  const approximateBytes = Buffer.byteLength(JSON.stringify(item) ?? "");
+  const approximateKilobytes = approximateBytes / 1024;
+
+  if (approximateKilobytes < 100) {
+    return "under-100-kb";
+  }
+  if (approximateKilobytes < 200) {
+    return "100-199-kb";
+  }
+  if (approximateKilobytes < 300) {
+    return "200-299-kb";
+  }
+  if (approximateKilobytes < 400) {
+    return "300-399-kb";
+  }
+  return "400-kb-or-more";
+};
+
+export const toDatabaseThrottlingError = (
+  error: unknown,
+  context: DatabaseThrottlingContext,
+): DatabaseThrottlingError => {
+  if (error instanceof DatabaseThrottlingError) {
+    return error;
+  }
+
+  return new DatabaseThrottlingError(context, { cause: error });
+};

--- a/api/src/db/DynamoMigrationDataClient.test.ts
+++ b/api/src/db/DynamoMigrationDataClient.test.ts
@@ -1,6 +1,7 @@
 import { type DynamoDBDocumentClient, TransactWriteCommand } from "@aws-sdk/lib-dynamodb";
 import { DynamoMigrationDataClient } from "@db/DynamoMigrationDataClient";
 import {
+  DatabaseThrottlingError,
   MigrationConflictError,
   type MigrationDataClient,
   type UserDataClient,
@@ -203,6 +204,39 @@ describe("DynamoMigrationDataClient", () => {
     await expect(makeClient().migrateAndPut(generateOutdatedUser())).rejects.toBeInstanceOf(
       MigrationConflictError,
     );
+  });
+
+  it.each(["ThrottlingError", "ProvisionedThroughputExceeded"])(
+    "classifies a %s transaction cancellation as database throttling",
+    async (cancellationCode) => {
+      send.mockRejectedValueOnce({
+        name: "TransactionCanceledException",
+        CancellationReasons: [{ Code: "None" }, { Code: cancellationCode }],
+      });
+
+      const result = makeClient().migrateAndPut(generateOutdatedUser());
+
+      await expect(result).rejects.toBeInstanceOf(DatabaseThrottlingError);
+      await expect(result).rejects.toMatchObject({
+        context: {
+          operation: "migration-transaction",
+          itemSizeBucket: "under-100-kb",
+          transactionItemCount: 3,
+        },
+      });
+    },
+  );
+
+  it("classifies a direct throughput exception as database throttling", async () => {
+    send.mockRejectedValueOnce({ name: "ProvisionedThroughputExceededException" });
+
+    await expect(makeClient().migrateAndPut(generateOutdatedUser())).rejects.toMatchObject({
+      name: "DatabaseThrottlingError",
+      context: {
+        operation: "migration-transaction",
+        transactionItemCount: 3,
+      },
+    });
   });
 
   it("rejects users that exceed DynamoDB's 100-item transaction limit", async () => {

--- a/api/src/db/DynamoMigrationDataClient.ts
+++ b/api/src/db/DynamoMigrationDataClient.ts
@@ -4,6 +4,11 @@ import {
   type TransactWriteCommandInput,
 } from "@aws-sdk/lib-dynamodb";
 import { createBusinessDataItem } from "@db/DynamoBusinessDataClient";
+import {
+  getDynamoDbItemSizeBucket,
+  isDynamoDbThrottlingError,
+  toDatabaseThrottlingError,
+} from "@db/DynamoDbErrors";
 import { createUserDataItem } from "@db/DynamoUserDataClient";
 import {
   MigrationConflictError,
@@ -107,6 +112,13 @@ export const DynamoMigrationDataClient = ({
     } catch (error) {
       if (isMigrationConflict(error)) {
         throw new MigrationConflictError();
+      }
+      if (isDynamoDbThrottlingError(error)) {
+        throw toDatabaseThrottlingError(error, {
+          operation: "migration-transaction",
+          itemSizeBucket: getDynamoDbItemSizeBucket(createUserDataItem(migratedUserData)),
+          transactionItemCount: transactItems.length,
+        });
       }
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Atomic migration transaction failed: ${message}`, { cause: error });

--- a/api/src/domain/types.ts
+++ b/api/src/domain/types.ts
@@ -114,6 +114,30 @@ export class MigrationConflictError extends Error {
   }
 }
 
+export type DatabaseWriteOperation = "migration-transaction" | "put-business" | "put-user";
+export type DatabaseItemSizeBucket =
+  | "under-100-kb"
+  | "100-199-kb"
+  | "200-299-kb"
+  | "300-399-kb"
+  | "400-kb-or-more";
+
+export interface DatabaseThrottlingContext {
+  readonly operation: DatabaseWriteOperation;
+  readonly itemSizeBucket: DatabaseItemSizeBucket;
+  readonly transactionItemCount?: number;
+}
+
+export class DatabaseThrottlingError extends Error {
+  readonly context: DatabaseThrottlingContext;
+
+  constructor(context: DatabaseThrottlingContext, options?: ErrorOptions) {
+    super("Database write capacity is temporarily unavailable", options);
+    this.name = "DatabaseThrottlingError";
+    this.context = context;
+  }
+}
+
 export interface BusinessesDataClient {
   get: (businessId: string) => Promise<Business>;
   put: (businessData: Business) => Promise<Business>;


### PR DESCRIPTION
## Description

Prod API alarms were firing when DynamoDB write throttling caused migrations and writes to fail as unhandled errors. This PR classifies DynamoDB throttling responses, makes migrations and writes back off gracefully instead of erroring, and adds a CloudWatch alarm to monitor sustained write throttling directly.

### Approach

- Added a `DatabaseThrottlingError` domain error type with context (`operation`, `itemSizeBucket`, and an optional `transactionItemCount`).

- Added `api/src/db/DynamoDbErrors.ts` with `isDynamoDbThrottlingError` (recognizes DynamoDB throttling exceptions, retryable flags, 429 responses, and throttling-related transaction cancellation reasons, including causes nested in wrapped errors), `toDatabaseThrottlingError` (wraps SDK errors into `DatabaseThrottlingError` without leaking the source message), and `getDynamoDbItemSizeBucket` (buckets item size for observability).

- `DynamoMigrationDataClient.migrateAndPut` now classifies throttling failures during the migration transaction and throws `DatabaseThrottlingError` with transaction context.

- `DynamoDataClient` changes:
  - Scheduled migration batches stop early (without logging an error) when throttled, leaving the remaining users to retry on the next run.
  - Request-time migrations catch throttling and return the stored, unmigrated record instead of failing the request.
  - Direct user and business writes classify throttling and rethrow `DatabaseThrottlingError` instead of a generic `Error`.

- `userRouter` now catches `DatabaseThrottlingError` and responds with `503 Service Unavailable`, a `Retry-After: 30` header, and `{ error: "DATABASE_THROTTLED" }`, so clients back off instead of seeing a 500.

- Added a CDK alarm in `monitoringStack.ts` that sums `WriteThrottleEvents` across the Users and Businesses tables and alerts on sustained throttling (threshold of 5 within a 5 minute period), wired to the existing API error SNS topic.

### Steps to Test

- `yarn workspace @businessnjgovnavigator/api test` covers the throttling classification, migration pause behavior, and the new 503 response.

- `yarn workspace @businessnjgovnavigator/api-cdk test` covers the new alarm resource and its metric configuration.

- No user-facing UI changes. Clients calling the user API will see a 503 with `Retry-After: 30` instead of a 500 when DynamoDB is throttled.

### Notes

This is a follow-up to the migration-conflict reconciliation and quarantine-logging work already released, targeting the remaining source of prod API alarm noise caused by unhandled DynamoDB throttling.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews