### PR TITLE
feat: report CMS collection slug collisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "validate:dependencies": "tsx scripts/validate-dependency-policy.ts",
     "verify:node": "check-node-version --node $(cat .nvmrc) --npm 11.16.0",
     "wipit": "git add -A && git commit -m 'wip [skip ci]' --no-verify",
-    "cms:map": "yarn dlx tsx scripts/generate-collection-map.ts"
+    "cms:map": "yarn dlx tsx scripts/generate-collection-map.ts",
+    "cms:check-slugs": "tsx scripts/check-decap-slug-collisions.ts"
   },
   "dependencies": {
     "@aws-crypto/client-node": "4.2.1",

--- a/scripts/check-decap-slug-collisions.ts
+++ b/scripts/check-decap-slug-collisions.ts
@@ -1,0 +1,154 @@
+/**
+ * Reports entries within a single CMS collection that declare the same `slug` or `urlSlug` in
+ * their file metadata. Those values are the public URL segment for an entry.
+ */
+
+import matter from "gray-matter";
+import yaml from "js-yaml";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CONFIG_FILE = "web/public/mgmt/config.yml";
+const SLUG_FIELDS = ["slug", "urlSlug"] as const; // not standardized and used interchangably
+
+type SlugField = (typeof SLUG_FIELDS)[number];
+
+interface CollectionConfig {
+  readonly extension?: string;
+  readonly fields?: readonly { readonly name?: string }[];
+  readonly folder?: string;
+  readonly name: string;
+}
+
+type FolderCollection = CollectionConfig & { readonly folder: string };
+
+interface Entry {
+  readonly data: Record<string, unknown>;
+  readonly location: string;
+}
+
+interface Declaration {
+  readonly location: string;
+  readonly value: string;
+}
+
+interface Duplicate {
+  readonly collection: string;
+  readonly declarations: readonly Declaration[];
+  readonly slugField: SlugField;
+  readonly value: string;
+}
+
+interface Report {
+  readonly checkedCount: number;
+  readonly collectionCount: number;
+  readonly duplicates: readonly Duplicate[];
+}
+
+const loadCollections = (): CollectionConfig[] => {
+  const parsed = yaml.load(fs.readFileSync(CONFIG_FILE, "utf8")) as {
+    readonly collections?: readonly CollectionConfig[];
+  } | null;
+  return [...(parsed?.collections ?? [])];
+};
+
+const isCollectionLabel = (collection: CollectionConfig): boolean =>
+  (collection.fields ?? []).every((field) => !field.name);
+
+const isFolderCollection = (collection: CollectionConfig): collection is FolderCollection =>
+  Boolean(collection.folder) && !isCollectionLabel(collection);
+
+const readEntryData = (filePath: string): Record<string, unknown> => {
+  const contents = fs.readFileSync(filePath, "utf8");
+  const extension = path.extname(filePath).toLowerCase();
+  if (extension === ".json") {
+    return JSON.parse(contents) as Record<string, unknown>;
+  }
+  // if not json assumes md
+  return matter(contents).data;
+};
+
+const readEntries = (folder: string, extension: string): Entry[] =>
+  fs
+    .readdirSync(folder)
+    .filter((name: string) => name.endsWith(`.${extension}`))
+    .map((name: string) => {
+      const location = path.join(folder, name);
+      return { data: readEntryData(location), location };
+    });
+
+const normalize = (value: unknown): string => String(value).trim().toLowerCase();
+
+const findDuplicates = (
+  declarations: readonly Declaration[],
+): Map<string, readonly Declaration[]> => {
+  const byValue = new Map<string, Declaration[]>();
+  for (const declaration of declarations) {
+    const key = normalize(declaration.value);
+    byValue.set(key, [...(byValue.get(key) ?? []), declaration]);
+  }
+  return new Map([...byValue].filter(([, group]) => group.length > 1));
+};
+
+const checkSlugCollisions = (): Report => {
+  const collections = loadCollections();
+  const toBeChecked = collections.filter(isFolderCollection);
+  const duplicates: Duplicate[] = [];
+
+  for (const collection of toBeChecked) {
+    const folder = collection.folder;
+    const entries = readEntries(folder, collection.extension ?? "md");
+
+    for (const slugField of SLUG_FIELDS) {
+      const declarations = entries
+        .filter((entry) => entry.data[slugField])
+        .map((entry) => ({
+          location: entry.location,
+          value: String(entry.data[slugField]),
+        }));
+
+      for (const [value, group] of findDuplicates(declarations)) {
+        duplicates.push({
+          collection: collection.name,
+          declarations: group,
+          slugField,
+          value,
+        });
+      }
+    }
+  }
+
+  return {
+    checkedCount: toBeChecked.length,
+    collectionCount: collections.length,
+    duplicates,
+  };
+};
+
+const run = (): void => {
+  const report = checkSlugCollisions();
+
+  for (const duplicate of report.duplicates) {
+    const { collection, declarations, slugField, value } = duplicate;
+    console.log(`\n  ${collection} — ${slugField} "${value}" declared by ${declarations.length}:`);
+    for (const declaration of declarations) {
+      const raw = normalize(declaration.value) === value ? "" : ` (${declaration.value})`;
+      console.log(`      ${declaration.location}${raw}`);
+    }
+  }
+
+  console.log(
+    `\nChecked ${report.checkedCount} collections of ${report.collectionCount} total collections`,
+  );
+  console.log(
+    report.duplicates.length === 0
+      ? "✅ No duplicates"
+      : `❌ ${report.duplicates.length} duplicate slug value(s)`,
+  );
+  process.exitCode = report.duplicates.length === 0 ? 0 : 1;
+};
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  run();
+}


### PR DESCRIPTION
## Description

Adds a script that reports entries within a single Decap CMS collection that declare the same `slug` or `urlSlug` value in their file metadata.

These values are the public URL segment for an entry, a collision can route a user to the wrong content item, and can produce React `key` collisions that only surface at runtime.

### Ticket

This pull request **partially** resolves [#17813](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17813).

### Approach

- New `scripts/check-decap-slug-collisions.ts`
  - run via `cms:check-slugs` package script.
- Collections are filtered to "folder collections" only
  - skips collections used as label-only collections
- Checks for the value of `slug` and `urlSlug`
- Compares these values within the context of a collection
  - The comparison is case-insensitive and whitespace-trimmed
- Returns any possible duplicates as output

```bash
➜  web git:(17813-cms-slug-collisions) ✗ yarn cms:check-slugs

  license-calendar-events — urlSlug "certified-public-accountant" declared by 2:
      content/src/license-calendar-events/certified-public-accountant.md
      content/src/license-calendar-events/certified-public-accountant_1.md

  license-calendar-events — urlSlug "landscape-architecture" declared by 2:
      content/src/license-calendar-events/landscape-architecture.md
      content/src/license-calendar-events/landscape-architecture_1.md

Checked 26 folder collections of 103 total collections
❌ 2 duplicate slug value(s)
```

### Steps to Test

1. Run `yarn cms:check-slugs`
1. Confirm the report lists the current collisions in `content/src/license-calendar-events` (`certified-public-accountant` and `landscape-architecture`, each declared by two files)
1. Confirm the exit code is non-zero when duplicates exist
    - (`echo $?` after the run).
1. Temporarily change one of the colliding `urlSlug` values, re-run, and confirm the report shows no duplicates and exits zero.

### Notes

## Code author checklist

- [x] I have rebased this branch from the latest main branch
- [x] I have performed a self-review of my code
- [x] My code follows the style guide
- [x] I have created and/or updated relevant documentation on the engineering documentation website
- [x] I have not used any relative imports
- [x] I have pruned any instances of unused code
- [x] I have not added any markdown to labels, titles and button text in config
- [x] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [x] I have checked for and removed instances of unused config from CMS
- [x] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [x] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [x] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
