### PR TITLE
feat: [AB#17813] adds slugCollisions script to CI workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -129,6 +129,40 @@ jobs:
           name: workspace
           path: ./
           retention-days: 3
+
+  cms-slug-check:
+    name: CMS Slug Collision Check
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    concurrency:
+      group: cms-slug-check-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      # `build` doesn't run on content-repo branches
+      # This is a little redundant, but knowingly included
+      - name: Install Dependencies
+        run: yarn install --immutable --mode skip-build
+
+      - name: Build Decap CMS Config
+        run: yarn decap:build-config
+
+      - name: Check CMS Slug Collisions
+        run: yarn workspace @businessnjgovnavigator/api cms-slug-check
+
   unit-tests:
     if: &tests_allowed >
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (

--- a/api/package.json
+++ b/api/package.json
@@ -27,7 +27,8 @@
     "start:wiremock:with-port": "wiremock --root-dir ./wiremock",
     "test": "jest",
     "typecheck": "tsc --noemit",
-    "cms-integrity-tests": "yarn dlx tsx ./scripts/cms-content-integrity-tests/runCmsIntegrityTests.ts"
+    "cms-integrity-tests": "yarn dlx tsx ./scripts/cms-content-integrity-tests/runCmsIntegrityTests.ts",
+    "cms-slug-check": "tsx ./scripts/cms-content-integrity-tests/runSlugCollisionCheck.ts"
   },
   "engines": {
     "node": ">=24.18.0"
@@ -56,6 +57,7 @@
     "dayjs": "1.11.21",
     "dedent": "1.7.2",
     "express": "5.2.1",
+    "gray-matter": "4.0.3",
     "helmet": "8.3.0",
     "http-status-codes": "2.3.0",
     "jsonwebtoken": "9.0.3",

--- a/api/scripts/cms-content-integrity-tests/runCmsIntegrityTests.ts
+++ b/api/scripts/cms-content-integrity-tests/runCmsIntegrityTests.ts
@@ -1,5 +1,6 @@
 import { checkAnytimeActionCategoryUsage } from "@businessnjgovnavigator/api/scripts/cms-content-integrity-tests/anytimeActionCategoryUsage";
 import { checkContextualInfoLinksUsage } from "@businessnjgovnavigator/api/scripts/cms-content-integrity-tests/contextualInfoLinks";
+import { checkSlugCollisions } from "@businessnjgovnavigator/api/scripts/cms-content-integrity-tests/slugCollisions";
 import { checkTaskUsage } from "@businessnjgovnavigator/api/scripts/cms-content-integrity-tests/taskIntegrityTests";
 import { getConfigValue } from "@libs/ssmUtils";
 
@@ -9,8 +10,16 @@ const runCmsIntegrityTests = async (): Promise<void> => {
   const anytimeActionCategoryHasErrors = await checkAnytimeActionCategoryUsage(topicArn);
   const taskHasErrors = await checkTaskUsage(topicArn);
   const contextualInfoHasErrors = await checkContextualInfoLinksUsage(topicArn);
+  const slugCollisionHasErrors = await checkSlugCollisions(topicArn);
 
-  if ([anytimeActionCategoryHasErrors, taskHasErrors, contextualInfoHasErrors].some(Boolean)) {
+  if (
+    [
+      anytimeActionCategoryHasErrors,
+      taskHasErrors,
+      contextualInfoHasErrors,
+      slugCollisionHasErrors,
+    ].some(Boolean)
+  ) {
     console.error("Failed with Errors");
     throw new Error("Failed with Errors, see console errors above");
   }

--- a/api/scripts/cms-content-integrity-tests/runSlugCollisionCheck.ts
+++ b/api/scripts/cms-content-integrity-tests/runSlugCollisionCheck.ts
@@ -1,0 +1,24 @@
+/**
+ * Fails the build on CMS slug collisions without notifying anyone. `runCmsIntegrityTests.ts` runs
+ * the same check with SNS alerting for pull requests into `content-repo`, where content editors
+ * never see a red GitHub check.
+ */
+
+import {
+  findSlugCollisions,
+  logSlugCollisionReport,
+} from "@businessnjgovnavigator/api/scripts/cms-content-integrity-tests/slugCollisions";
+
+const runSlugCollisionCheck = (): void => {
+  const report = findSlugCollisions();
+  logSlugCollisionReport(report);
+
+  if (report.collisions.length > 0) {
+    console.error("Failed with Errors");
+    process.exitCode = 1;
+    return;
+  }
+  console.log("Succeeded No Errors");
+};
+
+runSlugCollisionCheck();

--- a/api/scripts/cms-content-integrity-tests/slugCollisions.ts
+++ b/api/scripts/cms-content-integrity-tests/slugCollisions.ts
@@ -3,14 +3,14 @@
  * their file metadata. Those values are the public URL segment for an entry.
  */
 
+import { loadCmsConfig } from "@businessnjgovnavigator/shared/src/static";
+import { publishSnsMessage } from "@libs/awsSns";
 import matter from "gray-matter";
-import yaml from "js-yaml";
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
-const CONFIG_FILE = "web/public/mgmt/config.yml";
-const SLUG_FIELDS = ["slug", "urlSlug"] as const; // not standardized and used interchangably
+const SLUG_FIELDS = ["slug", "urlSlug"] as const; // not standardized and used interchangeably
+const SLUG_COLLISION_TITLE = ":warning: CMS Slug Collision";
 
 type SlugField = (typeof SLUG_FIELDS)[number];
 
@@ -33,24 +33,24 @@ interface Declaration {
   readonly value: string;
 }
 
-interface Duplicate {
+interface SlugCollision {
   readonly collection: string;
   readonly declarations: readonly Declaration[];
   readonly slugField: SlugField;
   readonly value: string;
 }
 
-interface Report {
+export interface SlugCollisionReport {
   readonly checkedCount: number;
   readonly collectionCount: number;
-  readonly duplicates: readonly Duplicate[];
+  readonly collisions: readonly SlugCollision[];
 }
 
 const loadCollections = (): CollectionConfig[] => {
-  const parsed = yaml.load(fs.readFileSync(CONFIG_FILE, "utf8")) as {
+  const config = loadCmsConfig(true) as {
     readonly collections?: readonly CollectionConfig[];
   } | null;
-  return [...(parsed?.collections ?? [])];
+  return [...(config?.collections ?? [])];
 };
 
 const isCollectionLabel = (collection: CollectionConfig): boolean =>
@@ -61,22 +61,23 @@ const isFolderCollection = (collection: CollectionConfig): collection is FolderC
 
 const readEntryData = (filePath: string): Record<string, unknown> => {
   const contents = fs.readFileSync(filePath, "utf8");
-  const extension = path.extname(filePath).toLowerCase();
-  if (extension === ".json") {
+  if (path.extname(filePath).toLowerCase() === ".json") {
     return JSON.parse(contents) as Record<string, unknown>;
   }
   // if not json assumes md
   return matter(contents).data;
 };
 
-const readEntries = (folder: string, extension: string): Entry[] =>
-  fs
-    .readdirSync(folder)
-    .filter((name: string) => name.endsWith(`.${extension}`))
-    .map((name: string) => {
-      const location = path.join(folder, name);
-      return { data: readEntryData(location), location };
-    });
+const readEntries = (folder: string, extension: string): Entry[] => {
+  const directory = path.join(process.cwd(), "..", folder);
+  return fs
+    .readdirSync(directory)
+    .filter((name) => name.endsWith(`.${extension}`))
+    .map((name) => ({
+      data: readEntryData(path.join(directory, name)),
+      location: path.join(folder, name),
+    }));
+};
 
 const normalize = (value: unknown): string => String(value).trim().toLowerCase();
 
@@ -91,14 +92,15 @@ const findDuplicates = (
   return new Map([...byValue].filter(([, group]) => group.length > 1));
 };
 
-const checkSlugCollisions = (): Report => {
+export const findSlugCollisions = (): SlugCollisionReport => {
   const collections = loadCollections();
-  const toBeChecked = collections.filter(isFolderCollection);
-  const duplicates: Duplicate[] = [];
+  const toBeChecked = collections.filter((collection): collection is FolderCollection =>
+    isFolderCollection(collection),
+  );
+  const collisions: SlugCollision[] = [];
 
   for (const collection of toBeChecked) {
-    const folder = collection.folder;
-    const entries = readEntries(folder, collection.extension ?? "md");
+    const entries = readEntries(collection.folder, collection.extension ?? "md");
 
     for (const slugField of SLUG_FIELDS) {
       const declarations = entries
@@ -109,7 +111,7 @@ const checkSlugCollisions = (): Report => {
         }));
 
       for (const [value, group] of findDuplicates(declarations)) {
-        duplicates.push({
+        collisions.push({
           collection: collection.name,
           declarations: group,
           slugField,
@@ -122,33 +124,31 @@ const checkSlugCollisions = (): Report => {
   return {
     checkedCount: toBeChecked.length,
     collectionCount: collections.length,
-    duplicates,
+    collisions,
   };
 };
 
-const run = (): void => {
-  const report = checkSlugCollisions();
-
-  for (const duplicate of report.duplicates) {
-    const { collection, declarations, slugField, value } = duplicate;
-    console.log(`\n  ${collection} — ${slugField} "${value}" declared by ${declarations.length}:`);
-    for (const declaration of declarations) {
-      const raw = normalize(declaration.value) === value ? "" : ` (${declaration.value})`;
-      console.log(`      ${declaration.location}${raw}`);
-    }
-  }
-
-  console.log(
-    `\nChecked ${report.checkedCount} collections of ${report.collectionCount} total collections`,
-  );
-  console.log(
-    report.duplicates.length === 0
-      ? "✅ No duplicates"
-      : `❌ ${report.duplicates.length} duplicate slug value(s)`,
-  );
-  process.exitCode = report.duplicates.length === 0 ? 0 : 1;
+const describeCollision = (collision: SlugCollision): string => {
+  const locations = collision.declarations.map((declaration) => `*"${declaration.location}"*`);
+  return `The *"${collision.collection}"* collection has ${collision.declarations.length} entries declaring the same ${collision.slugField} (*"${collision.value}"*): ${locations.join(", ")}. Entries cannot share a slug. Please update update the entries to differentiate.`;
 };
 
-if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  run();
-}
+export const logSlugCollisionReport = (report: SlugCollisionReport): void => {
+  console.log(`Checked ${report.checkedCount} of ${report.collectionCount} total collections`);
+  for (const collision of report.collisions) {
+    console.error(describeCollision(collision));
+  }
+};
+
+export const checkSlugCollisions = async (topicArn: string): Promise<boolean> => {
+  console.log("\n Starting Check Slug Collisions");
+
+  const report = findSlugCollisions();
+  logSlugCollisionReport(report);
+
+  for (const collision of report.collisions) {
+    await publishSnsMessage(describeCollision(collision), topicArn, SLUG_COLLISION_TITLE);
+  }
+
+  return report.collisions.length > 0;
+};

--- a/api/src/libs/awsSns.ts
+++ b/api/src/libs/awsSns.ts
@@ -2,16 +2,19 @@ import { PublishCommand, PublishCommandOutput, SNSClient } from "@aws-sdk/client
 
 export const snsClient = new SNSClient({});
 
+const DEFAULT_TITLE = ":warning: CMS Integrity Test Failure";
+
 export const publishSnsMessage = async (
   message: string,
   topicArn: string,
+  title: string = DEFAULT_TITLE,
 ): Promise<PublishCommandOutput | void> => {
   const formattedMessage = {
     version: "1.0",
     source: "custom",
     content: {
       textType: "client-markdown",
-      title: `:warning: CMS Integrity Test Failure`,
+      title,
       description: `${message}`,
     },
     metadata: {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "validate:dependencies": "tsx scripts/validate-dependency-policy.ts",
     "verify:node": "check-node-version --node $(cat .nvmrc) --npm 11.16.0",
     "wipit": "git add -A && git commit -m 'wip [skip ci]' --no-verify",
-    "cms:map": "yarn dlx tsx scripts/generate-collection-map.ts",
-    "cms:check-slugs": "tsx scripts/check-decap-slug-collisions.ts"
+    "cms:map": "yarn dlx tsx scripts/generate-collection-map.ts"
   },
   "dependencies": {
     "@aws-crypto/client-node": "4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4843,6 +4843,7 @@ __metadata:
     eslint-plugin-jest-formatting: "npm:3.1.0"
     eslint-plugin-unicorn: "npm:51.0.1"
     express: "npm:5.2.1"
+    gray-matter: "npm:4.0.3"
     helmet: "npm:8.3.0"
     http-status-codes: "npm:2.3.0"
     jest: "npm:30.4.2"


### PR DESCRIPTION
## Description

This work modifies the `build-and-test` and `cms-content-integrity-tests` workflows to include the `slugCollisions` script as a step.

The `build-and-test` workflow will output results within GHA, while the `cms-content-integrity-tests` workflow will post results to Slack. 

### Ticket

This pull request resolves [#17813](https://dev.azure.com/NJInnovation/BizX/_workitems/edit/17813).

### Approach

**`slugCollisions` Script**
This was previously added in #12988 as `scripts/check-decap-slug-collisions.ts`. I moved this under `api/` primarily for convenience sake when incorporating it in the `cms-content-integrity-tests` workflow. As a result, I needed `grey-matter` to be available in the api.

> [!NOTE]
> This script only checks within the context of a given collection. 

**`build-and-test` Workflow**
The script is executed during the `build-and-test` workflow to surface any slug collisions that may occur as a result of development work. The script is invoked in a new step added to this workflow

**`cms-content-integrity-tests` Workflow**
This workflow already runs against all CMS related branches. It invokes a function `runCmsIntegrityTests` which contains logic to post an alert to Slack if one of the checks were to fail. `checkSlugCollisions` was added to the list of check-type functions, and extends the existing logic for these.

### Steps to Test

- Create a condition for a collision to exist (e.g. modify 2 slug values so that they are the same)
- Trigger the workflow to invoke the script
- In `build-and-test` check that the GHA logs show a failure
- In `cms-content-integrity-tests` check that a Slack message was posted to `#bizx-alerts-cms` with the warning

### Notes

As stated above, this script only checks within the context of a given collection. There are cases where we join collections. A more robust implementation would consider that. Short of identifying all the places where collections are joined, and maintaining that list for this script, I opted for the simpler route.

## Code author checklist

- [ ] I have rebased this branch from the latest main branch
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guide
- [ ] I have created and/or updated relevant documentation on the engineering documentation website
- [ ] I have not used any relative imports
- [ ] I have pruned any instances of unused code
- [ ] I have not added any markdown to labels, titles and button text in config
- [ ] If I added/updated any values in `userData` (including `profileData`, `formationData` etc), then I added a new migration file
- [ ] I have checked for and removed instances of unused config from CMS
- [ ] If I added any new collections to the CMS config, then I updated the search tool and `cmsCollections.ts` (see CMS Additions in Engineering Reference/FAQ on the engineering documentation site)
- [ ] I have updated relevant `.env` values in `.env-template`, in Bitwarden, and in our workspaces
- [ ] I have added the `pr-show` or `pr-review` label on GitHub to show or request reviews
