### PR TITLE
chore: update navigator sitemap builder

### DIFF
--- a/web/src/scripts/generateSitemap.ts
+++ b/web/src/scripts/generateSitemap.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { getAllStarterKitUrls } from "@/lib/utils/starterKits";
 
 const generateSitemap = (): void => {
+  const baseUrl = process.env.NEXT_PUBLIC_WEB_BASE_URL ?? "http://localhost:3000";
   const urls = [{ loc: "/", changefreq: "monthly", priority: "1.0" }];
 
   for (const pathObject of getAllStarterKitUrls()) {
@@ -22,7 +23,7 @@ const generateSitemap = (): void => {
       .map(
         (url) => `
       <url>
-        <loc>${`https://navigator.business.nj.gov${url.loc}`}</loc>
+        <loc>${`${baseUrl}${url.loc}`}</loc>
         <lastmod>${new Date().toISOString().split("T")[0]}</lastmod>
         <changefreq>${url.changefreq}</changefreq>
         <priority>${url.priority}</priority>


### PR DESCRIPTION
## Description

The generated `web/public/sitemap.xml` was pointing at the old `https://navigator.business.nj.gov` domain instead of the app's current domain, `https://account.business.nj.gov`.

Root cause: `web/src/scripts/generateSitemap.ts` hardcoded `https://navigator.business.nj.gov` as the URL base for every `<loc>` entry, instead of reading `NEXT_PUBLIC_WEB_BASE_URL` like the rest of `web/` does (`_app.tsx`, `_document.tsx`, `getNextSeoTitle.ts`). The env var itself is already correctly set to `https://account.business.nj.gov` in prod (repo variable `WEB_BASE_URL_PROD`), so the sitemap script was the only place still baking in the old domain.

### Approach

Derive the sitemap's base URL from `process.env.NEXT_PUBLIC_WEB_BASE_URL`, falling back to `http://localhost:3000` to match the existing pattern used elsewhere in `web/`.

### Steps to Test

1. `cd web`
2. `NEXT_PUBLIC_WEB_BASE_URL=https://account.business.nj.gov yarn dlx tsx src/scripts/generateSitemap.ts`
3. Confirm `public/sitemap.xml` now contains `https://account.business.nj.gov/` entries instead of `navigator.business.nj.gov`.

### Notes

`web/public/sitemap.xml` is gitignored and regenerated at build time, so no committed sitemap output needed updating.

A few other stale `navigator.business.nj.gov` references remain elsewhere in the repo (e.g. `api/src/functions/express/app.ts`, `api/src/functions/updateExternalStatus/app.ts`, `web/decap-config/config-base.yml`, a handful of content markdown files) — out of scope for this fix, flagged for a follow-up.

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews