### PR TITLE
chore: improve CSR generation script

### DIFF
--- a/scripts/generate_csr.py
+++ b/scripts/generate_csr.py
@@ -1,13 +1,68 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""Generate a private key and Certificate Signing Request (CSR).
 
-from cryptography import x509
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import ec, rsa
-from cryptography.hazmat.primitives import serialization
-from cryptography.x509.oid import NameOID
-from datetime import datetime
+Supports RSA and ECDSA keys via named `--key` presets. Any subject field not
+passed as a flag is collected with an interactive prompt, so the script can
+be run with zero arguments or fully scripted for automation. The private key
+and CSR are written to timestamped files (owner-only permissions on the key)
+and existing files are never overwritten unless `--force` is passed.
+
+Usage:
+    Fully interactive:
+        $ ./generate_csr.py
+
+    Fully scripted:
+        $ ./generate_csr.py --country US --state "New Jersey" --locality Newark \\
+              --organization MyOrg --organizational-unit IT \\
+              --common-name www.example.com --email admin@example.com \\
+              --san www.example.com example.com --key ecdsa-p384 \\
+              --output-dir ./certs
+
+    Mixed (prompts only for what's missing):
+        $ ./generate_csr.py --common-name www.example.com --key rsa-4096
+"""
+
+from __future__ import annotations
 
 import argparse
+import re
+import stat
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Final, NamedTuple, Union
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import NameOID
+
+__all__ = [
+    "KEY_PRESETS",
+    "DEFAULT_KEY_PRESET",
+    "PrivateKey",
+    "SubjectFields",
+    "generate_rsa_private_key",
+    "generate_ecc_private_key",
+    "generate_private_key",
+    "generate_csr",
+    "save_private_key",
+    "save_csr",
+    "validate_country_code",
+    "sanitize_filename_component",
+    "build_output_paths",
+    "resolve_subject_fields",
+    "main",
+]
+
+PrivateKey = Union[rsa.RSAPrivateKey, ec.EllipticCurvePrivateKey]
+
+# Characters that are safe to leave unescaped in a generated filename.
+_UNSAFE_FILENAME_CHARS: Final[re.Pattern[str]] = re.compile(r"[^A-Za-z0-9._-]")
+
+# Owner-only permissions (0600) for the generated private key file.
+_PRIVATE_KEY_FILE_MODE: Final[int] = stat.S_IRUSR | stat.S_IWUSR
 
 
 def generate_rsa_private_key(key_size: int = 2048) -> rsa.RSAPrivateKey:
@@ -17,8 +72,7 @@ def generate_rsa_private_key(key_size: int = 2048) -> rsa.RSAPrivateKey:
     :param key_size: Size of the key to be generated (default is 2048).
     :return: RSA private key.
     """
-    private_key = rsa.generate_private_key(public_exponent=65537, key_size=key_size)
-    return private_key
+    return rsa.generate_private_key(public_exponent=65537, key_size=key_size)
 
 
 def generate_ecc_private_key(curve: ec.EllipticCurve) -> ec.EllipticCurvePrivateKey:
@@ -28,13 +82,50 @@ def generate_ecc_private_key(curve: ec.EllipticCurve) -> ec.EllipticCurvePrivate
     :param curve: An instance of EllipticCurve to use for key generation.
     :return: ECC private key.
     """
-    private_key = ec.generate_private_key(curve)
-    return private_key
+    return ec.generate_private_key(curve)
+
+
+class KeyPreset(NamedTuple):
+    """A named, human-readable private-key algorithm and size/curve choice."""
+
+    description: str
+    generate: Callable[[], PrivateKey]
+
+
+# Named `--key` choices. Keep names stable: they're a public CLI contract.
+KEY_PRESETS: Final[dict[str, KeyPreset]] = {
+    "rsa-2048": KeyPreset("RSA 2048-bit", lambda: generate_rsa_private_key(2048)),
+    "rsa-3072": KeyPreset("RSA 3072-bit", lambda: generate_rsa_private_key(3072)),
+    "rsa-4096": KeyPreset("RSA 4096-bit", lambda: generate_rsa_private_key(4096)),
+    "ecdsa-p256": KeyPreset(
+        "ECDSA P-256 (secp256r1)", lambda: generate_ecc_private_key(ec.SECP256R1())
+    ),
+    "ecdsa-p384": KeyPreset(
+        "ECDSA P-384 (secp384r1)", lambda: generate_ecc_private_key(ec.SECP384R1())
+    ),
+}
+DEFAULT_KEY_PRESET: Final[str] = "rsa-2048"
+
+
+def generate_private_key(preset: str) -> PrivateKey:
+    """
+    Generate a private key for the given KEY_PRESETS name.
+
+    :param preset: One of the KEY_PRESETS keys (e.g. "rsa-2048", "ecdsa-p384").
+    :return: A newly generated RSA or ECDSA private key.
+    :raises KeyError: If preset is not a recognized preset name.
+    """
+    try:
+        return KEY_PRESETS[preset].generate()
+    except KeyError:
+        valid = ", ".join(sorted(KEY_PRESETS))
+        raise KeyError(
+            f"Unknown key preset {preset!r}. Valid presets: {valid}."
+        ) from None
 
 
 def generate_csr(
-    private_key: rsa.RSAPrivateKey,
-    # private_key: ec.EllipticCurvePrivateKey,
+    private_key: PrivateKey,
     country: str,
     state: str,
     locality: str,
@@ -42,11 +133,12 @@ def generate_csr(
     organizational_unit: str,
     common_name: str,
     email: str,
-    san_dns_names: list,
+    san_dns_names: list[str],
 ) -> x509.CertificateSigningRequest:
     """
     Generate a CSR using the provided private key and subject information.
-    :param private_key: ECC private key.
+
+    :param private_key: RSA or ECDSA private key.
     :param country: Country Name (2 letter code).
     :param state: State or Province Name (full name).
     :param locality: Locality Name (e.g., city).
@@ -81,112 +173,285 @@ def generate_csr(
             x509.SubjectAlternativeName(san_list), critical=False
         )
 
-    csr = csr_builder.sign(private_key, hashes.SHA384())
-    return csr
+    return csr_builder.sign(private_key, hashes.SHA384())
 
 
-def save_private_key(private_key: ec.EllipticCurvePrivateKey, filename: str) -> None:
+def save_private_key(private_key: PrivateKey, path: str | Path) -> None:
     """
-    Save an ECC private key to a file.
+    Save a private key to a file, restricting permissions to the owner.
 
-    :param private_key: ECC private key to save.
-    :param filename: Name of the file to save the key in.
+    :param private_key: RSA or ECDSA private key to save.
+    :param path: Destination file path.
     """
-    with open(filename, "wb") as key_file:
-        key_file.write(
-            private_key.private_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PrivateFormat.PKCS8,
-                encryption_algorithm=serialization.NoEncryption(),
-            )
+    destination = Path(path)
+    destination.write_bytes(
+        private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
         )
+    )
+    destination.chmod(_PRIVATE_KEY_FILE_MODE)
 
 
-def save_csr(csr: x509.CertificateSigningRequest, filename: str) -> None:
+def save_csr(csr: x509.CertificateSigningRequest, path: str | Path) -> None:
     """
     Save a CSR to a file.
 
     :param csr: CSR to save.
-    :param filename: Name of the file to save the CSR in.
+    :param path: Destination file path.
     """
-    with open(filename, "wb") as csr_file:
-        csr_file.write(csr.public_bytes(serialization.Encoding.PEM))
+    Path(path).write_bytes(csr.public_bytes(serialization.Encoding.PEM))
 
 
-def main():
+def validate_country_code(value: str) -> str:
+    """
+    Normalize and validate an ISO 3166-1 alpha-2 country code.
+
+    :param value: A country code, in any case, optionally with whitespace.
+    :return: The normalized (uppercased, trimmed) 2-letter country code.
+    :raises ValueError: If value isn't exactly two alphabetic characters.
+    """
+    normalized = value.strip().upper()
+    if len(normalized) != 2 or not normalized.isalpha():
+        raise ValueError(
+            f"Country code must be exactly 2 letters (e.g. US), got {value!r}."
+        )
+    return normalized
+
+
+def _argparse_country_code(value: str) -> str:
+    """Adapt validate_country_code for use as an argparse `type=`."""
+    try:
+        return validate_country_code(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
+
+
+def sanitize_filename_component(value: str) -> str:
+    """
+    Replace characters that are unsafe in filenames with underscores.
+
+    :param value: Arbitrary text (e.g. a Common Name) to embed in a filename.
+    :return: value with anything other than letters, digits, `.`, `_`, `-`
+        replaced by `_`.
+    """
+    return _UNSAFE_FILENAME_CHARS.sub("_", value)
+
+
+def build_output_paths(output_dir: Path, common_name: str) -> tuple[Path, Path]:
+    """
+    Build the private key and CSR file paths for a given Common Name.
+
+    Filenames encode the Common Name and the current year/month, matching
+    the existing on-disk naming convention used for issued certificates.
+
+    :param output_dir: Directory the files will be written into.
+    :param common_name: The CSR's Common Name.
+    :return: A (private_key_path, csr_path) tuple.
+    """
+    current_date = datetime.now().strftime("%Y%m")
+    base_name = f"{sanitize_filename_component(common_name)}_{current_date}"
+    return (
+        output_dir / f"{base_name}_private.pem",
+        output_dir / f"{base_name}_csr.pem",
+    )
+
+
+@dataclass(frozen=True)
+class SubjectFields:
+    """Resolved CSR subject fields, ready to pass to generate_csr()."""
+
+    country: str
+    state: str
+    locality: str
+    organization: str
+    organizational_unit: str
+    common_name: str
+    email: str
+    san_dns_names: list[str]
+
+
+def _prompt_required(label: str, validate: Callable[[str], str] | None = None) -> str:
+    """
+    Prompt on stdin until the user enters a non-empty (and valid) value.
+
+    :param label: Text shown before the prompt colon.
+    :param validate: Optional function that raises ValueError on invalid
+        input and otherwise returns the normalized value.
+    :return: The user-provided value.
+    """
+    while True:
+        value = input(f"{label}: ").strip()
+        if not value:
+            print("A value is required.", file=sys.stderr)
+            continue
+        if validate is None:
+            return value
+        try:
+            return validate(value)
+        except ValueError as error:
+            print(str(error), file=sys.stderr)
+
+
+def _prompt_optional_list(label: str) -> list[str]:
+    """
+    Prompt for a space- or comma-separated list; empty input returns [].
+
+    :param label: Text shown before the prompt colon.
+    :return: The parsed list of non-empty items.
+    """
+    raw = input(f"{label} (optional, space or comma separated, Enter to skip): ")
+    return [item for item in re.split(r"[\s,]+", raw.strip()) if item]
+
+
+def resolve_subject_fields(args: argparse.Namespace) -> SubjectFields:
+    """
+    Fill in any subject fields missing from argv via interactive prompts.
+
+    :param args: Parsed CLI arguments from parse_arguments().
+    :return: Fully-populated SubjectFields.
+    """
+    return SubjectFields(
+        country=args.country
+        or _prompt_required(
+            "Country Name (2 letter code, e.g. US)", validate_country_code
+        ),
+        state=args.state
+        or _prompt_required("State or Province Name (full name, e.g. New Jersey)"),
+        locality=args.locality or _prompt_required("Locality Name (e.g. city)"),
+        organization=args.organization
+        or _prompt_required("Organization Name (e.g. company)"),
+        organizational_unit=args.organizational_unit
+        or _prompt_required("Organizational Unit Name (e.g. department or team)"),
+        common_name=args.common_name
+        or _prompt_required("Common Name (e.g. server FQDN or YOUR name)"),
+        email=args.email or _prompt_required("Email Address"),
+        san_dns_names=(
+            args.san
+            if args.san is not None
+            else _prompt_optional_list("Subject Alternative Names (SANs)")
+        ),
+    )
+
+
+def _build_epilog() -> str:
+    """Build the --help epilog, listing key presets and an example."""
+    preset_lines = "\n".join(
+        f"  {name:<12} {preset.description}"
+        for name, preset in sorted(KEY_PRESETS.items())
+    )
+    return (
+        "Key presets:\n"
+        f"{preset_lines}\n\n"
+        "Any subject field not passed as a flag is prompted for interactively.\n\n"
+        "Example usage:\n"
+        '  ./generate_csr.py --country US --state "New Jersey" --locality Newark \\\n'
+        "                     --organization MyOrg --organizational-unit IT \\\n"
+        "                     --common-name www.example.com --email admin@example.com \\\n"
+        "                     --san www.example.com example.com --key ecdsa-p384"
+    )
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
-        description="Generate ECC-based private key and CSR.",
-        formatter_class=argparse.RawTextHelpFormatter,
-    )
-    parser.add_argument("--country", required=True, help="Country Name (2 letter code)")
-    parser.add_argument(
-        "--state", required=True, help="State or Province Name (full name)"
-    )
-    parser.add_argument("--locality", required=True, help="Locality Name (eg, city)")
-    parser.add_argument(
-        "--organization", required=True, help="Organization Name (eg, company)"
+        description="Generate a private key (RSA or ECDSA) and a matching CSR.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=_build_epilog(),
     )
     parser.add_argument(
-        "--organizational_unit",
-        required=True,
-        help="Organizational Unit Name (eg, section)",
+        "--country", type=_argparse_country_code, help="Country Name (2 letter code)"
+    )
+    parser.add_argument("--state", help="State or Province Name (full name)")
+    parser.add_argument("--locality", help="Locality Name (eg, city)")
+    parser.add_argument("--organization", help="Organization Name (eg, company)")
+    parser.add_argument(
+        "--organizational-unit", help="Organizational Unit Name (eg, section)"
     )
     parser.add_argument(
-        "--common_name",
-        required=True,
-        help="Common Name (e.g. server FQDN or YOUR name)",
+        "--common-name", help="Common Name (e.g. server FQDN or YOUR name)"
     )
-    parser.add_argument("--email", required=True, help="Email Address")
+    parser.add_argument("--email", help="Email Address")
     parser.add_argument(
         "--san",
         nargs="*",
-        help="Subject Alternative Names (SANs) - space-separated list",
-        default=[],
+        metavar="DNS_NAME",
+        help=(
+            "Subject Alternative Names (SANs), space-separated. Omit this "
+            "flag entirely to be prompted; pass it with no names to skip SANs."
+        ),
+    )
+    parser.add_argument(
+        "--key",
+        choices=sorted(KEY_PRESETS),
+        default=DEFAULT_KEY_PRESET,
+        help=f"Private key algorithm and size/curve (default: {DEFAULT_KEY_PRESET})",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("."),
+        help="Directory to write the private key and CSR into (default: current directory)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite the private key and CSR files if they already exist",
     )
 
-    parser.epilog = (
-        "Example usage:\n"
-        "./generate_csr.py --country US --state NJ --locality Newark --organization MyOrg \\\n"
-        "                      --organizational_unit IT --common_name www.example.com --email admin@example.com \\\n"
-        "                      --san www.example.com example.com sub.example.com"
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_arguments()
+
+    try:
+        subject = resolve_subject_fields(args)
+        private_key = generate_private_key(args.key)
+        csr = generate_csr(
+            private_key,
+            subject.country,
+            subject.state,
+            subject.locality,
+            subject.organization,
+            subject.organizational_unit,
+            subject.common_name,
+            subject.email,
+            subject.san_dns_names,
+        )
+    except (EOFError, KeyboardInterrupt):
+        print("\nAborted.", file=sys.stderr)
+        sys.exit(1)
+    except (ValueError, KeyError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)
+
+    private_key_path, csr_path = build_output_paths(
+        args.output_dir, subject.common_name
     )
 
-    args = parser.parse_args()
+    if not args.force:
+        existing = [path for path in (private_key_path, csr_path) if path.exists()]
+        if existing:
+            names = ", ".join(str(path) for path in existing)
+            print(
+                f"Error: refusing to overwrite existing file(s): {names}\n"
+                "Re-run with --force to overwrite them.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
-    print(args)
+    private_key_path.parent.mkdir(parents=True, exist_ok=True)
+    save_private_key(private_key, private_key_path)
+    save_csr(csr, csr_path)
 
-    # Generate the ECC private key (RSA 2048)
-    private_key = generate_rsa_private_key(2048)
-
-    # Choose this option for ECDSA 384:
-    # private_key = generate_ecc_private_key(ec.SECP384R1())
-
-    # Generate the CSR
-    csr = generate_csr(
-        private_key,
-        args.country,
-        args.state,
-        args.locality,
-        args.organization,
-        args.organizational_unit,
-        args.common_name,
-        args.email,
-        args.san,
+    print(
+        f"Generated {KEY_PRESETS[args.key].description} key and CSR "
+        f"for {subject.common_name!r}:"
     )
-
-    # Format the current date as year and month
-    current_date = datetime.now().strftime("%Y%m")
-
-    # Replace spaces and periods with underscores in the common name
-    formatted_common_name = args.common_name.replace(" ", "_").replace(".", "_")
-
-    # Construct the filenames using the given naming convention
-    private_key_filename = f"{formatted_common_name}_{current_date}_private.pem"
-    csr_filename = f"{formatted_common_name}_{current_date}_csr.pem"
-
-    # Save the private key and CSR to files
-    save_private_key(private_key, private_key_filename)
-    save_csr(csr, csr_filename)
+    print(f"  Private key: {private_key_path}")
+    print(f"  CSR:         {csr_path}")
 
 
 if __name__ == "__main__":

--- a/scripts/test_generate_csr.py
+++ b/scripts/test_generate_csr.py
@@ -1,130 +1,434 @@
 #!/usr/bin/env python
+"""Tests for generate_csr.py."""
 
-import unittest
-from cryptography import x509
-from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives import serialization
-from generate_csr import (
-    generate_ecc_private_key,
-    save_private_key,
-    generate_csr,
-    save_csr,
-)
+from __future__ import annotations
+
+import argparse
+import io
 import os
+import stat
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+
+from generate_csr import (
+    DEFAULT_KEY_PRESET,
+    KEY_PRESETS,
+    build_output_paths,
+    generate_csr,
+    generate_ecc_private_key,
+    generate_private_key,
+    generate_rsa_private_key,
+    main,
+    parse_arguments,
+    resolve_subject_fields,
+    sanitize_filename_component,
+    save_csr,
+    save_private_key,
+    validate_country_code,
+)
+
+SAMPLE_SUBJECT = {
+    "country": "US",
+    "state": "California",
+    "locality": "San Francisco",
+    "organization": "My Company Inc.",
+    "organizational_unit": "IT Department",
+    "common_name": "www.example.com",
+    "email": "admin@example.com",
+    "san_dns_names": ["www.example.com", "example.com", "sub.example.com"],
+}
 
 
-class TestECCKeyAndCSRGeneration(unittest.TestCase):
-    def test_save_private_key(self):
-        """Test that the correct kind of private key is generated."""
+class TestGeneratePrivateKey(unittest.TestCase):
+    """Tests for the key-generation helpers and KEY_PRESETS."""
 
-        # Generate a temporary ECC private key
+    def test_rsa_key_has_requested_size(self):
+        private_key = generate_rsa_private_key(2048)
+        self.assertIsInstance(private_key, rsa.RSAPrivateKey)
+        self.assertEqual(private_key.key_size, 2048)
+
+    def test_ecc_key_has_requested_curve(self):
+        private_key = generate_ecc_private_key(ec.SECP384R1())
+        self.assertIsInstance(private_key, ec.EllipticCurvePrivateKey)
+        self.assertEqual(private_key.curve.name, ec.SECP384R1().name)
+
+    def test_default_preset_is_registered(self):
+        self.assertIn(DEFAULT_KEY_PRESET, KEY_PRESETS)
+
+    def test_generate_private_key_for_each_preset(self):
+        expected_types = {
+            "rsa-2048": rsa.RSAPrivateKey,
+            "rsa-3072": rsa.RSAPrivateKey,
+            "rsa-4096": rsa.RSAPrivateKey,
+            "ecdsa-p256": ec.EllipticCurvePrivateKey,
+            "ecdsa-p384": ec.EllipticCurvePrivateKey,
+        }
+        self.assertEqual(set(expected_types), set(KEY_PRESETS))
+
+        for preset_name, expected_type in expected_types.items():
+            with self.subTest(preset=preset_name):
+                private_key = generate_private_key(preset_name)
+                self.assertIsInstance(private_key, expected_type)
+
+    def test_generate_private_key_rejects_unknown_preset(self):
+        with self.assertRaises(KeyError):
+            generate_private_key("not-a-real-preset")
+
+
+class TestSaveKeyAndCsr(unittest.TestCase):
+    """Tests for save_private_key() and save_csr()."""
+
+    def test_save_private_key_round_trips_and_restricts_permissions(self):
         private_key = generate_ecc_private_key(ec.SECP384R1())
 
-        # Save it to a file
-        filename = "test_private_key.pem"
-        save_private_key(private_key, filename)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "test_private_key.pem"
+            save_private_key(private_key, path)
 
-        # Read the content back
-        with open(filename, "rb") as key_file:
-            key_data = key_file.read()
+            loaded_key = serialization.load_pem_private_key(
+                path.read_bytes(), password=None
+            )
+            self.assertEqual(
+                private_key.private_numbers(), loaded_key.private_numbers()
+            )
 
-        # Load the key from the content
-        loaded_key = serialization.load_pem_private_key(key_data, password=None)
+            mode = stat.S_IMODE(path.stat().st_mode)
+            self.assertEqual(mode, stat.S_IRUSR | stat.S_IWUSR)
 
-        # Check if the loaded key is the same as the original key
-        self.assertEqual(private_key.private_numbers(), loaded_key.private_numbers())
-        self.assertEqual(loaded_key.key_size, ec.SECP384R1().key_size)
+    def test_save_private_key_accepts_string_path(self):
+        private_key = generate_rsa_private_key(2048)
 
-        # Clean up the file
-        os.remove(filename)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            filename = os.path.join(tmp_dir, "test_private_key.pem")
+            save_private_key(private_key, filename)
+            self.assertTrue(os.path.exists(filename))
 
     def test_csr_subject_and_sans(self):
-        """Test that the CSR contains the correct subject fields."""
+        private_key = generate_ecc_private_key(ec.SECP384R1())
+        csr = generate_csr(private_key, **SAMPLE_SUBJECT)
 
-        # Generate a private key
-        curve = ec.SECP384R1()
-        private_key = generate_ecc_private_key(curve)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            csr_path = Path(tmp_dir) / "test_csr.pem"
+            save_csr(csr, csr_path)
+            loaded_csr = x509.load_pem_x509_csr(csr_path.read_bytes())
 
-        # Subject information
-        country = "US"
-        state = "California"
-        locality = "San Francisco"
-        organization = "My Company Inc."
-        organizational_unit = "IT Department"
-        common_name = "www.example.com"
-        email = "admin@example.com"
-        san_dns_names = ["www.example.com", "example.com", "sub.example.com"]
-
-        # Generate CSR
-        csr = generate_csr(
-            private_key,
-            country,
-            state,
-            locality,
-            organization,
-            organizational_unit,
-            common_name,
-            email,
-            san_dns_names,
-        )
-
-        # Save CSR to a temporary file
-        csr_filename = "test_csr.pem"
-        save_csr(csr, csr_filename)
-
-        # Read the CSR back from the file
-        with open(csr_filename, "rb") as f:
-            csr_data = f.read()
-            loaded_csr = x509.load_pem_x509_csr(csr_data)
-
-        # Extract subject from CSR
         subject = loaded_csr.subject
-
-        # Verify that the subject fields match what was provided
         self.assertEqual(
-            subject.get_attributes_for_oid(x509.NameOID.COUNTRY_NAME)[0].value, country
+            subject.get_attributes_for_oid(x509.NameOID.COUNTRY_NAME)[0].value,
+            SAMPLE_SUBJECT["country"],
         )
         self.assertEqual(
             subject.get_attributes_for_oid(x509.NameOID.STATE_OR_PROVINCE_NAME)[
                 0
             ].value,
-            state,
+            SAMPLE_SUBJECT["state"],
         )
         self.assertEqual(
             subject.get_attributes_for_oid(x509.NameOID.LOCALITY_NAME)[0].value,
-            locality,
+            SAMPLE_SUBJECT["locality"],
         )
         self.assertEqual(
             subject.get_attributes_for_oid(x509.NameOID.ORGANIZATION_NAME)[0].value,
-            organization,
+            SAMPLE_SUBJECT["organization"],
         )
         self.assertEqual(
             subject.get_attributes_for_oid(x509.NameOID.ORGANIZATIONAL_UNIT_NAME)[
                 0
             ].value,
-            organizational_unit,
+            SAMPLE_SUBJECT["organizational_unit"],
         )
         self.assertEqual(
             subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)[0].value,
-            common_name,
+            SAMPLE_SUBJECT["common_name"],
         )
         self.assertEqual(
-            subject.get_attributes_for_oid(x509.NameOID.EMAIL_ADDRESS)[0].value, email
+            subject.get_attributes_for_oid(x509.NameOID.EMAIL_ADDRESS)[0].value,
+            SAMPLE_SUBJECT["email"],
         )
 
-        # Extract SANs from CSR
         san_extension = loaded_csr.extensions.get_extension_for_class(
             x509.SubjectAlternativeName
         )
         san_list = san_extension.value.get_values_for_type(x509.DNSName)
+        self.assertEqual(san_list, SAMPLE_SUBJECT["san_dns_names"])
 
-        # Verify that the SANs match what was provided
-        self.assertEqual(san_list, san_dns_names)
+    def test_csr_without_sans_omits_extension(self):
+        private_key = generate_rsa_private_key(2048)
+        subject = dict(SAMPLE_SUBJECT, san_dns_names=[])
+        csr = generate_csr(private_key, **subject)
 
-        # Clean up the temporary CSR file
-        os.remove(csr_filename)
+        with self.assertRaises(x509.ExtensionNotFound):
+            csr.extensions.get_extension_for_class(x509.SubjectAlternativeName)
 
 
-# Run the unit tests
+class TestValidateCountryCode(unittest.TestCase):
+    """Tests for validate_country_code()."""
+
+    def test_normalizes_case_and_whitespace(self):
+        self.assertEqual(validate_country_code(" us "), "US")
+
+    def test_rejects_wrong_length(self):
+        with self.assertRaises(ValueError):
+            validate_country_code("USA")
+
+    def test_rejects_non_alphabetic(self):
+        with self.assertRaises(ValueError):
+            validate_country_code("U1")
+
+
+class TestSanitizeFilenameComponent(unittest.TestCase):
+    """Tests for sanitize_filename_component()."""
+
+    def test_replaces_spaces_and_dots(self):
+        self.assertEqual(
+            sanitize_filename_component("www.example.com"), "www.example.com"
+        )
+        self.assertEqual(sanitize_filename_component("My Server"), "My_Server")
+
+    def test_replaces_path_separators_and_wildcards(self):
+        self.assertEqual(sanitize_filename_component("*.example.com"), "_.example.com")
+        self.assertEqual(sanitize_filename_component("a/b\\c"), "a_b_c")
+
+
+class TestBuildOutputPaths(unittest.TestCase):
+    """Tests for build_output_paths()."""
+
+    def test_builds_private_key_and_csr_paths_under_output_dir(self):
+        output_dir = Path("/tmp/certs")
+        private_key_path, csr_path = build_output_paths(output_dir, "www.example.com")
+
+        self.assertEqual(private_key_path.parent, output_dir)
+        self.assertEqual(csr_path.parent, output_dir)
+        self.assertTrue(private_key_path.name.startswith("www.example.com_"))
+        self.assertTrue(private_key_path.name.endswith("_private.pem"))
+        self.assertTrue(csr_path.name.endswith("_csr.pem"))
+
+
+class TestResolveSubjectFields(unittest.TestCase):
+    """Tests for resolve_subject_fields()."""
+
+    def _args(self, **overrides):
+        defaults = {
+            "country": None,
+            "state": None,
+            "locality": None,
+            "organization": None,
+            "organizational_unit": None,
+            "common_name": None,
+            "email": None,
+            "san": None,
+        }
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def test_uses_provided_flags_without_prompting(self):
+        args = self._args(
+            country="US",
+            state="New Jersey",
+            locality="Newark",
+            organization="MyOrg",
+            organizational_unit="IT",
+            common_name="www.example.com",
+            email="admin@example.com",
+            san=["www.example.com"],
+        )
+        with patch("builtins.input", side_effect=AssertionError("should not prompt")):
+            subject = resolve_subject_fields(args)
+
+        self.assertEqual(subject.country, "US")
+        self.assertEqual(subject.common_name, "www.example.com")
+        self.assertEqual(subject.san_dns_names, ["www.example.com"])
+
+    def test_prompts_for_missing_fields(self):
+        args = self._args(common_name="www.example.com")
+        prompt_answers = iter(
+            ["US", "New Jersey", "Newark", "MyOrg", "IT", "admin@example.com", ""]
+        )
+        with patch("builtins.input", side_effect=lambda _prompt: next(prompt_answers)):
+            subject = resolve_subject_fields(args)
+
+        self.assertEqual(subject.country, "US")
+        self.assertEqual(subject.common_name, "www.example.com")
+        self.assertEqual(subject.san_dns_names, [])
+
+    def test_reprompts_on_invalid_country_code(self):
+        args = self._args(common_name="www.example.com")
+        prompt_answers = iter(
+            [
+                "USA",  # invalid, should reprompt
+                "US",
+                "New Jersey",
+                "Newark",
+                "MyOrg",
+                "IT",
+                "admin@example.com",
+                "",
+            ]
+        )
+        with patch("builtins.input", side_effect=lambda _prompt: next(prompt_answers)):
+            subject = resolve_subject_fields(args)
+
+        self.assertEqual(subject.country, "US")
+
+    def test_san_flag_with_no_values_skips_prompt(self):
+        args = self._args(
+            country="US",
+            state="New Jersey",
+            locality="Newark",
+            organization="MyOrg",
+            organizational_unit="IT",
+            common_name="www.example.com",
+            email="admin@example.com",
+            san=[],
+        )
+        with patch("builtins.input", side_effect=AssertionError("should not prompt")):
+            subject = resolve_subject_fields(args)
+
+        self.assertEqual(subject.san_dns_names, [])
+
+    def test_san_prompt_accepts_comma_separated_values(self):
+        args = self._args(
+            country="US",
+            state="New Jersey",
+            locality="Newark",
+            organization="MyOrg",
+            organizational_unit="IT",
+            common_name="www.example.com",
+            email="admin@example.com",
+        )
+        with patch("builtins.input", return_value="a.example.com, b.example.com"):
+            subject = resolve_subject_fields(args)
+
+        self.assertEqual(subject.san_dns_names, ["a.example.com", "b.example.com"])
+
+
+class TestParseArguments(unittest.TestCase):
+    """Tests for parse_arguments()."""
+
+    def test_defaults(self):
+        with patch.object(sys, "argv", ["generate_csr.py"]):
+            args = parse_arguments()
+
+        self.assertEqual(args.key, DEFAULT_KEY_PRESET)
+        self.assertEqual(args.output_dir, Path("."))
+        self.assertFalse(args.force)
+        self.assertIsNone(args.san)
+
+    def test_rejects_unknown_key_preset(self):
+        with patch.object(sys, "argv", ["generate_csr.py", "--key", "rot13"]):
+            with patch("sys.stderr", io.StringIO()), self.assertRaises(SystemExit):
+                parse_arguments()
+
+    def test_rejects_invalid_country_code_early(self):
+        with patch.object(sys, "argv", ["generate_csr.py", "--country", "USA"]):
+            stderr_buffer = io.StringIO()
+            with self.assertRaises(SystemExit), patch("sys.stderr", stderr_buffer):
+                parse_arguments()
+            self.assertIn("2 letters", stderr_buffer.getvalue())
+
+    def test_organizational_unit_and_common_name_flags(self):
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "generate_csr.py",
+                "--organizational-unit",
+                "IT",
+                "--common-name",
+                "www.example.com",
+            ],
+        ):
+            args = parse_arguments()
+
+        self.assertEqual(args.organizational_unit, "IT")
+        self.assertEqual(args.common_name, "www.example.com")
+
+
+class TestMain(unittest.TestCase):
+    """End-to-end tests for main()."""
+
+    def _argv(self, output_dir: Path, **overrides) -> list[str]:
+        values = {
+            "--country": "US",
+            "--state": "New Jersey",
+            "--locality": "Newark",
+            "--organization": "MyOrg",
+            "--organizational-unit": "IT",
+            "--common-name": "www.example.com",
+            "--email": "admin@example.com",
+        }
+        values.update(overrides)
+        argv = ["generate_csr.py"]
+        for flag, value in values.items():
+            argv.extend([flag, value])
+        argv.extend(["--san", "--output-dir", str(output_dir)])
+        return argv
+
+    def test_writes_key_and_csr_to_output_dir(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_dir = Path(tmp_dir) / "certs"
+            with patch.object(sys, "argv", self._argv(output_dir)):
+                stdout_buffer = io.StringIO()
+                with redirect_stdout(stdout_buffer):
+                    main()
+
+            pem_files = list(output_dir.glob("*.pem"))
+            self.assertEqual(len(pem_files), 2)
+            self.assertIn("www.example.com_", stdout_buffer.getvalue())
+
+    def test_refuses_to_overwrite_without_force(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_dir = Path(tmp_dir)
+            argv = self._argv(output_dir)
+
+            with patch.object(sys, "argv", argv):
+                main()
+
+            with patch.object(sys, "argv", argv):
+                stderr_buffer = io.StringIO()
+                with self.assertRaises(SystemExit) as exit_info:
+                    with patch("sys.stderr", stderr_buffer):
+                        main()
+
+            self.assertEqual(exit_info.exception.code, 1)
+            self.assertIn("refusing to overwrite", stderr_buffer.getvalue())
+
+    def test_force_overwrites_existing_files(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_dir = Path(tmp_dir)
+            argv = self._argv(output_dir)
+
+            with patch.object(sys, "argv", argv):
+                main()
+
+            with patch.object(sys, "argv", [*argv, "--force"]):
+                main()  # should not raise
+
+    def test_invalid_key_generation_error_is_reported_cleanly(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_dir = Path(tmp_dir)
+            argv = self._argv(output_dir)
+
+            with patch(
+                "generate_csr.generate_private_key", side_effect=KeyError("boom")
+            ):
+                with patch.object(sys, "argv", argv):
+                    stderr_buffer = io.StringIO()
+                    with self.assertRaises(SystemExit) as exit_info:
+                        with patch("sys.stderr", stderr_buffer):
+                            main()
+
+            self.assertEqual(exit_info.exception.code, 1)
+            self.assertIn("Error:", stderr_buffer.getvalue())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

Updates `scripts/generate_csr.py` so the private key algorithm (RSA vs. ECDSA) is a real, documented CLI option instead of a commented-out code swap, and improves the script's developer experience end to end.

### Approach

- Added a `KEY_PRESETS` registry (`rsa-2048`, `rsa-3072`, `rsa-4096`, `ecdsa-p256`, `ecdsa-p384`), selectable via `--key` (default `rsa-2048`).
- Any subject flag not passed on the command line (country, state, locality, organization, organizational unit, common name, email) is now collected via an interactive prompt, instead of failing with a `required=True` argparse error.
- Renamed `--organizational_unit`/`--common_name` to the more conventional `--organizational-unit`/`--common-name`.
- Added `--output-dir` and `--force`. The script refuses to overwrite an existing private key or CSR unless `--force` is passed.
- Private key files are now written with owner-only (`0600`) permissions.
- Country codes are validated (ISO 3166-1 alpha-2) both at argument-parse time and at the interactive prompt, with a clear error message instead of a raw `cryptography` traceback.
- Filenames generated from the Common Name are sanitized against a broader set of unsafe characters (slashes, wildcards, etc).
- Expanded `scripts/test_generate_csr.py` from 2 to 28 tests, covering every key preset, CSR generation, country code validation, filename sanitization, interactive prompting (including re-prompt on invalid input), argument parsing, and end-to-end `main()` behavior (output directory, overwrite protection, `--force`, key file permissions).

No dependency changes; `cryptography` was already listed in `pyproject.toml`.

### Steps to Test

1. Run `python3 -m unittest discover -b -s scripts -p "test_generate_csr.py"` (or `yarn test:python`) and confirm all tests pass.
2. Run `./scripts/generate_csr.py --help` and review the new flags and key preset table.
3. Run `./scripts/generate_csr.py --common-name test.example.com --key ecdsa-p384 --output-dir /tmp/csr-test` and confirm a private key (mode `600`) and CSR are written to `/tmp/csr-test`.
4. Re-run the same command and confirm it refuses to overwrite the existing files without `--force`.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
