### PR TITLE
feat: [AB#17928] add register your business button

### DIFF
--- a/content/src/pages/register-your-business.md
+++ b/content/src/pages/register-your-business.md
@@ -7,6 +7,8 @@ sub-heading-text: Registering your business is a key part of getting up and runn
 meta-data: How do I register a business in New Jersey? We are here to help with resources on employer IDs, taxes and DBAs. Learn More.
 main-link-text: How to Register
 main-text-1: "The steps required to register your business may vary depending on the business structure and industry. Most businesses can expect to:\_\n\n* Search for Available Business Names\n* Obtain an Employer Identification Number (EIN) from the IRS\n* Form Your Business\n* Register for New Jersey Tax and Employer Purposes\n\nLearn more about these steps below. \n\nIf you are an out-of-state business, you can use our [Out-of-State registration guide](http://business.nj.gov/pages/out-of-state-business-registration)."
+link-text-1: Register Your Business
+link-url-1: https://account.business.nj.gov/onboarding
 heading-2: Search Available Business Names Based on Business Structure
 main-text-2: "Your business name is the name you will use to represent your business.\n\n**If you are an LLC, C-Corp, S-Corp, LP, or LLP,** you should check if your business name is available with the New Jersey Department of Treasury. If your name is available, you will reserve your name when you submit your business formation documents. You will need your business Certificate of Formation to officially register your business name.\_\n\n**If you are a sole proprietor or a general partnership**, and you do not want to use your personal name as your business name, you can register a business name at your local county clerk’s office."
 link-text-2: Check If Your Business Name Is Available

--- a/packages/static-site/components/learn/PageContent.tsx
+++ b/packages/static-site/components/learn/PageContent.tsx
@@ -90,7 +90,7 @@ const PageContent = ({ page }: Props) => {
               </div>
             )}
             {section.linkText && section.linkUrl && (
-              <a href={section.linkUrl} className="usa-button">
+              <a href={section.linkUrl} className="usa-button margin-top-105">
                 {section.linkText}
                 {section.linkUrl.startsWith("http") && (
                   <svg className="usa-icon" aria-hidden="true" focusable="false">


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description
Added a register your business button, additionally added spacing between the button and the text above. 

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to the URL for the board that owns it.
     Board routing is not a clean cutover; run `python3 scripts/fetch_ado_ticket.py <id>`
     or check scripts/ado-boards.json for the current cutover and exceptions list. -->

This pull request resolves [#17928](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17928).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test
Navigate to `/pages/register-your-business`. There should now be a button under the first paragraph that navigates to onboarding.

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
