### PR TITLE
chore: remove ex-engineers from project, add new engineer to pickaroo

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -47,9 +47,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           INCLUDE_TEAMS: "business-dev"
-          EXCLUDE_USERS:
-            "NJ-Innovation-CI cleong14 FearHar jphechter jtabron1 mjackson21 ${{
-            steps.find-comment.outputs.previously-picked }}"
+          EXCLUDE_USERS: "NJ-Innovation-CI ${{ steps.find-comment.outputs.previously-picked }}"
           NUMBER_OF_REVIEWERS: 2
           GH_PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_PR_AUTHOR: ${{ github.event.pull_request.user.login }}


### PR DESCRIPTION
## Description

Updates `EXCLUDE_USERS` var in `pr-review.yml` workflow to remove old team members, and re-enable me!

This is part of both the off/onboarding workflow for our engineering team.

### Ticket

n/a

### Approach

- Updated the `EXCLUED_USERS` var in the workflow file

Old team members have been removed from the GH user group used to source picks, so specifically listing them in this variable is no longer required.

### Steps to Test

- If Pickaroo picks me at some point in the future we'll know this works

### Notes

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [X] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
