### PR TITLE
fix: [AB#17953] hide search links in account nav bar

### DIFF
--- a/web/src/components/navbar/desktop/NavBarDesktop.test.tsx
+++ b/web/src/components/navbar/desktop/NavBarDesktop.test.tsx
@@ -47,7 +47,6 @@ describe("<NavBarDesktop />", () => {
     expect(screen.getByText(Config.navigationQuickLinks.navBarOperateText)).toBeInTheDocument();
     expect(screen.getByText(Config.navigationQuickLinks.navBarGrowText)).toBeInTheDocument();
     expect(screen.getByText(Config.navigationQuickLinks.navBarUpdatesText)).toBeInTheDocument();
-    expect(screen.getByTestId("navbar-search-icon")).toBeInTheDocument();
   };
 
   const quickLinksDoNotExist = (): void => {

--- a/web/src/components/navbar/desktop/NavBarDesktopQuickLinks.test.tsx
+++ b/web/src/components/navbar/desktop/NavBarDesktopQuickLinks.test.tsx
@@ -18,7 +18,11 @@ describe("<NavBarDesktopQuickLinks />", () => {
     expect(screen.getByText(Config.navigationQuickLinks.navBarOperateText)).toBeInTheDocument();
     expect(screen.getByText(Config.navigationQuickLinks.navBarGrowText)).toBeInTheDocument();
     expect(screen.getByText(Config.navigationQuickLinks.navBarUpdatesText)).toBeInTheDocument();
-    expect(screen.getByTestId("navbar-search-icon")).toBeInTheDocument();
+  });
+
+  it("does not render the search icon while search is hidden", () => {
+    render(<NavBarDesktopQuickLinks />);
+    expect(screen.queryByTestId("navbar-search-icon")).not.toBeInTheDocument();
   });
 
   it("renders the plan quick link and redirects correctly", async () => {
@@ -60,17 +64,6 @@ describe("<NavBarDesktopQuickLinks />", () => {
 
     expect(window.open).toHaveBeenCalledWith(
       Config.navigationQuickLinks.navBarUpdatesLink,
-      "_blank",
-      "noopener noreferrer",
-    );
-  });
-
-  it("renders the search quick link and redirects correctly", async () => {
-    render(<NavBarDesktopQuickLinks />);
-    fireEvent.click(screen.getByTestId("navbar-search-icon"));
-
-    expect(window.open).toHaveBeenCalledWith(
-      Config.navigationQuickLinks.navBarSearchLink,
       "_blank",
       "noopener noreferrer",
     );

--- a/web/src/components/navbar/desktop/NavBarDesktopQuickLinks.tsx
+++ b/web/src/components/navbar/desktop/NavBarDesktopQuickLinks.tsx
@@ -8,6 +8,9 @@ export const NavBarDesktopQuickLinks = (): ReactElement => {
   const { Config } = useConfig();
 
   const sharedMargins = "margin-right-3";
+  // Since migrating the static site off of Webflow,
+  // search is deprecated until we implement a fresh solution.
+  const SHOW_SEARCH = false;
 
   return (
     <div className={"display-flex flex-row flex-align-center"}>
@@ -51,15 +54,17 @@ export const NavBarDesktopQuickLinks = (): ReactElement => {
         </UnStyledButton>
       </div>
 
-      <div className={`${sharedMargins} nav-bar-icon-search-outline`}>
-        <UnStyledButton
-          onClick={(): void => openInNewTab(Config.navigationQuickLinks.navBarSearchLink)}
-          dataTestid={"navbar-search-icon"}
-          ariaLabel={"search-icon"}
-        >
-          <Icon iconName="search" />
-        </UnStyledButton>
-      </div>
+      {SHOW_SEARCH && (
+        <div className={`${sharedMargins} nav-bar-icon-search-outline`}>
+          <UnStyledButton
+            onClick={(): void => openInNewTab(Config.navigationQuickLinks.navBarSearchLink)}
+            dataTestid={"navbar-search-icon"}
+            ariaLabel={"search-icon"}
+          >
+            <Icon iconName="search" />
+          </UnStyledButton>
+        </div>
+      )}
     </div>
   );
 };

--- a/web/src/components/navbar/mobile/NavBarMobileQuickLinksSlideOutMenu.test.tsx
+++ b/web/src/components/navbar/mobile/NavBarMobileQuickLinksSlideOutMenu.test.tsx
@@ -42,9 +42,6 @@ describe("<NavBarMobileQuickLinksSlideOutMenu />", () => {
   it("opens when the icon is clicked", async () => {
     render(<NavBarMobileQuickLinksSlideOutMenu />);
 
-    expect(
-      screen.queryByText(Config.navigationQuickLinks.navBarSearchText),
-    ).not.toBeInTheDocument();
     expect(screen.queryByText(Config.navigationQuickLinks.navBarPlanText)).not.toBeInTheDocument();
     expect(screen.queryByText(Config.navigationQuickLinks.navBarStartText)).not.toBeInTheDocument();
     expect(
@@ -59,12 +56,14 @@ describe("<NavBarMobileQuickLinksSlideOutMenu />", () => {
     expect(openMenuIcon).toBeInTheDocument();
     fireEvent.click(openMenuIcon);
 
-    expect(screen.getByText(Config.navigationQuickLinks.navBarSearchText)).toBeInTheDocument();
     expect(screen.getByText(Config.navigationQuickLinks.navBarPlanText)).toBeInTheDocument();
     expect(screen.getByText(Config.navigationQuickLinks.navBarStartText)).toBeInTheDocument();
     expect(screen.getByText(Config.navigationQuickLinks.navBarOperateText)).toBeInTheDocument();
     expect(screen.getByText(Config.navigationQuickLinks.navBarGrowText)).toBeInTheDocument();
     expect(screen.getByText(Config.navigationQuickLinks.navBarUpdatesText)).toBeInTheDocument();
+    expect(
+      screen.queryByText(Config.navigationQuickLinks.navBarSearchText),
+    ).not.toBeInTheDocument();
 
     await waitFor(() => {
       expect(
@@ -80,7 +79,6 @@ describe("<NavBarMobileQuickLinksSlideOutMenu />", () => {
     expect(openMenuIcon).toBeInTheDocument();
     fireEvent.click(openMenuIcon);
 
-    expect(screen.getByText(Config.navigationQuickLinks.navBarSearchText)).toBeInTheDocument();
     expect(screen.getByText(Config.navigationQuickLinks.navBarPlanText)).toBeInTheDocument();
     expect(screen.getByText(Config.navigationQuickLinks.navBarStartText)).toBeInTheDocument();
     expect(screen.getByText(Config.navigationQuickLinks.navBarOperateText)).toBeInTheDocument();
@@ -93,11 +91,9 @@ describe("<NavBarMobileQuickLinksSlideOutMenu />", () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByText(Config.navigationQuickLinks.navBarSearchText),
+        screen.queryByText(Config.navigationQuickLinks.navBarPlanText),
       ).not.toBeInTheDocument();
     });
-
-    expect(screen.queryByText(Config.navigationQuickLinks.navBarPlanText)).not.toBeInTheDocument();
     expect(screen.queryByText(Config.navigationQuickLinks.navBarStartText)).not.toBeInTheDocument();
     expect(
       screen.queryByText(Config.navigationQuickLinks.navBarOperateText),
@@ -121,7 +117,6 @@ describe("<NavBarMobileQuickLinksSlideOutMenu />", () => {
     expect(openMenuIcon).toBeInTheDocument();
     fireEvent.click(openMenuIcon);
 
-    expect(screen.getByText(Config.navigationQuickLinks.navBarSearchText)).toBeInTheDocument();
     expect(screen.getByText(Config.navigationQuickLinks.navBarPlanText)).toBeInTheDocument();
     expect(screen.getByText(Config.navigationQuickLinks.navBarStartText)).toBeInTheDocument();
     expect(screen.getByText(Config.navigationQuickLinks.navBarOperateText)).toBeInTheDocument();
@@ -134,11 +129,9 @@ describe("<NavBarMobileQuickLinksSlideOutMenu />", () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByText(Config.navigationQuickLinks.navBarSearchText),
+        screen.queryByText(Config.navigationQuickLinks.navBarPlanText),
       ).not.toBeInTheDocument();
     });
-
-    expect(screen.queryByText(Config.navigationQuickLinks.navBarPlanText)).not.toBeInTheDocument();
     expect(screen.queryByText(Config.navigationQuickLinks.navBarStartText)).not.toBeInTheDocument();
     expect(
       screen.queryByText(Config.navigationQuickLinks.navBarOperateText),
@@ -202,19 +195,6 @@ describe("<NavBarMobileQuickLinksSlideOutMenu />", () => {
 
     expect(window.open).toHaveBeenCalledWith(
       Config.navigationQuickLinks.navBarUpdatesLink,
-      "_blank",
-      "noopener noreferrer",
-    );
-  });
-
-  it("renders the search quick link redirects", async () => {
-    render(<NavBarMobileQuickLinksSlideOutMenu />);
-    const openMenuIcon = screen.getByTestId("nav-menu-mobile-quick-link-open");
-    fireEvent.click(openMenuIcon);
-    fireEvent.click(screen.getByText(Config.navigationQuickLinks.navBarSearchText));
-
-    expect(window.open).toHaveBeenCalledWith(
-      Config.navigationQuickLinks.navBarSearchLink,
       "_blank",
       "noopener noreferrer",
     );

--- a/web/src/components/navbar/mobile/NavBarMobileQuickLinksSlideOutMenu.tsx
+++ b/web/src/components/navbar/mobile/NavBarMobileQuickLinksSlideOutMenu.tsx
@@ -27,6 +27,10 @@ export const NavBarMobileQuickLinksSlideOutMenu = (): ReactElement => {
 
   const { Config } = useConfig();
 
+  // Since migrating the static site off of Webflow,
+  // search is deprecated until we implement a fresh solution.
+  const SHOW_SEARCH = false;
+
   return (
     <>
       <button
@@ -74,8 +78,12 @@ export const NavBarMobileQuickLinksSlideOutMenu = (): ReactElement => {
               <Icon className="font-sans-xl" iconName="close" />
             </button>
 
-            <Search />
-            <hr className="margin-0 margin-x-3 hr-2px" key="middle-break" />
+            {SHOW_SEARCH && (
+              <>
+                <Search />
+                <hr className="margin-0 margin-x-3 hr-2px" key="middle-break" />
+              </>
+            )}
             <Plan />
             <Start />
             <Operate />


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

Adds conditional flags to disable the links to search. This was a Webflow-powered feature that will stay hidden until we decide to reimplement search on the new static site

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to the URL for the board that owns it.
     Board routing is not a clean cutover; run `python3 scripts/fetch_ado_ticket.py <id>`
     or check scripts/ado-boards.json for the current cutover and exceptions list. -->

This pull request resolves [#17953](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17953).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->
Straightforward boolean flag + test cleanup

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->
- `yarn start:dev`
- check that the desktop nav no longer has the magnifying glass icon search link and the mobile sidebar nav doesn't have a "Search" link

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
