### PR TITLE
feat: [AB#17816] hide survey monkey prompt on smaller screen widths

### DIFF
--- a/packages/static-site/app/[locale]/page.tsx
+++ b/packages/static-site/app/[locale]/page.tsx
@@ -7,8 +7,8 @@
 
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import Script from "next/script";
 
+import { SurveyMonkey } from "@/components/analytics/SurveyMonkey";
 import { BroughtToYouBySection } from "@/components/landing/BroughtToYouBySection";
 import { CtaBannerSection } from "@/components/landing/CtaBannerSection";
 import { HeroSection } from "@/components/landing/HeroSection";
@@ -88,16 +88,7 @@ const LocalizedLandingPage = async ({ params }: LocalizedPageProps) => {
       <WhatsNewSection content={messages.landing.whatsNew} recents={recents} />
       <SupportSection content={messages.landing.support} />
       <BroughtToYouBySection content={messages.landing.broughtToYouBy} />
-      {
-        // biome-ignore lint/style/noProcessEnv: NEXT_PUBLIC_ vars are inlined at build time.
-        process.env.NEXT_PUBLIC_SURVEY_MONKEY_ENABLED === "true" && (
-          <Script
-            id="smcx-sdk"
-            src="https://widget.surveymonkey.com/collect/website/js/tRaiETqnLgj758hTBazgd_2Fl0hAvWCD8cNdKnWc8kt0IafoTskhMiZ5h9m_2FJavuow.js"
-            strategy="afterInteractive"
-          />
-        )
-      }
+      <SurveyMonkey />
     </>
   );
 };

--- a/packages/static-site/components/analytics/SurveyMonkey.test.tsx
+++ b/packages/static-site/components/analytics/SurveyMonkey.test.tsx
@@ -1,0 +1,70 @@
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Imports the component fresh so the module-scoped env read re-runs per test.
+ */
+const importSurveyMonkey = async () => {
+  vi.resetModules();
+  const module = await import("./SurveyMonkey");
+
+  return module.SurveyMonkey;
+};
+
+/**
+ * Stubs `window.matchMedia` to report the given tablet-and-up match state.
+ */
+const stubTabletAndUp = (matches: boolean) => {
+  vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches }));
+};
+
+describe("SurveyMonkey", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    // next/script appends `afterInteractive` scripts to document.body directly,
+    // outside the render container, so testing-library's auto-cleanup misses them.
+    document.body.querySelector("#smcx-sdk")?.remove();
+  });
+
+  it("renders the widget script on tablet and up when enabled", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SURVEY_MONKEY_ENABLED", "true");
+    stubTabletAndUp(true);
+    const SurveyMonkey = await importSurveyMonkey();
+
+    render(<SurveyMonkey />);
+
+    expect(document.body.querySelector("#smcx-sdk")).not.toBeNull();
+  });
+
+  it("renders nothing on mobile even when enabled", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SURVEY_MONKEY_ENABLED", "true");
+    stubTabletAndUp(false);
+    const SurveyMonkey = await importSurveyMonkey();
+
+    render(<SurveyMonkey />);
+
+    expect(document.body.querySelector("#smcx-sdk")).toBeNull();
+  });
+
+  it("renders nothing when disabled, even on tablet and up", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SURVEY_MONKEY_ENABLED", "false");
+    stubTabletAndUp(true);
+    const SurveyMonkey = await importSurveyMonkey();
+
+    render(<SurveyMonkey />);
+
+    expect(document.body.querySelector("#smcx-sdk")).toBeNull();
+  });
+
+  it("renders nothing when the flag is unset", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SURVEY_MONKEY_ENABLED", "");
+    stubTabletAndUp(true);
+    const SurveyMonkey = await importSurveyMonkey();
+
+    render(<SurveyMonkey />);
+
+    expect(document.body.querySelector("#smcx-sdk")).toBeNull();
+  });
+});

--- a/packages/static-site/components/analytics/SurveyMonkey.tsx
+++ b/packages/static-site/components/analytics/SurveyMonkey.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Script from "next/script";
+
+const SURVEY_MONKEY_SCRIPT_SRC =
+  "https://widget.surveymonkey.com/collect/website/js/tRaiETqnLgj758hTBazgd_2Fl0hAvWCD8cNdKnWc8kt0IafoTskhMiZ5h9m_2FJavuow.js";
+
+const TABLET_AND_UP_QUERY = "(min-width: 40em)";
+
+const isEnabled = (): boolean =>
+  // biome-ignore lint/style/noProcessEnv: NEXT_PUBLIC_ vars are inlined at build time.
+  process.env.NEXT_PUBLIC_SURVEY_MONKEY_ENABLED === "true";
+
+// SurveyMonkey's own layout does not adapt to small screens, so
+// we just skip rendering below the tablet breakpoint.
+const isTabletAndUp = (): boolean =>
+  typeof window !== "undefined" &&
+  typeof window.matchMedia === "function" &&
+  window.matchMedia(TABLET_AND_UP_QUERY).matches;
+
+export const SurveyMonkey = () => {
+  if (!isEnabled() || !isTabletAndUp()) {
+    return null;
+  }
+
+  return <Script id="smcx-sdk" src={SURVEY_MONKEY_SCRIPT_SRC} strategy="afterInteractive" />;
+};


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->
In addition to the existing feature flag, move the survey monkey script to a component that can call `"use client"` and conditionally render based on media queries

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to the URL for the board that owns it.
     Board routing is not a clean cutover; run `python3 scripts/fetch_ado_ticket.py <id>`
     or check scripts/ado-boards.json for the current cutover and exceptions list. -->

This pull request resolves [#17816](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17816).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [ ] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
