### PR TITLE
chore: [AB#17944] add Quick Services e2e test

### DIFF
--- a/packages/static-site/tests/e2e/quickServicesAnalytics.e2e.spec.ts
+++ b/packages/static-site/tests/e2e/quickServicesAnalytics.e2e.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "@playwright/test";
+import { getApplicationMessages } from "@/domain/i18n/messages";
+import { LANGUAGE_PROMPT_DISMISSED_COOKIE } from "@/domain/siteConfig";
+
+interface AnalyticsEvent {
+  readonly click_text: string;
+  readonly event: "all_elements_clicked";
+}
+
+const GTM_SCRIPT_URL = "https://www.googletagmanager.com/gtm.js";
+const ANALYTICS_COLLECTOR_URL = "https://analytics.test/collect";
+
+/**
+ * Mimics the relevant GTM click handler without loading the mutable production
+ * container. It emits the clicked Quick Services link's DOM text to a test-only
+ * collector and prevents the internal link from navigating away before the
+ * assertion can observe the request.
+ */
+const mockGtmContainer = `
+document.addEventListener("click", function(event) {
+  var target = event.target;
+  if (!(target instanceof Element)) return;
+
+  var link = target.closest("a.quick-service-card__link");
+  if (!link) return;
+
+  event.preventDefault();
+  void fetch("${ANALYTICS_COLLECTOR_URL}", {
+    method: "POST",
+    body: JSON.stringify({
+      event: "all_elements_clicked",
+      click_text: link.textContent.trim()
+    })
+  });
+});
+`;
+
+test.describe("Quick Services analytics", () => {
+  test.beforeEach(async ({ context, page }) => {
+    await context.addCookies([
+      {
+        name: LANGUAGE_PROMPT_DISMISSED_COOKIE,
+        value: "true",
+        url: "http://127.0.0.1:3100",
+      },
+    ]);
+
+    await page.route(`${GTM_SCRIPT_URL}*`, async (route) => {
+      await route.fulfill({
+        body: mockGtmContainer,
+        contentType: "application/javascript",
+      });
+    });
+  });
+
+  test("sends only the service title when its description area is clicked", async ({ page }) => {
+    const [quickService] = getApplicationMessages({ locale: "en-US" }).landing.quickServices.items;
+    const analyticsEvents: AnalyticsEvent[] = [];
+
+    await page.route(ANALYTICS_COLLECTOR_URL, async (route) => {
+      const payload = route.request().postData();
+
+      if (!payload) {
+        throw new Error("Expected the mocked GTM container to send an analytics payload.");
+      }
+
+      analyticsEvents.push(JSON.parse(payload) as AnalyticsEvent);
+      await route.fulfill({ status: 204 });
+    });
+
+    await page.goto("/");
+
+    const link = page.getByRole("link", { name: quickService.title });
+    const card = page.locator(".quick-service-card").filter({ has: link });
+    const description = card.getByText(quickService.description, { exact: true });
+
+    const [cardBox, descriptionBox] = await Promise.all([
+      card.boundingBox(),
+      description.boundingBox(),
+    ]);
+
+    if (!cardBox || !descriptionBox) {
+      throw new Error("Expected the Quick Services card and description to have visible bounds.");
+    }
+
+    await card.click({
+      position: {
+        x: descriptionBox.x - cardBox.x + descriptionBox.width / 2,
+        y: descriptionBox.y - cardBox.y + descriptionBox.height / 2,
+      },
+    });
+
+    await expect
+      .poll(() => analyticsEvents)
+      .toEqual([
+        {
+          event: "all_elements_clicked",
+          click_text: quickService.title,
+        },
+      ]);
+  });
+});


### PR DESCRIPTION
## Description

Adds a Playwright end-to-end test covering the Quick Services card analytics behavior on the static site homepage, so the GA4 `click_text` fix has browser-level regression coverage in addition to the existing component test.

### Ticket

This pull request continues work on [#17944](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17944).

### Approach

- Adds `packages/static-site/tests/e2e/quickServicesAnalytics.e2e.spec.ts`.

- Stubs the GTM container request rather than loading the real production container, which is mutable and would make the test flaky and network dependent.

- The stub reproduces only the relevant click handler: it matches `a.quick-service-card__link`, reads the link's DOM text, and posts an `all_elements_clicked` payload to a test-only collector URL that the test intercepts.

- Calls `preventDefault()` in the stub so the internal link does not navigate away before the assertion can observe the request.

- Clicks the card at the computed center of the description paragraph, the area that previously contributed the extra `click_text` value, and asserts exactly one event with `click_text` equal to the service title.

- Presets the language prompt dismissal cookie so the preferred-language modal does not intercept the click.

- Reads the expected title and description from `getApplicationMessages` instead of hardcoding copy, per the static site testing rules.

No production code, dependencies, or configuration changed.

### Steps to Test

1. From `packages/static-site`, run `pnpm test:e2e`.

2. Confirm the "Quick Services analytics" spec passes.

3. Optionally run `pnpm test:e2e -- quickServicesAnalytics` to run only this spec.

4. To confirm the test is meaningful, temporarily revert `components/landing/QuickServicesSection.tsx` so the link wraps both the title and the description, and confirm the spec fails because `click_text` then includes the description.

### Notes

Ran `pnpm test:e2e` from `packages/static-site` in this session. The new spec and the full 18-test suite (6 skipped by design) passed.

The e2e suite is not part of `static-site-ci.yml`, which runs `lint`, `typecheck`, `test`, and `build`. This spec runs locally with `pnpm test:e2e`.

The mocked GTM container intentionally mirrors only the click-to-`click_text` behavior. It is not a fixture of the real container, so tag configuration changes in GTM are still out of scope for this test.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews