### PR TITLE
fix: [AB#17910] race condition for injecting Intercom

### DIFF
--- a/packages/static-site/components/analytics/Intercom.test.tsx
+++ b/packages/static-site/components/analytics/Intercom.test.tsx
@@ -1,0 +1,45 @@
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Intercom } from "./Intercom";
+
+/**
+ * jsdom does not execute the textContent of scripts inserted by next/script,
+ * so re-append a fresh <script> with the same body to trigger real execution,
+ * matching what the browser does for the rendered page.
+ */
+const runInlineScript = (id: string) => {
+  const original = document.body.querySelector<HTMLScriptElement>(`script#${id}`);
+  expect(original).not.toBeNull();
+  const executable = document.createElement("script");
+  executable.textContent = original?.textContent ?? "";
+  document.body.append(executable);
+  executable.remove();
+};
+
+describe("Intercom", () => {
+  afterEach(() => {
+    document.body.querySelector("#intercom-settings")?.remove();
+    document.body.querySelector("#intercom-widget")?.remove();
+    for (const node of document.body.querySelectorAll(
+      'script[src^="https://widget.intercom.io"]',
+    )) {
+      node.remove();
+    }
+    Reflect.deleteProperty(window, "Intercom");
+    Reflect.deleteProperty(window, "intercomSettings");
+  });
+
+  it("injects the Intercom widget script even when window.load already fired", () => {
+    render(<Intercom />);
+    runInlineScript("intercom-settings");
+
+    Object.defineProperty(document, "readyState", {
+      configurable: true,
+      value: "complete",
+    });
+
+    runInlineScript("intercom-widget");
+
+    expect(document.body.querySelector('script[src^="https://widget.intercom.io"]')).not.toBeNull();
+  });
+});

--- a/packages/static-site/components/analytics/Intercom.tsx
+++ b/packages/static-site/components/analytics/Intercom.tsx
@@ -51,7 +51,7 @@ export const Intercom = () => {
 };`}
       </Script>
       <Script id="intercom-widget" strategy="afterInteractive">
-        {`(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/${INTERCOM_WIDGET_ID}';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();`}
+        {`(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/${INTERCOM_WIDGET_ID}';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(d.readyState==='complete'){l();}else if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();`}
       </Script>
     </>
   );

--- a/web/public/intercom/identity.js
+++ b/web/public/intercom/identity.js
@@ -82,7 +82,9 @@ window.intercomSettings = {
       var x = d.getElementsByTagName("script")[0];
       x.parentNode.insertBefore(s, x);
     };
-    if (w.attachEvent) {
+    if (d.readyState === "complete") {
+      l();
+    } else if (w.attachEvent) {
       w.attachEvent("onload", l);
     } else {
       w.addEventListener("load", l, false);

--- a/web/public/intercom/init.js
+++ b/web/public/intercom/init.js
@@ -1,2 +1,34 @@
 // We pre-filled your app ID in the widget URL: 'https://widget.intercom.io/widget/ozxx8n5h'
-(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/ozxx8n5h';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
+(function () {
+  var w = window;
+  var ic = w.Intercom;
+  if (typeof ic === "function") {
+    ic("reattach_activator");
+    ic("update", w.intercomSettings);
+  } else {
+    var d = document;
+    var i = function () {
+      i.c(arguments);
+    };
+    i.q = [];
+    i.c = function (args) {
+      i.q.push(args);
+    };
+    w.Intercom = i;
+    var l = function () {
+      var s = d.createElement("script");
+      s.type = "text/javascript";
+      s.async = true;
+      s.src = "https://widget.intercom.io/widget/ozxx8n5h";
+      var x = d.getElementsByTagName("script")[0];
+      x.parentNode.insertBefore(s, x);
+    };
+    if (d.readyState === "complete") {
+      l();
+    } else if (w.attachEvent) {
+      w.attachEvent("onload", l);
+    } else {
+      w.addEventListener("load", l, false);
+    }
+  }
+})();


### PR DESCRIPTION
Our code has fallen out of sync with the current provided code by Intercom's official embeddable widget. Since it's not based on a package, it makes sense that this might have gotten out of date.

This adds in a missing `document.readyState === 'complete'` guard for more reliable injection of the Intercom widget.

<!-- Please complete the following sections as necessary. -->

## Description

<!-- Summary of the changes, related issue, relevant motivation, and context -->

### Ticket

<!-- Link to ticket in ADO. Append ticket_id to the URL for the board that owns it.
     Board routing is not a clean cutover; run `python3 scripts/fetch_ado_ticket.py <id>`
     or check scripts/ado-boards.json for the current cutover and exceptions list. -->

This pull request resolves [#17910](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17910/).

### Approach

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

### Steps to Test

<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

### Notes

<!-- Additional information, key learnings, and future development considerations. -->

We should periodically check this for needing updates if we observe similar issues in the future.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [ ] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
