### PR TITLE
fix: [AB#17994] keep Decap dates as strings

### DIFF
--- a/.github/workflows/validate-content.yml
+++ b/.github/workflows/validate-content.yml
@@ -5,6 +5,26 @@ on:
     types: ["opened", "synchronize"]
 
 jobs:
+  validate-frontmatter-dates:
+    runs-on: ubuntu-latest
+    if: github.base_ref == 'content-repo'
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - name: Install Dependencies
+        run: yarn install --immutable --mode skip-build
+
+      - name: Check for unquoted dates in content frontmatter
+        run: yarn workspace @businessnjgovnavigator/content validate-frontmatter-dates
+
   spellcheck:
     runs-on: ubuntu-latest
     if: github.base_ref == 'content-repo'

--- a/content/build.ts
+++ b/content/build.ts
@@ -859,9 +859,9 @@ export const main = (): void => {
   // Create configuration
   const config = createBuildConfig();
 
-  // Fail fast if any Markdown frontmatter has an unquoted date that YAML
-  // resolved to a native Date (see AB#17994), rather than letting it
-  // surface much later as a downstream serialization failure.
+  // Fail fast on frontmatter that YAML resolved to a native Date instead
+  // of a string, rather than letting it surface later as a serialization
+  // failure downstream.
   validateNoDateObjectsInFrontmatter(path.join(config.rootDir, "src"));
 
   // Execute build (content parsing handled by shared loaders)

--- a/content/build.ts
+++ b/content/build.ts
@@ -43,6 +43,7 @@ import {
 import { LookupTaskAgencyById } from "@businessnjgovnavigator/shared/taskAgency";
 import { loadAllTasks } from "@businessnjgovnavigator/shared/static/loadTasks";
 import type { License } from "@businessnjgovnavigator/content-types";
+import { validateNoDateObjectsInFrontmatter } from "./validateFrontmatterDates";
 
 // ============================================================================
 // DOMAIN TYPES
@@ -857,6 +858,11 @@ export const main = (): void => {
 
   // Create configuration
   const config = createBuildConfig();
+
+  // Fail fast if any Markdown frontmatter has an unquoted date that YAML
+  // resolved to a native Date (see AB#17994), rather than letting it
+  // surface much later as a downstream serialization failure.
+  validateNoDateObjectsInFrontmatter(path.join(config.rootDir, "src"));
 
   // Execute build (content parsing handled by shared loaders)
   const result = executeBuild(fileSystem, config);

--- a/content/package.json
+++ b/content/package.json
@@ -10,6 +10,7 @@
     "clean": "rimraf lib",
     "dev": "yarn build",
     "test": "vitest run",
+    "validate-frontmatter-dates": "tsx -r tsconfig-paths/register ./validateFrontmatterDates.ts",
     "prettier": "prettier --write . --ignore-path=../.eslintignore",
     "prettier:check": "prettier . --check --ignore-path=../.eslintignore",
     "spellcheck": "cspell '**/*.md' '**/*.json' '*.ts' '!*.test.ts' --config ../cspell.json --no-progress"

--- a/content/validateFrontmatterDates.test.ts
+++ b/content/validateFrontmatterDates.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  createMarkdownFileSystemPort,
+  findDatePaths,
+  formatFrontmatterDateViolationsMessage,
+  type MarkdownFileSystemPort,
+  validateNoDateObjectsInFrontmatter,
+} from "./validateFrontmatterDates";
+
+const createMockFileSystem = (files: Record<string, string>): MarkdownFileSystemPort => ({
+  listMarkdownFiles: () => Object.keys(files),
+  readFile: (filePath: string) => files[filePath],
+});
+
+describe("findDatePaths", () => {
+  it("returns an empty array for primitives and strings", () => {
+    expect(findDatePaths("2025-09-03")).toEqual([]);
+    expect(findDatePaths(5)).toEqual([]);
+    expect(findDatePaths(true)).toEqual([]);
+    expect(findDatePaths(null)).toEqual([]);
+    expect(findDatePaths(undefined)).toEqual([]);
+  });
+
+  it("finds a Date at the root", () => {
+    expect(findDatePaths(new Date("2025-09-03"))).toEqual(["(root)"]);
+  });
+
+  it("finds a Date on a top-level object property", () => {
+    expect(findDatePaths({ name: "Test", date: new Date("2025-09-03") })).toEqual(["date"]);
+  });
+
+  it("finds a Date nested inside an object", () => {
+    expect(findDatePaths({ meta: { date: new Date("2025-09-03") } })).toEqual(["meta.date"]);
+  });
+
+  it("finds a Date nested inside an array, with an index in the path", () => {
+    expect(findDatePaths({ recents: [{ date: new Date("2025-09-03") }] })).toEqual([
+      "recents[0].date",
+    ]);
+  });
+
+  it("finds multiple Date values across a structure", () => {
+    expect(
+      findDatePaths({
+        date: new Date("2025-09-03"),
+        items: [{ openDate: new Date("2025-01-01") }, { name: "no date here" }],
+      }),
+    ).toEqual(["date", "items[0].openDate"]);
+  });
+
+  it("does not flag a quoted date string", () => {
+    expect(findDatePaths({ date: "2025-09-03" })).toEqual([]);
+  });
+});
+
+describe("validateNoDateObjectsInFrontmatter", () => {
+  it("does not throw when every file's frontmatter is Date-free", () => {
+    const fileSystem = createMockFileSystem({
+      "/content/src/recents/a.md": '---\nname: A\ndate: "2025-09-03"\n---\nBody.',
+      "/content/src/recents/b.md": "---\nname: B\n---\nBody.",
+    });
+
+    expect(() => validateNoDateObjectsInFrontmatter("/content/src", fileSystem)).not.toThrow();
+  });
+
+  it("throws with the file path and key path when a date is unquoted", () => {
+    const fileSystem = createMockFileSystem({
+      "/content/src/recents/a.md": '---\nname: A\ndate: "2025-09-03"\n---\nBody.',
+      "/content/src/recents/b.md": "---\nname: B\ndate: 2025-09-03\n---\nBody.",
+    });
+
+    expect(() => validateNoDateObjectsInFrontmatter("/content/src", fileSystem)).toThrowError(
+      /\/content\/src\/recents\/b\.md: date/,
+    );
+  });
+
+  it("aggregates every violation across every file into a single error", () => {
+    const fileSystem = createMockFileSystem({
+      "/content/src/recents/a.md": "---\nname: A\ndate: 2025-09-03\n---\nBody.",
+      "/content/src/recents/b.md": "---\nname: B\ndate: 2025-12-17\n---\nBody.",
+    });
+
+    try {
+      validateNoDateObjectsInFrontmatter("/content/src", fileSystem);
+      throw new Error("expected validateNoDateObjectsInFrontmatter to throw");
+    } catch (error) {
+      const message = (error as Error).message;
+      expect(message).toContain("/content/src/recents/a.md: date");
+      expect(message).toContain("/content/src/recents/b.md: date");
+      expect(message).toContain("Found 2 unquoted date-like value(s)");
+    }
+  });
+});
+
+describe("formatFrontmatterDateViolationsMessage", () => {
+  it("includes guidance to quote the value", () => {
+    const message = formatFrontmatterDateViolationsMessage([
+      { filePath: "/content/src/recents/a.md", keyPath: "date" },
+    ]);
+
+    expect(message).toContain('date: "2025-09-03"');
+    expect(message).toContain("/content/src/recents/a.md: date");
+  });
+});
+
+describe("createMarkdownFileSystemPort", () => {
+  it("finds Markdown files recursively and can read their contents", () => {
+    const fileSystem = createMarkdownFileSystemPort();
+
+    const files = fileSystem.listMarkdownFiles(`${__dirname}/src/recents`);
+
+    expect(files.length).toBeGreaterThan(0);
+    expect(files.every((filePath) => filePath.endsWith(".md"))).toBe(true);
+    expect(fileSystem.readFile(files[0])).toContain("---");
+  });
+
+  it("returns an empty array for a directory that doesn't exist", () => {
+    const fileSystem = createMarkdownFileSystemPort();
+
+    expect(fileSystem.listMarkdownFiles(`${__dirname}/src/does-not-exist`)).toEqual([]);
+  });
+});

--- a/content/validateFrontmatterDates.ts
+++ b/content/validateFrontmatterDates.ts
@@ -1,22 +1,6 @@
-/**
- * Frontmatter Date Validation
- *
- * Guards against a specific YAML pitfall: an unquoted ISO date in Markdown
- * frontmatter (e.g. `date: 2025-09-03`) parses to a native JS `Date` via
- * gray-matter/js-yaml, even though every content type in this repo declares
- * its date fields as `string`. A `Date` there silently breaks downstream
- * consumers that expect JSON-serializable data, most visibly Next.js's
- * `getStaticProps`, which fails the whole static export (see AB#17994,
- * caused by Decap CMS writing an unquoted date for a Recents entry).
- *
- * This module scans every Markdown file's frontmatter and fails loudly,
- * with the offending file and key path, instead of only surfacing the
- * problem much later at build/export time.
- */
-
 import fs from "node:fs";
 import path from "node:path";
-import matter from "gray-matter";
+import { getMarkdown } from "@businessnjgovnavigator/shared/markdownReader";
 
 export interface FrontmatterDateViolation {
   filePath: string;
@@ -24,8 +8,8 @@ export interface FrontmatterDateViolation {
 }
 
 /**
- * Recursively finds native `Date` instances anywhere inside a parsed
- * frontmatter value (including nested objects and arrays), returning a
+ * Recursively finds native `Date` instances inside a parsed frontmatter
+ * value (including nested objects and arrays), returning a
  * dotted/bracketed key path for each one found.
  */
 export const findDatePaths = (value: unknown, keyPath = ""): string[] => {
@@ -49,6 +33,9 @@ export interface MarkdownFileSystemPort {
   readFile: (filePath: string) => string;
 }
 
+// No existing loader enumerates every content/src subdirectory (each one
+// only knows its own content type), so this walks the filesystem directly
+// to guarantee full coverage.
 const listMarkdownFilesRecursively = (rootDir: string): string[] => {
   if (!fs.existsSync(rootDir)) return [];
 
@@ -88,11 +75,6 @@ export const formatFrontmatterDateViolationsMessage = (
   ].join("\n");
 };
 
-/**
- * Validates that no Markdown frontmatter file under `rootDir` contains a
- * native `Date` value. Throws a single aggregated error listing every
- * offending file and key path when violations are found.
- */
 export const validateNoDateObjectsInFrontmatter = (
   rootDir: string,
   fileSystem: MarkdownFileSystemPort = createMarkdownFileSystemPort(),
@@ -100,8 +82,8 @@ export const validateNoDateObjectsInFrontmatter = (
   const violations: FrontmatterDateViolation[] = [];
 
   for (const filePath of fileSystem.listMarkdownFiles(rootDir)) {
-    const { data } = matter(fileSystem.readFile(filePath));
-    for (const keyPath of findDatePaths(data)) {
+    const { grayMatter } = getMarkdown(fileSystem.readFile(filePath));
+    for (const keyPath of findDatePaths(grayMatter)) {
       violations.push({ filePath, keyPath });
     }
   }
@@ -111,8 +93,6 @@ export const validateNoDateObjectsInFrontmatter = (
   throw new Error(formatFrontmatterDateViolationsMessage(violations));
 };
 
-// Run as a standalone check (e.g. `yarn workspace @businessnjgovnavigator/content validate-frontmatter-dates`)
-// when invoked directly, rather than only via the full content build.
 /* istanbul ignore next */
 if (import.meta.url === `file://${process.argv[1]}`) {
   validateNoDateObjectsInFrontmatter(path.join(__dirname, "src"));

--- a/content/validateFrontmatterDates.ts
+++ b/content/validateFrontmatterDates.ts
@@ -1,0 +1,120 @@
+/**
+ * Frontmatter Date Validation
+ *
+ * Guards against a specific YAML pitfall: an unquoted ISO date in Markdown
+ * frontmatter (e.g. `date: 2025-09-03`) parses to a native JS `Date` via
+ * gray-matter/js-yaml, even though every content type in this repo declares
+ * its date fields as `string`. A `Date` there silently breaks downstream
+ * consumers that expect JSON-serializable data, most visibly Next.js's
+ * `getStaticProps`, which fails the whole static export (see AB#17994,
+ * caused by Decap CMS writing an unquoted date for a Recents entry).
+ *
+ * This module scans every Markdown file's frontmatter and fails loudly,
+ * with the offending file and key path, instead of only surfacing the
+ * problem much later at build/export time.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import matter from "gray-matter";
+
+export interface FrontmatterDateViolation {
+  filePath: string;
+  keyPath: string;
+}
+
+/**
+ * Recursively finds native `Date` instances anywhere inside a parsed
+ * frontmatter value (including nested objects and arrays), returning a
+ * dotted/bracketed key path for each one found.
+ */
+export const findDatePaths = (value: unknown, keyPath = ""): string[] => {
+  if (value instanceof Date) {
+    return [keyPath || "(root)"];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) => findDatePaths(item, `${keyPath}[${index}]`));
+  }
+  if (value && typeof value === "object") {
+    return Object.entries(value).flatMap(([key, nested]) =>
+      findDatePaths(nested, keyPath ? `${keyPath}.${key}` : key),
+    );
+  }
+  return [];
+};
+
+export interface MarkdownFileSystemPort {
+  /** Returns the absolute paths of every `.md` file under `rootDir`. */
+  listMarkdownFiles: (rootDir: string) => string[];
+  readFile: (filePath: string) => string;
+}
+
+const listMarkdownFilesRecursively = (rootDir: string): string[] => {
+  if (!fs.existsSync(rootDir)) return [];
+
+  const results: string[] = [];
+  const directoriesToVisit = [rootDir];
+
+  while (directoriesToVisit.length > 0) {
+    const currentDir = directoriesToVisit.pop() as string;
+    for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+      const entryPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        directoriesToVisit.push(entryPath);
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        results.push(entryPath);
+      }
+    }
+  }
+
+  return results;
+};
+
+export const createMarkdownFileSystemPort = (): MarkdownFileSystemPort => ({
+  listMarkdownFiles: listMarkdownFilesRecursively,
+  readFile: (filePath: string): string => fs.readFileSync(filePath, "utf8"),
+});
+
+export const formatFrontmatterDateViolationsMessage = (
+  violations: FrontmatterDateViolation[],
+): string => {
+  return [
+    `Found ${violations.length} unquoted date-like value(s) in content frontmatter.`,
+    "YAML resolves an unquoted date (e.g. `date: 2025-09-03`) to a native Date object, " +
+      "but every content type here declares date fields as `string`. Quote the value " +
+      'instead (e.g. `date: "2025-09-03"`).',
+    "",
+    ...violations.map((violation) => `  ${violation.filePath}: ${violation.keyPath}`),
+  ].join("\n");
+};
+
+/**
+ * Validates that no Markdown frontmatter file under `rootDir` contains a
+ * native `Date` value. Throws a single aggregated error listing every
+ * offending file and key path when violations are found.
+ */
+export const validateNoDateObjectsInFrontmatter = (
+  rootDir: string,
+  fileSystem: MarkdownFileSystemPort = createMarkdownFileSystemPort(),
+): void => {
+  const violations: FrontmatterDateViolation[] = [];
+
+  for (const filePath of fileSystem.listMarkdownFiles(rootDir)) {
+    const { data } = matter(fileSystem.readFile(filePath));
+    for (const keyPath of findDatePaths(data)) {
+      violations.push({ filePath, keyPath });
+    }
+  }
+
+  if (violations.length === 0) return;
+
+  throw new Error(formatFrontmatterDateViolationsMessage(violations));
+};
+
+// Run as a standalone check (e.g. `yarn workspace @businessnjgovnavigator/content validate-frontmatter-dates`)
+// when invoked directly, rather than only via the full content build.
+/* istanbul ignore next */
+if (import.meta.url === `file://${process.argv[1]}`) {
+  validateNoDateObjectsInFrontmatter(path.join(__dirname, "src"));
+  console.log("✓ No unquoted dates found in content frontmatter");
+}

--- a/web/decap-config/collections/15-static-site-content.yml
+++ b/web/decap-config/collections/15-static-site-content.yml
@@ -98,6 +98,7 @@ collections:
   - name: "recents"
     label: "Recents"
     folder: "content/src/recents"
+    format: "recents-frontmatter"
     summary: "{{name}}"
     identifier_field: "slug"
     slug: "{{slug}}"

--- a/web/src/lib/cms/formatters/recentsFrontmatterFormat.test.ts
+++ b/web/src/lib/cms/formatters/recentsFrontmatterFormat.test.ts
@@ -1,0 +1,130 @@
+import matter from "gray-matter";
+import {
+  orderKeysBySortedKeys,
+  recentsFrontmatterFormat,
+} from "@/lib/cms/formatters/recentsFrontmatterFormat";
+
+describe("recentsFrontmatterFormat", () => {
+  describe("toFile", () => {
+    it("quotes a date-like string so it round-trips as a string, not a Date", () => {
+      const file = recentsFrontmatterFormat.toFile({
+        name: "Test Recent",
+        slug: "test-recent",
+        date: "2025-09-03",
+      });
+
+      // js-yaml quotes the value (style may be single or double) precisely
+      // because it would otherwise resolve to a timestamp; that quoting is
+      // the fix for AB#17994.
+      expect(file).toMatch(/date: ["']2025-09-03["']/);
+
+      // Read the output back with the exact parser the site's build-time
+      // content loader uses (`loadAllRecents`), to guard against the bug
+      // this formatter exists to prevent.
+      const { data } = matter(file);
+      expect(typeof data.date).toBe("string");
+      expect(data.date).not.toBeInstanceOf(Date);
+      expect(data.date).toEqual("2025-09-03");
+    });
+
+    it("preserves the Markdown body", () => {
+      const file = recentsFrontmatterFormat.toFile({
+        name: "Test Recent",
+        slug: "test-recent",
+        body: "Some article body text.",
+      });
+
+      const { content } = matter(file);
+      expect(content.trim()).toEqual("Some article body text.");
+    });
+
+    it("does not wrap long values onto a YAML block scalar", () => {
+      const longUrl =
+        "https://www.njeda.gov/some-really-long-url-path-that-would-normally-wrap-in-yaml-output-if-not-configured/";
+
+      const file = recentsFrontmatterFormat.toFile({
+        name: "Test Recent",
+        slug: "test-recent",
+        source: longUrl,
+      });
+
+      const { data } = matter(file);
+      expect(data.source).toEqual(longUrl);
+      // Without `lineWidth: -1`, js-yaml folds long scalars onto a `>-`
+      // block instead of keeping them on the `key: value` line.
+      expect(file).not.toContain(">-");
+      expect(file).toContain(`source: '${longUrl}'`);
+    });
+
+    it("orders frontmatter keys by sortedKeys, leaving unlisted keys in their original position", () => {
+      const file = recentsFrontmatterFormat.toFile(
+        {
+          webflowId: "abc123",
+          name: "Test Recent",
+          date: "2025-09-03",
+          slug: "test-recent",
+        },
+        ["name", "slug", "date"],
+      );
+
+      const { data } = matter(file);
+      // webflowId isn't in sortedKeys, so it stays in its original (first)
+      // position; name/date/slug are reordered relative to each other to
+      // match sortedKeys.
+      expect(Object.keys(data)).toEqual(["webflowId", "name", "slug", "date"]);
+    });
+
+    it("round-trips fromFile -> toFile -> fromFile without accumulating blank lines", () => {
+      const original = [
+        "---",
+        "name: Test Recent",
+        "slug: test-recent",
+        "---",
+        "",
+        "Body content.",
+        "",
+      ].join("\n");
+
+      const parsed = recentsFrontmatterFormat.fromFile(original) as Record<string, unknown>;
+      const written = recentsFrontmatterFormat.toFile(parsed);
+      expect(written).toEqual(original);
+
+      const parsedAgain = recentsFrontmatterFormat.fromFile(written);
+      expect(parsedAgain).toEqual(parsed);
+    });
+  });
+
+  describe("fromFile", () => {
+    it("parses a quoted date as a string", () => {
+      const content = ["---", "name: Test Recent", 'date: "2025-09-03"', "---", ""].join("\n");
+
+      const data = recentsFrontmatterFormat.fromFile(content) as { date: unknown };
+      expect(typeof data.date).toBe("string");
+      expect(data.date).toEqual("2025-09-03");
+    });
+
+    it("includes the Markdown body under `body`", () => {
+      const content = ["---", "name: Test Recent", "---", "", "Body content.", ""].join("\n");
+
+      const data = recentsFrontmatterFormat.fromFile(content) as { body: string };
+      expect(data.body.trim()).toEqual("Body content.");
+    });
+
+    it("omits `body` when the file has no content after the frontmatter", () => {
+      const content = ["---", "name: Test Recent", "---", ""].join("\n");
+
+      const data = recentsFrontmatterFormat.fromFile(content) as Record<string, unknown>;
+      expect("body" in data).toBe(false);
+    });
+  });
+});
+
+describe("orderKeysBySortedKeys", () => {
+  it("orders listed keys according to sortedKeys", () => {
+    expect(orderKeysBySortedKeys(["b", "a", "c"], ["a", "b", "c"])).toEqual(["a", "b", "c"]);
+  });
+
+  it("leaves keys not present in sortedKeys in their original relative position", () => {
+    expect(orderKeysBySortedKeys(["z", "a", "y", "b"], ["a", "b"])).toEqual(["z", "a", "y", "b"]);
+  });
+});

--- a/web/src/lib/cms/formatters/recentsFrontmatterFormat.test.ts
+++ b/web/src/lib/cms/formatters/recentsFrontmatterFormat.test.ts
@@ -13,14 +13,11 @@ describe("recentsFrontmatterFormat", () => {
         date: "2025-09-03",
       });
 
-      // js-yaml quotes the value (style may be single or double) precisely
-      // because it would otherwise resolve to a timestamp; that quoting is
-      // the fix for AB#17994.
+      // js-yaml quotes the value (style may be single or double) because
+      // it would otherwise resolve to a timestamp.
       expect(file).toMatch(/date: ["']2025-09-03["']/);
 
-      // Read the output back with the exact parser the site's build-time
-      // content loader uses (`loadAllRecents`), to guard against the bug
-      // this formatter exists to prevent.
+      // Read it back with the same parser the build-time content loader uses.
       const { data } = matter(file);
       expect(typeof data.date).toBe("string");
       expect(data.date).not.toBeInstanceOf(Date);

--- a/web/src/lib/cms/formatters/recentsFrontmatterFormat.ts
+++ b/web/src/lib/cms/formatters/recentsFrontmatterFormat.ts
@@ -1,0 +1,83 @@
+import matter from "gray-matter";
+
+/**
+ * Custom Decap frontmatter formatter for the Recents collection (AB#17994).
+ *
+ * Decap's built-in Markdown frontmatter formatter serializes with the `yaml`
+ * npm package, whose default schema does not treat a bare `YYYY-MM-DD`
+ * scalar as a timestamp, so it writes `date: 2025-09-03` unquoted. The
+ * site's build-time content loader (`loadAllRecents`) parses that same file
+ * with `gray-matter` (js-yaml), whose schema DOES resolve an unquoted
+ * `YYYY-MM-DD` scalar to a native `Date`. `RecentItem.date` is typed as
+ * `string`, and a `Date` there fails Next.js's `getStaticProps`
+ * serialization for `/mgmt/search`, breaking the whole build.
+ *
+ * Using `gray-matter` here too, instead of Decap's default formatter, keeps
+ * Decap's read/write behavior consistent with the loader that will parse the
+ * file at build time: `gray-matter`'s own YAML engine already quotes any
+ * scalar that would otherwise round-trip as a different type, including
+ * date-like strings, so this collection can no longer produce the
+ * unquoted shape that broke the build.
+ */
+
+interface FrontmatterEntryData {
+  body?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * gray-matter forwards options it doesn't recognize straight through to its
+ * underlying js-yaml engine (see gray-matter's own `stringify`
+ * implementation), but its published types constrain the options parameter
+ * to gray-matter's own option names, so a real js-yaml `DumpOptions` field
+ * like `lineWidth` doesn't type-check against it even though gray-matter
+ * passes it through correctly at runtime. Re-typing `stringify` here (once,
+ * locally) documents that intentional pass-through instead of reaching for
+ * `any` at every call site.
+ */
+const stringifyFrontmatter = matter.stringify as (
+  file: string,
+  data: object,
+  options?: Record<string, unknown>,
+) => string;
+
+/**
+ * Orders `keys` by their position in `sortedKeys`, leaving any key not
+ * present in `sortedKeys` in its original relative position. Mirrors the
+ * comparator Decap's own YAML/TOML formatters use (decap-cms-core's
+ * `sortKeys` helper) so switching this collection to a custom formatter
+ * doesn't change the field order authors see when editing.
+ */
+export const orderKeysBySortedKeys = (keys: string[], sortedKeys: string[]): string[] => {
+  return [...keys].sort((a, b) => {
+    const indexOfA = sortedKeys.indexOf(a);
+    const indexOfB = sortedKeys.indexOf(b);
+    if (indexOfA === -1 || indexOfB === -1) return 0;
+    return indexOfA - indexOfB;
+  });
+};
+
+export const recentsFrontmatterFormat = {
+  fromFile(content: string): unknown {
+    const { data, content: body } = matter(content);
+    return {
+      ...data,
+      ...(body.trim() && { body }),
+    };
+  },
+  toFile(data: object, sortedKeys: string[] = []): string {
+    const { body = "", ...frontmatter } = data as FrontmatterEntryData;
+    const orderedFrontmatter: Record<string, unknown> = {};
+    for (const key of orderKeysBySortedKeys(Object.keys(frontmatter), sortedKeys)) {
+      orderedFrontmatter[key] = frontmatter[key];
+    }
+    // gray-matter always adds a trailing line break, which trips Decap's
+    // change-detection logic, so trim it back off when the source body
+    // lacked one. Mirrors decap-cms-core's own default frontmatter
+    // formatter (`FrontmatterFormatter.toFile`), which this replaces for
+    // this collection.
+    const trimLastLineBreak = body.slice(-1) !== "\n";
+    const file = stringifyFrontmatter(body, orderedFrontmatter, { lineWidth: -1 });
+    return trimLastLineBreak && file.slice(-1) === "\n" ? file.slice(0, -1) : file;
+  },
+};

--- a/web/src/lib/cms/formatters/recentsFrontmatterFormat.ts
+++ b/web/src/lib/cms/formatters/recentsFrontmatterFormat.ts
@@ -1,23 +1,13 @@
+import { getMarkdown } from "@businessnjgovnavigator/shared/markdownReader";
 import matter from "gray-matter";
 
 /**
- * Custom Decap frontmatter formatter for the Recents collection (AB#17994).
- *
- * Decap's built-in Markdown frontmatter formatter serializes with the `yaml`
- * npm package, whose default schema does not treat a bare `YYYY-MM-DD`
- * scalar as a timestamp, so it writes `date: 2025-09-03` unquoted. The
- * site's build-time content loader (`loadAllRecents`) parses that same file
- * with `gray-matter` (js-yaml), whose schema DOES resolve an unquoted
- * `YYYY-MM-DD` scalar to a native `Date`. `RecentItem.date` is typed as
- * `string`, and a `Date` there fails Next.js's `getStaticProps`
- * serialization for `/mgmt/search`, breaking the whole build.
- *
- * Using `gray-matter` here too, instead of Decap's default formatter, keeps
- * Decap's read/write behavior consistent with the loader that will parse the
- * file at build time: `gray-matter`'s own YAML engine already quotes any
- * scalar that would otherwise round-trip as a different type, including
- * date-like strings, so this collection can no longer produce the
- * unquoted shape that broke the build.
+ * Decap's default frontmatter formatter and the site's build-time content
+ * loader disagree on whether a bare `YYYY-MM-DD` scalar is a timestamp, so
+ * Decap can write an unquoted date that the loader then reads back as a
+ * `Date` instead of a `string`. Using `gray-matter` (the loader's own
+ * engine) here instead keeps the two in sync, so this collection can't
+ * produce that shape.
  */
 
 interface FrontmatterEntryData {
@@ -25,16 +15,10 @@ interface FrontmatterEntryData {
   [key: string]: unknown;
 }
 
-/**
- * gray-matter forwards options it doesn't recognize straight through to its
- * underlying js-yaml engine (see gray-matter's own `stringify`
- * implementation), but its published types constrain the options parameter
- * to gray-matter's own option names, so a real js-yaml `DumpOptions` field
- * like `lineWidth` doesn't type-check against it even though gray-matter
- * passes it through correctly at runtime. Re-typing `stringify` here (once,
- * locally) documents that intentional pass-through instead of reaching for
- * `any` at every call site.
- */
+// gray-matter passes unrecognized options straight through to js-yaml at
+// runtime, but its types don't include js-yaml's own option names (e.g.
+// `lineWidth`), so this re-types `stringify` once instead of casting at
+// every call site.
 const stringifyFrontmatter = matter.stringify as (
   file: string,
   data: object,
@@ -43,10 +27,9 @@ const stringifyFrontmatter = matter.stringify as (
 
 /**
  * Orders `keys` by their position in `sortedKeys`, leaving any key not
- * present in `sortedKeys` in its original relative position. Mirrors the
- * comparator Decap's own YAML/TOML formatters use (decap-cms-core's
- * `sortKeys` helper) so switching this collection to a custom formatter
- * doesn't change the field order authors see when editing.
+ * present in `sortedKeys` in its original relative position. Mirrors
+ * decap-cms-core's own `sortKeys` helper so this formatter doesn't change
+ * field order relative to Decap's built-in ones.
  */
 export const orderKeysBySortedKeys = (keys: string[], sortedKeys: string[]): string[] => {
   return [...keys].sort((a, b) => {
@@ -59,9 +42,9 @@ export const orderKeysBySortedKeys = (keys: string[], sortedKeys: string[]): str
 
 export const recentsFrontmatterFormat = {
   fromFile(content: string): unknown {
-    const { data, content: body } = matter(content);
+    const { content: body, grayMatter } = getMarkdown(content);
     return {
-      ...data,
+      ...(grayMatter as object),
       ...(body.trim() && { body }),
     };
   },
@@ -71,11 +54,9 @@ export const recentsFrontmatterFormat = {
     for (const key of orderKeysBySortedKeys(Object.keys(frontmatter), sortedKeys)) {
       orderedFrontmatter[key] = frontmatter[key];
     }
-    // gray-matter always adds a trailing line break, which trips Decap's
-    // change-detection logic, so trim it back off when the source body
-    // lacked one. Mirrors decap-cms-core's own default frontmatter
-    // formatter (`FrontmatterFormatter.toFile`), which this replaces for
-    // this collection.
+    // Mirrors decap-cms-core's own default formatter: gray-matter always
+    // appends a trailing newline, which would otherwise trip Decap's
+    // change-detection when the source body didn't have one.
     const trimLastLineBreak = body.slice(-1) !== "\n";
     const file = stringifyFrontmatter(body, orderedFrontmatter, { lineWidth: -1 });
     return trimLastLineBreak && file.slice(-1) === "\n" ? file.slice(0, -1) : file;

--- a/web/src/pages/mgmt/cms.tsx
+++ b/web/src/pages/mgmt/cms.tsx
@@ -7,6 +7,7 @@ import { default as MiniCallout } from "@/lib/cms/editors/mini-callout";
 import Note from "@/lib/cms/editors/note";
 import { NoSpaceControl } from "@/lib/cms/fields/nospacefield";
 import { WriteOnceReadOnlyNoSpaceControl } from "@/lib/cms/fields/writeoncereadonlynospacefield";
+import { recentsFrontmatterFormat } from "@/lib/cms/formatters/recentsFrontmatterFormat";
 import { applyTheme } from "@/lib/cms/helpers/applyTheme";
 import CannabisEligibilityModalPreview from "@/lib/cms/previews/CannabisEligibilityModalPreview";
 import CannabisLicensePreview from "@/lib/cms/previews/CannabisLicensePreview";
@@ -110,6 +111,11 @@ const CMS = dynamic(
             lineWidth: -1,
           }),
       });
+      // Parses/serializes frontmatter with the same gray-matter engine the site's
+      // build-time content loader uses, so this collection can't produce an
+      // unquoted date-like scalar that the loader would read back as a `Date`
+      // and fail Next.js's static export (AB#17994).
+      CMS.registerCustomFormat("recents-frontmatter", "md", recentsFrontmatterFormat);
 
       registerPreview(CMS, "tasks", TaskPreview);
       registerPreview(CMS, "license-tasks", TaskPreview);

--- a/web/src/pages/mgmt/cms.tsx
+++ b/web/src/pages/mgmt/cms.tsx
@@ -111,10 +111,8 @@ const CMS = dynamic(
             lineWidth: -1,
           }),
       });
-      // Parses/serializes frontmatter with the same gray-matter engine the site's
-      // build-time content loader uses, so this collection can't produce an
-      // unquoted date-like scalar that the loader would read back as a `Date`
-      // and fail Next.js's static export (AB#17994).
+      // Keeps the Recents collection's frontmatter parsing/serialization
+      // consistent with the build-time content loader that reads it back.
       CMS.registerCustomFormat("recents-frontmatter", "md", recentsFrontmatterFormat);
 
       registerPreview(CMS, "tasks", TaskPreview);


### PR DESCRIPTION
## Description

Decap's built-in Markdown frontmatter formatter serializes dates with the `yaml` npm package, whose default schema doesn't treat a bare `YYYY-MM-DD` scalar as a timestamp, so it writes `date: 2025-09-03` unquoted.

The site's build-time content loader (`loadAllRecents`) parses that same file with `gray-matter` (js-yaml), whose schema does resolve an unquoted date to a native `Date`, even though `RecentItem.date` is typed as `string`. A `Date` there fails Next.js's `getStaticProps` serialization for `/mgmt/search`, breaking the whole build.

This surfaced in three separate Decap-authored PRs opened within the same 24-hour window, all failing CI the same way (#12968, #12969, #12970). Those three PRs have already been repaired directly. This PR fixes the underlying cause so it can't recur.

### Ticket

This pull request resolves [AB#17994](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17994).

### Approach

No dependency changes.

- Registered a custom Decap frontmatter formatter for the Recents collection that reads and writes frontmatter with `gray-matter` instead of Decap's default `yaml`-package formatter, matching the loader that will parse the file at build time, so this collection can no longer produce an unquoted date.

- Added a content build-time validator (`content/validateFrontmatterDates.ts`) that recursively scans every Markdown file under `content/src` and rejects any native `Date` value in frontmatter, reporting the offending file and key path. It's wired into `content/build.ts`'s `main()` and into `.github/workflows/validate-content.yml` as its own job, for fast, direct feedback on Decap/CMS PRs.

- Regenerated `web/public/mgmt/config.yml` via `yarn decap:build-config` to pick up the new `format: recents-frontmatter` collection setting (generated file, not hand-edited).

### Steps to Test

1. In the CMS, edit or create a Recents entry and set a date.

2. Save, then check the resulting Markdown file in `content/src/recents/`: the `date` field should be quoted (e.g. `date: "2025-09-03"`), not bare.

3. `yarn workspace @businessnjgovnavigator/content validate-frontmatter-dates` should pass against current content.

4. To see the guard rail catch a regression, temporarily unquote a date in any `content/src/**/*.md` file and run `yarn workspace @businessnjgovnavigator/content build` (or the validate script above); it should fail with the exact file and key path, then revert the temporary edit.

### Notes

Root cause: Decap's own YAML library and the site's `gray-matter`/js-yaml build-time parser disagree on whether a bare `YYYY-MM-DD` scalar is a timestamp. Decap doesn't quote it because *its* parser wouldn't reinterpret it, but the site's parser does. Making Decap use the same `gray-matter` engine for this collection resolves the mismatch at the source; the content build-time validator is a generic backstop for any other collection/field that hits the same pattern in the future.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
