### PR TITLE
chore: add dummy creds for dynamodb-local init

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,9 @@ For pair programming, we recommend Visual Studio Code with the Live Share extens
 
 ### Pre-flight
 
-You will then setup your AWS credentials:
+You will then set up your AWS credentials. See [Set up AWS CLI with SSO](https://newjersey.github.io/innovation-engineering/guides/development/aws-sso/) for step by step guide.
 
-```shell
-aws configure
-```
+SSO sessions expire. Run `aws sso login` to log back in.
 
 Clone the code and navigate to the root of this repository. There is an installation script that
 will install all required development tools, yarn packages, and execute a yarn build.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,12 @@ services:
     depends_on:
       - dynamodb-local
     volumes:
-      - ~/.aws/credentials:/root/.aws/credentials:ro
       - ./api/users-dynamodb-schema.json:/users-dynamodb-schema.json:ro
       - ./api/businesses-dynamodb-schema.json:/businesses-dynamodb-schema.json:ro
+    environment:
+      - AWS_ACCESS_KEY_ID=local
+      - AWS_SECRET_ACCESS_KEY=local
+      - AWS_REGION=us-east-1
     entrypoint: ""
     command: |
       bash -c "


### PR DESCRIPTION
## Description

Adds dummy credentials to the `docker-compose.yml` script that we use to initialize the database for local development.

### Ticket

n/a

### Approach

In setting up my new machine, I noticed that the script was not creating local database tables. The commands that do this use the AWS CLI which are looking for values that may not exist in an AWS config file given the new SSO approach we're taking over using long-lived local credentials.

To address this, I added the following to `dynamodb-init`
```yml
environment:
  - AWS_ACCESS_KEY_ID=local
  - AWS_SECRET_ACCESS_KEY=local
  - AWS_REGION=us-east-1
```
DynamoDB Local does not communicate with AWS. These values should be fine for our local development purposes.

This likely wouldn't have been caught until someone else configured a new machine because our local tables are not ephemeral.

### Steps to Test

- Start the app
- Purge any existing tables (localhost:8001)
- Tear down
- Restart the app
- Check that tables exist (localhost:8001)

### Notes

## Code author checklist

- [X] I have rebased this branch from the latest main branch
- [X] I have performed a self-review of my code
- [X] My code follows the style guide
- [X] I have created and/or updated relevant documentation on the engineering documentation website
- [X] I have not used any relative imports
- [X] I have pruned any instances of unused code
- [X] I have not added any markdown to labels, titles and button text in config
- [X] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [X] I have checked for and removed instances of unused config from CMS
- [X] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [X] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [X] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
