### PR TITLE
feat: add Navigator AWS analysis skill

### DIFF
--- a/.claude/skills/analyze-navigator-aws/SKILL.md
+++ b/.claude/skills/analyze-navigator-aws/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: analyze-navigator-aws
+description: Investigate Navigator AWS incidents, alarms, recurring errors, and operational questions using read-only AWS CLI commands, CloudWatch logs and metrics, and repository source. Use only when an engineer explicitly invokes /analyze-navigator-aws and wants evidence-based root-cause analysis rather than a predetermined diagnostic workflow.
+disable-model-invocation: true
+argument-hint: "[profile=Innov-Prod] [window=168h] [focus=<question, alarm, or component>]"
+---
+
+# Analyze Navigator AWS
+
+Investigate the engineer's question rather than replaying a fixed checklist.
+Collect bounded, redacted AWS evidence, follow signals into adjacent telemetry and
+repository code, and state the confidence of every root-cause conclusion.
+
+## Arguments
+
+Interpret `$ARGUMENTS` as optional key-value arguments:
+
+- `profile`: default `Innov-Prod`
+- `window`: default `168h`; accept hours such as `36h` or `168h`
+- `focus`: default `all`; accept a question, alarm, service, endpoint, component,
+  migration, or other investigation target
+- `stage`: infer from the profile unless supplied
+
+Require `stage` for `Innov-Dev` when the target is `content` or `testing`.
+
+## Workflow
+
+1. Convert the requested window to exact UTC and America/New_York boundaries.
+2. Validate the requested identity with `aws sts get-caller-identity`. Stop
+   rather than substituting another profile or stage.
+3. Read [resource-map.md](references/resource-map.md), then inspect the relevant
+   CDK definitions. Treat documented names as discovery hints, not an exhaustive
+   inventory.
+4. Discover relevant current alarms, alarm history, log groups, and resources.
+   Start from the stated focus, then follow evidence into adjacent components.
+5. Use alarm `StateReason` datapoint timestamps, not only transition timestamps,
+   to establish bounded log and metric query windows.
+6. Query relevant CloudWatch log groups iteratively:
+   - begin with the alarm period or reported failure window
+   - group repeated signatures and count affected requests or invocations
+   - widen or narrow the query based on evidence
+   - inspect raw events only long enough to identify the source without exposing
+     sensitive values
+7. Retrieve supporting metrics, configuration, deployment history, dependency
+   responses, or AWS Health events only when they help confirm or reject a
+   hypothesis.
+8. Read [analysis-playbook.md](references/analysis-playbook.md). Follow its
+   causal-chain and confidence rules.
+9. Inspect the repository path implicated by the evidence: monitoring
+   definitions, log emitters, handlers, clients, migrations, and error handling.
+10. Determine whether each signal is ongoing, resolved, expected validation,
+    monitoring noise, application failure, dependency failure, or an AWS
+    service-boundary failure.
+11. Format the answer with [report-template.md](references/report-template.md).
+
+## AWS Safety
+
+- Use only read-only AWS operations. Typical operation names begin with
+  `describe`, `get`, `list`, `lookup`, or `filter`; CloudWatch Logs
+  `start-query` and `get-query-results` are also permitted.
+- Never call operations that create, update, delete, invoke, publish, start
+  workloads, or otherwise change AWS resources.
+- Do not run DynamoDB scans, exports, PartiQL queries, or other bulk record
+  access unless the engineer explicitly requests that specific data access.
+  Read-only operations can still consume table capacity.
+- Bound all log, metric, and history queries to the requested window. Use
+  pagination and result limits deliberately.
+- Do not request decrypted parameter values unless the specific parameter is
+  directly relevant and known to contain operational state rather than a secret.
+
+## Evidence Rules
+
+- Never reproduce user IDs, emails, tax identifiers, sensitive record contents,
+  request bodies, credentials, secrets, account IDs, IP addresses, or
+  unredacted log lines. Summarize or normalize signatures instead.
+- Treat failed commands, missing permissions, unavailable telemetry, and
+  deliberately omitted data access as evidence limitations.
+- Do not call an event a root cause merely because it occurred nearby.
+- Label conclusions as `confirmed-application`, `confirmed-dependency`,
+  `aws-service-boundary`, `inferred`, or `unknown`.
+- Separate user-facing failures from successful but excessive traffic.
+- Do not change AWS state, source code, parameters, alarms, or records.
+
+## Stop Conditions
+
+- Stop and report an authentication problem if STS identity validation fails.
+- Stop rather than substitute a different AWS profile.
+- If evidence cannot distinguish an application error from an AWS internal
+  failure, stop the causal chain at the AWS service boundary and identify the
+  missing telemetry needed to go further.

--- a/.claude/skills/analyze-navigator-aws/references/analysis-playbook.md
+++ b/.claude/skills/analyze-navigator-aws/references/analysis-playbook.md
@@ -1,0 +1,78 @@
+# Root-Cause Analysis Playbook
+
+## Causal chain
+
+Build the chain in this order:
+
+1. Alarm transition and the metric datapoint that breached.
+2. Resource and operation represented by the metric.
+3. Log events in the datapoint window.
+4. Repeated or isolated signature and affected invocation/request count.
+5. AWS service telemetry such as throttles, system errors, latency, deployment
+   events, or Health events.
+6. Repository code path that emits or handles the failure.
+7. Resulting automation or downstream impact.
+
+Do not skip from an alarm directly to a source-code hypothesis.
+
+## Confidence labels
+
+- `confirmed-application`: Code and logs identify the failing application path
+  and behavior.
+- `confirmed-dependency`: The application received a specific upstream response
+  and handled it as logged.
+- `aws-service-boundary`: AWS returned a service-side failure, but internal AWS
+  causation is unavailable.
+- `inferred`: Multiple signals support the explanation, but a decisive request
+  identifier, trace, access log, or data event is missing.
+- `unknown`: Evidence is insufficient or contradictory.
+
+## Recurrence
+
+Call a problem ongoing only when at least one condition holds:
+
+- Its alarm remains active.
+- The normalized signature recurs near the end of the requested window.
+- Recent metrics continue to breach or trend abnormally.
+- An operational control or degraded configuration remains active.
+
+Otherwise call it historical or resolved and give the last occurrence.
+
+Do not promote events outside the requested window to the most important current
+issue unless their resulting state remains active in the window. Present them as
+historical context and recommend a longer window when appropriate.
+
+## Interpretation checks
+
+- Literal `error` metric filters count expected validation and duplicate log
+  lines. Report requests separately from emitted log records.
+- Lambda `Errors` metrics indicate failed invocations; custom log metrics may
+  only indicate text matches.
+- A CloudWatch metric with no datapoints is unknown or inactive telemetry, not a
+  measured zero. Use the matching `Invocations` metric before claiming a Lambda
+  did not run.
+- DynamoDB `SystemErrors` without throttle metrics indicate an AWS
+  service-boundary failure, not capacity exhaustion.
+- DynamoDB `ProvisionedThroughputExceededException` is a capacity problem even
+  if the broad write-throttle alarm did not breach.
+- `TargetTracking-*AlarmLow*` transitions normally drive scale-down behavior.
+- Static-site router-state, server-reference, and server-action errors often
+  indicate malformed or stale Next.js requests. Call automated probing an
+  inference unless access logs identify the source.
+- Successful but excessive requests can indicate a client retry, polling, or
+  autosave loop even when error metrics remain healthy.
+- A dependency response becomes an application failure when application code
+  incorrectly maps, retries, or exposes it. Distinguish the initiating response
+  from the user-visible result.
+
+## Evidence limitations
+
+Always mention applicable gaps:
+
+- X-Ray disabled or unavailable.
+- CloudTrail data events not enabled.
+- AWS Health unavailable to the account.
+- Request IDs or SDK metadata discarded by application wrapping.
+- Access logs unavailable for source attribution.
+- Data access not explicitly authorized.
+- Sampling or Logs Insights limits that may omit low-frequency signatures.

--- a/.claude/skills/analyze-navigator-aws/references/report-template.md
+++ b/.claude/skills/analyze-navigator-aws/references/report-template.md
@@ -1,0 +1,56 @@
+# Report Template
+
+## Current status
+
+- Analysis window in America/New_York and UTC.
+- Current relevant alarm and operational-control state.
+- Whether the reported condition is ongoing, resolved, or unknown.
+
+## Findings
+
+Lead with ongoing, user-impacting problems. For each finding provide:
+
+- Component and normalized signature.
+- First and last occurrence.
+- Requests or invocations affected, not only log-line count.
+- Root-cause confidence label.
+- Evidence chain from metric to logs to code or dependency.
+- Whether the condition is ongoing, resolved, expected, or monitoring noise.
+
+Keep events outside the requested window in a clearly labeled historical
+context section. Do not rank them above in-window findings unless their impact
+remains active.
+
+## Causal timeline
+
+For related events, show the sequence from:
+
+- Metric datapoint or reported symptom.
+- Alarm transition.
+- Correlated log signature.
+- Application, dependency, or AWS service behavior.
+- Downstream automation or user impact.
+
+Omit this section when events are independent or timestamps do not establish a
+defensible sequence.
+
+## Most important attention item
+
+Name one issue. Explain why it outranks the others using current impact,
+recurrence, data-safety risk, or monitoring blindness.
+
+## Focus-specific evidence
+
+Include evidence specific to the engineer's question, such as deployment
+changes, dependency responses, migration progress, configuration state, traffic
+patterns, or capacity metrics. State clearly when potentially useful scans or
+other data access were not requested and therefore not performed.
+
+## Recommended actions
+
+Provide a short ordered list. Do not implement changes during analysis.
+
+## Limitations
+
+List failed evidence sources, omitted scans, unavailable telemetry, and any
+causal conclusion that remains inferred.

--- a/.claude/skills/analyze-navigator-aws/references/resource-map.md
+++ b/.claude/skills/analyze-navigator-aws/references/resource-map.md
@@ -1,0 +1,57 @@
+# Navigator AWS Resource Map
+
+Use repository definitions as the source of truth. Treat these names as
+discovery patterns, not permanent inventory or a mandatory checklist.
+
+## Profiles and stages
+
+| Profile         | Stages                      |
+| --------------- | --------------------------- |
+| `Innov-Dev`     | `dev`, `content`, `testing` |
+| `Innov-Staging` | `staging`                   |
+| `Innov-Prod`    | `prod`                      |
+
+Default `Innov-Prod` to `prod`. Require `--stage` for `content` and `testing`.
+
+## Repository discovery
+
+- API monitoring definitions: `api/cdk/lib/monitoringStack.ts`
+- Static-site monitoring definitions: `api/cdk/lib/staticSiteMonitoring.ts`
+- CDK stacks and resource names: `api/cdk/lib/`
+- API handlers, clients, and log emitters: `api/src/`
+- Static-site application and logging: `packages/static-site/`
+- Frontend request behavior: `web/src/`
+- Shared domain and migration types: `shared/src/`
+
+Search these sources before assuming that a resource name, alarm threshold, log
+group, or metric remains current.
+
+## Common discovery patterns
+
+- API application logs commonly use `/NavigatorWebService/{stage}/...`.
+- Database client logs commonly use `/NavigatorDBClient/{stage}/...`.
+- Lambda logs use `/aws/lambda/{function-name}`.
+- Static-site logs commonly use `/ecs/bfs-static-site/{stage}`.
+- API Lambda names commonly contain `businessnjgov-api-v2-{stage}`.
+- DynamoDB tables commonly include the stage in their name.
+- Static-site resources commonly include `bfs-static-site` and the stage.
+
+Use `describe-alarms` and `describe-log-groups` to discover the live inventory.
+Filter by stage and the investigation focus; do not query every log group by
+default.
+
+## Evidence sources
+
+- CloudWatch alarm state and history identify when a signal breached.
+- CloudWatch metrics distinguish failures, traffic, latency, capacity, and
+  missing telemetry.
+- CloudWatch Logs Insights identifies repeated signatures and affected
+  requests or invocations.
+- Lambda and ECS descriptions identify deployed configuration.
+- CloudTrail lookup events identify relevant deployments and configuration
+  changes when management events are available.
+- AWS Health can support an AWS service-boundary conclusion.
+- Repository source explains how the observed event is handled and surfaced.
+
+Choose evidence sources based on the question. Do not collect every source for
+every investigation.


### PR DESCRIPTION
## Description

Adds a manually invoked Claude Code skill for investigating Navigator AWS alarms, recurring errors, and operational questions.

The skill guides engineers through open-ended, evidence-based root-cause analysis using read-only AWS CLI commands, CloudWatch telemetry, and repository source without embedding an incident-specific collector.

### Approach

- Add `/analyze-navigator-aws` with profile, stage, window, and free-form focus options.
- Begin with the engineer’s question and discover relevant alarms, log groups, metrics, and resources at runtime.
- Treat CDK definitions and documented resource patterns as discovery hints rather than a fixed inventory.
- Correlate alarm datapoints, bounded CloudWatch queries, AWS telemetry, and implicated source-code paths.
- Distinguish ongoing failures, historical incidents, expected validation, monitoring noise, dependency failures, and AWS service-boundary failures.
- Require explicit authorization before DynamoDB scans or other bulk record access.
- Document confidence labels, evidence limitations, causal analysis, and a consistent report structure.

### Steps to Test

Invoke the skill in Claude Code without running an investigation:

   `/analyze-navigator-aws profile=Innov-Prod window=1h focus="an API alarm"`

Confirm the skill scopes the requested window, validates the requested AWS identity, discovers resources from the stated focus, and follows evidence iteratively rather than running a predetermined checklist.

Confirm the skill restricts itself to read-only AWS operations, does not perform bulk record access without explicit authorization, and reports unavailable telemetry as a limitation.

Confirm the resulting report identifies ongoing versus historical conditions, provides a causal chain and confidence label, and does not expose sensitive log data.

### Notes

- The skill is manual-only and cannot be invoked automatically by Claude.
- AWS commands use the normal Claude Code permission model and must remain read-only.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
